### PR TITLE
Add GitOps k8s manifests for dev pseudoenvironment

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -1,0 +1,23 @@
+# Canadian Dental Care Plan GitOps Manifests
+
+This repository contains the configuration and application manifests used to manage both the production and
+non-production Canadian Dental Care Plan Kubernetes clusters.
+
+## Requirements
+
+This project has been tested with the following toolchain:
+
+| Tool                                               | Version  |
+| -------------------------------------------------- | -------- |
+| [Kubectl](https://kubernetes.io/docs/tasks/tools/) | ≥ 1.25.x |
+| [Kustomize](https://kustomize.io/)                 | ≥ 5.0.x  |
+
+## Running the project
+
+1. Clone this repository to your local development environment.
+1. Navigate to the root directory of the project.
+1. Run the following command to apply the kustomize manifests to the target environment:
+
+    ``` shell
+    kubectl --kubeconfig {path-to-kubeconfig} apply --kustomize {application}/overlays/{target-cluster}
+    ```

--- a/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/deployments.yaml
+++ b/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/deployments.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canada-dental-care-plan-frontend
+  labels:
+    app.kubernetes.io/name: canada-dental-care-plan-frontend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: canada-dental-care-plan-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: canada-dental-care-plan-frontend
+    spec:
+      containers:
+        - name: canada-dental-care-plan-frontend
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend
+          envFrom:
+            - configMapRef:
+                name: canada-dental-care-plan-frontend
+          ports:
+            - name: http
+              containerPort: 3000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1024Mi

--- a/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/ingresses.yaml
+++ b/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/ingresses.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canada-dental-care-plan-frontend
+  labels:
+    app.kubernetes.io/name: canada-dental-care-plan-frontend
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: cdcp-dev.dev-dp.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: canada-dental-care-plan-frontend
+                port:
+                  name: http
+    - host: cdcp-dev.dev-dp-internal.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: canada-dental-care-plan-frontend
+                port:
+                  name: http

--- a/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/kustomization.yaml
+++ b/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+
+labels:
+  - pairs:
+      app.kubernetes.io/application: canada-dental-care-plan-frontend
+      app.kubernetes.io/part-of: canada-dental-care-plan
+      app.kubernetes.io/managed-by: teamcity
+      app.kubernetes.io/cluster: dts-dev-sced-rhp-spoke-aks
+      app.kubernetes.io/tier: nonprod
+
+resources:
+  - ./deployments.yaml
+  - ./ingresses.yaml
+  - ./services.yaml
+
+configMapGenerator:
+  - name: canada-dental-care-plan-frontend
+    literals:
+      - LOG_LEVEL=debug

--- a/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/services.yaml
+++ b/gitops/frontend/overlays/dts-dev-sced-rhp-spoke-aks/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: canada-dental-care-plan-frontend
+  labels:
+    app.kubernetes.io/name: canada-dental-care-plan-frontend
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: canada-dental-care-plan-frontend


### PR DESCRIPTION
This PR adds a deployable Kustomize configuration for the application that allows it to be deployed to our nonprod/dev pseudoenvironment.

Initial manifests are rudimentary and basic, but represent a practical starting point to build upon.