### PR TITLE
AB#2827 -- Unit testing /personal-information/address/edit

### DIFF
--- a/frontend/__tests__/loaders/personal-information.address.edit.test.tsx
+++ b/frontend/__tests__/loaders/personal-information.address.edit.test.tsx
@@ -1,0 +1,41 @@
+import { loader } from '~/routes/_gcweb-app.personal-information.address.edit';
+import { userService } from '~/services/user-service.server';
+
+vi.mock('~/services/user-service.server.ts', () => ({
+  userService: {
+    getUserId: vi.fn().mockReturnValue('some-id'),
+    getUserInfo: vi.fn(),
+  },
+}));
+
+describe('/personal-information/address/edit', () => {
+  it('should return userInfo object if userInfo is found', async () => {
+    vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
+
+    const response = await loader({
+      request: new Request('http://localhost:3000/personal-information/address/edit'),
+      context: {},
+      params: {},
+    });
+
+    const data = await response.json();
+
+    expect(data).toEqual({
+      userInfo: { id: 'some-id', firstName: 'John', lastName: 'Maverick' },
+    });
+  });
+
+  it('should throw 404 response if userInfo is not found', async () => {
+    vi.mocked(userService.getUserInfo).mockResolvedValue(null);
+
+    try {
+      await loader({
+        request: new Request('http://localhost:3000/personal-information/address/edit'),
+        context: {},
+        params: {},
+      });
+    } catch (error) {
+      expect((error as Response).status).toEqual(404);
+    }
+  });
+});


### PR DESCRIPTION
Adding unit tests for `loader` function within `/personal-information/address/edit`.