### PR TITLE
AB#2770 -- Creating Address component to be used within Personal Information section

### DIFF
--- a/frontend/__tests__/components/address.test.tsx
+++ b/frontend/__tests__/components/address.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { Address } from '~/components/address';
+
+expect.extend(toHaveNoViolations);
+
+describe('Address', () => {
+  it('should render country when not a Canadian address', async () => {
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual).toHaveTextContent('USA');
+  });
+
+  it('should not render country when address is Canadian', async () => {
+    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual).not.toHaveTextContent('Canada');
+  });
+
+  it('should not have any a11y issues', async () => {
+    const { container } = render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -1,0 +1,37 @@
+import type { ComponentProps } from 'react';
+
+import clsx from 'clsx';
+
+export interface AddressProps extends ComponentProps<'address'> {
+  address: string;
+  city: string;
+  provinceState?: string;
+  postalZipCode?: string;
+  country: string;
+}
+
+function formatAddress({ address, city, provinceState, postalZipCode, country }: AddressProps): string {
+  // TODO 'canada' shouldn't be hardcoded as we may deal with different values of the country field such as abbreviations
+  const isNotCanadianAddress = 'canada' !== country.toLowerCase();
+
+  // prettier-ignore
+  const lines = [`${address}`, 
+    `${city}${provinceState ? ` ${provinceState}` : ''}${postalZipCode ? `  ${postalZipCode}` : ''}`, 
+    `${isNotCanadianAddress ? country : ''}`];
+
+  return lines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function Address(props: AddressProps) {
+  const { className, ...restProps } = props;
+  const formattedAddress = formatAddress(props);
+
+  return (
+    <address className={clsx('mb-0 whitespace-pre-wrap', className)} data-testid="address-id" {...restProps}>
+      {formattedAddress}
+    </address>
+  );
+}

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -23,7 +23,7 @@ const db = factory({
     addressApartmentUnitNumber: faker.location.buildingNumber,
     addressStreet: faker.location.street,
     addressCity: faker.location.city,
-    addressProvince: faker.location.state,
+    addressProvince: () => faker.location.state({ abbreviated: true }),
     addressPostalZipCode: faker.location.zipCode,
     addressCountry: () => 'Canada',
   },


### PR DESCRIPTION
### Description
Creating Address component to be used within the "Personal Information" section to provide a common way of rendering an address. Formatting of the address is based off [Canada Post's Address guidelines](https://www.canadapost-postescanada.ca/cpc/en/support/articles/addressing-guidelines/overview.page).

### Related Azure Boards Work Items
[AB#2770](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2770)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e -- run`

### Test Instructions
Run application locally and render the component on any route. For example,
```
<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />
```

### Additional Notes
Component was only tested locally and has not yet been included in any pages.