### PR TITLE
modify playwright webserver command

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   use: { baseURL: `http://localhost:${port}/`, trace: 'on-first-retry' },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: `npm run-script build && MOCKS_ENABLED=true npm start`,
+    command: `npm run-script build && cross-env MOCKS_ENABLED=true npm start`,
     port: Number(port),
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
Running into some issues with running e2e test on Windows.  

Running `npm run test:e2e` on windows produces:

```javascript
[WebServer]  info  building... (NODE_ENV=production)
[WebServer]  info  built (4s)
[WebServer] 'MOCKS_ENABLED' is not recognized as an internal or external command,
operable program or batch file.Error: Process from config.webServer was not able to start. Exit code: 1
```

cross-env is needed here to make it play nice with Windows.