### PR TITLE
Change root font-size

### DIFF
--- a/frontend/app/cdcp.css
+++ b/frontend/app/cdcp.css
@@ -1,0 +1,3 @@
+html {
+    font-size: 16px;
+}

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -5,6 +5,7 @@ import { Link, Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/re
 
 import { Trans, useTranslation } from 'react-i18next';
 
+import cdcpStylesheet from '~/cdcp.css';
 import { LanguageSwitcher } from '~/components/language-switcher';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier } from '~/utils/route-utils';
@@ -13,7 +14,10 @@ const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
 export const handle = { i18nNamespaces } as const satisfies RouteHandleData;
 
-export const links: LinksFunction = () => [{ rel: 'stylesheet', href: '/theme/gcweb/css/theme.min.css' }];
+export const links: LinksFunction = () => [
+  { rel: 'stylesheet', href: '/theme/gcweb/css/theme.min.css' },
+  { rel: 'stylesheet', href: cdcpStylesheet },
+];
 
 export function ErrorBoundary() {
   const error = useRouteError();


### PR DESCRIPTION
Opt for a root font size of 16px since Tailwind sizes predominantly use rem units. This becomes problematic when the font size is set to 10px. It's important to mention that using rem units offers better scalability and responsiveness, as it is relative to the root font size. This ensures a more consistent and adaptable design, especially across different devices and screen sizes. Additionally, relying on rem units promotes better accessibility and a more user-friendly experience.