### PR TITLE
change vitest config

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
+    pool: 'forks',
     testTimeout: 50000,
     globals: true,
     // happy-dom doesn't support button submit or FormData


### PR DESCRIPTION
There is an issue where unit tests will randomly hang (i.e. not reproducible) with the logs outputting:

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/147d31ff-e287-464e-b023-a425c15411a9)

After a cursory look into the vitest github issues/discussions, some contributors have asserted that after adding`pool: "forks"` solved the issue.  This is a hail Mary PR at this point with nothing to lose other than trying it out and seeing if will resolve.