### PR TITLE
Add **/tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,osx,windows
+
+#
+# Custom entries below...
+#
+
+**/tmp/


### PR DESCRIPTION
Add `**/tmp/` to `.gitignore` so it can be used as a dumping ground during local development.