### PR TITLE
Add ErrorSummary component

### DIFF
--- a/frontend/__tests__/utils/link-utils.test.tsx
+++ b/frontend/__tests__/utils/link-utils.test.tsx
@@ -1,0 +1,92 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
+
+const scrollIntoViewMock = vi.fn();
+Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+describe('scrollAndFocusFromAnchorLink', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should scroll and focus on the target element', async () => {
+    const { findByTestId } = render(
+      <h1 id="heading" tabIndex={-1} data-testid="heading">
+        heading
+      </h1>,
+    );
+
+    const actual = await waitFor(() => findByTestId('heading'));
+    const spyFocus = vi.spyOn(actual, 'focus');
+
+    const url = new URL(window.location.href);
+    url.hash = 'heading';
+    scrollAndFocusFromAnchorLink(url.toString());
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveFocus();
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(spyFocus).toHaveBeenCalled();
+  });
+
+  it("should not scroll and focus on the target element when href can't be parsed", async () => {
+    const { findByTestId } = render(
+      <h1 id="heading" tabIndex={-1} data-testid="heading">
+        heading
+      </h1>,
+    );
+
+    const actual = await waitFor(() => findByTestId('heading'));
+    const spyFocus = vi.spyOn(actual, 'focus');
+
+    scrollAndFocusFromAnchorLink('not-parsable-href');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).not.toHaveFocus();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(spyFocus).not.toHaveBeenCalled();
+  });
+
+  it('should not scroll and focus on the target element when href have no hash', async () => {
+    const { findByTestId } = render(
+      <h1 id="heading" tabIndex={-1} data-testid="heading">
+        heading
+      </h1>,
+    );
+
+    const actual = await waitFor(() => findByTestId('heading'));
+    const spyFocus = vi.spyOn(actual, 'focus');
+
+    const url = new URL(window.location.href);
+    url.hash = '';
+    scrollAndFocusFromAnchorLink(url.toString());
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).not.toHaveFocus();
+    expect(spyFocus).not.toHaveBeenCalled();
+  });
+
+  it("should not scroll and focus on the target element when element can't be found", async () => {
+    const { findByTestId } = render(
+      <h1 id="heading" tabIndex={-1} data-testid="heading">
+        heading
+      </h1>,
+    );
+
+    const actual = await waitFor(() => findByTestId('heading'));
+    const spyFocus = vi.spyOn(actual, 'focus');
+
+    const url = new URL(window.location.href);
+    url.hash = 'retemele';
+    scrollAndFocusFromAnchorLink(url.toString());
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).not.toHaveFocus();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(spyFocus).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -1,0 +1,120 @@
+import { type MouseEvent } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
+
+/**
+ * Represents an item in an error summary, containing information about
+ * an error message and the associated field ID where the error occurred.
+ */
+export interface ErrorSummaryItem {
+  errorMessage: string;
+  feildId: string;
+}
+
+/**
+ * Creates an ErrorSummaryItem with the specified field ID and error message.
+ *
+ * @param feildId - The field ID where the error occurred.
+ * @param errorMessage - The error message describing the issue.
+ * @returns An object of type ErrorSummaryItem.
+ */
+export function createErrorSummaryItem(feildId: string, errorMessage: string) {
+  return {
+    errorMessage,
+    feildId,
+  } as const satisfies ErrorSummaryItem;
+}
+
+/**
+ * Creates an array of ErrorSummaryItems based on the provided object, which
+ * represents field IDs and their associated error messages.
+ *
+ * @param obj - A record containing field IDs and associated error messages.
+ * @returns An array of ErrorSummaryItems.
+ */
+export function createErrorSummaryItems(obj: Record<string, string | undefined>) {
+  return Object.keys(obj)
+    .map((key) => {
+      const value = obj[key];
+      if (!value) return undefined;
+      return createErrorSummaryItem(key, value);
+    })
+    .filter((item): item is ErrorSummaryItem => item !== undefined);
+}
+
+/**
+ * Checks if there are any errors in the provided object by examining the
+ * existence and truthiness of error messages associated with field IDs.
+ *
+ * @param obj - A record containing field IDs and associated error messages.
+ * @returns True if there are errors, false otherwise.
+ */
+export function hasErrors(obj: Record<string, string | undefined>) {
+  return (
+    obj &&
+    Object.keys(obj)
+      .map((key) => obj[key])
+      .filter(Boolean).length > 0
+  );
+}
+
+/**
+ * Scrolls the page to the specified error summary section identified by the given errorSummaryId
+ * and focuses on it by updating the URL hash accordingly.
+ *
+ * @param errorSummaryId - The identifier of the error summary section to scroll and focus on.
+ */
+export function scrollAndFocusToErrorSummary(errorSummaryId: string) {
+  // Create a new URL object based on the current window location
+  const url = new URL(window.location.href);
+
+  // Update the URL hash to point to the specified errorSummaryId
+  url.hash = errorSummaryId;
+
+  // Use the scrollAndFocusFromAnchorLink function to handle scrolling and focusing
+  scrollAndFocusFromAnchorLink(url.toString());
+}
+
+/**
+ * Props for the ErrorSummary component.
+ */
+export interface ErrorSummaryProps {
+  errors: ErrorSummaryItem[];
+  id: string;
+}
+
+/**
+ * ErrorSummary component displays a list of errors with associated field IDs
+ * and provides anchor links for users to navigate to specific error messages.
+ */
+export function ErrorSummary({ errors, id }: ErrorSummaryProps) {
+  const { t } = useTranslation(['gcweb']);
+
+  /**
+   * Handles click events on anchor links, preventing the default behavior and
+   * scrolling and focusing on the associated error message.
+   */
+  function handleOnAnchorLinkClick(e: MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    scrollAndFocusFromAnchorLink(e.currentTarget.href);
+  }
+
+  return (
+    <section id={id} className="my-5 space-y-3 border-l-[6px] border-[#d3080c] p-5" tabIndex={-1}>
+      <h2 className="m-0 text-2xl font-bold">{t('gcweb:error-summary.header', { count: errors.length })}</h2>
+      {errors.length > 0 && (
+        <ul className="m-0 list-disc space-y-2 pl-10 ">
+          {errors.map(({ feildId, errorMessage }) => (
+            <li key={feildId}>
+              <a href={`#${feildId}`} onClick={handleOnAnchorLinkClick}>
+                {errorMessage}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -44,7 +44,7 @@ const InputRadios = ({ errorMessage, helpMessage, helpMessageSecondary, id, lege
           const inputRadioId = `${id}-option-${index}`;
           return (
             <li key={inputRadioId} className="radio">
-              <InputRadio aria-describedby={getAriaDescribedby()} aria-errormessage={errorMessage ? inputErrorId : undefined} aria-invalid={!!errorMessage} aria-required={required} id={inputRadioId} name={name} required={required} {...option} />
+              <InputRadio aria-describedby={getAriaDescribedby()} aria-errormessage={errorMessage && inputErrorId} aria-invalid={!!errorMessage} aria-required={required} id={inputRadioId} name={name} required={required} {...option} />
             </li>
           );
         })}

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -49,7 +49,7 @@ const InputTextarea = forwardRef<HTMLTextAreaElement, InputTextareaProps>((props
       <textarea
         ref={ref}
         aria-describedby={getAriaDescribedby()}
-        aria-errormessage={errorMessage ? inputErrorId : undefined}
+        aria-errormessage={errorMessage && inputErrorId}
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -26,7 +26,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (!userInfo) {
     throw new Response(null, { status: 404 });
   }
-  const preferredLanguage = userInfo.preferredLanguage ? await lookupService.getPreferredLanguage(userInfo?.preferredLanguage) : undefined;
+  const preferredLanguage = userInfo.preferredLanguage && (await lookupService.getPreferredLanguage(userInfo?.preferredLanguage));
 
   return json({ user: userInfo, preferredLanguage });
 }

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 
 import { type LinksFunction } from '@remix-run/node';
 import { Link, Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
@@ -7,6 +7,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import cdcpStylesheet from '~/cdcp.css';
 import { LanguageSwitcher } from '~/components/language-switcher';
+import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier } from '~/utils/route-utils';
 
@@ -61,17 +62,22 @@ function ApplicationLayout({ children }: { children?: ReactNode }) {
 function PageHeader() {
   const { i18n, t } = useTranslation(i18nNamespaces);
 
+  function handleOnSkipLinkClick(e: MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    scrollAndFocusFromAnchorLink(e.currentTarget.href);
+  }
+
   return (
     <>
       <nav>
         <ul id="wb-tphp">
           <li className="wb-slc">
-            <a className="wb-sl" href="#wb-cont">
+            <a className="wb-sl" href="#wb-cont" onClick={handleOnSkipLinkClick}>
               {t('gcweb:nav.skip-to-content')}
             </a>
           </li>
           <li className="wb-slc visible-sm visible-md visible-lg">
-            <a className="wb-sl" href="#wb-info">
+            <a className="wb-sl" href="#wb-info" onClick={handleOnSkipLinkClick}>
               {t('gcweb:nav.skip-to-about')}
             </a>
           </li>

--- a/frontend/app/utils/link-utils.ts
+++ b/frontend/app/utils/link-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Scrolls and focuses on the element identified by the anchor link's hash.
+ *
+ * @param {string} href - The anchor link URL.
+ */
+export function scrollAndFocusFromAnchorLink(href: string): void {
+  if (!URL.canParse(href)) return;
+
+  const { hash } = new URL(href);
+  if (!hash) return;
+
+  const targetElement = document.querySelector<HTMLElement>(hash);
+  if (!targetElement) return;
+
+  targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  targetElement.focus();
+}

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -51,5 +51,9 @@
   },
   "input-legend": {
     "required": "required"
+  },
+  "error-summary": {
+    "header_one": "The following error was found in the form:",
+    "header_other": "The following {{count}} errors were found in the form:"
   }
 }

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -51,5 +51,9 @@
   },
   "input-legend": {
     "required": "requis"
+  },
+  "error-summary": {
+    "header_one": "L'erreur suivante a été trouvée dans le formulaire\u00a0:",
+    "header_other": "Les {{count}} erreurs suivantes ont été trouvées dans le formulaire\u00a0:"
   }
 }


### PR DESCRIPTION
## Pull Request

### Description

Add ErrorSummary component and integrate it in phone number and addresses edit routes. If the error summary links are clicked then the matching url's hash will be used to scroll and focus the related element with his matching id.

### Related Azure Boards Work Items

- [AB#2864](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2864)

### Screenshots (if applicable)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/09f9b019-d149-491b-8dc2-cbc405c82a23)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Test Instructions

Go on `/personal-information/phone-number/edit` route and enter an invalid phone number. Click on the summary error link and the input should be scrolled into view and focused.

### Additional Notes

I needed to customize the default behavior of the browser hash anchor link due to Remix's interference when the URL changes, causing the loss of state and the disappearance of error messages. To address this, I implemented a handler function for the anchor's `onclick` event, which cancels the default behavior and manages scrolling and focusing manually.