### PR TITLE
Uniqifying input field test ids

### DIFF
--- a/frontend/__tests__/components/input-label.test.tsx
+++ b/frontend/__tests__/components/input-label.test.tsx
@@ -2,58 +2,60 @@ import { getByTestId, render, screen } from '@testing-library/react';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-//import { axe, toHaveNoViolations } from 'jest-axe';
 import { InputLabel } from '~/components/input-label';
 
+//import { axe, toHaveNoViolations } from 'jest-axe';
 //expect.extend(toHaveNoViolations);
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
 }));
 
-describe('InputLabel', async () => {
+describe('InputLabel', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   it('should render', () => {
-    render(<InputLabel id="input-label">input label</InputLabel>);
+    render(<InputLabel id="id">input label</InputLabel>);
 
-    const actualLabel = screen.getByTestId('input-label');
+    const actualLabel = screen.getByTestId('input-label-id');
     expect(actualLabel).toBeInTheDocument();
-    expect(actualLabel.id).toBe('input-label');
+    expect(actualLabel.id).toBe('id');
 
-    expect(() => getByTestId(actualLabel, 'input-label-required')).toThrow();
-    expect(() => getByTestId(actualLabel, 'input-label-error-message')).toThrow();
+    expect(() => getByTestId(actualLabel, 'input-label-required-id')).toThrow();
+    expect(() => getByTestId(actualLabel, 'input-label-error-message-id')).toThrow();
   });
 
   it('should render with required text', () => {
     render(
-      <InputLabel id="input-label" required>
+      <InputLabel id="id" required>
         input label
       </InputLabel>,
     );
 
-    const actualLabel = screen.getByTestId('input-label');
+    const actualLabel = screen.getByTestId('input-label-id');
     expect(actualLabel).toBeInTheDocument();
 
-    const actualRequired = getByTestId(actualLabel, 'input-label-required');
-    expect(actualRequired.textContent).toBe(' (input-label.required)');
+    const actualRequired = getByTestId(actualLabel, 'input-label-required-id');
+    expect(actualRequired.textContent).toBe('(input-label.required)');
 
-    expect(() => getByTestId(actualLabel, 'input-label-error-message')).toThrow();
+    expect(() => getByTestId(actualLabel, 'input-label-error-message-id')).toThrow();
   });
 
   it('should render with error message', () => {
     render(
-      <InputLabel id="input-label" errorMessage="error message">
+      <InputLabel id="id" errorMessage="error message">
         input label
       </InputLabel>,
     );
 
-    const actualLabel = screen.getByTestId('input-label');
+    const actualLabel = screen.getByTestId('input-label-id');
     expect(actualLabel).toBeInTheDocument();
 
-    const actualErrorMessage = getByTestId(actualLabel, 'input-label-error-message');
+    const actualErrorMessage = getByTestId(actualLabel, 'input-label-error-message-id');
     expect(actualErrorMessage).toBeInTheDocument();
     expect(actualErrorMessage.textContent).toBe('error message');
 

--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -28,18 +28,18 @@ export const InputField = (props: InputFieldProps) => {
   }
 
   return (
-    <div id={inputWrapperId} className="form-group" data-testid="input-field">
-      <InputLabel id={inputLabelId} htmlFor={id} required={required} errorMessage={errorMessage}>
+    <div id={inputWrapperId} data-testid={inputWrapperId} className="form-group">
+      <InputLabel id={inputLabelId} data-testid={inputLabelId} htmlFor={id} required={required} errorMessage={errorMessage}>
         {label}
       </InputLabel>
       {helpMessage && (
-        <div className="mb-1.5 max-w-prose text-base text-gray-600" id={inputHelpMessageId}>
+        <div className="mb-1.5 max-w-prose text-base text-gray-600" id={inputHelpMessageId} data-testid={inputHelpMessageId}>
           {helpMessage}
         </div>
       )}
-      <input aria-describedby={getAriaDescribedby()} aria-invalid={!!errorMessage} aria-labelledby={inputLabelId} aria-required={required} className={clsx('form-control', className)} id={id} {...restInputProps} />
+      <input aria-describedby={getAriaDescribedby()} aria-invalid={!!errorMessage} aria-labelledby={inputLabelId} aria-required={required} className={clsx('form-control', className)} id={id} data-testid={id} {...restInputProps} />
       {helpMessageSecondary && (
-        <div className="mt-1.5 max-w-prose text-base text-gray-600" id={inputHelpMessageSecondaryId}>
+        <div className="mt-1.5 max-w-prose text-base text-gray-600" id={inputHelpMessageSecondaryId} data-testid={inputHelpMessageId}>
           {helpMessageSecondary}
         </div>
       )}

--- a/frontend/app/components/input-label.tsx
+++ b/frontend/app/components/input-label.tsx
@@ -12,17 +12,18 @@ export interface InputLabelProps extends Omit<React.ComponentProps<'label'>, ''>
 
 export const InputLabel = (props: InputLabelProps) => {
   const { t } = useTranslation('gcweb');
-  const { children, className, errorMessage, required, ...restLabelProps } = props;
+  const { children, className, errorMessage, id, required, ...restLabelProps } = props;
+
   return (
-    <label className={clsx(required && 'required', className)} data-testid="input-label" {...restLabelProps}>
+    <label className={clsx(required && 'required', className)} id={id} data-testid={`input-label-${id}`} {...restLabelProps}>
       <span className="field-name">{children}</span>
       {required && (
-        <strong className="required" data-testid="input-label-required">
-          &#32;({t('input-label.required')})
+        <strong className="required mrgn-lft-sm" data-testid={`input-label-required-${id}`}>
+          ({t('input-label.required')})
         </strong>
       )}
       {errorMessage && (
-        <span className="label label-danger wb-server-error" data-testid="input-label-error-message">
+        <span className="label label-danger wb-server-error" data-testid={`input-label-error-message-${id}`}>
           {errorMessage}
         </span>
       )}


### PR DESCRIPTION
The `data-testid` attributes in `<InputField>` and `<InputLabel>` were not unique, which could potentially cause issues in tests.