### PR TITLE
Add .env.example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,26 @@
+# Example .env configuration file.
+# Copy this file to `.env` and edit as required.
+
+# application log level; valid values are: error, warn, info, http, verbose, debug, silly
+# (optional; default: info)
+LOG_LEVEL=debug
+
+# i18n language cookie name
+# (optional; default: _gc_lang)
+LANG_COOKIE_NAME=_gc_lang
+# i18n language cookie domain
+# (optional; default: undefined)
+LANG_COOKIE_DOMAIN=localhost
+# i18n language cookie path
+# (optional; default: /)
+LANG_COOKIE_PATH=/
+# i18n language cookie httpOnly flag
+# (optional; default: true)
+LANG_COOKIE_HTTP_ONLY=true
+# i18n language cookie secure flag
+# (optional; default: true)
+LANG_COOKIE_SECURE=false
+
+# i18n language querystring key
+# (optional; default: lang)
+LANG_QUERY_PARAM=lang

--- a/frontend/app/routes/_gcweb-app/language-switcher.tsx
+++ b/frontend/app/routes/_gcweb-app/language-switcher.tsx
@@ -1,6 +1,8 @@
-import { Link, type LinkProps, useLocation } from '@remix-run/react';
+import { Link, type LinkProps, useLoaderData, useLocation } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
+
+import { type loader } from './route';
 
 /**
  * Props for the LanguageSwitcher component.
@@ -11,10 +13,11 @@ export type LanguageSwitcherProps = Omit<LinkProps, 'to' | 'reloadDocument'>;
  * A component that renders a link to switch between languages.
  */
 export function LanguageSwitcher({ ...props }: LanguageSwitcherProps) {
+  const { langQueryParam } = useLoaderData<typeof loader>();
   const { pathname } = useLocation();
   const { i18n, t } = useTranslation(['gcweb']);
 
-  const to = `${pathname}?lang=${i18n.language === 'fr' ? 'en' : 'fr'}`;
+  const to = `${pathname}?${langQueryParam}=${i18n.language === 'fr' ? 'en' : 'fr'}`;
 
   return (
     <Link {...props} to={to} data-testid="language-switcher" reloadDocument>

--- a/frontend/app/routes/_gcweb-app/route.tsx
+++ b/frontend/app/routes/_gcweb-app/route.tsx
@@ -1,11 +1,16 @@
-import { type LinksFunction } from '@remix-run/node';
+import { type LinksFunction, type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
 
 import { ApplicationLayout } from './application-layout';
 import { ServerError } from './server-error';
+import { getEnv } from '~/utils/environment.server';
 
 export const handle = {
   i18nNamespaces: ['gcweb'],
+};
+
+export const loader = ({ request }: LoaderFunctionArgs) => {
+  return json({ langQueryParam: getEnv('LANG_QUERY_PARAM') ?? 'lang' });
 };
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: '/theme/gcweb/css/theme.min.css' }];

--- a/frontend/app/utils/environment.server.ts
+++ b/frontend/app/utils/environment.server.ts
@@ -2,14 +2,18 @@
  * Return the requested environment variable, or undefined if not set.
  */
 export function getEnv(key: string) {
-  return process.env[key];
+  const value = process.env[key];
+  if (value === '') {
+    return undefined;
+  }
+  return value;
 }
 
 /**
  * Return the requested environment variable, or throw if not set.
  */
 export function getRequiredEnv(key: string) {
-  const value = process.env[key];
+  const value = getEnv(key);
   if (value === undefined) {
     throw new Error(`Environment variable ${key} is required`);
   }

--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -48,7 +48,7 @@ export async function getFixedT<N extends Namespace>(request: Request, namespace
  */
 export async function getLocale(request: Request) {
   const searchParams = new URL(request.url).searchParams;
-  const searchParamsLang = searchParams.get(getEnv('LANG_PARAM') ?? 'lang');
+  const searchParamsLang = searchParams.get(getEnv('LANG_QUERY_PARAM') ?? 'lang');
 
   if (searchParamsLang === 'en') {
     log.debug('Locale [en] detected in URL search params');


### PR DESCRIPTION
Add a `.env.example` file and tweak how empty (ie: `''`) environment variables are handled.