### PR TITLE
remove client worker msw

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -12,29 +12,19 @@ import { I18nextProvider } from 'react-i18next';
 
 import { getNamespaces, initI18n } from '~/utils/locale-utils';
 
-async function prepareApp() {
-  if (process.env.NODE_ENV === 'development') {
-    const { worker } = await import('./mocks/browser');
-    return worker.start();
-  }
-  return Promise.resolve();
-}
-
 async function hydrate() {
   const routes = Object.values(window.__remixRouteModules);
   const i18n = await initI18n(getNamespaces(routes));
 
-  prepareApp().then(() => {
-    startTransition(() => {
-      hydrateRoot(
-        document,
-        <StrictMode>
-          <I18nextProvider i18n={i18n}>
-            <RemixBrowser />
-          </I18nextProvider>
-        </StrictMode>,
-      );
-    });
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <I18nextProvider i18n={i18n}>
+          <RemixBrowser />
+        </I18nextProvider>
+      </StrictMode>,
+    );
   });
 }
 


### PR DESCRIPTION
Remove client side mocks.  As far as Greg and I can tell, it likely isn't needed.  If in the future is needed, refer back to the [with-remix](https://github.com/mswjs/examples/tree/main/examples/with-remix) for setting up again.