### PR TITLE
Move the page title at the layout level

### DIFF
--- a/frontend/__tests__/components/page-title.test.tsx
+++ b/frontend/__tests__/components/page-title.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+
+import { describe, expect, it } from 'vitest';
+
+import { PageTitle } from '~/components/page-title';
+
+describe('PageTitle', () => {
+  it('renders children and applies additional props', () => {
+    const mockChildren = 'Hello, World!';
+    const mockAdditionalProps = { className: 'custom-class' };
+
+    const { getByText } = render(<PageTitle {...mockAdditionalProps}>{mockChildren}</PageTitle>);
+
+    const pageTitleElement = getByText(mockChildren);
+
+    expect(pageTitleElement).toBeInTheDocument();
+    expect(pageTitleElement.tagName).toBe('H1');
+    expect(pageTitleElement.textContent).toBe(mockChildren);
+    expect(pageTitleElement).toHaveClass(mockAdditionalProps.className);
+    expect(pageTitleElement).toHaveAttribute('id', 'wb-cont');
+    expect(pageTitleElement).toHaveAttribute('property', 'name');
+  });
+});

--- a/frontend/app/components/page-title.tsx
+++ b/frontend/app/components/page-title.tsx
@@ -1,0 +1,9 @@
+import type { ComponentProps } from 'react';
+
+export function PageTitle({ children, ...restProps }: Omit<ComponentProps<'h1'>, 'id' | 'property'>) {
+  return (
+    <h1 id="wb-cont" property="name" {...restProps}>
+      {children}
+    </h1>
+  );
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -10,7 +10,7 @@ import { NonceContext } from '~/components/nonce-context';
 import stylesheet from '~/tailwind.css';
 import { readBuildInfo } from '~/utils/build-info.server';
 import { getEnv, getPublicEnv } from '~/utils/env.server';
-import { useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
+import { useDocumentTitleI18nKey, useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
 
 export const links = () => [{ rel: 'stylesheet', href: stylesheet }];
 
@@ -31,18 +31,38 @@ export async function loader({ request }: LoaderFunctionArgs) {
   });
 }
 
+/**
+ * Custom hook to get the translated document title based on internationalization keys.
+ *
+ * @function
+ * @returns {string|undefined} - Translated document title or undefined if no internationalization key is provided.
+ *
+ * @description
+ * This hook initializes the translation function and retrieves internationalization keys for the
+ * document title and page title. It returns the translated document title or undefined if no key is provided.
+ */
+function useDocumentTitle() {
+  const ns = useI18nNamespaces();
+  const { t } = useTranslation(ns);
+  const documentTitleI18nKey = useDocumentTitleI18nKey();
+  const pageTitleI18nKey = usePageTitleI18nKey();
+  const i18nKey = documentTitleI18nKey ?? pageTitleI18nKey;
+  return i18nKey && (t(i18nKey) as string); // as string otherwise it's typeof any
+}
+
 export default function () {
   const { nonce } = useContext(NonceContext);
   const { env, javascriptEnabled } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(useI18nNamespaces());
-  const pageTitleI18nKey = usePageTitleI18nKey();
+  const ns = useI18nNamespaces();
+  const { i18n } = useTranslation(ns);
+  const documentTitle = useDocumentTitle();
 
   return (
     <html lang={i18n.language}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{pageTitleI18nKey && t(pageTitleI18nKey)}</title>
+        <title>{documentTitle}</title>
         <Meta />
         <Links />
       </head>

--- a/frontend/app/routes/_gcweb-app.$.tsx
+++ b/frontend/app/routes/_gcweb-app.$.tsx
@@ -3,14 +3,15 @@ import { Link } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 
+import { PageTitle } from '~/components/page-title';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
 export const handle = {
+  documentTitleI18nKey: 'gcweb:not-found.document-title',
   i18nNamespaces,
   pageIdentifier: 'CDCP-0404',
-  pageTitleI18nKey: 'gcweb:not-found.page-title',
 } as const satisfies RouteHandleData;
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -26,9 +27,9 @@ export default function NotFound() {
 
   return (
     <>
-      <h1>
-        <span>{t('gcweb:not-found.page-header')}</span> <small className="help-inline">{t('gcweb:not-found.page-subheader')}</small>
-      </h1>
+      <PageTitle>
+        <span>{t('gcweb:not-found.page-title')}</span> <small className="help-inline">{t('gcweb:not-found.page-subtitle')}</small>
+      </PageTitle>
       <p>{t('gcweb:not-found.page-message')}</p>
       <ul>
         <li>

--- a/frontend/app/routes/_gcweb-app._index.tsx
+++ b/frontend/app/routes/_gcweb-app._index.tsx
@@ -34,9 +34,6 @@ export default function Index() {
   const { t } = useTranslation(i18nNamespaces);
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('index:page-title')}
-      </h1>
       <p>{t('index:welcome', { firstName: userInfo.firstName, lastName: userInfo.lastName })}</p>
       <div className="grid gap-4 md:grid-cols-2">
         <LandingPageLink title={t('index:personal-info')} to="/personal-information">

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -37,9 +37,6 @@ export default function PersonalInformationIndex() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:index.page-title')}
-      </h1>
       <p>{t('personal-information:index.on-file')}</p>
       <div className="grid gap-6 md:grid-cols-2">
         <PersonalInformationSection title={t('personal-information:index.full-name')} icon="glyphicon-user">

--- a/frontend/app/routes/_gcweb-app.personal-information.address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.confirm.tsx
@@ -42,9 +42,6 @@ export default function ConfirmAddress() {
   const { t } = useTranslation(i18nNamespaces);
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:address.confirm.change-address')}
-      </h1>
       <Form method="post">
         <h2>{t('personal-information:address.confirm.changed-address')}</h2>
         <div className="grid gap-6 md:grid-cols-2">

--- a/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.address.edit.tsx
@@ -115,9 +115,6 @@ export default function PersonalInformationAddressEdit() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:address.edit.page-title')}
-      </h1>
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
       <Form className="max-w-prose" method="post">
         <InputTextarea className="!w-full" defaultValue={defaultValues.homeAddress} errorMessage={errorMessages.homeAddress} id="homeAddress" label={t('personal-information:address.edit.home-address')} name="homeAddress" required />

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -46,9 +46,6 @@ export default function ConfirmAddress() {
   const { t } = useTranslation(i18nNamespaces);
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:home-address.confirm.page-title')}
-      </h1>
       <Form method="post">
         <h2>{t('personal-information:home-address.confirm.change-of-address')}</h2>
         <div className="grid gap-6 md:grid-cols-2">

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -104,9 +104,6 @@ export default function ChangeAddress() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:home-address.edit.page-title')}
-      </h1>
       <Form method="post">
         <InputField id="unit" label="Unit" name="addressApartmentUnitNumber" defaultValue={defaultValues.addressApartmentUnitNumber} />
         <InputField id="address" label={t('personal-information:home-address.edit.field.address')} name="addressStreet" required defaultValue={defaultValues.addressStreet} />

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
@@ -55,9 +55,6 @@ export default function PhoneNumberConfirm() {
   const { t } = useTranslation(i18nNamespaces);
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:phone-number.confirm.page-title')}
-      </h1>
       <p>{t('personal-information:phone-number.confirm.confirm-message')}</p>
       <Form method="post">
         <div className="form-group">

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
@@ -105,9 +105,6 @@ export default function PhoneNumberEdit() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:phone-number.edit.page-title')}
-      </h1>
       <p>{t('personal-information:phone-number.edit.update-message')}</p>
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
       <Form method="post">

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
@@ -46,9 +46,6 @@ export default function PreferredLanguageConfirm() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:preferred-language.confirm.page-title')}
-      </h1>
       <p>{t('personal-information:preferred-language.confirm.confirm-message')}</p>
       <Form method="post">
         <dl>

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -65,9 +65,6 @@ export default function PreferredLanguageEdit() {
 
   return (
     <>
-      <h1 id="wb-cont" property="name">
-        {t('personal-information:preferred-language.edit.page-title')}
-      </h1>
       <Form method="post">
         {preferredLanguages.length > 0 && (
           <InputRadios

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { type LinksFunction } from '@remix-run/node';
 import { Link, Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
@@ -8,8 +8,9 @@ import { Trans, useTranslation } from 'react-i18next';
 import cdcpStylesheet from '~/cdcp.css';
 import { AnchorLink } from '~/components/anchor-link';
 import { LanguageSwitcher } from '~/components/language-switcher';
+import { PageTitle } from '~/components/page-title';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier } from '~/utils/route-utils';
+import { useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey } from '~/utils/route-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -51,6 +52,7 @@ function ApplicationLayout({ children }: { children?: ReactNode }) {
     <>
       <PageHeader />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+        <AppPageTitle />
         {children}
         <PageDetails />
       </main>
@@ -115,6 +117,13 @@ function PageHeader() {
       <Breadcrumbs />
     </>
   );
+}
+
+function AppPageTitle(props: Omit<ComponentProps<typeof PageTitle>, 'children'>) {
+  const { t } = useTranslation(useI18nNamespaces());
+  const pageTitleI18nKey = usePageTitleI18nKey();
+
+  return pageTitleI18nKey && <PageTitle {...props}>{t(pageTitleI18nKey)}</PageTitle>;
 }
 
 function PageDetails() {
@@ -240,7 +249,7 @@ function ServerError({ error }: { error: unknown }) {
     <ApplicationLayout>
       <h1>
         <span className="glyphicon glyphicon-warning-sign mrgn-rght-md"></span>
-        <span>{t('gcweb:server-error.page-header')}</span> <small className="help-inline">{t('gcweb:server-error.page-subheader')}</small>
+        <span>{t('gcweb:server-error.page-title')}</span> <small className="help-inline">{t('gcweb:server-error.page-subtitle')}</small>
       </h1>
       <p>{t('gcweb:server-error.page-message')}</p>
       <ul className="list-disc ps-16">

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -81,6 +81,7 @@ declare global {
    */
   interface RouteHandleData extends Record<string, unknown | undefined> {
     breadcrumbs?: Breadcrumbs;
+    documentTitleI18nKey?: PageTitleI18nKey;
     i18nNamespaces?: I18nNamespaces;
     pageIdentifier?: PageIdentifier;
     pageTitleI18nKey?: PageTitleI18nKey;

--- a/frontend/e2e/_gcweb-app.personal-information.address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.address.confirm.spec.ts
@@ -5,7 +5,7 @@ test.describe('address change confirmation page', () => {
   test('should navigate to address change confirmation page', async ({ page }) => {
     await page.goto('/personal-information/address/confirm');
 
-    await expect(page.locator('h1')).toHaveText(/change address/i);
+    await expect(page.locator('h1')).toHaveText(/confirm/i);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "redis": "^4.6.12",
         "source-map-support": "^0.5.21",
         "undici": "^6.6.0",
+        "validator": "^13.11.0",
         "web-streams-node": "^0.4.0",
         "winston": "^3.11.0",
         "zod": "^3.22.4"
@@ -57,6 +58,7 @@
         "@types/react": "^18.2.51",
         "@types/react-dom": "^18.2.18",
         "@types/source-map-support": "^0.5.10",
+        "@types/validator": "^13.11.8",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "^1.2.2",
         "@vitest/ui": "^1.2.2",
@@ -3205,6 +3207,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "node_modules/@types/validator": {
+      "version": "13.11.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
+      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -14381,6 +14389,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "redis": "^4.6.12",
     "source-map-support": "^0.5.21",
     "undici": "^6.6.0",
+    "validator": "^13.11.0",
     "web-streams-node": "^0.4.0",
     "winston": "^3.11.0",
     "zod": "^3.22.4"
@@ -74,6 +75,7 @@
     "@types/react": "^18.2.51",
     "@types/react-dom": "^18.2.18",
     "@types/source-map-support": "^0.5.10",
+    "@types/validator": "^13.11.8",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^1.2.2",
     "@vitest/ui": "^1.2.2",

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -32,16 +32,16 @@
     "version": "Version:"
   },
   "not-found": {
-    "page-title": "Not found",
-    "page-header": "We couldn't find that web page",
-    "page-subheader": "(Error 404)",
+    "document-title": "Not found",
+    "page-title": "We couldn't find that web page",
+    "page-subtitle": "(Error 404)",
     "page-message": "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.",
     "page-link": "Return to the <home>home page</home>"
   },
   "server-error": {
-    "page-title": "Internal server error",
-    "page-header": "We're having a problem with that page",
-    "page-subheader": "(Error 500)",
+    "document-title": "Internal server error",
+    "page-title": "We're having a problem with that page",
+    "page-subtitle": "(Error 500)",
     "page-message": "We expect the problem to be fixed shortly. It's not your computer or Internet connection but a problem with our website's server. What next?",
     "option-01": "Try refreshing the page or try again later",
     "option-02": "Return to the <home>home page</home>"

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -32,16 +32,16 @@
     "version": "Version\u00a0:"
   },
   "not-found": {
-    "page-title": "Page introuvable",
-    "page-header": "Nous ne pouvons trouver cette page",
-    "page-subheader": "(Erreur 404)",
+    "document-title": "Page introuvable",
+    "page-title": "Nous ne pouvons trouver cette page",
+    "page-subtitle": "(Erreur 404)",
     "page-message": "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.",
     "page-link": "Retournez à la <home>page d'accueil</home>"
   },
   "server-error": {
-    "page-title": "Erreur interne du serveur",
-    "page-header": "Nous éprouvons des difficultés avec cette page",
-    "page-subheader": "(Erreur 500)",
+    "document-title": "Erreur interne du serveur",
+    "page-title": "Nous éprouvons des difficultés avec cette page",
+    "page-subtitle": "(Erreur 500)",
     "page-message": "Nous espérons résoudre le problème sous peu. Il ne s'agit pas d'un problème avec votre ordinateur ou Internet, mais plutôt avec le serveur de notre site Web. Que faire?",
     "option-01": "Actualisez la page ou réessayez plus tard",
     "option-02": "Retournez à la <home>page d'accueil</home>"


### PR DESCRIPTION
### Description

Add reusable PageTitle component. Remove the page title `<h1>` in the majority of the route and add logic in `./app/routes/_gcweb-app.tsx` to conditionally render PageTitle component based on the route handle's `pageTitleI18nKey`. The document title will default to `pageTitleI18nKey` if the route handle's `documentTitleI18nKey` is not provided.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e -- run`

### Test Instructions
Open the application and ensure the page and document title is correct in any pages.

### Additional Notes

I've added `zod.refine` to `i18nKeySchema` and `i18nNamespacesSchema` and used [validator.js](https://github.com/validatorjs/validator.js) package to validate strings.

Zod recommeds [validator.js](https://github.com/validatorjs/validator.js).

> Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](https://zod.dev/?id=refine).
