### PR TITLE
Add coverage exclude config

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
@@ -14,7 +14,10 @@ export default defineConfig({
     // https://github.com/capricorn86/happy-dom/issues/585
     environment: 'jsdom',
     setupFiles: ['./__tests__/setup-test-env.ts'],
-    include: ['./**/*.{test,test-d,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    exclude: ['**/node_modules/**', '**/build/**', '**/e2e/**'],
+    include: [...configDefaults.include, '**/*.test-d.ts(x)'],
+    exclude: [...configDefaults.exclude, '**/build/**', '**/e2e/**'],
+    coverage: {
+      exclude: [...(configDefaults.coverage.exclude ?? []), '**/build/**', '**/e2e/**'],
+    },
   },
 });


### PR DESCRIPTION
## Pull Request

### Description

Add vitest coverage config to exclude `build` and `e2e` directories from vitest coverage report.

### Screenshots (if applicable)

Here's a screenshot when the coverage report was failing.

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/960353fa-0223-4d71-8278-f39611c155df)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] All new and existing tests passed.

### Test Instructions

Run vitest coverage report script: `npm run test:unit:coverage`
