### PR TITLE
AB#2659 -- RAOIDC integration (prepwork: feature flag)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -82,7 +82,9 @@ REDIS_USERNAME=username
 # (optional; default undefined)
 REDIS_PASSWORD=password
 
-
+# enable RAOIDC authentication
+# (optional; default: false.. for now)
+AUTH_ENABLED=false
 # enable client-side javascript; useful for testing progressive enhancement
 # (optional; default: true)
 JAVASCRIPT_ENABLED=true

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -57,6 +57,7 @@ const serverEnv = z.object({
   REDIS_PASSWORD: z.string().trim().min(1).optional(),
 
   // feature flags (ie: THING_ENABLED=true/false)
+  AUTH_ENABLED: z.string().transform(toBoolean).default('false'),
   JAVASCRIPT_ENABLED: z.string().transform(toBoolean).default('true'),
   MOCKS_ENABLED: z.string().transform(toBoolean).default('false'),
 });


### PR DESCRIPTION
This PR adds a (currently unused) feature flag to enable/disable authentication.

Authentication is disabled by default (for now) so as not to disrupt other developers before the full implementation is finished.

## Related ADO workitems
- AB#2659 