### PR TITLE
2823 add e2e test for edit preferred language page

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -70,11 +70,11 @@ export default function PreferredLanguageEdit() {
           <ul className="list-unstyled lst-spcd-2">
             <li className="radio">
               <input type="radio" name="preferredLanguage" id="preferred-language-option-en" value="en" defaultChecked={userInfo.preferredLanguage === 'en'} />
-              <label htmlFor="en">{t('personal-information:preferred-language.nameEn')}</label>
+              <label htmlFor="preferred-language-option-en">{t('personal-information:preferred-language.nameEn')}</label>
             </li>
             <li className="radio">
               <input type="radio" name="preferredLanguage" id="preferred-language-option-fr" value="fr" defaultChecked={userInfo.preferredLanguage === 'fr'} />
-              <label htmlFor="fr">{t('personal-information:preferred-language.nameFr')}</label>
+              <label htmlFor="preferred-language-option-fr">{t('personal-information:preferred-language.nameFr')}</label>
             </li>
           </ul>
         </fieldset>

--- a/frontend/e2e/personal-information.preferred-language.edit.spec.ts
+++ b/frontend/e2e/personal-information.preferred-language.edit.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('preferred language edit page', async () => {
+  test('should navigate to page and render', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language/edit');
+    const locator = page.locator('h1');
+    await expect(locator).toHaveText(/preferred language/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language/edit');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Add a11y check for edit preferred language page, fixed an violation on the `label` for radio button

## Related ADO workitems

- [AB#2823](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2823)