### PR TITLE
AB#2659 -- refactoring

### DIFF
--- a/frontend/app/routes/auth.callback.$providerId.tsx
+++ b/frontend/app/routes/auth.callback.$providerId.tsx
@@ -1,19 +1,11 @@
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 
-import { raoidcService } from '~/services/raoidc-service.server';
+import { getRaoidcService } from '~/services/raoidc-service.server';
 import { sessionService } from '~/services/session-service.server';
-import { getLogger } from '~/utils/logging.server';
 import { generateCallbackUri } from '~/utils/raoidc-utils.server';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const log = getLogger('auth.login');
-
-  if (!raoidcService) {
-    log.warn('Call to /auth/callback/%s but authentication is disabled', params.providerId);
-    // TODO :: GjB :: handle this better than just throwing an error
-    throw new Error('RAOIDC service not configured');
-  }
-
+  const raoidcService = await getRaoidcService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const codeVerifier = session.get('codeVerifier');
   const state = session.get('state');

--- a/frontend/app/routes/auth.login.$providerId.tsx
+++ b/frontend/app/routes/auth.login.$providerId.tsx
@@ -1,8 +1,7 @@
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 
-import { raoidcService } from '~/services/raoidc-service.server';
+import { getRaoidcService } from '~/services/raoidc-service.server';
 import { sessionService } from '~/services/session-service.server';
-import { getLogger } from '~/utils/logging.server';
 import { generateCallbackUri } from '~/utils/raoidc-utils.server';
 
 /**
@@ -10,16 +9,10 @@ import { generateCallbackUri } from '~/utils/raoidc-utils.server';
  * back to the browser to initiate the login process.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const log = getLogger('auth.login');
-
-  if (!raoidcService) {
-    log.warn('Call to /auth/login/%s but authentication is disabled', params.providerId);
-    // TODO :: GjB :: handle this better than just throwing an error
-    throw new Error('RAOIDC service not configured');
-  }
+  const raoidcService = await getRaoidcService();
 
   const redirectUri = generateCallbackUri(new URL(request.url).origin, params.providerId);
-  const { authUrl, codeVerifier, state } = raoidcService.generateAuthRequest(redirectUri);
+  const { authUrl, codeVerifier, state } = raoidcService.generateSigninRequest(redirectUri);
 
   // codeVerifier and state will have to be validated in the callback handler
   const session = await sessionService.getSession(request.headers.get('Cookie'));

--- a/frontend/app/services/raoidc-service.server.ts
+++ b/frontend/app/services/raoidc-service.server.ts
@@ -1,39 +1,66 @@
 /**
- * RAOIDC Service is a service module responsible for managing authentication with RAOIDC.
+ * The RAOIDC Service module is responsible for all RAOIDC interactions in the
+ * application. It exports a single getRaoidcService() factory function that
+ * should be used to get an instance of the service.
+ *
+ * The service exports three functions for making calls to the downstream RAOIDC
+ * service:
+ *
+ *   - generateSigninRequest() -- generates a standard OIDC signing request
+ *   - handleCallback() -- handles the OIDC callback request
+ *   - handleLogout() -- handles an RAOIDC logout
+ *
+ * If an HTTP proxy is configured (via the AUTH_RAOIDC_PROXY_URL environment
+ * variable), the service will make all RAOIDC calls with a custom fetch()
+ * function that uses that HTTP proxy. This is most commonly used during
+ * development, when the nonprod RAOIDC instance is not accessible outside of
+ * the ESDC network.
+ *
+ * The service module memoizes the service instance once it is successfully
+ * initialized. This ensures that only a single instance of the service is
+ * created for the application.
  */
-import { createHash, subtle } from 'node:crypto';
+import moize from 'moize';
+import { subtle } from 'node:crypto';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
 import { toNodeReadable } from 'web-streams-node';
 
-import { privateKeyPemToCryptoKey } from '~/utils/crypto-utils.server';
+import { generateJwkId, privateKeyPemToCryptoKey } from '~/utils/crypto-utils.server';
 import { getEnv } from '~/utils/env.server';
+import { getLogger } from '~/utils/logging.server';
 import { type ClientMetadata, type FetchFunctionInit, fetchAccessToken, fetchServerMetadata, fetchUserInfo, generateAuthorizationRequest, generateCodeChallenge, generateRandomState } from '~/utils/raoidc-utils.server';
 
-const { AUTH_ENABLED } = getEnv();
+const log = getLogger('raoidc-service.server');
 
+/**
+ * Return a singleton instance (by means of memomization) of the RAOIDC service.
+ */
+export const getRaoidcService = moize.promise(createRaoidcService, { onCacheAdd: () => log.info('Creating new RAOIDC service') });
+
+/**
+ * Create and intialize an instance of the RAOID service.
+ */
 async function createRaoidcService() {
-  const { AUTH_JWT_PRIVATE_KEY } = getEnv();
-  const { AUTH_RAOIDC_BASE_URL, AUTH_RAOIDC_CLIENT_ID, AUTH_RAOIDC_PROXY_URL } = getEnv();
-
+  const { AUTH_JWT_PRIVATE_KEY, AUTH_RAOIDC_BASE_URL, AUTH_RAOIDC_CLIENT_ID, AUTH_RAOIDC_PROXY_URL } = getEnv();
   const fetchFn = getFetchFn(AUTH_RAOIDC_PROXY_URL);
-  const { jwkSet: serverJwkSet, serverMetadata } = await fetchServerMetadata(AUTH_RAOIDC_BASE_URL, fetchFn);
+  const { jwkSet, serverMetadata } = await fetchServerMetadata(AUTH_RAOIDC_BASE_URL, fetchFn);
 
   /**
-   * Generates an OAuth authentication request. Used to kickstart the OAuth login process.
+   * Generates an OIDC signin request.
+   * Used to kickstart the OIDC login process.
    */
-  function generateAuthRequest(redirectUri: string) {
+  function generateSigninRequest(redirectUri: string) {
     const { codeChallenge, codeVerifier } = generateCodeChallenge();
     const clientId = AUTH_RAOIDC_CLIENT_ID;
     const scope = 'openid profile';
     const state = generateRandomState();
-
     const authUrl = generateAuthorizationRequest(serverMetadata.authorization_endpoint, clientId, codeChallenge, redirectUri, scope, state);
 
     return { authUrl, codeVerifier, state };
   }
 
   /**
-   * Handle an OAuth login callback.
+   * Handle an OIDC login callback.
    */
   async function handleCallback(request: Request, codeVerifier: string, expectedState: string, redirectUri: string) {
     const authCode = new URL(request.url).searchParams.get('code');
@@ -45,7 +72,7 @@ async function createRaoidcService() {
     }
 
     if (!authCode) {
-      throw new Error('Missing authcode in response');
+      throw new Error('Missing authorization code in response');
     }
 
     if (state !== expectedState) {
@@ -61,35 +88,34 @@ async function createRaoidcService() {
       privateKeyId: privateKeyId,
     };
 
-    const authTokenSet = await fetchAccessToken(serverMetadata, serverJwkSet, authCode, client, codeVerifier, redirectUri, fetchFn);
+    const authTokenSet = await fetchAccessToken(serverMetadata, jwkSet, authCode, client, codeVerifier, redirectUri, fetchFn);
     const userInfo = await fetchUserInfo(serverMetadata.userinfo_endpoint, authTokenSet.access_token, client, fetchFn);
 
     return { auth: authTokenSet, user_info: userInfo };
   }
 
-  /**
-   * Generate a key id from the modulus of a jwk.
-   */
-  function generateJwkId(jwk: JsonWebKey) {
-    return createHash('md5')
-      .update(jwk.n ?? '')
-      .digest('hex');
+  async function handleLogout() {
+    /* TODO :: GjB :: implement logout */
+    throw new Error('Not yet implemented');
   }
 
+  /**
+   * Return a custom fetch() function if a proxy URL has been provided.
+   * If no proxy has been provided, simply return global.fetch().
+   */
   function getFetchFn(proxyUrl?: string) {
     if (proxyUrl) {
+      log.debug('A proxy has been configured: [%s]; using custom fetch for RAOIDC calls', proxyUrl);
       return async (input: string | URL, init?: FetchFunctionInit) => {
-        const dispatcher = new ProxyAgent({ uri: proxyUrl, proxyTls: { timeout: 30000 } });
+        const dispatcher = new ProxyAgent({ uri: proxyUrl, proxyTls: { timeout: 30000 } }); // TODO :: GjB :: make timeout configurable?
         const response = await undiciFetch(input, { ...init, dispatcher });
         return new Response(toNodeReadable(response.body));
       };
     }
 
-    return async (input: string | URL, init?: FetchFunctionInit) => fetch(input, init);
+    log.debug('No proxy configured; using global fetch for RAOIDC calls');
+    return global.fetch;
   }
 
-  return { generateAuthRequest, handleCallback };
+  return { generateSigninRequest, handleCallback, handleLogout };
 }
-
-// TODO :: GjB :: this seems wrong; is there a better way to avoid creating the service if AUTH_ENABLED is false?
-export const raoidcService = AUTH_ENABLED ? await createRaoidcService() : undefined;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "isbot": "^4.4.0",
         "jose": "^5.2.0",
         "libphonenumber-js": "^1.10.54",
+        "moize": "^6.1.6",
         "morgan": "^1.10.0",
         "msw": "^2.1.5",
         "patch-package": "^8.0.0",
@@ -6711,6 +6712,11 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-3.0.3.tgz",
+      "integrity": "sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -9356,6 +9362,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/micro-memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.1.2.tgz",
+      "integrity": "sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g=="
+    },
     "node_modules/micromark": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
@@ -10215,6 +10226,15 @@
       "resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.0.1.tgz",
       "integrity": "sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA==",
       "dev": true
+    },
+    "node_modules/moize": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-6.1.6.tgz",
+      "integrity": "sha512-vSKdIUO61iCmTqhdoIDrqyrtp87nWZUmBPniNjO0fX49wEYmyDO4lvlnFXiGcaH1JLE/s/9HbiK4LSHsbiUY6Q==",
+      "dependencies": {
+        "fast-equals": "^3.0.1",
+        "micro-memoize": "^4.1.2"
+      }
     },
     "node_modules/morgan": {
       "version": "1.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "isbot": "^4.4.0",
     "jose": "^5.2.0",
     "libphonenumber-js": "^1.10.54",
+    "moize": "^6.1.6",
     "morgan": "^1.10.0",
     "msw": "^2.1.5",
     "patch-package": "^8.0.0",


### PR DESCRIPTION
### Description

Refactoring of `raoidc-service.server.ts`. Changes include:

- introduce `getRaoidcService()` factory function to ensure lazy-initialization of service
- introduce memozation of `createRaoidcService()` function to ensure only a single instance of the service is ever created
- remove some now-unnecessary feature flag checks in the auth routes

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)

### Checklist

- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] All new and existing tests passed.

### Test Instructions

There is no easy way to test this (yet) without doing some kubernetes port forwarding and proxy setups.
