### PR TITLE
AB#2673 -- session management

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,7 +7,7 @@ LOG_LEVEL=debug
 
 # i18next debug flag
 # (optional; default: false)
-I18NEXT_DEBUG=true
+I18NEXT_DEBUG=false
 
 # i18n language cookie name
 # (optional; default: _gc_lang)
@@ -23,26 +23,56 @@ LANG_COOKIE_PATH=/
 LANG_COOKIE_HTTP_ONLY=true
 # i18n language cookie secure flag
 # (optional; default: true)
-LANG_COOKIE_SECURE=false
+LANG_COOKIE_SECURE=true
 
 # i18n language querystring key
 # (optional; default: lang)
 LANG_QUERY_PARAM=lang
+
+# Session storage type; valid values are: file, memory, redis
+# (optional; default: memory)
+SESSION_STORAGE_TYPE=memory
+# Session expiry time in seconds
+# (optional; default: 600)
+SESSION_EXPIRES_SECONDS=600
+# Session cookie name
+# (optional; default: __CDCP//session)
+SESSION_COOKIE_NAME=__CDCP//session
+# Session cookie domain
+# (optional; default: undefined)
+SESSION_COOKIE_DOMAIN=localhost
+# Session cookie path
+# (optional; default: /)
+SESSION_COOKIE_PATH=/
+# Session cookie encryption secret
+# (optional; default: a random UUID)
+SESSION_COOKIE_SECRET=0123456789ABCDEF
+# Session cookie max age in seconds
+# (optional; default: 600)
+SESSION_COOKIE_MAX_AGE=600
+# session cookie httpOnly flag
+# (optional; default: true)
+SESSION_COOKIE_HTTP_ONLY=true
+# session cookie secure flag
+# (optional; default: true)
+SESSION_COOKIE_SECURE=true
+# Location of session files when using file storage
+# (optional; default: ./node_modules/.cache/sessions/)
+SESSION_FILE_DIR=./node_modules/.cache/sessions/
 
 # Redis server URL
 # (optional; default: redis://localhost)
 REDIS_URL=redis://localhost
 # Redis server username
 # (optional; default undefined)
-REDIS_USERNAME=
+REDIS_USERNAME=username
 # Redis server password
 # (optional; default undefined)
-REDIS_PASSWORD=
+REDIS_PASSWORD=password
 
 # enable client-side javascript; useful for testing progressive enhancement
 # (optional; default: true)
-JAVASCRIPT_ENABLED=false
-
+JAVASCRIPT_ENABLED=true
 # enable mock API calls
 # (optional; default: false)
 MOCKS_ENABLED=true

--- a/frontend/__tests__/services/session-service.server.test.ts
+++ b/frontend/__tests__/services/session-service.server.test.ts
@@ -1,0 +1,109 @@
+import { createFileSessionStorage, createMemorySessionStorage, createSessionStorage } from '@remix-run/node';
+
+import { describe, expect, it } from 'vitest';
+
+import { getRedisService } from '~/services/redis-service.server';
+import { getSessionService } from '~/services/session-service.server';
+import { getEnv } from '~/utils/env.server';
+
+describe('session-service.server tests', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  vi.mock('@remix-run/node');
+  vi.mock('~/services/redis-service.server');
+  vi.mock('~/utils/env.server');
+
+  describe('getSessionService() -- SESSION_STORAGE_TYPE flag tests', () => {
+    it('should create a new memory-backed session storage when SESSION_STORAGE_TYPE=memory', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'memory' } as any);
+      vi.mocked(createMemorySessionStorage).mockReturnValue({} as any);
+
+      const sessionService = getSessionService();
+      const sessionStorage = await sessionService.createSessionStorage();
+
+      expect(sessionStorage).toBeDefined();
+      expect(vi.mocked(getEnv)).toHaveBeenCalled();
+      expect(vi.mocked(createMemorySessionStorage)).toHaveBeenCalled();
+    });
+
+    it('should create a new file-backed session storage when SESSION_STORAGE_TYPE=file', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'file' } as any);
+      vi.mocked(createFileSessionStorage).mockReturnValue({} as any);
+
+      const sessionService = getSessionService();
+      const sessionStorage = await sessionService.createSessionStorage();
+
+      expect(sessionStorage).toBeDefined();
+      expect(vi.mocked(getEnv)).toHaveBeenCalled();
+      expect(vi.mocked(createFileSessionStorage)).toHaveBeenCalled();
+    });
+
+    it('should create a new redis-backed session storage when SESSION_STORAGE_TYPE=redis', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' } as any);
+      vi.mocked(createSessionStorage).mockReturnValue({} as any);
+
+      const sessionService = getSessionService();
+      const sessionStorage = await sessionService.createSessionStorage();
+
+      expect(sessionStorage).toBeDefined();
+      expect(vi.mocked(getEnv)).toHaveBeenCalled();
+      expect(vi.mocked(createSessionStorage)).toHaveBeenCalled();
+    });
+  });
+
+  describe('getSessionService() -- redis-backed session storage tests', () => {
+    it('should call redisService.set() when creating redis-backed session storage', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' } as any);
+      vi.mocked(getRedisService).mockReturnValue({ set: vi.fn() } as any);
+
+      await getSessionService().createSessionStorage();
+
+      // sessionService.createRedisSessionStorage.createSessionStorage(sessionStrategy)
+      const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
+      const sessionId = await sessionStrategy.createData('value');
+
+      expect(sessionId).toBeDefined();
+      expect(vi.mocked(getRedisService().set)).toHaveBeenCalled();
+    });
+
+    it('should call redisService.get() when reading from redis-backed session storage', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' } as any);
+      vi.mocked(getRedisService).mockReturnValue({ get: () => JSON.stringify('value') } as any);
+
+      const sessionService = getSessionService();
+      await sessionService.createSessionStorage();
+
+      // sessionService.createRedisSessionStorage.createSessionStorage(sessionStrategy)
+      const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
+      const data = await sessionStrategy.readData('id');
+
+      expect(data).toBe('value');
+    });
+
+    it('should call redisService.set() when updating redis-backed session storage', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' } as any);
+      vi.mocked(getRedisService).mockReturnValue({ set: vi.fn() } as any);
+
+      await getSessionService().createSessionStorage();
+
+      // sessionService.createRedisSessionStorage.createSessionStorage(sessionStrategy)
+      const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
+      await sessionStrategy.updateData('id', 'value');
+
+      expect(vi.mocked(getRedisService().set)).toHaveBeenCalled();
+    });
+
+    it('should call redisService.del() when deleting from redis-backed session storage', async () => {
+      vi.mocked(getEnv).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' } as any);
+      vi.mocked(getRedisService).mockReturnValue({ del: vi.fn() } as any);
+
+      await getSessionService().createSessionStorage();
+
+      // sessionService.createRedisSessionStorage.createSessionStorage(sessionStrategy)
+      const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
+      await sessionStrategy.deleteData('id');
+
+      expect(vi.mocked(getRedisService().del)).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/services/session-service.server.ts
+++ b/frontend/app/services/session-service.server.ts
@@ -1,0 +1,89 @@
+/**
+ * SessionService is a service module responsible for managing user sessions.
+ * Sessions can be stored in memory, as files on disk, or in a Redis database.
+ *
+ * All createSessionStorage() functions take a cookie object, which is used to
+ * create browser's the session cookie. The session cookie is then used to track
+ * the user's session.
+ *
+ * The SessionService module provides functions for creating, reading,
+ * updating, and deleting session data.
+ *
+ * Example usage:
+ *
+ *    const sessionStorage = await getSessionService().createSessionStorage();
+ *    const session = await sessionStorage.getSession(request.headers.get('Cookie'));
+ *    return json({}, {
+ *      headers: {
+ *        'Set-Cookie': await sessionStorage.commitSession(session)
+ *      }
+ *    });
+ *
+ * @see https://remix.run/docs/en/main/utils/sessions
+ */
+import { type Cookie, createCookie, createFileSessionStorage, createMemorySessionStorage, createSessionStorage } from '@remix-run/node';
+
+import { randomUUID } from 'node:crypto';
+
+import { getRedisService } from '~/services/redis-service.server';
+import { getEnv } from '~/utils/env.server';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('session-service.server');
+
+export function getSessionService() {
+  const env = getEnv();
+
+  const sessionCookie = createCookie(env.SESSION_COOKIE_NAME, {
+    path: env.SESSION_COOKIE_PATH,
+    domain: env.SESSION_COOKIE_DOMAIN,
+    maxAge: env.SESSION_COOKIE_MAX_AGE,
+    secrets: [env.SESSION_COOKIE_SECRET],
+    secure: env.SESSION_COOKIE_SECURE,
+    httpOnly: env.SESSION_COOKIE_HTTP_ONLY,
+    // TODO :: GjB :: make these configurable?
+    sameSite: true,
+  });
+
+  async function createRedisSessionStorage({ cookie }: { cookie: Cookie }) {
+    const sessionId = randomUUID();
+    const redisService = getRedisService();
+    const setCommandOptions = { EX: env.SESSION_EXPIRES_SECONDS };
+
+    return createSessionStorage({
+      cookie,
+      createData: async (data) => {
+        log.debug(`Creating new session storage slot with id=[${sessionId}]`);
+        await redisService.set(sessionId, JSON.stringify(data), setCommandOptions);
+        return sessionId;
+      },
+      readData: async (id) => {
+        log.debug(`Reading session data for session id=[${id}]`);
+        return JSON.parse(await redisService.get(id));
+      },
+      updateData: async (id, data) => {
+        log.debug(`Updating session data for session id=[${id}]`);
+        await redisService.set(id, JSON.stringify(data), setCommandOptions);
+      },
+      deleteData: async (id) => {
+        log.debug(`Deleting all session data for session id=[${id}]`);
+        await redisService.del(id);
+      },
+    });
+  }
+
+  return {
+    createSessionStorage: () => {
+      switch (env.SESSION_STORAGE_TYPE) {
+        case 'memory':
+          // note: memory-backed sessions are not cleaned up; so use only during development!
+          return createMemorySessionStorage({ cookie: sessionCookie });
+        case 'file':
+          // note: file-backed sessions are not cleaned up; so use only during development!
+          return createFileSessionStorage({ cookie: sessionCookie, dir: env.SESSION_FILE_DIR });
+        case 'redis':
+          return createRedisSessionStorage({ cookie: sessionCookie });
+      }
+    },
+  };
+}

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 const toBoolean = (val: string) => val === 'true';
@@ -17,6 +18,18 @@ const serverEnv = z.object({
   LANG_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),
   LANG_COOKIE_SECURE: z.string().transform(toBoolean).default('true'),
   LANG_QUERY_PARAM: z.string().default('lang'),
+
+  // session configuration
+  SESSION_STORAGE_TYPE: z.enum(['file', 'memory', 'redis']).default('memory'),
+  SESSION_EXPIRES_SECONDS: z.coerce.number().default(600),
+  SESSION_COOKIE_NAME: z.string().trim().min(1).default('__CDCP//session'),
+  SESSION_COOKIE_DOMAIN: z.string().trim().min(1).optional(),
+  SESSION_COOKIE_PATH: z.string().trim().min(1).default('/'),
+  SESSION_COOKIE_SECRET: z.string().trim().min(16).default(randomUUID()),
+  SESSION_COOKIE_MAX_AGE: z.coerce.number().default(600),
+  SESSION_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),
+  SESSION_COOKIE_SECURE: z.string().transform(toBoolean).default('true'),
+  SESSION_FILE_DIR: z.string().trim().min(1).default('./node_modules/cache/sessions/'),
 
   // redis server configuration
   REDIS_URL: z.string().trim().min(1).default('redis://localhost'),

--- a/frontend/other/docker-compose.yml
+++ b/frontend/other/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  # Start a password-protected Redis instance on the default port.
+  # @see https://redis.io/docs/management/security/#authentication
+  redis:
+    image: docker.io/redis:7.2
+    command: >
+      --requirepass password
+    ports:
+      - 6379:6379


### PR DESCRIPTION
## Initial implementation of application session management.

This commit adds three types of session management to the application: `memory`, `file`, and `redis`.

Configuration for each type of session is handled through environment variables starting with `SESSION_*`, with sane defaults provided for all configurations.

~A basic unit test is included in this PR, but coverage is not yet 100% (need to validate that redis `get`, `set`, and `del` are called when expected).~ **EDIT:** I have force-pushed a new commit with a more exhaustive set of tests.

### Future PR considerations

Sessions must be manually committed, as per [the Remix docs](https://remix.run/docs/en/main/utils/sessions#using-sessions). A future improvement would be to auto-commit sessions in `express.server.ts` by firing the `commitSession(..)` automatically in middleware *after* the Remix request handler has executed.

### Related ADO workitems:

- [AB#2673](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2673) 