### PR TITLE
Random cleanup of address and phone flows as well as formatting CSS

### DIFF
--- a/frontend/app/cdcp.css
+++ b/frontend/app/cdcp.css
@@ -3,11 +3,11 @@ html {
 }
 
 .header-bg h2 {
-	background: linear-gradient(297.5deg, transparent, transparent 25px, white 26px, white 31px, #26374a 32px, #26374a);
-	color: #ffffff;
-	display: inline-block;
-	margin: 0px;
-	padding: 5px 40px 10px 15px;
-	font-size: 1.3em;
-	min-width: 300px;
+  background: linear-gradient(297.5deg, transparent, transparent 25px, white 26px, white 31px, #26374a 32px, #26374a);
+  color: #ffffff;
+  display: inline-block;
+  margin: 0px;
+  padding: 5px 40px 10px 15px;
+  font-size: 1.3em;
+  min-width: 300px;
 }

--- a/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
@@ -35,12 +35,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const isHomeAddressValid = (val: string) => addressValidationService.isValidAddress(val);
-  const isMailingAddressValid = (val: string) => addressValidationService.isValidAddress(val);
+  const isValidAddress = (val: string) => val && addressValidationService.isValidAddress(val);
 
   const formDataSchema = z.object({
-    homeAddress: z.string().min(1).refine(isHomeAddressValid, { message: 'Invalid home address' }),
-    mailingAddress: z.string().min(1).refine(isMailingAddressValid, { message: 'Invalid mailing address' }),
+    homeAddress: z.string().min(1, { message: 'Enter a home address' }).refine(isValidAddress, { message: 'Invalid home address' }),
+    mailingAddress: z.string().min(1, { message: 'Enter a mailing address' }).refine(isValidAddress, { message: 'Invalid mailing address' }),
   });
 
   const formData = Object.fromEntries(await request.formData());

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
@@ -70,7 +70,7 @@ export default function PhoneNumberConfirm() {
         </div>
         <div className="form-group">
           <button className="btn btn-primary btn-lg mrgn-rght-sm">{t('personal-information:phone-number.confirm.button.confirm')}</button>
-          <Link id="cancelButton" to="/update-info" className="btn btn-default btn-lg">
+          <Link id="cancelButton" to="/personal-information" className="btn btn-default btn-lg">
             {t('personal-information:phone-number.confirm.button.cancel')}
           </Link>
         </div>

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
@@ -79,7 +79,7 @@ export default function PhoneNumberEdit() {
       </h1>
       <p>{t('personal-information:phone-number.edit.update-message')}</p>
       <Form method="post">
-        <InputField id="phone-number" name="phoneNumber" type="tel" label={t('personal-information:phone-number.edit.component.phone')} defaultValue={defaultValues.phoneNumber} errorMessage={errorMessages.phoneNumber} />
+        <InputField id="phone-number" name="phoneNumber" type="tel" label={t('personal-information:phone-number.edit.component.phone')} required defaultValue={defaultValues.phoneNumber} errorMessage={errorMessages.phoneNumber} />
         <div className="form-group">
           <button className="btn btn-primary btn-lg mrgn-rght-sm">{t('personal-information:phone-number.edit.button.save')}</button>
           <Link id="cancelButton" to="/personal-information" className="btn btn-default btn-lg">

--- a/frontend/app/services/address-validation-service.server.ts
+++ b/frontend/app/services/address-validation-service.server.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
 const addressValidationSchema = z.object({
@@ -8,9 +9,10 @@ const addressValidationSchema = z.object({
 
 function createAddressValidationService() {
   const logger = getLogger('address-validation-service.server');
+  const { INTEROP_API_BASE_URI } = getEnv();
 
   async function isValidAddress(addressString: string) {
-    const url = `https://api.example.com/address/correct/${addressString}`;
+    const url = `${INTEROP_API_BASE_URI}/address/correct/${addressString}`;
     const response = await fetch(url);
 
     if (response.ok) {


### PR DESCRIPTION
- Cleaning `action` function for `/personal-information/address/edit` form as it would throw if a user manually removes the `required` attribute from an address `input` field and submits an empty form
- Adding `INTEROP_API_BASE_URI` environment variable rather than hard-coding example URI in address validation service
- Adding `required` attribute to phone `input` field in `/personal-information/phone-number/edit`
- Redirecting to `/personal-information` if user hits cancel from `/personal-information/phone-number/confirm`
- Running `npm run format` to format `cdcp.css`