### PR TITLE
tie up loose ends between view and edit pages

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -19,6 +19,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
 
+  if (!userInfo) {
+    throw new Response(null, { status: 404 });
+  }
+
   return json({ user: userInfo });
 }
 
@@ -33,19 +37,25 @@ export default function PersonalInformationIndex() {
       <p>{t('personal-information:index.on-file')}</p>
       <dl>
         <dt>{t('personal-information:index.first-name')}</dt>
-        <dd>{user?.firstName}</dd>
+        <dd>{user.firstName}</dd>
         <dt>{t('personal-information:index.last-name')}</dt>
-        <dd>{user?.lastName}</dd>
-        <dt>{t('personal-information:index.phone-number')}</dt>
-        <dd>{user?.phoneNumber}</dd>
-        <dt>{t('personal-information:index.home-address')}</dt>
-        <dd>{user?.homeAddress}</dd>
-        <dt>{t('personal-information:index.mailing-address')}</dt>
-        <dd>{user?.mailingAddress}</dd>
+        <dd>{user.lastName}</dd>
+        <dt>
+          <Link to="/personal-information/phone-number">{t('personal-information:index.phone-number')}</Link>
+        </dt>
+        <dd>{user.phoneNumber}</dd>
+        <dt>
+          <Link to="/personal-information/address">{t('personal-information:index.home-address')}</Link>
+        </dt>
+        <dd>{user.homeAddress}</dd>
+        <dt>
+          <Link to="/personal-information/address">{t('personal-information:index.mailing-address')}</Link>
+        </dt>
+        <dd>{user.mailingAddress}</dd>
         <dt>
           <Link to="/personal-information/preferred-language">{t('personal-information:index.preferred-language')}</Link>
         </dt>
-        <dd>{user?.preferredLanguage}</dd>
+        <dd>{user.preferredLanguage}</dd>
       </dl>
     </>
   );

--- a/frontend/app/routes/_gcweb-app.personal-information.address._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address._index.tsx
@@ -1,0 +1,54 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import { Link, useLoaderData } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { userService } from '~/services/user-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'personal-information:address.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'personal-information:address.breadcrumbs.personal-information', to: '/personal-information' },
+    { labelI18nKey: 'personal-information:address.breadcrumbs.address' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0007',
+  pageTitleI18nKey: 'personal-information:address.page-title',
+} as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await userService.getUserId();
+  const userInfo = await userService.getUserInfo(userId);
+
+  if (!userInfo) {
+    throw new Response(null, { status: 404 });
+  }
+
+  return json({ userInfo });
+}
+
+export default function AddressIndex() {
+  const { userInfo } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
+
+  return (
+    <>
+      <h1 id="wb-cont" property="name">
+        {t('personal-information:address.page-title')}
+      </h1>
+
+      <dl>
+        <dt>{t('personal-information:address.home-address')}</dt>
+        <dd>{userInfo.homeAddress}</dd>
+        <dt>{t('personal-information:address.mailing-address')}</dt>
+        <dd>{userInfo.mailingAddress}</dd>
+      </dl>
+      <Link to="/personal-information/address/edit" className="btn btn-primary">
+        {t('personal-information:address.change')}
+      </Link>
+    </>
+  );
+}

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number._index.tsx
@@ -1,0 +1,52 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import { Link, useLoaderData } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { userService } from '~/services/user-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'personal-information:phone-number.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'personal-information:phone-number.breadcrumbs.personal-information', to: '/personal-information' },
+    { labelI18nKey: 'personal-information:phone-number.breadcrumbs.phone-number' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0007',
+  pageTitleI18nKey: 'personal-information:phone-number.page-title',
+} as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await userService.getUserId();
+  const userInfo = await userService.getUserInfo(userId);
+
+  if (!userInfo) {
+    throw new Response(null, { status: 404 });
+  }
+
+  return json({ userInfo });
+}
+
+export default function PhoneNumberIndex() {
+  const { userInfo } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
+
+  return (
+    <>
+      <h1 id="wb-cont" property="name">
+        {t('personal-information:phone-number.page-title')}
+      </h1>
+
+      <dl>
+        <dt>{t('personal-information:phone-number.phone-number')}</dt>
+        <dd>{userInfo.phoneNumber}</dd>
+      </dl>
+      <Link to="/personal-information/phone-number/edit" className="btn btn-primary">
+        {t('personal-information:phone-number.change')}
+      </Link>
+    </>
+  );
+}

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -13,6 +13,27 @@
     "mailing-address": "Mailing address",
     "preferred-language": "Preferred language"
   },
+  "address": {
+    "page-title": "Address",
+    "breadcrumbs": {
+      "home": "Home",
+      "personal-information": "Personal information",
+      "address": "Address"
+    },
+    "home-address": "Home address",
+    "mailing-address": "Mailing address",
+    "change": "Change"
+  },
+  "phone-number":{
+    "page-title": "Phone number",
+    "breadcrumbs": {
+      "home": "Home",
+      "personal-information": "Personal information",
+      "phone-number": "Phone number"
+    },
+    "phone-number": "Phone number",
+    "change": "Change"
+  },
   "preferred-language": {
     "page-title": "Preferred language",
     "breadcrumbs": {

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -13,6 +13,27 @@
     "mailing-address": "(FR) Mailing address",
     "preferred-language": "(FR) Preferred language"
   },
+  "address": {
+    "page-title": "(FR) Address",
+    "breadcrumbs": {
+      "home": "(FR) Home",
+      "personal-information": "(FR) Personal information",
+      "address": "(FR) Address"
+    },
+    "home-address": "(FR) Home address",
+    "mailing-address": "(FR) Mailing address",
+    "change": "(FR) Change"
+  },
+  "phone-number":{
+    "page-title": "(FR) Phone number",
+    "breadcrumbs": {
+      "home": "(FR) Home",
+      "personal-information": "(FR) Personal information",
+      "phone-number": "(FR) Phone number"
+    },
+    "phone-number": "(FR) Phone number",
+    "change": "(FR) Change"
+  },
   "preferred-language": {
     "page-title": "(FR) Preferred language",
     "breadcrumbs": {


### PR DESCRIPTION
/This PR is the result of a comment in slack requesting the links between views and edit pages:

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/9b4e40ce-56de-4f8e-94f4-aeaff898561c)

## Changes
- added views for `/personal-information/address`, `/personal-information/phone-number`
- linked to the respective 'edit' pages for both views

### Additional information 
- page identifiers will definitely need to be changed (I'm not doing it here since there's no point until that convention is finalized)
- locale structuring will definitely need to be refined and cleaned in a future PR across all pages 