### PR TITLE
Prepwork for future PR

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -13,7 +13,8 @@ import { I18nextProvider } from 'react-i18next';
 import { getNamespaces, initI18n } from '~/utils/locale-utils';
 
 async function hydrate() {
-  const i18n = await initI18n(getNamespaces(window.__remixRouteModules));
+  const routes = Object.values(window.__remixRouteModules);
+  const i18n = await initI18n(getNamespaces(routes));
 
   startTransition(() => {
     hydrateRoot(

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -20,9 +20,10 @@ export default async function handleRequest(request: Request, responseStatusCode
   const handlerFnName = isbot(request.headers.get('user-agent')) ? 'onAllReady' : 'onShellReady';
   log.debug(`Handling [${request.method}] request to [${request.url}] with handler function [${handlerFnName}]`);
 
+  const routes = Object.values(remixContext.routeModules);
   const locale = (await getLocale(request)) ?? 'en';
   const langCookie = await createLangCookie().serialize(locale);
-  const i18n = await initI18n(locale, getNamespaces(remixContext.routeModules));
+  const i18n = await initI18n(locale, getNamespaces(routes));
 
   const nonce = generateNonce(32);
   const contentSecurityPolicy = generateContentSecurityPolicy(nonce);

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -7,27 +7,18 @@ import { type RouteHandle } from '~/types';
 
 /**
  * Returns all namespaces required by the given routes by examining the route's i18nNamespaces handle property.
- *
- * @param {RouteModules} routeModules - Object containing route modules
  * @see https://remix.run/docs/en/main/route/handle
  */
-export function getNamespaces(routeModules: Record<string, { handle?: unknown }>) {
-  const namespaces = new Set(
-    Object.values(routeModules)
-      .map((route) => route.handle)
-      .filter((handle): handle is RouteHandle => handle !== undefined)
-      .map((handle) => handle.i18nNamespaces)
-      .filter((i18nNamespaces): i18nNamespaces is Namespace => i18nNamespaces !== undefined)
-      .flatMap((i18nNamespaces) => i18nNamespaces),
-  );
-
-  return [...namespaces];
+export function getNamespaces(routes: Array<{ handle?: unknown }>) {
+  const routeHandles = routes.map((route) => route.handle).filter((handle): handle is RouteHandle => handle !== undefined);
+  const i18nNamespaces = routeHandles.map((handle) => handle.i18nNamespaces).filter((i18nNamespaces): i18nNamespaces is Namespace => i18nNamespaces !== undefined);
+  return [...new Set(i18nNamespaces.flatMap((i18nNamespace) => i18nNamespace))];
 }
 
 /**
  * Initializes the client instance of i18next.
  */
-export async function initI18n(namespaces: string[]) {
+export async function initI18n(namespaces: Array<string>) {
   const i18n = createInstance();
 
   await i18n

--- a/frontend/remix.env.d.ts
+++ b/frontend/remix.env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
-// i18next - import all namespaces (for the default language, only)
-import type common from '../public/locales/en/common.json';
-import type gcweb from '../public/locales/en/gcweb.json';
+import type common from './public/locales/en/common.json';
+import type gcweb from './public/locales/en/gcweb.json';
 
 declare global {
   interface Window {
@@ -14,9 +13,7 @@ declare global {
  * @see https://www.i18next.com/overview/typescript
  */
 declare module 'i18next' {
-  // Extend CustomTypeOptions
   interface CustomTypeOptions {
-    // custom resources type
     resources: {
       common: typeof common;
       gcweb: typeof gcweb;


### PR DESCRIPTION
Updating types in the i18n `getNamespaces()` function in preparation for an upcoming overhaul to the page metadata subsystem (page title, page id, build info, etc).

(also fixed broken types)