### PR TITLE
AB#2659 -- enable `X-Forwarded-*` support in express

### DIFF
--- a/frontend/express.server.ts
+++ b/frontend/express.server.ts
@@ -87,6 +87,7 @@ async function runServer() {
   // since remix fingerprints assets served from build/ we can use aggressive caching
   app.use(build.publicPath, express.static(build.assetsBuildDirectory, { immutable: true, maxAge: '1y' }));
   app.use(morgan(process.env.NODE_ENV === 'development' ? 'dev' : 'tiny', loggingOptions));
+  app.set('trust proxy', true); // enable X-Forwarded-* header support to build OAuth callback URLs
   app.all('*', process.env.NODE_ENV === 'development' ? createDevRequestHandler(build, buildPath, versionPath) : createRequestHandler({ build, mode: process.env.NODE_ENV }));
 
   const server = app.listen(port, () => {


### PR DESCRIPTION
To build OAuth callback URLs, we must know the original URL that was requested to hit the application. Express handles this automatically if you enable proxy support via the `trust proxy` server setting.

Related ADO workitems:
- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)