### PR TITLE
Adding breadcrumbs based on GCWeb theme

### DIFF
--- a/frontend/app/routes/_gcweb-app._index.tsx
+++ b/frontend/app/routes/_gcweb-app._index.tsx
@@ -8,6 +8,7 @@ import { getFixedT } from '~/utils/locale-utils.server';
 
 export const handle = {
   i18nNamespaces: ['common'],
+  breadcrumbs: [{ i18nKey: 'gcweb.breadcrumbs.index' }],
 } satisfies RouteHandle;
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {

--- a/frontend/app/routes/_gcweb-app.about.tsx
+++ b/frontend/app/routes/_gcweb-app.about.tsx
@@ -7,6 +7,7 @@ import { getFixedT } from '~/utils/locale-utils.server';
 
 export const handle = {
   i18nNamespaces: ['common'],
+  breadcrumbs: [{ i18nKey: 'gcweb.breadcrumbs.index', to: '/' }, { i18nKey: 'gcweb.breadcrumbs.about' }],
 } satisfies RouteHandle;
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -6,8 +6,9 @@ import { Link, Outlet, isRouteErrorResponse, useMatches, useRouteError } from '@
 import { Trans, useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
-import { type RouteHandle } from '~/types';
+import { type RouteHandle, type RouteHandleBreadcrumb } from '~/types';
 import { useBuildInfo } from '~/utils/build-info';
+import { getNamespaces } from '~/utils/locale-utils';
 
 export const handle: RouteHandle = { i18nNamespaces: ['gcweb'] };
 
@@ -191,10 +192,13 @@ function PageFooter() {
 
 function Breadcrumbs() {
   const matches = useMatches();
-  const match = matches.filter((match) => (match.handle as RouteHandle)?.breadcrumbs);
-  const breadcrumbs = match.flatMap((match) => (match.handle as RouteHandle).breadcrumbs);
+  const { t } = useTranslation(getNamespaces(matches));
 
-  const { t } = useTranslation(['gcweb']);
+  const breadcrumbs = matches
+    .map((match) => match.handle)
+    .filter((handle): handle is RouteHandle => handle !== undefined)
+    .flatMap((handle) => handle.breadcrumbs)
+    .filter((breadcrumb): breadcrumb is RouteHandleBreadcrumb => breadcrumb !== undefined);
 
   if (breadcrumbs.length === 0) {
     return <></>;
@@ -211,7 +215,7 @@ function Breadcrumbs() {
                 <span property="name">{t(breadcrumb.i18nKey)}</span>
               </Link>
             ) : (
-              <span property="name">{t(breadcrumb?.i18nKey)}</span>
+              <span property="name">{t(breadcrumb.i18nKey)}</span>
             );
 
             return (

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -107,6 +107,7 @@ function PageHeader() {
           </h2>
         </div>
       </section>
+      <Breadcrumbs />
     </>
   );
 }
@@ -185,6 +186,44 @@ function PageFooter() {
         </div>
       </div>
     </footer>
+  );
+}
+
+function Breadcrumbs() {
+  const matches = useMatches();
+  const match = matches.filter((match) => (match.handle as RouteHandle)?.breadcrumbs);
+  const breadcrumbs = match.flatMap((match) => (match.handle as RouteHandle).breadcrumbs);
+
+  const { t } = useTranslation(['gcweb']);
+
+  if (breadcrumbs.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <nav id="wb-bc" property="breadcrumb">
+      <h2>{t('gcweb.breadcrumbs.you-are-here')}</h2>
+      <div className="container">
+        <ol className="breadcrumb" typeof="BreadcrumbList">
+          {breadcrumbs.map((breadcrumb, index) => {
+            const breadcrumbItem = breadcrumb?.to ? (
+              <Link to={breadcrumb.to} property="item" typeof="WebPage">
+                <span property="name">{t(breadcrumb.i18nKey)}</span>
+              </Link>
+            ) : (
+              <span property="name">{t(breadcrumb?.i18nKey)}</span>
+            );
+
+            return (
+              <li key={index} property="itemListElement" typeof="ListItem">
+                {breadcrumbItem}
+                <meta property="position" content={index + 1 + ''} />
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </nav>
   );
 }
 

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -1,5 +1,8 @@
 import { type Namespace } from 'i18next';
 
+import type gcweb from '~/public/locales/en/gcweb.json';
+
 export interface RouteHandle extends Record<string, unknown> {
   i18nNamespaces?: Namespace;
+  breadcrumbs?: Array<{ i18nKey: typeof gcweb; to?: string }>;
 }

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -1,8 +1,35 @@
-import { type Namespace } from 'i18next';
+import { type Namespace, type ParseKeys } from 'i18next';
 
-import type gcweb from '~/public/locales/en/gcweb.json';
+import type common from '../public/locales/en/common.json';
+import type gcweb from '../public/locales/en/gcweb.json';
+import { type ClientEnv } from '~/utils/env.server';
+
+export type I18nResources = {
+  common: typeof common;
+  gcweb: typeof gcweb;
+};
+
+export type RouteHandleBreadcrumb = {
+  i18nKey: ParseKeys<keyof I18nResources>;
+  to?: string;
+};
+
+declare global {
+  interface Window {
+    env: ClientEnv;
+  }
+}
+
+/**
+ * @see https://www.i18next.com/overview/typescript
+ */
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    resources: I18nResources;
+  }
+}
 
 export interface RouteHandle extends Record<string, unknown> {
   i18nNamespaces?: Namespace;
-  breadcrumbs?: Array<{ i18nKey: typeof gcweb; to?: string }>;
+  breadcrumbs?: Array<RouteHandleBreadcrumb>;
 }

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -23,6 +23,11 @@
       "alt-lang": "Français",
       "alt-lang-abbr": "FR"
     },
+    "breadcrumbs": {
+      "you-are-here": "You are here:",
+      "index": "Home",
+      "about": "About us"
+    },
     "page-details": {
       "page-details": "Page details",
       "date-modfied": "Date modified:",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -23,6 +23,11 @@
       "alt-lang": "English",
       "alt-lang-abbr": "EN"
     },
+    "breadcrumbs": {
+      "you-are-here": "Vous êtes ici\u00a0:",
+      "index": "Accueil",
+      "about": "Qui sommes-nous?"
+    },
     "page-details": {
       "page-details": "Détails de la page",
       "date-modfied": "Date de modification\u00a0:",

--- a/frontend/remix.env.d.ts
+++ b/frontend/remix.env.d.ts
@@ -1,23 +1,2 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
-import type common from './public/locales/en/common.json';
-import type gcweb from './public/locales/en/gcweb.json';
-import { type ClientEnv } from '~/utils/env.server';
-
-declare global {
-  interface Window {
-    env: ClientEnv;
-  }
-}
-
-/**
- * @see https://www.i18next.com/overview/typescript
- */
-declare module 'i18next' {
-  interface CustomTypeOptions {
-    resources: {
-      common: typeof common;
-      gcweb: typeof gcweb;
-    };
-  }
-}


### PR DESCRIPTION
Breadcrumb implementation is based off of https://wet-boew.github.io/GCWeb/sites/breadcrumbs/breadcrumbs-en.html

Note that i18next types are not yet handled.