### PR TITLE
Add InputTextarea

### DIFF
--- a/frontend/__tests__/components/input-textarea.test.tsx
+++ b/frontend/__tests__/components/input-textarea.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { InputTextarea } from '~/components/input-textarea';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('InputTextarea', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should render', async () => {
+    render(<InputTextarea id="test-id" name="test" label="label test" defaultValue="default value" />);
+
+    const actual: HTMLInputElement = screen.getByTestId('input-textarea');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('default value');
+    expect(actual).not.toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with help message', async () => {
+    render(<InputTextarea id="test-id" name="test" label="label test" defaultValue="default value" helpMessage="help message" />);
+
+    const actual = screen.getByTestId('input-textarea');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleDescription('help message');
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('default value');
+    expect(actual).not.toBeRequired();
+  });
+
+  it('should render with help message secondary', async () => {
+    render(<InputTextarea id="test-id" name="test" label="label test" defaultValue="default value" helpMessageSecondary="help message secondary" />);
+
+    const actual = screen.getByTestId('input-textarea');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleDescription('help message secondary');
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('default value');
+    expect(actual).not.toBeRequired();
+  });
+
+  it('should render with required', async () => {
+    render(<InputTextarea id="test-id" name="test" label="label test" defaultValue="default value" required />);
+
+    const actual = screen.getByTestId('input-textarea');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test (input-label.required)');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('default value');
+    expect(actual).toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with error message', async () => {
+    render(<InputTextarea id="test-id" name="test" label="label test" defaultValue="default value" errorMessage="error message" />);
+
+    const actual = screen.getByTestId('input-textarea');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toBeInvalid();
+    expect(actual).toHaveAccessibleErrorMessage('error message');
+  });
+});

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -1,0 +1,74 @@
+import { forwardRef } from 'react';
+
+import clsx from 'clsx';
+
+import { InputError } from './input-error';
+import { InputHelp } from './input-help';
+import { InputLabel } from '~/components/input-label';
+
+export interface InputTextareaProps extends Omit<React.ComponentProps<'textarea'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
+  errorMessage?: string;
+  helpMessage?: React.ReactNode;
+  helpMessageSecondary?: React.ReactNode;
+  id: string;
+  label: string;
+  name: string;
+}
+
+const InputTextarea = forwardRef<HTMLTextAreaElement, InputTextareaProps>((props, ref) => {
+  const { errorMessage, className, helpMessage, helpMessageSecondary, id, label, required, rows, ...restInputProps } = props;
+
+  const inputErrorId = `input-${id}-error`;
+  const inputHelpMessageId = `input-${id}-help`;
+  const inputHelpMessageSecondaryId = `input-${id}-help-secondary`;
+  const inputLabelId = `input-${id}-label`;
+  const inputWrapperId = `input-${id}`;
+
+  function getAriaDescribedby() {
+    const ariaDescribedby = [];
+    if (helpMessage) ariaDescribedby.push(inputHelpMessageId);
+    if (helpMessageSecondary) ariaDescribedby.push(inputHelpMessageSecondaryId);
+    return ariaDescribedby.length > 0 ? ariaDescribedby.join(' ') : undefined;
+  }
+
+  return (
+    <div id={inputWrapperId} data-testid={inputWrapperId} className="form-group">
+      <InputLabel id={inputLabelId} htmlFor={id} required={required}>
+        {label}
+      </InputLabel>
+      {errorMessage && (
+        <InputError id={inputErrorId} className="mb-1.5">
+          {errorMessage}
+        </InputError>
+      )}
+      {helpMessage && (
+        <InputHelp id={inputHelpMessageId} className="mb-1.5" data-testid="input-textarea-help">
+          {helpMessage}
+        </InputHelp>
+      )}
+      <textarea
+        ref={ref}
+        aria-describedby={getAriaDescribedby()}
+        aria-errormessage={errorMessage ? inputErrorId : undefined}
+        aria-invalid={!!errorMessage}
+        aria-labelledby={inputLabelId}
+        aria-required={required}
+        className={clsx('form-control', className)}
+        data-testid="input-textarea"
+        id={id}
+        required={required}
+        rows={rows ?? 3}
+        {...restInputProps}
+      />
+      {helpMessageSecondary && (
+        <InputHelp id={inputHelpMessageSecondaryId} className="mt-1.5" data-testid="input-textarea-help-secondary">
+          {helpMessageSecondary}
+        </InputHelp>
+      )}
+    </div>
+  );
+});
+
+InputTextarea.displayName = 'InputTextarea';
+
+export { InputTextarea };

--- a/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
@@ -4,7 +4,7 @@ import { Form, Link, useActionData, useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import { InputField } from '~/components/input-field';
+import { InputTextarea } from '~/components/input-textarea';
 import { addressValidationService } from '~/services/address-validation-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
@@ -38,8 +38,16 @@ export async function action({ request }: ActionFunctionArgs) {
   const isValidAddress = (val: string) => val && addressValidationService.isValidAddress(val);
 
   const formDataSchema = z.object({
-    homeAddress: z.string().min(1, { message: 'empty-home-address' }).refine(isValidAddress, { message: 'invalid-home-address' }),
-    mailingAddress: z.string().min(1, { message: 'empty-mailing-address' }).refine(isValidAddress, { message: 'invalid-mailing-address' }),
+    homeAddress: z
+      .string()
+      .min(1, { message: 'empty-home-address' })
+      .refine(isValidAddress, { message: 'invalid-home-address' })
+      .transform((val) => val.trim()),
+    mailingAddress: z
+      .string()
+      .min(1, { message: 'empty-mailing-address' })
+      .refine(isValidAddress, { message: 'invalid-mailing-address' })
+      .transform((val) => val.trim()),
   });
 
   const formData = Object.fromEntries(await request.formData());
@@ -99,7 +107,7 @@ export default function ChangeAddress() {
         {t('personal-information:address.edit.page-title')}
       </h1>
       <Form method="post">
-        <InputField
+        <InputTextarea
           id="home-address"
           label={t('personal-information:address.edit.home-address')}
           name="homeAddress"
@@ -108,7 +116,7 @@ export default function ChangeAddress() {
           defaultValue={defaultValues.homeAddress}
           errorMessage={getErrorMessage(errorMessages.homeAddress)}
         />
-        <InputField
+        <InputTextarea
           id="mailing-address"
           label={t('personal-information:address.edit.mailing-address')}
           name="mailingAddress"


### PR DESCRIPTION
## Pull Request

### Description

Add InputTextarea component. The `/personal-information/address/edit` requires textarea inputs to add the ability to have the addresses on multiple lines.

### Related Azure Boards Work Items

[AB#2767](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2767)

### Screenshots (if applicable)

Before
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/03b18723-765e-4e94-90b3-f5187d2bea23)

After
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/69fddc76-8e27-4c70-be9d-477b3051514c)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Test Instructions

Go to `/personal-information/address/edit` and you should be able to edit the addresses with a textarea.