### PR TITLE
AB#2827 -- Adding unit tests for loader and action for confirm address route

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.address.confirm.test.tsx
@@ -1,0 +1,60 @@
+import { redirect } from '@remix-run/node';
+
+import { action, loader } from '~/routes/_gcweb-app.personal-information.address.confirm';
+import { sessionService } from '~/services/session-service.server';
+import { userService } from '~/services/user-service.server';
+
+vi.mock('~/services/session-service.server', () => ({
+  sessionService: {
+    getSession: vi.fn().mockReturnValue({
+      get: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('~/services/user-service.server', () => ({
+  userService: {
+    getUserId: vi.fn().mockReturnValue('some-id'),
+    getUserInfo: vi.fn(),
+    updateUserInfo: vi.fn(),
+  },
+}));
+
+describe('_gcweb-app.personal-information.address.confirm', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('loader()', () => {
+    it('should return userInfo and newAddress objects', async () => {
+      vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
+      vi.mocked((await sessionService.getSession()).get).mockResolvedValue({ homeAddress: '123 Fake Home St.', mailingAddress: '456 Fake Mailing St.' });
+
+      const response = await loader({
+        request: new Request('http://localhost:3000/personal-information/address/confirm'),
+        context: {},
+        params: {},
+      });
+
+      const data = await response.json();
+
+      expect(data).toEqual({
+        userInfo: { id: 'some-id', firstName: 'John', lastName: 'Maverick' },
+        newAddress: { homeAddress: '123 Fake Home St.', mailingAddress: '456 Fake Mailing St.' },
+      });
+    });
+  });
+
+  describe('action()', () => {
+    it('should redirect to personal information page when updating user info is successful', async () => {
+      const response = await action({
+        request: new Request('http://localhost:3000/personal-information/address/confirm', { method: 'POST' }),
+        context: {},
+        params: {},
+      });
+
+      expect(response).toEqual(redirect('/personal-information'));
+    });
+  });
+});


### PR DESCRIPTION
Note that the actual implementation of `loader(..)` and `action(..)` don't currently check for valid session variables (see https://remix.run/docs/en/main/utils/sessions#sessionhaskey) so these are the most basic unit tests. 
