### PR TITLE
Fix broken buildinfo

### DIFF
--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { Outlet } from '@remix-run/react';
+import { Outlet, json } from '@remix-run/react';
 import { createRemixStub } from '@remix-run/testing';
 
-import type { Breadcrumbs, BuildInfo, I18nNamespaces, PageIdentifier, PageTitleI18nKey } from '~/utils/route-utils';
+import type { Breadcrumbs, I18nNamespaces, PageIdentifier, PageTitleI18nKey } from '~/utils/route-utils';
 import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey } from '~/utils/route-utils';
 
 describe('coalesce<T> reducer', () => {
@@ -90,25 +90,29 @@ describe('useBuildInfo()', () => {
     const RemixStub = createRemixStub([
       {
         Component: () => <Outlet />,
-        handle: {
-          buildInfo: {
-            buildDate: '0000-00-00T00:00:00Z',
-            buildId: '0000',
-            buildRevision: '00000000',
-            buildVersion: '0.0.0+00000000-0000',
-          },
-        } satisfies BuildInfo,
+        loader: () => {
+          return json({
+            buildInfo: {
+              buildDate: '0000-00-00T00:00:00Z',
+              buildId: '0000',
+              buildRevision: '00000000',
+              buildVersion: '0.0.0+00000000-0000',
+            },
+          });
+        },
         children: [
           {
             Component: () => <div data-testid="data">{JSON.stringify(useBuildInfo())}</div>,
-            handle: {
-              buildInfo: {
-                buildDate: '2000-01-01T00:00:00Z',
-                buildId: '6969',
-                buildRevision: '69696969',
-                buildVersion: '0.0.0+69696969-6969',
-              },
-            } satisfies BuildInfo,
+            loader: () => {
+              return json({
+                buildInfo: {
+                  buildDate: '2000-01-01T00:00:00Z',
+                  buildId: '6969',
+                  buildRevision: '69696969',
+                  buildVersion: '0.0.0+69696969-6969',
+                },
+              });
+            },
             path: '/',
           },
         ],

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -3,7 +3,7 @@ import { type ParseKeys } from 'i18next';
 import type common from '../public/locales/en/common.json';
 import type gcweb from '../public/locales/en/gcweb.json';
 import { type PublicEnv } from '~/utils/env.server';
-import { type Breadcrumbs, type BuildInfo, type I18nNamespaces, type PageIdentifier, type PageTitleI18nKey } from '~/utils/route-utils';
+import { type Breadcrumbs, type I18nNamespaces, type PageIdentifier, type PageTitleI18nKey } from '~/utils/route-utils';
 
 /**
  * A type that converts a type T to a function type that takes T as a parameter.
@@ -76,7 +76,7 @@ declare global {
   /**
    * Common data returned from a route's handle object.
    */
-  type RouteHandleData = Partial<Breadcrumbs & BuildInfo & I18nNamespaces & PageIdentifier & PageTitleI18nKey>;
+  type RouteHandleData = Partial<Breadcrumbs & I18nNamespaces & PageIdentifier & PageTitleI18nKey>;
 }
 
 declare module 'i18next' {

--- a/frontend/app/utils/build-info.server.ts
+++ b/frontend/app/utils/build-info.server.ts
@@ -1,9 +1,15 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 import { getLogger } from '~/utils/logging.server';
-import { type BuildInfo } from '~/utils/route-utils';
 
 const logger = getLogger('build-info.server');
+
+export type BuildInfo = {
+  buildDate: string;
+  buildId: string;
+  buildRevision: string;
+  buildVersion: string;
+};
 
 /**
  * The readBuildInfo function takes a filename as an argument and returns a BuildInfo object. The BuildInfo object

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -59,7 +59,7 @@ export function useBreadcrumbs() {
 
 export function useBuildInfo() {
   return useMatches()
-    .map(({ handle }) => buildInfoSchema.safeParse(handle))
+    .map(({ data }) => buildInfoSchema.safeParse(data))
     .map((result) => (result.success ? result.data.buildInfo : undefined))
     .reduce(coalesce);
 }


### PR DESCRIPTION
Build info still needs to be passed around via the loader, since it requires server-side code.