### PR TITLE
AB#2886 -- Creating fake address entities and mocking endpoint for getting an address

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -6,7 +6,6 @@ import { factory, primaryKey } from '@mswjs/data';
 faker.seed(123);
 
 const phoneFormat = '([0-9]{3}) [0-9]{3}-[0-9]{4}';
-const fullAddressFormat = '{{location.street}} {{location.buildingNumber}} {{location.secondaryAddress}}\n{{location.city}} {{location.state}} {{location.zipCode}}';
 
 const db = factory({
   user: {
@@ -14,9 +13,19 @@ const db = factory({
     firstName: faker.person.firstName,
     lastName: faker.person.lastName,
     phoneNumber: () => faker.helpers.fromRegExp(phoneFormat),
-    homeAddress: () => faker.helpers.fake(fullAddressFormat),
-    mailingAddress: () => faker.helpers.fake(fullAddressFormat),
+    homeAddress: () => 'home-address-id',
+    mailingAddress: () => 'mailing-address-id',
     preferredLanguage: () => faker.helpers.arrayElement(['en', 'fr']),
+  },
+  // address field names are based off of Power Platform API elements
+  address: {
+    id: primaryKey(String),
+    addressApartmentUnitNumber: faker.location.buildingNumber,
+    addressStreet: faker.location.street,
+    addressCity: faker.location.city,
+    addressProvince: faker.location.state,
+    addressPostalZipCode: faker.location.zipCode,
+    addressCountry: () => 'Canada',
   },
   preferredLanguage: {
     id: primaryKey(String),
@@ -36,6 +45,15 @@ db.preferredLanguage.create({
   id: 'fr',
   nameEn: 'French',
   nameFr: 'Français',
+});
+
+// seed avaliable addresses (before user)
+db.address.create({
+  id: 'home-address-id',
+});
+
+db.address.create({
+  id: 'mailing-address-id',
 });
 
 // seed users


### PR DESCRIPTION
## Pull Request

### Description
- Using faker to create two new address entities in `mocks/db.ts` to represent a user's home and mailing address
- Exposing an example endpoint that retrieves a specific address given an address identifier in `mocks/node.ts`

### Related Azure Boards Work Items
[AB#2886](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2886)

### Checklist
- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [x] I have updated the documentation if necessary.
- [x] All new and existing tests passed.

### Test Instructions
This is an incremental PR and as such, the only way to confirm it works is by checking that the address identifiers display in the Address panel on `/personal-information`.

### Additional Notes
This PR will result in the address identifier being shown instead of the previous home and mailing address strings. This will be resolved in future PRs.