### PR TITLE
AB#2826: integrate lookup service to personal index and confirm preference language pages

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
@@ -15,7 +15,27 @@ vi.mock('~/services/user-service.server.ts', () => ({
     }),
   },
 }));
-
+vi.mock('~/services/lookup-service.server.ts', () => ({
+  lookupService: {
+    getAllPreferredLanguages: vi.fn().mockReturnValue([
+      {
+        id: 'en',
+        nameEn: 'English',
+        nameFr: 'Anglais',
+      },
+      {
+        id: 'fr',
+        nameEn: 'French',
+        nameFr: 'Français',
+      },
+    ]),
+    getPreferredLanguage: vi.fn().mockReturnValue({
+      id: 'fr',
+      nameEn: 'French',
+      nameFr: 'Français',
+    }),
+  },
+}));
 describe('_gcweb-app.personal-information._index', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -61,6 +81,7 @@ describe('_gcweb-app.personal-information._index', () => {
           phoneNumber: '(555) 555-5555',
           preferredLanguage: 'fr',
         },
+        preferredLanguage: { id: 'fr', nameEn: 'French', nameFr: 'Français' },
       });
     });
   });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
@@ -1,0 +1,87 @@
+import { loader } from '~/routes/_gcweb-app.personal-information.preferred-language.confirm';
+import { lookupService } from '~/services/lookup-service.server';
+import { userService } from '~/services/user-service.server';
+import { getEnv } from '~/utils/env.server';
+
+vi.mock('~/services/user-service.server.ts', () => ({
+  userService: {
+    getUserId: vi.fn().mockReturnValue('some-id'),
+    getUserInfo: vi.fn(),
+  },
+}));
+vi.mock('~/services/lookup-service.server.ts', () => ({
+  lookupService: {
+    getPreferredLanguage: vi.fn().mockReturnValue({
+      id: 'fr',
+      nameEn: 'French',
+      nameFr: 'Français',
+    }),
+  },
+}));
+vi.mock('~/utils/env.server.ts', () => ({
+  getEnv: vi.fn().mockReturnValue({
+    createCookie: vi.fn(),
+  }),
+}));
+vi.mock('~/services/session-service.server.ts', () => ({
+  createSessionService: vi.fn(),
+  sessionService: {
+    getSession: vi.fn().mockReturnValue({
+      get: vi.fn(),
+    }),
+  },
+}));
+
+describe('_gcweb-app.personal-information.preferred-language.confirm', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('loader()', () => {
+    it('should return userInfo object if userInfo is found', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({
+        SESSION_STORAGE_TYPE: 'file',
+        AUTH_JWT_PUBLIC_KEY: 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDT04V6j20+5DQPA7rZCBfabQeyhfNLrKuKSs1yZF/7+y+47Pw80eOmqhgsLQXK9avPMZSvjd++viZ/++jIdej5+J6ifH5KpuVskfgAMY9kPsRLFkJAK8Orph2gibQT/PdfKweSokRmErJxdTWJOqKYTOw607QPh91ubdlgx+VcVwIDAQAB',
+        AUTH_JWT_PRIVATE_KEY:
+          'MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANPThXqPbT7kNA8DutkIF9ptB7KF80usq4pKzXJkX/v7L7js/DzR46aqGCwtBcr1q88xlK+N376+Jn/76Mh16Pn4nqJ8fkqm5WyR+AAxj2Q+xEsWQkArw6umHaCJtBP8918rB5KiRGYSsnF1NYk6ophM7DrTtA+H3W5t2WDH5VxXAgMBAAECgYEAkW80wcUfuIJty7E/5CrOVcVt94BIXriavkRFcjjAPf1j8o+jTw68Qn2eQxZWV9b8szDTaQT7jbZ4MH8AgEGURmroSY2mesHYJtypGkV7ciZj9Z2hnhN0RcOZnl594ZElGljBl83howpwpYhuFDvtCtv9znDYfxeZJnbqWyTenoECQQD/nJ7rOHxk0JG6kHYDqXqZT4hCpnwAtPSppSXa4cHOTTdKM4PBHKBUu5fr003PPpcekbHRQ78HbkhZUdT+NYTxAkEA1CXgk/sLc5AJoFqkbUSnkhPQUBLzCu7kjDAwoQ1DSBerCtbU0/Kg1C1sLixt7g6xgDtMRvfElmqnXZlxzZdVxwJABeWvJO4gsJK/SfabQmpekbrsAd2lbr6+BkvxG6OpvQC7DdMybvoiGNJbJu2xFd7zzZi+6X0OozVAJg9lQpgpgQJBAMBohhHQm6c5GPH9o6mSneSH4ePt+86Lsm9O+Zvn+oC1LqULCUYdhS5K8BXEqANEAkrJ/TlUWFEP9DGZDLUpL1sCQGx9AJNJP6JajA4JWBCUpY2XpRqX7mr3g4TxmFGaXU6CMbz1LVL+2knWZx4wg53BemWEu8KY7v5FISzIyMfBjVs=',
+      });
+      vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', preferredLanguage: 'fr' });
+      vi.mocked(lookupService.getPreferredLanguage).mockResolvedValue({ id: 'fr', nameEn: 'French', nameFr: 'Français' });
+
+      const response = await loader({
+        request: new Request('http://localhost:3000/personal-information/preferred/confirm'),
+        context: {},
+        params: {},
+      });
+
+      const data = await response.json();
+
+      expect(data).toEqual({
+        userInfo: { id: 'some-id', preferredLanguage: 'fr' },
+        preferredLanguage: { id: 'fr', nameEn: 'French', nameFr: 'Français' },
+      });
+    });
+
+    it('should throw 404 response if userInfo is not found', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({
+        SESSION_STORAGE_TYPE: 'file',
+        AUTH_JWT_PUBLIC_KEY: 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDT04V6j20+5DQPA7rZCBfabQeyhfNLrKuKSs1yZF/7+y+47Pw80eOmqhgsLQXK9avPMZSvjd++viZ/++jIdej5+J6ifH5KpuVskfgAMY9kPsRLFkJAK8Orph2gibQT/PdfKweSokRmErJxdTWJOqKYTOw607QPh91ubdlgx+VcVwIDAQAB',
+        AUTH_JWT_PRIVATE_KEY:
+          'MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANPThXqPbT7kNA8DutkIF9ptB7KF80usq4pKzXJkX/v7L7js/DzR46aqGCwtBcr1q88xlK+N376+Jn/76Mh16Pn4nqJ8fkqm5WyR+AAxj2Q+xEsWQkArw6umHaCJtBP8918rB5KiRGYSsnF1NYk6ophM7DrTtA+H3W5t2WDH5VxXAgMBAAECgYEAkW80wcUfuIJty7E/5CrOVcVt94BIXriavkRFcjjAPf1j8o+jTw68Qn2eQxZWV9b8szDTaQT7jbZ4MH8AgEGURmroSY2mesHYJtypGkV7ciZj9Z2hnhN0RcOZnl594ZElGljBl83howpwpYhuFDvtCtv9znDYfxeZJnbqWyTenoECQQD/nJ7rOHxk0JG6kHYDqXqZT4hCpnwAtPSppSXa4cHOTTdKM4PBHKBUu5fr003PPpcekbHRQ78HbkhZUdT+NYTxAkEA1CXgk/sLc5AJoFqkbUSnkhPQUBLzCu7kjDAwoQ1DSBerCtbU0/Kg1C1sLixt7g6xgDtMRvfElmqnXZlxzZdVxwJABeWvJO4gsJK/SfabQmpekbrsAd2lbr6+BkvxG6OpvQC7DdMybvoiGNJbJu2xFd7zzZi+6X0OozVAJg9lQpgpgQJBAMBohhHQm6c5GPH9o6mSneSH4ePt+86Lsm9O+Zvn+oC1LqULCUYdhS5K8BXEqANEAkrJ/TlUWFEP9DGZDLUpL1sCQGx9AJNJP6JajA4JWBCUpY2XpRqX7mr3g4TxmFGaXU6CMbz1LVL+2knWZx4wg53BemWEu8KY7v5FISzIyMfBjVs=',
+      });
+
+      vi.mocked(userService.getUserInfo).mockResolvedValue(null);
+
+      try {
+        await loader({
+          request: new Request('http://localhost:3000/personal-information/preferred-language/confirm'),
+          context: {},
+          params: {},
+        });
+      } catch (error) {
+        expect((error as Response).status).toEqual(404);
+      }
+    });
+  });
+});

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
@@ -44,7 +44,7 @@ describe('_gcweb-app.personal-information.preferred-language.edit', () => {
   describe('loader()', () => {
     it('should return userInfo object if userInfo is found', async () => {
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', preferredLanguage: 'fr' });
-      vi.mocked(lookupService.getPreferredLanguage).mockResolvedValue({ id: 'fr', nameEn: 'French', nameFr: 'fr' });
+      vi.mocked(lookupService.getPreferredLanguage).mockResolvedValue({ id: 'fr', nameEn: 'French', nameFr: 'Français' });
       vi.mocked(lookupService.getAllPreferredLanguages).mockResolvedValue([
         {
           id: 'en',

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -6,8 +6,9 @@ import { Link, useLoaderData } from '@remix-run/react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 
+import { lookupService } from '~/services/lookup-service.server';
 import { userService } from '~/services/user-service.server';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
@@ -25,14 +26,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (!userInfo) {
     throw new Response(null, { status: 404 });
   }
+  const preferredLanguage = userInfo.preferredLanguage ? await lookupService.getPreferredLanguage(userInfo?.preferredLanguage) : undefined;
 
-  return json({ user: userInfo });
+  return json({ user: userInfo, preferredLanguage });
 }
 
 export default function PersonalInformationIndex() {
-  const { user } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
-  const languageName = user?.preferredLanguage === 'fr' ? t('personal-information:index.french-language-name') : t('personal-information:index.english-language-name');
+  const { user, preferredLanguage } = useLoaderData<typeof loader>();
+  const { i18n, t } = useTranslation(i18nNamespaces);
 
   return (
     <>
@@ -53,7 +54,7 @@ export default function PersonalInformationIndex() {
           title={t('personal-information:index.preferred-language')}
           icon="glyphicon-globe"
         >
-          {languageName}
+          {preferredLanguage && getNameByLanguage(i18n.language, preferredLanguage)}
         </PersonalInformationSection>
         <PersonalInformationSection
           footer={

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
@@ -4,9 +4,10 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
+import { lookupService } from '~/services/lookup-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
@@ -26,23 +27,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
   const session = await sessionService.getSession(request.headers.get('Cookie'));
-
-  return json({ userInfo, preferredLanguage: await session.get('preferredLanguage') });
+  const preferredLanguageSession = await session.get('preferredLanguage');
+  const preferredLanguage = await lookupService.getPreferredLanguage(preferredLanguageSession);
+  return json({ userInfo, preferredLanguage });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await userService.getUserId();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
-
-  const preferredLanguage = await session.get('preferredLanguage');
-  await userService.updateUserInfo(userId, { preferredLanguage });
-
+  const preferredLanguageSession = await session.get('preferredLanguage');
+  await userService.updateUserInfo(userId, { preferredLanguage: preferredLanguageSession });
   return redirect('/personal-information');
 }
 
 export default function PreferredLanguageConfirm() {
-  const loaderData = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { preferredLanguage } = useLoaderData<typeof loader>();
+  const { i18n, t } = useTranslation(i18nNamespaces);
+
   return (
     <>
       <h1 id="wb-cont" property="name">
@@ -52,7 +53,7 @@ export default function PreferredLanguageConfirm() {
       <Form method="post">
         <dl>
           <dt>{t('personal-information:preferred-language.edit.language')}</dt>
-          <dd>{loaderData.preferredLanguage === 'en' ? t('personal-information:preferred-language.edit.nameEn') : t('personal-information:preferred-language.edit.nameFr')}</dd>
+          <dd>{preferredLanguage && getNameByLanguage(i18n.language, preferredLanguage)}</dd>
         </dl>
         <div className="flex flex-wrap gap-3">
           <button className="btn btn-primary btn-lg">{t('personal-information:preferred-language.confirm.button.confirm')}</button>

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -120,6 +120,6 @@ export async function switchLanguageCookie<T extends SwitchLanguageData['languag
  * @param { english translation, french translation}
  * @returns either the english translation or the french translation.
  */
-export function getNameByLanguage(language: string, { nameEn, nameFr }: { nameEn?: string; nameFr?: string }) {
-  return language == 'fr' ? nameFr : nameEn;
+export function getNameByLanguage(language: string, obj: { nameEn?: string; nameFr?: string }) {
+  return language == 'fr' ? obj.nameFr : obj.nameEn;
 }

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -12,8 +12,6 @@
     "home-address": "Home address",
     "mailing-address": "Mailing address",
     "preferred-language": "Preferred language",
-    "french-language-name": "French",
-    "english-language-name": "English",
     "change-addresses": "Change addresses",
     "change-phone-number": "Change phone number",
     "change-preferred-language": "Change preferred language"
@@ -101,8 +99,6 @@
         "edit": "Edit"
       },
       "id": "ID",
-      "nameEn": "English",
-      "nameFr": "French",
       "language": "Language",
       "change": "Change",
       "cancel": "Cancel"

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -12,8 +12,6 @@
     "home-address": "(FR) Home address",
     "mailing-address": "(FR) Mailing address",
     "preferred-language": "(FR) Preferred language",
-    "french-language-name": "Français",
-    "english-language-name": "(FR) English",
     "change-addresses": "(FR) Change addresses",
     "change-phone-number": "(FR) Change phone number",
     "change-preferred-language": "(FR) Change preferred language"
@@ -111,8 +109,6 @@
         "edit": "(FR) Edit"
       },
       "id": "(FR) ID",
-      "nameEn": "(FR) English",
-      "nameFr": "(FR) French",
       "language": "(FR) Language",
       "change": "(FR) Change",
       "cancel": "(FR) Cancel"


### PR DESCRIPTION
[AB#2826](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2826): 
* integrated `lookup-service` `getPreferenceLanguage` to `personal-info-index` and `preference-language-confirm`  pages
* removed unused locale files