### PR TITLE
Change required asterisk css font-size

### DIFF
--- a/frontend/app/cdcp.css
+++ b/frontend/app/cdcp.css
@@ -1,3 +1,9 @@
 html {
   font-size: 16px;
 }
+
+.checkbox.required:before,
+label.required:before,
+legend.required:before {
+  font-size: 1rem;
+}


### PR DESCRIPTION
Change required asterisk css font-size to `1rem` otherwise it match the parrent element and can be outside of the margin of the content.

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/66467b69-7b9e-49e0-99bc-1aa34842cfc2)
