### PR TITLE
AB#2659 -- RAOIDC integration (state management)

### DIFF
--- a/frontend/app/utils/raoidc-utils.server.ts
+++ b/frontend/app/utils/raoidc-utils.server.ts
@@ -148,11 +148,10 @@ export async function fetchServerMetadata(authServerUrl: string, fetchFn?: Fetch
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
  */
-export function generateAuthorizationRequest(authorizationUri: string, clientId: string, codeChallenge: string, redirectUri: string, scope: string) {
+export function generateAuthorizationRequest(authorizationUri: string, clientId: string, codeChallenge: string, redirectUri: string, scope: string, state: string) {
   const codeChallengeMethod = 'S256';
   const nonce = generateRandomNonce();
   const responseType = 'code';
-  const state = generateRandomState();
 
   const authorizationRequest = new URL(authorizationUri);
   authorizationRequest.searchParams.set('client_id', clientId);


### PR DESCRIPTION
To be RFC compliant, the state that is sent to RAOIDC must be checked and validated in the application's callback handler. In order to do this, the state must be returned and accepted by the relevant functions.

## Related ADO workitems
- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)