### PR TITLE
AB#2827 -- Unit testing action for edit address route

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.address.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.address.edit.test.tsx
@@ -1,7 +1,26 @@
-import { loader } from '~/routes/_gcweb-app.personal-information.address.edit';
+import { redirect } from '@remix-run/node';
+
+import { action, loader } from '~/routes/_gcweb-app.personal-information.address.edit';
+import { addressValidationService } from '~/services/address-validation-service.server';
+import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 
-vi.mock('~/services/user-service.server.ts', () => ({
+vi.mock('~/services/address-validation-service.server', () => ({
+  addressValidationService: {
+    isValidAddress: vi.fn(),
+  },
+}));
+
+vi.mock('~/services/session-service.server', () => ({
+  sessionService: {
+    getSession: vi.fn().mockReturnValue({
+      set: vi.fn(),
+    }),
+    commitSession: vi.fn(),
+  },
+}));
+
+vi.mock('~/services/user-service.server', () => ({
   userService: {
     getUserId: vi.fn().mockReturnValue('some-id'),
     getUserInfo: vi.fn(),
@@ -43,6 +62,39 @@ describe('_gcweb-app.personal-information.address.edit', () => {
       } catch (error) {
         expect((error as Response).status).toEqual(404);
       }
+    });
+  });
+
+  describe('action()', () => {
+    it('should redirect to confirm page if validation is successful', async () => {
+      vi.mocked(addressValidationService.isValidAddress).mockResolvedValue(true);
+      vi.mocked(sessionService.commitSession).mockResolvedValue('some-set-cookie-header');
+
+      const formData = new FormData();
+      formData.append('homeAddress', '123 Fake Home St.');
+      formData.append('mailingAddress', '456 Fake Mailing St.');
+
+      const response = await action({
+        request: new Request('http://localhost:3000/personal-information/address/edit', { method: 'POST', body: formData }),
+        context: {},
+        params: {},
+      });
+
+      expect(response).toEqual(redirect('/personal-information/address/confirm', { headers: { 'Set-Cookie': 'some-set-cookie-header' } }));
+    });
+
+    it('should return validation errors if validation is unsuccessful', async () => {
+      vi.mocked(addressValidationService.isValidAddress).mockResolvedValue(false);
+
+      const response = await action({
+        request: new Request('http://localhost:3000/personal-information/address/edit', { method: 'POST', body: new FormData() }),
+        context: {},
+        params: {},
+      });
+
+      const errors = (await response.json()).errors;
+      expect(errors.homeAddress?._errors[0]).toBeTruthy();
+      expect(errors.mailingAddress?._errors[0]).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Adding unit tests for `action` function for `/personal-information/address/edit`.