### PR TITLE
Add TS generic type parameter declaration

### DIFF
--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -40,7 +40,7 @@ export function createLangCookie() {
  * Returns a t function that defaults to the language resolved through the request.
  * @see https://www.i18next.com/overview/api#getfixedt
  */
-export async function getFixedT(request: Request, namespaces: Namespace) {
+export async function getFixedT<N extends Namespace>(request: Request, namespaces: N) {
   const locale = await getLocale(request);
   const i18n = await initI18n(locale, namespaces);
   return i18n.getFixedT(locale ?? null, namespaces);


### PR DESCRIPTION
`<N extends Namespace>`: This is a TypeScript generic type parameter declaration. It means that the function `getFixedT` can be called with a type argument `N` that extends or satisfies the `Namespace` type.