### PR TITLE
Fix lang switcher url search params

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -1,4 +1,4 @@
-import { Link, type LinkProps, useHref } from '@remix-run/react';
+import { Link, type LinkProps, useSearchParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -13,13 +13,18 @@ export type LanguageSwitcherProps = Omit<LinkProps, 'to' | 'reloadDocument'>;
  */
 export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) {
   const { i18n } = useTranslation(['gcweb']);
+  const [currentSearchParams] = useSearchParams();
 
   const { LANG_QUERY_PARAM: langParam } = useClientEnv();
   const langValue = getAltLanguage(i18n.language);
-  const to = useHref(`?${langParam}=${langValue}`);
+
+  const searchParams = new URLSearchParams(currentSearchParams);
+  searchParams.set(langParam, langValue);
+
+  const search = searchParams.toString();
 
   return (
-    <Link data-testid="language-switcher" reloadDocument to={to} {...props}>
+    <Link data-testid="language-switcher" reloadDocument to={{ search }} {...props}>
       {children}
     </Link>
   );


### PR DESCRIPTION
Add `lang` search param in the existint search params for the current url.