### PR TITLE
AB#2769 add preferred language view

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -1,10 +1,12 @@
 import { type LoaderFunctionArgs, json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { Link, useLoaderData } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
 
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('common');
+const i18nNamespaces = getTypedI18nNamespaces('common', 'personal-information');
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'common:personal-information.breadcrumbs.home', to: '/' }, { labelI18nKey: 'common:personal-information.page-title' }],
@@ -22,10 +24,29 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function PersonalInformationIndex() {
   const { user } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
   return (
     <>
-      <p>Personal information! 😎</p>
-      <pre>{JSON.stringify(user, null, 2)}</pre>
+      <h1 id="wb-cont" property="name">
+        {t('common:personal-information.page-title')}
+      </h1>
+      <p>{t('personal-information:index.on-file')}</p>
+      <dl>
+        <dt>{t('personal-information:index.first-name')}</dt>
+        <dd>{user?.firstName}</dd>
+        <dt>{t('personal-information:index.last-name')}</dt>
+        <dd>{user?.lastName}</dd>
+        <dt>{t('personal-information:index.phone-number')}</dt>
+        <dd>{user?.phoneNumber}</dd>
+        <dt>{t('personal-information:index.home-address')}</dt>
+        <dd>{user?.homeAddress}</dd>
+        <dt>{t('personal-information:index.mailing-address')}</dt>
+        <dd>{user?.mailingAddress}</dd>
+        <dt>
+          <Link to="/personal-information/preferred-language">{t('personal-information:index.preferred-language')}</Link>
+        </dt>
+        <dd>{user?.preferredLanguage}</dd>
+      </dl>
     </>
   );
 }

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.tsx
@@ -1,0 +1,44 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { userService } from '~/services/user-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('common', 'personal-information');
+
+export const handle = {
+  breadcrumbs: [{ labelI18nKey: 'common:personal-information.breadcrumbs.home', to: '/' }, { labelI18nKey: 'common:personal-information.page-title', to: '/personal-information' }, { labelI18nKey: 'common:preferred-language.page-title' }],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0004',
+  pageTitleI18nKey: 'common:preferred-language.page-title',
+} as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await userService.getUserId();
+  const userInfo = await userService.getUserInfo(userId);
+
+  if (userInfo === null) {
+    throw new Response(null, { status: 404 });
+  }
+
+  return json({ user: userInfo });
+}
+
+export default function PersonalInformationIndex() {
+  const { user } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
+  return (
+    <>
+      <h1 id="wb-cont" property="name">
+        {t('common:preferred-language.page-title')}
+      </h1>
+      <p>{t('personal-information:preferred-language.on-file')}</p>
+      <dl>
+        <dt>{t('personal-information:preferred-language.language')}</dt>
+        <dd>{user.preferredLanguage}</dd>
+      </dl>
+    </>
+  );
+}

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -2,6 +2,7 @@ import { type ParseKeys } from 'i18next';
 
 import type common from '../public/locales/en/common.json';
 import type gcweb from '../public/locales/en/gcweb.json';
+import type personalInformation from '../public/locales/en/personal-information.json';
 import { type PublicEnv } from '~/utils/env.server';
 import { type Breadcrumbs, type I18nNamespaces, type PageIdentifier, type PageTitleI18nKey } from '~/utils/route-utils';
 
@@ -93,6 +94,7 @@ declare module 'i18next' {
     resources: {
       common: typeof common;
       gcweb: typeof gcweb;
+      'personal-information': typeof personalInformation;
     };
   }
 }

--- a/frontend/e2e/personal-information.preferred-language.spec.ts
+++ b/frontend/e2e/personal-information.preferred-language.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('preferred language page', async () => {
+  test('should navigate to page and render', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language');
+    const locator = page.locator('h1');
+    await expect(locator).toHaveText(/preferred language/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -18,5 +18,13 @@
       "home": "Home",
       "personal-information": "Personal information"
     }
+  },
+  "preferred-language": {
+    "page-title": "Preferred language",
+    "breadcrumbs": {
+      "home": "Home",
+      "personal-information":"Personal information",
+      "preferred-language": "Preferred language"
+    }
   }
 }

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "on-file": "We have the following information for you on file.",
+    "first-name": "First name",
+    "last-name": "Last name",
+    "phone-number": "Phone number",
+    "home-address": "Home address",
+    "mailing-address":"Mailing address",
+    "preferred-language": "Preferred language"
+  },
+  "preferred-language": {
+    "on-file": "We have the following preferred language for you on file.",
+    "language": "Language"
+  }
+}

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -18,5 +18,13 @@
       "home": "Accueil",
       "personal-information": "(FR) Personal information"
     }
+  },
+  "preferred-language": {
+    "page-title": "(FR) Preferred language",
+    "breadcrumbs": {
+      "home": "Accueil",
+      "personal-information":"(FR) Personal information",
+      "preferred-language": "(FR) Preferred language"
+    }
   }
 }

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "on-file": "(FR) We have the following information for you on file.",
+    "first-name": "(FR) First name",
+    "last-name": "(FR) Last name",
+    "phone-number": "(FR) Phone number",
+    "home-address": "(FR) Home address",
+    "mailing-address":"(FR) Mailing address",
+    "preferred-language": "(FR) Preferred language"
+  },
+  "preferred-language": {
+    "on-file": "(FR) We have the following preferred language for you on file.",
+    "language": "(FR) Language"
+  }
+}


### PR DESCRIPTION
This PR creates a new route:  `/personal-information/preferred-language`, and displays the user's preferred language.  There isn't much to render (yet), as designs haven't been finalized, so this PR is intended as more of a scaffold for future iterations.

## Changes
- add `/personal-information/preferred-language` route
- add new locale(s) files (`personal-information.json`)
- add new locale type to type declarations
- stub out e2e test for a11y checking