### PR TITLE
Extract language switcher to component

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -1,0 +1,26 @@
+import { Link, type LinkProps, useHref } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { useClientEnv } from '~/components/client-env';
+import { getAltLanguage } from '~/utils/locale-utils';
+
+export type LanguageSwitcherProps = Omit<LinkProps, 'to' | 'reloadDocument'>;
+
+/**
+ * Component that can be used to switch from one language to another.
+ * (ie: 'en' → 'fr'; 'fr' → 'en')
+ */
+export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) {
+  const { i18n } = useTranslation(['gcweb']);
+
+  const langParam = useClientEnv('LANG_QUERY_PARAM') ?? 'lang';
+  const langValue = getAltLanguage(i18n.language);
+  const to = useHref(`?${langParam}=${langValue}`);
+
+  return (
+    <Link data-testid="language-switcher" reloadDocument to={to} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode } from 'react';
 
 import { type LinksFunction } from '@remix-run/node';
-import { Link, type LinkProps, Outlet, isRouteErrorResponse, useLocation, useMatches, useRouteError } from '@remix-run/react';
+import { Link, Outlet, isRouteErrorResponse, useMatches, useRouteError } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 
-import { useClientEnv } from '~/components/client-env';
+import { LanguageSwitcher } from '~/components/language-switcher';
 import { type RouteHandle } from '~/types';
 import { useBuildInfo } from '~/utils/build-info';
 
@@ -80,7 +80,12 @@ function PageHeader() {
               <h2 className="wb-inv">{t('gcweb.header.language-selection')}</h2>
               <ul className="list-inline mrgn-bttm-0">
                 <li>
-                  <LanguageSwitcher />
+                  <LanguageSwitcher>
+                    <span className="hidden-xs">{t('gcweb.language-switcher.alt-lang')}</span>
+                    <abbr title="Français" className="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">
+                      {t('gcweb.language-switcher.alt-lang-abbr')}
+                    </abbr>
+                  </LanguageSwitcher>
                 </li>
               </ul>
             </section>
@@ -180,23 +185,6 @@ function PageFooter() {
         </div>
       </div>
     </footer>
-  );
-}
-
-function LanguageSwitcher({ ...props }: Omit<LinkProps, 'to' | 'reloadDocument'>) {
-  const langQueryParam = useClientEnv('LANG_QUERY_PARAM') ?? 'lang';
-  const { pathname } = useLocation();
-  const { i18n, t } = useTranslation(['gcweb']);
-
-  const to = `${pathname}?${langQueryParam}=${i18n.language === 'fr' ? 'en' : 'fr'}`;
-
-  return (
-    <Link {...props} to={to} data-testid="language-switcher" reloadDocument>
-      <span className="hidden-xs">{t('gcweb.language-switcher.alt-lang')}</span>
-      <abbr title="Français" className="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">
-        {t('gcweb.language-switcher.alt-lang-abbr')}
-      </abbr>
-    </Link>
   );
 }
 

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -6,6 +6,21 @@ import { initReactI18next } from 'react-i18next';
 import { type RouteHandle } from '~/types';
 
 /**
+ * Returns the alternate language for the given input language.
+ * (ie: 'en' → 'fr'; 'fr' → 'en')
+ */
+export function getAltLanguage(language: string) {
+  switch (language) {
+    case 'en':
+      return 'fr';
+    case 'fr':
+      return 'en';
+    default:
+      throw new Error(`Unexpected language: ${language}`);
+  }
+}
+
+/**
  * Returns all namespaces required by the given routes by examining the route's i18nNamespaces handle property.
  * @see https://remix.run/docs/en/main/route/handle
  */


### PR DESCRIPTION
The language switcher is not specific to the GCWeb template/layout, so it should be extracted out into its own component.