### PR TITLE
Fix mocks in personal-information tests

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
@@ -4,6 +4,15 @@ import { describe, expect, it } from 'vitest';
 
 import { action } from '~/routes/_gcweb-app.personal-information.phone-number.edit';
 
+vi.mock('~/services/session-service.server', () => ({
+  sessionService: {
+    commitSession: vi.fn(),
+    getSession: vi.fn().mockReturnValue({
+      set: vi.fn(),
+    }),
+  },
+}));
+
 describe('_gcweb-app.personal-information.phone-number.edit', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
@@ -2,13 +2,7 @@ import { loader } from '~/routes/_gcweb-app.personal-information.preferred-langu
 import { lookupService } from '~/services/lookup-service.server';
 import { userService } from '~/services/user-service.server';
 
-vi.mock('~/services/user-service.server.ts', () => ({
-  userService: {
-    getUserId: vi.fn().mockReturnValue('some-id'),
-    getUserInfo: vi.fn(),
-  },
-}));
-vi.mock('~/services/lookup-service.server.ts', () => ({
+vi.mock('~/services/lookup-service.server', () => ({
   lookupService: {
     getAllPreferredLanguages: vi.fn().mockReturnValue([
       {
@@ -27,6 +21,17 @@ vi.mock('~/services/lookup-service.server.ts', () => ({
       nameEn: 'French',
       nameFr: 'Français',
     }),
+  },
+}));
+
+vi.mock('~/services/session-service.server', () => ({
+  /* intentionally left blank */
+}));
+
+vi.mock('~/services/user-service.server', () => ({
+  userService: {
+    getUserId: vi.fn().mockReturnValue('some-id'),
+    getUserInfo: vi.fn(),
   },
 }));
 


### PR DESCRIPTION
Some unit tests were not mocking the session service, making the tests fragile.