### PR TITLE
Restructuring /__tests__ to reflect /app

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
@@ -16,7 +16,7 @@ vi.mock('~/services/user-service.server.ts', () => ({
   },
 }));
 
-describe('Loader for _gcweb-app.personal-information._index', () => {
+describe('Loader for /personal-information', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.address.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.address.edit.test.tsx
@@ -8,7 +8,7 @@ vi.mock('~/services/user-service.server.ts', () => ({
   },
 }));
 
-describe('/personal-information/address/edit', () => {
+describe('Loader for /personal-information/address/edit', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
@@ -30,8 +30,7 @@ vi.mock('~/services/session-service.server.ts', () => ({
   },
 }));
 
-
-describe('Confirm Phone Number Action', () => {
+describe('Action for /personal-information/phone-number/confirm', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
@@ -45,7 +44,7 @@ describe('Confirm Phone Number Action', () => {
     const response = await action({ request, context: {}, params: {} });
 
     expect(response.status).toBe(302);
-    expect(response).toEqual(redirect('/personal-information/phone-number/success', { headers: { 'Set-Cookie': 'undefined' }}));
+    expect(response).toEqual(redirect('/personal-information/phone-number/success', { headers: { 'Set-Cookie': 'undefined' } }));
   });
 
   it('Should redirect to homepage page when newPhoneNumber is missing', async () => {

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { action } from '~/routes/_gcweb-app.personal-information.phone-number.edit';
 
-describe('Edit Phone Number Action', () => {
+describe('Action for /personal-information/phone-number/edit', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();


### PR DESCRIPTION
- Removed `loader` and `action` folders in favour of `routes` folder
- Renamed test files to reflect route file names
- Modified some of those `describe` to include the route path being tested