### PR TITLE
add placeholder e2e tests for page routes

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information.address.success.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.success.tsx
@@ -41,7 +41,7 @@ export default function UpdateAddressSuccess() {
         <div className="col-sm-6">
           <section className="panel panel-info">
             <header className="panel-heading">
-              <h3 className="panel-title">{t('personal-information:address.success.home-address')}</h3>
+              <h2 className="panel-title">{t('personal-information:address.success.home-address')}</h2>
             </header>
             <div className="panel-body">
               <p>{loaderData.userInfo?.homeAddress}</p>
@@ -54,7 +54,7 @@ export default function UpdateAddressSuccess() {
         <div className="col-sm-6">
           <section className="panel panel-info">
             <header className="panel-heading">
-              <h3 className="panel-title">{t('personal-information:address.success.mailing-address')}</h3>
+              <h2 className="panel-title">{t('personal-information:address.success.mailing-address')}</h2>
             </header>
             <div className="panel-body">
               <p>{loaderData.userInfo?.mailingAddress}</p>

--- a/frontend/e2e/_gcweb-app.personal-information._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information._index.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('h1')).toHaveText(/home/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.address._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.address._index.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/address');
+
+    await expect(page.locator('h1')).toHaveText(/address/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/address');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.address.confirm.spec.ts
@@ -1,15 +1,15 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('preferred language page', async () => {
-  test('should navigate to page and render', async ({ page }) => {
-    await page.goto('/personal-information/preferred-language');
-    const locator = page.locator('h1');
-    await expect(locator).toHaveText(/preferred language/i);
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/address/confirm');
+
+    await expect(page.locator('h1')).toHaveText(/change address/i);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/personal-information/preferred-language');
+    await page.goto('/personal-information/address/confirm');
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 

--- a/frontend/e2e/_gcweb-app.personal-information.address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.address.edit.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/address/edit');
+
+    await expect(page.locator('h1')).toHaveText(/change address/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/address/edit');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.address.success.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.address.success.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/address/success');
+
+    await expect(page.locator('h1')).toHaveText(/success/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/address/success');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number._index.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/phone-number');
+
+    await expect(page.locator('h1')).toHaveText(/phone number/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/phone-number');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.confirm.spec.ts
@@ -3,14 +3,13 @@ import { expect, test } from '@playwright/test';
 
 test.describe('homepage', () => {
   test('should navigate to index', async ({ page }) => {
-    await page.goto('/');
-
-    const screenId = await page.locator('span[property="identifier"]').textContent();
-    expect(screenId).toBe('CDCP-0001');
+    await page.goto('/personal-information/phone-number/edit');
+    page.locator('button', { hasText: /save/i }).click();
+    await expect(page.locator('h1')).toHaveText(/confirm phone number/i);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/personal-information/phone-number/confirm');
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/phone-number/edit');
+
+    await expect(page.locator('h1')).toHaveText(/update phone number/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/phone-number/edit');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.success.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.success.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('homepage', () => {
+  test('should navigate to index', async ({ page }) => {
+    await page.goto('/personal-information/phone-number/success');
+
+    await expect(page.locator('h1')).toHaveText(/phone number saved successfully/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/phone-number/success');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.preferred-language._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.preferred-language._index.spec.ts
@@ -1,15 +1,15 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('preferred language edit page', async () => {
+test.describe('preferred language page', async () => {
   test('should navigate to page and render', async ({ page }) => {
-    await page.goto('/personal-information/preferred-language/edit');
-    const locator = page.locator('h1');
-    await expect(locator).toHaveText(/preferred language edit/i);
+    await page.goto('/personal-information/preferred-language');
+
+    await expect(page.locator('h1')).toHaveText(/preferred language/i);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/personal-information/preferred-language/edit');
+    await page.goto('/personal-information/preferred-language');
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 

--- a/frontend/e2e/_gcweb-app.personal-information.preferred-language.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.preferred-language.edit.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('preferred language edit page', async () => {
+  test('should navigate to page and render', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language/edit');
+
+    await expect(page.locator('h1')).toHaveText(/preferred language edit/i);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/personal-information/preferred-language/edit');
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR aims to establish a naming convention for e2e tests for page routes as well as provides boilerplate for a11y checks.

### Changes
- add e2e tests for most page routes to date
- small changes to semantics on some pages to conform with a11y checks using axe

### Additional information
- some pages need a little more work when navigating to them (because of the session management in place, ex. `/phone-number` and it's associated routes); this is something we'll have to factor into the tests when the other pages incorporate the same session management 