### PR TITLE
bypass unhandled requests for msw

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -15,7 +15,14 @@ import { createLangCookie, getLocale, initI18n } from '~/utils/locale-utils.serv
 import { getLogger } from '~/utils/logging.server';
 
 if (process.env.NODE_ENV === 'development') {
-  server.listen();
+  server.listen({
+    onUnhandledRequest(request, print) {
+      if (request.url.includes('/ping')) {
+        return;
+      }
+      print.warning();
+    },
+  });
 }
 
 const abortDelay = 5_000;


### PR DESCRIPTION
When the application starts up in development mode, MSW makes a post request to `/ping`. Based on the [docs](https://mswjs.io/docs/api/setup-server/listen/), we can add a custom configuration to check for this request and conditionally turn off the warning.