### PR TITLE
AB#2659 -- RAOIDC integration (login redirect w/ msw)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -18,6 +18,12 @@ AUTH_JWT_PUBLIC_KEY=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDT04V6j20+5DQPA7rZCBfa
 # private key JWT -- single-line private key without BEGIN/END PRIVATE KEY headers and footers
 # (required; use the example below)
 AUTH_JWT_PRIVATE_KEY=MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANPThXqPbT7kNA8DutkIF9ptB7KF80usq4pKzXJkX/v7L7js/DzR46aqGCwtBcr1q88xlK+N376+Jn/76Mh16Pn4nqJ8fkqm5WyR+AAxj2Q+xEsWQkArw6umHaCJtBP8918rB5KiRGYSsnF1NYk6ophM7DrTtA+H3W5t2WDH5VxXAgMBAAECgYEAkW80wcUfuIJty7E/5CrOVcVt94BIXriavkRFcjjAPf1j8o+jTw68Qn2eQxZWV9b8szDTaQT7jbZ4MH8AgEGURmroSY2mesHYJtypGkV7ciZj9Z2hnhN0RcOZnl594ZElGljBl83howpwpYhuFDvtCtv9znDYfxeZJnbqWyTenoECQQD/nJ7rOHxk0JG6kHYDqXqZT4hCpnwAtPSppSXa4cHOTTdKM4PBHKBUu5fr003PPpcekbHRQ78HbkhZUdT+NYTxAkEA1CXgk/sLc5AJoFqkbUSnkhPQUBLzCu7kjDAwoQ1DSBerCtbU0/Kg1C1sLixt7g6xgDtMRvfElmqnXZlxzZdVxwJABeWvJO4gsJK/SfabQmpekbrsAd2lbr6+BkvxG6OpvQC7DdMybvoiGNJbJu2xFd7zzZi+6X0OozVAJg9lQpgpgQJBAMBohhHQm6c5GPH9o6mSneSH4ePt+86Lsm9O+Zvn+oC1LqULCUYdhS5K8BXEqANEAkrJ/TlUWFEP9DGZDLUpL1sCQGx9AJNJP6JajA4JWBCUpY2XpRqX7mr3g4TxmFGaXU6CMbz1LVL+2knWZx4wg53BemWEu8KY7v5FISzIyMfBjVs=
+# RAOIDC base URL -- the base URL for all RAOIDC calls
+# (required; use the example below)
+AUTH_RAOIDC_BASE_URL=https://auth.example.com/oauth
+# RAOIDC client ID -- the OAuth client id used for all RAOIDC calls
+# (required; use the example below)
+AUTH_RAOIDC_CLIENT_ID=CDCP
 
 
 # i18n language cookie name

--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -4,6 +4,7 @@ import { setupServer } from 'msw/node';
 import { z } from 'zod';
 
 import { db } from '~/mocks/db';
+import { raoidc } from '~/mocks/raoidc/raoidc.server';
 
 /**
  * Retrieves a user entity based on the provided user ID.
@@ -58,6 +59,8 @@ function toUserPatchDocument({ homeAddress, mailingAddress, phoneNumber, preferr
 }
 
 const handlers = [
+  ...raoidc, // TODO :: GjB :: eventually enable/disable RAOIDC mocks w/ a feature flag
+
   /**
    * Handler for GET requests to retrieve user details.
    */

--- a/frontend/app/mocks/raoidc/raoidc.server.ts
+++ b/frontend/app/mocks/raoidc/raoidc.server.ts
@@ -1,0 +1,30 @@
+import { HttpResponse, http } from 'msw';
+
+import openidConfiguration from '~/mocks/raoidc/responses/[.]well-known.openid-configuration.json';
+import jwk from '~/mocks/raoidc/responses/jwk.json';
+
+/**
+ * MSW mocks for the RAOIDC authentication service.
+ */
+export const raoidc = [
+  //
+  // RAOIDC /.well-known/openid-configuration
+  //
+  http.get('https://auth.example.com/oauth/.well-known/openid-configuration', () => {
+    return HttpResponse.json(openidConfiguration);
+  }),
+
+  //
+  // RAOIDC /oauth/jwk
+  //
+  http.get('https://auth.example.com/oauth/jwk', () => {
+    return HttpResponse.json(jwk);
+  }),
+
+  //
+  // RAOIDC catchall (404 Not found)
+  //
+  http.all('https://auth.example.com/**', () => {
+    return new HttpResponse(null, { status: 404 });
+  }),
+];

--- a/frontend/app/mocks/raoidc/responses/[.]well-known.openid-configuration.json
+++ b/frontend/app/mocks/raoidc/responses/[.]well-known.openid-configuration.json
@@ -1,0 +1,19 @@
+{
+  "issuer": "GC-ECAS-DEV",
+  "authorization_endpoint": "https://auth.example.com/oauth/authorize",
+  "token_endpoint": "https://auth.example.com/oauth/token",
+  "jwks_uri": "https://auth.example.com/oauth/jwk",
+  "scopes_supported": ["openid", "profile"],
+  "claims_supported": ["sub", "sin", "birthdate"],
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["pairwise"],
+  "id_token_signing_alg_values_supported": ["RS256", "RS512"],
+  "userinfo_endpoint": "https://auth.example.com/oauth/userinfo",
+  "revocation_endpoint": "https://auth.example.com/oauth/revoke",
+  "grant_types_supported": "authorization_code",
+  "id_token_encryption_alg_values_supported": ["RSA-OAEP-256"],
+  "id_token_encryption_enc_values_supported": ["A256GCM"],
+  "userinfo_signing_alg_values_supported": ["RS256", "RS512"],
+  "userinfo_encryption_alg_values_supported": ["RSA-OAEP-256"],
+  "userinfo_encryption_enc_values_supported": ["A256GCM"]
+}

--- a/frontend/app/mocks/raoidc/responses/jwk.json
+++ b/frontend/app/mocks/raoidc/responses/jwk.json
@@ -1,0 +1,19 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "RAOIDC_Client_Dev",
+      "n": "01qwfEOnI/xgDXvS2lJncDu7P/2a7IYeofOeuUbNVUlvQl7neBZPVgxgLKuu+hjCru3sMfR7+cxQpHVbYxTsxU68+Tb+BcRvY18Vebm/bqa31D22IuoqTZLjV540FP+EgJe+gggRivvj3UePCC7I41GN7B3DBGw2ejTUL8t/ziuAqFdhltKg4Y+Ztgci3mdUQQL4kZ+X8kVpJS81bmjS990gzVq0oiWa7OdnBCR5ppX7aoQTXeFaDw33BOaC5IPzHY3vw8bTr0NJ8sUZKvVqUuJ92qNfs7XTKWwuo+E8xJnDErbEHaeVDuIoKVeZ/kHz6Uu2SqTXH/B2OnE846DlwQ=="
+    },
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "RAOIDC_Client_Prod",
+      "n": "3iAMsHZ+ix/f5NAfzaP/Rx4ZkKPViOe9NV7HLjV/RO6sYyw0o+NSBGWF5EThKLCeKffDAIg5OqjFrrt1uDIFDn0352cxlnkWqbR9X+BN0wwnNQhGknPuyTaIDOecwK7a1uNIIQ1LlJ9KpWqkzVs4Wd2AlNEQ/+FVNZVcAN+dM49DA3k2gDSMUDpWvmxcDhQRfeWJW8vThCy8sTfjArlA3l1jX1uJs44kD+cOopA/S8JiQwMGVK1hq3FlI1SXr3nXsbpdAODRJ2cuHPzfAN377t4fEAhkE87jWWjyTVOETmg7JIsbA6UbT6yWvwSwOPQFY9+prkzv1T3sjgCDiX4dDQ==",
+      "alg": "RS256"
+    }
+  ]
+}

--- a/frontend/app/routes/auth.login.$providerId.tsx
+++ b/frontend/app/routes/auth.login.$providerId.tsx
@@ -1,0 +1,30 @@
+import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
+
+import { authService } from '~/services/auth-service.server';
+import { sessionService } from '~/services/session-service.server';
+
+/**
+ * Creates the OIDC callback URL.
+ */
+function createRedirectUri(baseUri: string, providerId?: string) {
+  return new URL(`/auth/callback/${providerId}`, baseUri).href;
+}
+
+/**
+ * The loader() function generates an OIDC auth request and sends a redirect
+ * back to the browser to initiate the login process.
+ */
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const redirectUri = createRedirectUri(new URL(request.url).origin, params.providerId);
+  const { authUrl, codeVerifier } = authService.generateAuthRequest(redirectUri);
+
+  // codeVerifier will have to be validated in the callback handler, so store it in session
+  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  session.set('codeVerifier', codeVerifier);
+
+  return redirect(authUrl.href, {
+    headers: {
+      'Set-Cookie': await sessionService.commitSession(session),
+    },
+  });
+}

--- a/frontend/app/routes/auth.login.tsx
+++ b/frontend/app/routes/auth.login.tsx
@@ -1,0 +1,9 @@
+import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
+
+/**
+ * Requests to /auth/login should be forwarded to /auth/login/{providerId}
+ */
+export function loader({ request }: LoaderFunctionArgs) {
+  // TODO :: GjB :: handle multiple providers
+  return redirect('/auth/login/raoidc');
+}

--- a/frontend/app/services/auth-service.server.ts
+++ b/frontend/app/services/auth-service.server.ts
@@ -1,43 +1,62 @@
 /**
- * TODO :: GjB :: DOCUMENT ME!
+ * Auth service is a service module responsible for managing authentication with RAOIDC.
  */
-import { createHash, subtle, type webcrypto } from 'node:crypto';
+import { createHash, subtle } from 'node:crypto';
 
 import { publicKeyPemToCryptoKey } from '~/utils/crypto-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
+import { fetchServerMetadata, generateAuthorizationRequest, generateCodeChallenge } from '~/utils/raoidc-utils.server';
+
+const log = getLogger('auth-service.server');
 
 /**
- * Generate a JWK ID from the modulus of the JWK.
+ * Instantiates the singleton isntance of auth service.
  */
-function generateJwkId(jwk: webcrypto.JsonWebKey) {
-  return createHash('md5')
-    .update(jwk.n ?? '')
-    .digest('hex');
-}
+async function createAuthService() {
+  log.debug('Creating auth service');
 
-function createAuthService() {
-  const log = getLogger('auth-service.server');
   const { AUTH_JWT_PUBLIC_KEY } = getEnv();
+  const { AUTH_RAOIDC_BASE_URL, AUTH_RAOIDC_CLIENT_ID } = getEnv();
+  const { serverMetadata } = await fetchServerMetadata(AUTH_RAOIDC_BASE_URL);
 
   /**
    * Return a promise that resolves to an array of public JWKs. If no public
    * keys have been configured, this function returns an empty array.
    */
-  async function getPublicJwks(): Promise<Array<{ kid: string } & webcrypto.JsonWebKey>> {
+  async function getPublicJwks() {
     if (!AUTH_JWT_PUBLIC_KEY) {
       log.warn('AUTH_JWT_PUBLIC_KEY is not set, returning empty JWKS');
       return [];
     }
 
-    const key = await publicKeyPemToCryptoKey(AUTH_JWT_PUBLIC_KEY);
-    const jwk = await subtle.exportKey('jwk', key);
-    const keyId = generateJwkId(jwk);
-
-    return [{ kid: keyId, ...jwk }];
+    const jwk = await subtle.exportKey('jwk', await publicKeyPemToCryptoKey(AUTH_JWT_PUBLIC_KEY));
+    return [{ ...jwk, kid: generateJwkId(jwk) } as JsonWebKey & { kid: string }];
   }
 
-  return { getPublicJwks };
+  /**
+   * Generates an OAuth authentication request. Used to kickstart the OAuth login process.
+   */
+  function generateAuthRequest(redirectUri: string) {
+    const { codeChallenge, codeVerifier } = generateCodeChallenge();
+    const clientId = AUTH_RAOIDC_CLIENT_ID;
+    const scope = 'openid profile';
+
+    const authUrl = generateAuthorizationRequest(serverMetadata.authorization_endpoint, clientId, codeChallenge, redirectUri, scope);
+
+    return { authUrl, codeVerifier };
+  }
+
+  /**
+   * Generate a key id from the modulus of a jwk.
+   */
+  function generateJwkId(jwk: JsonWebKey) {
+    return createHash('md5')
+      .update(jwk.n ?? '')
+      .digest('hex');
+  }
+
+  return { getPublicJwks, generateAuthRequest };
 }
 
-export const authService = createAuthService();
+export const authService = await createAuthService();

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -28,8 +28,10 @@ const serverEnv = z.object({
   INTEROP_API_BASE_URI: z.string().url().default('https://api.example.com'),
 
   // auth/oidc settings
-  AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),
-  AUTH_JWT_PUBLIC_KEY: z.string().refine(isValidPublicKey),
+  AUTH_JWT_PRIVATE_KEY: z.string().trim().refine(isValidPrivateKey),
+  AUTH_JWT_PUBLIC_KEY: z.string().trim().refine(isValidPublicKey),
+  AUTH_RAOIDC_BASE_URL: z.string().trim().min(1),
+  AUTH_RAOIDC_CLIENT_ID: z.string().trim().min(1),
 
   // language cookie settings
   LANG_COOKIE_NAME: z.string().default('_gc_lang'),

--- a/frontend/app/utils/raoidc-utils.server.ts
+++ b/frontend/app/utils/raoidc-utils.server.ts
@@ -2,7 +2,7 @@
  * Utility functions to help with RAOIDC requests.
  */
 import { SignJWT, compactDecrypt, decodeJwt, importJWK, jwtVerify } from 'jose';
-import { randomBytes, subtle } from 'node:crypto';
+import { createHash, randomBytes, subtle } from 'node:crypto';
 
 import { getLogger } from './logging.server';
 
@@ -285,6 +285,26 @@ async function decryptJwe(jwe: string, privateKey: CryptoKey) {
   const key = await importJWK({ ...jwk }, 'RSA-OAEP');
   const decryptResult = await compactDecrypt(jwe, key, { keyManagementAlgorithms: ['RSA-OAEP-256'] });
   return decryptResult.plaintext.toString();
+}
+
+/**
+ * Generate an OIDC code challenge from the verifier string.
+ *
+ * @see https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#pkce-code-challenge-method
+ */
+export function generateCodeChallenge() {
+  const codeVerifier = generateRandomCodeVerifier();
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeChallenge, codeVerifier };
+}
+
+/**
+ * Generate a random OIDC code verifier.
+ *
+ * @see https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#parameters
+ */
+export function generateRandomCodeVerifier(len = 64) {
+  return generateRandomString(len);
 }
 
 /**


### PR DESCRIPTION
This is an ***INCREMENTAL PR™*** that implements only the first two steps of an RAOIDC login via MSW mocks (discovery + auth URL forwarding).

Future PRs will each add an additional step to the login process, until a fully mocked RAOIDC login is implemented.

Unit/e2e tests will be handled in future PRs.

## How to test
- Copy the relevant entries from `.env.example` into your `.env` file:
  - `AUTH_RAOIDC_BASE_URL=https://auth.example.com/oauth`
  - `AUTH_RAOIDC_CLIENT_ID=CDCP`
- Run the application in dev mode using `npm run-script dev`
- Hit <http://localhost:3000/auth/login>

You should immediately be redirected to:

``` shell
https://auth.example.com/oauth/authorize
  ?client_id=CDCP
  &code_challenge={random} 
  &code_challenge_method=S256
  &nonce={random}
  &redirect_uri=http://localhost:3000/auth/callback/raoidc 
  &response_type=code
  &scope=openid+profile
  &state={random}
```

## Related ADO workitems
- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)