### PR TITLE
i18n fixups

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -15,7 +15,7 @@ import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector';
 import I18NextHttpBackend from 'i18next-http-backend';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 
-import { getNamespaces } from '~/utils/locale-utils';
+import { getLocale, getNamespaces } from '~/utils/locale-utils';
 
 function hydrate() {
   startTransition(() => {
@@ -32,16 +32,15 @@ function hydrate() {
 
 if (!i18n.isInitialized) {
   i18n
+    .use(initReactI18next)
     .use(I18nextBrowserLanguageDetector)
     .use(I18NextHttpBackend)
-    .use(initReactI18next)
     .init({
-      debug: process.env.NODE_ENV === 'development',
       detection: { order: ['path'] },
-      fallbackLng: 'en',
+      fallbackLng: getLocale(window.location.href),
       interpolation: { escapeValue: false },
+      lng: getLocale(window.location.href),
       ns: getNamespaces(window.__remixRouteModules),
-      supportedLngs: ['en', 'fr'],
     })
     .then(() => {
       if (typeof requestIdleCallback === 'function') {

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -45,15 +45,11 @@ export default async function handleRequest(request: Request, responseStatusCode
     .use(initReactI18next)
     .use(I18NexFsBackend)
     .init({
-      backend: {
-        loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json')
-      },
-      debug: process.env.NODE_ENV === 'development',
-      fallbackLng: 'en',
+      backend: { loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json') },
+      fallbackLng: getLocale(request.url),
       interpolation: { escapeValue: false },
       lng: getLocale(request.url),
       ns: getNamespaces(remixContext.routeModules),
-      supportedLngs: ['en', 'fr'],
     });
     
   const handlerFnName = isbot(request.headers.get('user-agent')) ? 'onAllReady' : 'onShellReady';

--- a/frontend/app/routes/$locale._index.tsx
+++ b/frontend/app/routes/$locale._index.tsx
@@ -17,7 +17,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     throw new Response('Not found', { status: 404, statusText: 'Not found' });
   }
 
-  const t = await getFixedT(request, 'common');
+  const t = await getFixedT(request, handle.i18nNamespaces);
   return json({ pageTitle: t('index.page-title') });
 };
 
@@ -26,7 +26,7 @@ export const handle = {
 };
 
 export default function Index() {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -18,6 +18,7 @@ export async function getFixedT<N extends Namespace>(request: Request, namespace
     .init({
       backend: { loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json') },
       debug: process.env.NODE_ENV === 'development',
+      fallbackLng: getLocale(request.url),
       interpolation: { escapeValue: false },
       lng: getLocale(request.url),
       ns: namespaces,


### PR DESCRIPTION
i18next was loading the fallback languages even when the language was known. This caused excess XHR requests to .json locale files.