### PR TITLE
Add style to addresses

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -66,9 +66,9 @@ export default function PersonalInformationIndex() {
         >
           <dl>
             <dt>{t('personal-information:index.home-address')}</dt>
-            <dd>{user.homeAddress}</dd>
+            <dd className="whitespace-pre-line">{user.homeAddress}</dd>
             <dt>{t('personal-information:index.mailing-address')}</dt>
-            <dd>{user.mailingAddress}</dd>
+            <dd className="whitespace-pre-line">{user.mailingAddress}</dd>
           </dl>
         </PersonalInformationSection>
         <PersonalInformationSection

--- a/frontend/app/routes/_gcweb-app.personal-information.address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.confirm.tsx
@@ -24,8 +24,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
   const session = await sessionService.getSession(request.headers.get('Cookie'));
-
-  return json({ userInfo, newAddress: await session.get('newAddress') });
+  const newAddress = await session.get('newAddress');
+  return json({ userInfo, newAddress });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -38,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function ConfirmAddress() {
-  const loaderData = useLoaderData<typeof loader>();
+  const { userInfo, newAddress } = useLoaderData<typeof loader>();
   const { t } = useTranslation(i18nNamespaces);
   return (
     <>
@@ -47,53 +47,43 @@ export default function ConfirmAddress() {
       </h1>
       <Form method="post">
         <h2>{t('personal-information:address.confirm.changed-address')}</h2>
-        <div className="row mrgn-tp-sm">
-          <div className="col-sm-6">
-            <section className="panel panel-info">
-              <header className="panel-heading">
-                <h3 className="panel-title">{t('personal-information:address.confirm.from')}</h3>
-              </header>
-              <div className="panel-body">
-                <p>{loaderData.userInfo?.homeAddress}</p>
-              </div>
-            </section>
-          </div>
-
-          <div className="col-sm-6">
-            <section className="panel panel-info">
-              <header className="panel-heading">
-                <h3 className="panel-title">{t('personal-information:address.confirm.to')}</h3>
-              </header>
-              <div className="panel-body">
-                <p>{loaderData.newAddress?.homeAddress}</p>
-              </div>
-            </section>
-          </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <section className="panel panel-info">
+            <header className="panel-heading">
+              <h3 className="panel-title">{t('personal-information:address.confirm.from')}</h3>
+            </header>
+            <div className="panel-body">
+              <p className="m-0 whitespace-pre-line">{userInfo?.homeAddress}</p>
+            </div>
+          </section>
+          <section className="panel panel-info">
+            <header className="panel-heading">
+              <h3 className="panel-title">{t('personal-information:address.confirm.to')}</h3>
+            </header>
+            <div className="panel-body">
+              <p className="m-0 whitespace-pre-line">{newAddress?.homeAddress}</p>
+            </div>
+          </section>
         </div>
 
         <h2>{t('personal-information:address.confirm.changed-mailing')}</h2>
-        <div className="row mrgn-tp-sm">
-          <div className="col-sm-6">
-            <section className="panel panel-info">
-              <header className="panel-heading">
-                <h3 className="panel-title">{t('personal-information:address.confirm.from')}</h3>
-              </header>
-              <div className="panel-body">
-                <p>{loaderData.userInfo?.mailingAddress}</p>
-              </div>
-            </section>
-          </div>
-
-          <div className="col-sm-6">
-            <section className="panel panel-info">
-              <header className="panel-heading">
-                <h4 className="panel-title">{t('personal-information:address.confirm.to')}</h4>
-              </header>
-              <div className="panel-body">
-                <p>{loaderData.newAddress?.mailingAddress}</p>
-              </div>
-            </section>
-          </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <section className="panel panel-info">
+            <header className="panel-heading">
+              <h3 className="panel-title">{t('personal-information:address.confirm.from')}</h3>
+            </header>
+            <div className="panel-body">
+              <p className="m-0 whitespace-pre-line">{userInfo?.mailingAddress}</p>
+            </div>
+          </section>
+          <section className="panel panel-info">
+            <header className="panel-heading">
+              <h4 className="panel-title">{t('personal-information:address.confirm.to')}</h4>
+            </header>
+            <div className="panel-body">
+              <p className="m-0 whitespace-pre-line">{newAddress?.mailingAddress}</p>
+            </div>
+          </section>
         </div>
 
         <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
## Pull Request

### Description

Add style to addresses with the usage of Tailwind CSS class `whitespace-pre-line` to preserve newlines but not spaces within an element. Text will be wrapped normally.

### Related Azure Boards Work Items

[AB#2767](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2767) & [AB#2700](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2700)

### Screenshots (if applicable)

Before:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/6ac6bc0a-fd5f-4ce5-957a-fc0cfa9f4b83)

After:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/5c3a0560-995c-4e6a-b7a8-f595e269cdca)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] All new and existing tests passed.

### Test Instructions

- Go to `/personal-information` route and the addresses should wrap if the content have newlines.
- Go to `/personal-information/address/confirm` route and the addresses should wrap if the content have newlines.

### Additional Notes

Tailwind CSS [Pre Line](https://tailwindcss.com/docs/whitespace#pre-line)