### PR TITLE
2898 Create dynamic route to view letter 

### DIFF
--- a/frontend/app/routes/_gcweb-app.view-letters.$referenceId.tsx
+++ b/frontend/app/routes/_gcweb-app.view-letters.$referenceId.tsx
@@ -1,0 +1,46 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import { useLoaderData, useParams } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('view-letters');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'view-letters:index.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'view-letters:index.page-title', to: '/view-letters' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0002',
+  pageTitleI18nKey: 'view-letters:index.page-title',
+} as const satisfies RouteHandleData;
+
+// TODO Refactor the loader to fetch pdf using service
+export async function loader({ request }: LoaderFunctionArgs) {
+  const filePath = '/test.pdf';
+  return json({ filePath });
+}
+
+type LoaderData = {
+  filePath: string;
+};
+
+export default function ViewLetter() {
+  const { referenceId } = useParams();
+  const { filePath } = useLoaderData<LoaderData>();
+  const { t } = useTranslation(i18nNamespaces);
+
+  return (
+    <>
+      <p>Reference ID: {referenceId}</p>
+      <a href={filePath} download={`${referenceId}.pdf`}>
+        <button type="button" className="btn btn-primary btn-sm">
+          {t('view-letters:view.download')}
+        </button>
+      </a>
+      <iframe src={filePath} title="Test PDF" className="mt-4 h-screen w-full" />
+    </>
+  );
+}

--- a/frontend/app/routes/_gcweb-app.view-letters._index.tsx
+++ b/frontend/app/routes/_gcweb-app.view-letters._index.tsx
@@ -85,7 +85,7 @@ function LetterList({ letters }: LetterListProps) {
           {sorted.map((letter) => (
             <li key={letter.id} className="grid grid-cols-3 divide-x divide-gray-300 md:grid-cols-[3fr_1fr_1fr]">
               <span className="border-b border-gray-300 px-4">
-                <Link to={`/letters/${letter.referenceId}`}>{letter.subject}</Link>
+                <Link to={`/view-letters/${letter.referenceId}`}>{letter.subject}</Link>
               </span>
               <span className="border-b border-gray-300 px-4">{new Date(letter.dateSent).toLocaleDateString()}</span>
               <span className="border-b border-gray-300 px-4">{letter.referenceId}</span>

--- a/frontend/app/utils/csp.server.ts
+++ b/frontend/app/utils/csp.server.ts
@@ -17,6 +17,7 @@ export function generateContentSecurityPolicy(nonce: string) {
     `default-src 'none'`,
     `connect-src 'self'` + (isDevelopment ? ' ws://localhost:3001' : ''),
     `font-src 'self' fonts.gstatic.com`,
+    `frame-src 'self'`,
     `img-src 'self'`,
     `script-src 'strict-dynamic' 'nonce-${nonce}'`,
     `style-src 'self'`,

--- a/frontend/public/locales/en/view-letters.json
+++ b/frontend/public/locales/en/view-letters.json
@@ -8,5 +8,8 @@
     "subject": "Subject",
     "date-sent": "Date sent",
     "reference-id": "Reference ID"
+  },
+  "view": {
+    "download": "Download PDF"
   }
 }

--- a/frontend/public/locales/fr/view-letters.json
+++ b/frontend/public/locales/fr/view-letters.json
@@ -8,5 +8,8 @@
     "subject": "(FR) Subject",
     "date-sent": "(FR) Date sent",
     "reference-id": "(FR) Reference ID"
+  },
+  "view": {
+    "download": "(FR) Download PDF"
   }
 }

--- a/frontend/public/test.pdf
+++ b/frontend/public/test.pdf
@@ -1,0 +1,247 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 612. 792.]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 247
+>>
+stream
+0.5670000000000001 w
+0 G
+BT
+/F10 16 Tf
+18.3999999999999986 TL
+0 g
+42.5196850393700814 749.4803149606299257 Td
+(Test) Tj
+ET
+BT
+/F9 12 Tf
+13.7999999999999989 TL
+0 g
+42.5196850393700814 729.6377952755905199 Td
+(This is an empty pdf for testing) Tj
+ET
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+6 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+7 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+9 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+10 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+11 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+17 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+/F2 6 0 R
+/F3 7 0 R
+/F4 8 0 R
+/F5 9 0 R
+/F6 10 0 R
+/F7 11 0 R
+/F8 12 0 R
+/F9 13 0 R
+/F10 14 0 R
+/F11 15 0 R
+/F12 16 0 R
+/F13 17 0 R
+/F14 18 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+19 0 obj
+<<
+/Producer (jsPDF 2.0.0)
+/CreationDate (D:20240202112107-05'00')
+>>
+endobj
+20 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 21
+0000000000 65535 f
+0000000418 00000 n
+0000002235 00000 n
+0000000015 00000 n
+0000000120 00000 n
+0000000475 00000 n
+0000000600 00000 n
+0000000730 00000 n
+0000000863 00000 n
+0000001000 00000 n
+0000001123 00000 n
+0000001252 00000 n
+0000001384 00000 n
+0000001520 00000 n
+0000001648 00000 n
+0000001775 00000 n
+0000001904 00000 n
+0000002037 00000 n
+0000002139 00000 n
+0000002483 00000 n
+0000002569 00000 n
+trailer
+<<
+/Size 21
+/Root 20 0 R
+/Info 19 0 R
+/ID [ <0B92D70C4B0E996C9BA4BC84FA5C6AFF> <0B92D70C4B0E996C9BA4BC84FA5C6AFF> ]
+>>
+startxref
+2673
+%%EOF


### PR DESCRIPTION
### Description

I've created a dynamic route to view letters and added a temporary PDF file to the /public directory. This file should be replaced once the endpoint mock is ready. The PDF is displayed within an <iframe>, which points to the temporary PDF file, allowing it to be viewed directly on the page. Additionally, there is a download button that allowa users to download the PDF file.

#### Looking for Help:

Currently, it seems that the content is being blocked due to security or content policy restrictions. You can see the error in the browser console when you hit the page. Will this be an issue when we have access to the actual API? I'm not sure what to do about this. Is there anything we should do about CSP configuration?

![Capture](https://github.com/DTS-STN/canadian-dental-care-plan/assets/64853947/f4a38537-048c-4ee6-92c9-c376a0f42b11)

### Related Azure Boards Work Items
[2898](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_sprints/taskboard/LiteBrite/Canada%20Dental%20Care%20Plan/Sprint%202?workitem=2898)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e -- run`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->