### PR TITLE
refactoring(frontend): add getTypedI18nNamespaces utility function

### DIFF
--- a/frontend/app/routes/_gcweb-app.$.tsx
+++ b/frontend/app/routes/_gcweb-app.$.tsx
@@ -1,22 +1,22 @@
 import { type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Link } from '@remix-run/react';
 
-import { type Namespace } from 'i18next';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 
-const i18nNamespaces: Namespace = ['gcweb'];
+const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const t = await getFixedT(request, i18nNamespaces);
 
-  return json<LoaderFunctionData>(
+  return json(
     {
       i18nNamespaces,
       pageIdentifier: 'CDCP-0404',
       pageTitle: t('gcweb:not-found.page-title'),
-    },
+    } as const satisfies LoaderFunctionData,
     { status: 404 },
   );
 };

--- a/frontend/app/routes/_gcweb-app._index.tsx
+++ b/frontend/app/routes/_gcweb-app._index.tsx
@@ -1,13 +1,13 @@
 import { type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 
-import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 
-const i18nNamespaces: Namespace = ['common'];
+const i18nNamespaces = getTypedI18nNamespaces('common', 'gcweb');
 
 const userSchema = z.object({ firstName: z.string(), lastName: z.string() });
 type User = z.infer<typeof userSchema>;
@@ -21,18 +21,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, i18nNamespaces);
 
   // TODO :: GjB :: figure out a cleaner way to type this
-  return json<LoaderFunctionData & { user: User }>({
+  return json({
     breadcrumbs: [{ label: t('common:index.breadcrumbs.home') }],
     i18nNamespaces,
     pageIdentifier: 'CDCP-0001',
     pageTitle: t('common:index.page-title'),
     user: await getUser(),
-  });
+  } as const satisfies LoaderFunctionData & { user: User });
 }
 
 export default function Index() {
-  const { t } = useTranslation(i18nNamespaces);
   const { user } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_gcweb-app.about.tsx
+++ b/frontend/app/routes/_gcweb-app.about.tsx
@@ -1,21 +1,21 @@
 import { type LoaderFunctionArgs, json } from '@remix-run/node';
 
-import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 
-const i18nNamespaces: Namespace = ['common'];
+const i18nNamespaces = getTypedI18nNamespaces('common');
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, i18nNamespaces);
 
-  return json<LoaderFunctionData>({
+  return json({
     breadcrumbs: [{ label: t('common:about.breadcrumbs.home'), to: '/' }, { label: t('common:about.breadcrumbs.about') }],
     i18nNamespaces,
     pageIdentifier: 'CDCP-0002',
     pageTitle: t('common:about.page-title'),
-  });
+  } as const satisfies LoaderFunctionData);
 }
 
 export default function About() {

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -3,18 +3,18 @@ import { type ReactNode } from 'react';
 import { type LinksFunction, type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Link, Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
 
-import { type Namespace } from 'i18next';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useBreadcrumbs, useBuildInfo, usePageIdentifier } from '~/utils/route-utils';
 
-const i18nNamespaces: Namespace = ['gcweb'];
+const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: '/theme/gcweb/css/theme.min.css' }];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  return json<LoaderFunctionData>({ i18nNamespaces });
+  return json({ i18nNamespaces } as const satisfies LoaderFunctionData);
 }
 
 export function ErrorBoundary() {

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -1,4 +1,4 @@
-import { type Namespace, createInstance } from 'i18next';
+import { type FlatNamespace, type Namespace, createInstance } from 'i18next';
 import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector';
 import I18NextHttpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
@@ -64,4 +64,24 @@ export async function initI18n(namespaces: Array<string>) {
     });
 
   return i18n;
+}
+
+/**
+ * Returns a tuple representing a typed list of namespaces.
+ *
+ * @template T - The primary namespace to include in the tuple.
+ * @template T2 - Additional namespaces to include in the tuple. Should only contain distinct values.
+ * @param ns - The primary namespace of type T.
+ * @param rest - Additional namespaces of type T2 (should be distinct).
+ * @returns A tuple containing the primary namespace and additional namespaces.
+ *
+ * @note Ensure that the values in the `rest` parameter are distinct to avoid duplicates in the resulting tuple.
+ *
+ * @example
+ * // Usage example:
+ * const result = getTypedI18nNs("common", "gcweb", "other");
+ * // result is of type: readonly ["common", "gcweb", "other"]
+ */
+export function getTypedI18nNamespaces<const T extends Readonly<FlatNamespace>, const T2 extends ReadonlyArray<Exclude<FlatNamespace, T>>>(ns: T, ...rest: T2) {
+  return [ns, ...rest] as const;
 }

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -1,6 +1,6 @@
 import { useMatches } from '@remix-run/react';
 
-import { type Namespace } from 'i18next';
+import { type FlatNamespace } from 'i18next';
 import { z } from 'zod';
 
 /**
@@ -27,7 +27,7 @@ const buildInfo = z.object({
 });
 
 const i18nNamespaces = z.object({
-  i18nNamespaces: z.custom<Namespace>(),
+  i18nNamespaces: z.array(z.custom<FlatNamespace>()).readonly(),
 });
 
 const pageIdentifier = z.object({


### PR DESCRIPTION
Using type `Namespace` to declare `i18nNamespaces` is not wrong but gives unwanted issue when using that variable with `getFixedT` or `useTranslation` because they cannot infer the actual values assignement to suggest or validate i18n keys to use or be used.

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/fe54d18c-f186-4159-abba-8d895edb9404)

One way to fix that is to declare the variable as `const i18nNamespaces = ['common'] as const satisfies Namespace;`.  The infered type is `readonly ["common"]` which is good but then you need to do it everywhere.

The `getTypedI18nNamespaces` utility function that I created will take care of returning `readonly ["common"]`.

Only keys for `common` namespace will be returned.

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/521db4e7-cdc1-4a50-ab34-a8d00ff48436)
