### PR TITLE
Change `headers.set()` to `headers.append()` in `entry.server.tsx`

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -45,9 +45,10 @@ export default async function handleRequest(request: Request, responseStatusCode
   responseHeaders.set('Content-Security-Policy', contentSecurityPolicy);
   responseHeaders.set('Content-Type', 'text/html; charset=UTF-8');
   responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  responseHeaders.set('Set-Cookie', langCookie);
   responseHeaders.set('X-Content-Type-Options', 'nosniff');
   responseHeaders.set('X-Frame-Options', 'deny');
+  // .append() because there can be more than one cookie in a response
+  responseHeaders.append('Set-Cookie', langCookie);
 
   return new Promise((resolve, reject) => {
     let shellRendered = false;


### PR DESCRIPTION
Change `headers.set()` to `headers.append()` in `entry.server.tsx` in preparation for upcoming server-side session implementation.

Reasoning: `headers.set()` will overwrite any existing headers of the same name. Since we will need to set multiple `Set-Cookie` headers in the response, we have to use `headers.append()` Since I have to change this for one line of code, I decided to change them all just for consistency.

Related ADO workitems
- [AB#2673](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2673)