### PR TITLE
refactoring(frontend): set ns prop to Trans component

### DIFF
--- a/frontend/app/routes/_gcweb-app.$.tsx
+++ b/frontend/app/routes/_gcweb-app.$.tsx
@@ -36,7 +36,7 @@ export default function NotFound() {
       <p>{t('gcweb:not-found.page-message')}</p>
       <ul>
         <li>
-          <Trans i18nKey="gcweb:not-found.page-link" components={{ home }} />
+          <Trans ns={i18nNamespaces} i18nKey="gcweb:not-found.page-link" components={{ home }} />
         </li>
       </ul>
     </>

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -239,7 +239,7 @@ function ServerError({ error }: { error: unknown }) {
       <ul className="list-disc ps-16">
         <li>{t('gcweb:server-error.option-01')}</li>
         <li>
-          <Trans i18nKey="gcweb:server-error.option-02" components={{ home }} />
+          <Trans ns={i18nNamespaces} i18nKey="gcweb:server-error.option-02" components={{ home }} />
         </li>
       </ul>
     </ApplicationLayout>


### PR DESCRIPTION
Set `ns` prop to `Trans` component to ensure only `i18nKey`s from provided the `ns` are suggested and validated.