### PR TITLE
AB#2826: intergrate lookup service to preferred-languages pages

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language._index.tsx
@@ -1,0 +1,62 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import { Link, useLoaderData } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { lookupService } from '~/services/lookup-service.server';
+import { userService } from '~/services/user-service.server';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'personal-information:preferred-language.index.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'personal-information:preferred-language.index.breadcrumbs.personal-information', to: '/personal-information' },
+    { labelI18nKey: 'personal-information:preferred-language.index.breadcrumbs.preferred-language' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0011',
+  pageTitleI18nKey: 'personal-information:preferred-language.index.page-title',
+} as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await userService.getUserId();
+  const userInfo = await userService.getUserInfo(userId);
+  if (userInfo === null) {
+    throw new Response(null, { status: 404 });
+  }
+
+  const preferredLanguage = userInfo?.preferredLanguage ? await lookupService.getPreferredLanguage(userInfo.preferredLanguage) : undefined;
+  if (preferredLanguage === null) {
+    throw new Response(null, { status: 404 });
+  }
+  return json({ user: userInfo, preferredLanguageDetails: preferredLanguage });
+}
+
+export default function PreferredLanguage() {
+  const { user, preferredLanguageDetails } = useLoaderData<typeof loader>();
+  const { i18n, t } = useTranslation(i18nNamespaces);
+  return (
+    <>
+      <h1 id="wb-cont" property="name">
+        {t('personal-information:preferred-language.index.page-title')}
+      </h1>
+      <p>{t('personal-information:preferred-language.index.on-file')}</p>
+      <dl>
+        <dt>{t('personal-information:preferred-language.index.language')}</dt>
+        <dd>{user?.preferredLanguage}</dd>
+        <dt>{t('personal-information:preferred-language.index.id')}</dt>
+        <dd>{preferredLanguageDetails?.id}</dd>
+        <dt>{t('personal-information:preferred-language.index.nameEn')}</dt>
+        <dd>{preferredLanguageDetails?.nameEn}</dd>
+        <dt>{t('personal-information:preferred-language.index.nameFr')}</dt>
+        <dd>{preferredLanguageDetails?.nameFr}</dd>
+        <dd>{preferredLanguageDetails ? getNameByLanguage(i18n.language, preferredLanguageDetails) : 'Preferred language defined'}</dd>
+      </dl>
+      <Link to="/personal-information/preferred-language/edit" className="btn btn-primary">
+        {t('personal-information:preferred-language.index.change')}
+      </Link>
+    </>
+  );
+}

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -4,9 +4,11 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
+import { lookupService } from '~/services/lookup-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { PREFFERRED_LANGUAGES } from '~/utils/constants';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
@@ -28,12 +30,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw new Response(null, { status: 404 });
   }
 
-  return json({ userInfo });
+  const preferredLanguageList = userInfo?.preferredLanguage ? await lookupService.getAllPreferredLanguages() : undefined;
+  return json({ userInfo, preferredLanguageList });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
   const formDataSchema = z.object({
-    preferredLanguage: z.enum(['en', 'fr']),
+    preferredLanguage: z.enum(PREFFERRED_LANGUAGES),
   });
   const formData = Object.fromEntries(await request.formData());
   const parsedDataResult = formDataSchema.safeParse(formData);
@@ -47,6 +50,8 @@ export async function action({ request }: ActionFunctionArgs) {
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('preferredLanguage', parsedDataResult.data.preferredLanguage);
 
+  const userId = await userService.getUserId();
+  await userService.updateUserInfo(userId, parsedDataResult.data);
   return redirect('/personal-information/preferred-language/confirm', {
     headers: {
       'Set-Cookie': await sessionService.commitSession(session),
@@ -55,8 +60,8 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function PreferredLanguageEdit() {
-  const { userInfo } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { userInfo, preferredLanguageList } = useLoaderData<typeof loader>();
+  const { i18n, t } = useTranslation(i18nNamespaces);
 
   return (
     <>
@@ -67,14 +72,15 @@ export default function PreferredLanguageEdit() {
         <fieldset className="gc-chckbxrdio">
           <legend>{t('personal-information:preferred-language.edit.page-title')}</legend>
           <ul className="list-unstyled lst-spcd-2">
-            <li className="radio">
-              <input type="radio" name="preferredLanguage" id="preferred-language-option-en" value="en" defaultChecked={userInfo.preferredLanguage === 'en'} />
-              <label htmlFor="preferred-language-option-en">{t('personal-information:preferred-language.edit.nameEn')}</label>
-            </li>
-            <li className="radio">
-              <input type="radio" name="preferredLanguage" id="preferred-language-option-fr" value="fr" defaultChecked={userInfo.preferredLanguage === 'fr'} />
-              <label htmlFor="preferred-language-option-fr">{t('personal-information:preferred-language.edit.nameFr')}</label>
-            </li>
+            {preferredLanguageList?.map((language) => {
+              const radioId = `preferred-language-option-${language.id}`;
+              return (
+                <li className="radio">
+                  <input type="radio" name="preferredLanguage" id={radioId} value={language.id} defaultChecked={userInfo.preferredLanguage === language.id} />
+                  <label htmlFor={radioId}> {getNameByLanguage(i18n.language, language)} </label>
+                </li>
+              );
+            })}
           </ul>
         </fieldset>
         <div className="form-group">

--- a/frontend/app/routes/api.switch-language.ts
+++ b/frontend/app/routes/api.switch-language.ts
@@ -2,13 +2,14 @@ import { type ActionFunctionArgs, json } from '@remix-run/node';
 
 import { z } from 'zod';
 
+import { PREFFERRED_LANGUAGES } from '~/utils/constants';
 import { createLangCookie } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 const logger = getLogger('routes/api.switch-language');
 
 const switchLanguageDataSchema = z.object({
-  language: z.enum(['en', 'fr']),
+  language: z.enum(PREFFERRED_LANGUAGES),
 });
 
 export type SwitchLanguageData = z.infer<typeof switchLanguageDataSchema>;

--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -39,7 +39,6 @@ function createLookupService() {
     const response = await fetch(url);
 
     if (response.ok) return preferredLanguageSchema.parse(await response.json());
-    if (response.status === 404) return null;
 
     logger.error('%j', {
       message: 'Failed to fetch data',

--- a/frontend/app/utils/constants.ts
+++ b/frontend/app/utils/constants.ts
@@ -1,0 +1,1 @@
+export const PREFFERRED_LANGUAGES = ['en', 'fr'] as const;

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -22,6 +22,10 @@ export function getAltLanguage(language: string) {
   }
 }
 
+export function getNameByLanguage(language: string, { nameEn, nameFr }: { nameEn?: string; nameFr?: string }) {
+  return language == 'en' ? nameEn : nameFr;
+}
+
 /**
  * Returns all namespaces required by the given routes by examining the route's i18nNamespaces handle property.
  * @see https://remix.run/docs/en/main/route/handle


### PR DESCRIPTION
[AB#2826](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2826) - Integrated the `lookupService`'s `getPreferredLanguages` to populate `preferred-languages` radiolist. Updated user with new preferred-language set.