### PR TITLE
AB#2659 -- add mock authorize endpoint

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -100,3 +100,8 @@ JAVASCRIPT_ENABLED=true
 # enable mock API calls
 # (optional; default: false)
 MOCKS_ENABLED=true
+
+
+# Allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
+# (optional; default: http://localhost:3000/auth/callback/raoidc)
+MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/routes/mock-auth.$endpoint.tsx
+++ b/frontend/app/routes/mock-auth.$endpoint.tsx
@@ -1,0 +1,65 @@
+import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
+
+import { z } from 'zod';
+
+import { getEnv } from '~/utils/env.server';
+import { getLogger } from '~/utils/logging.server';
+import { generateRandomString } from '~/utils/raoidc-utils.server';
+
+const log = getLogger('mock-auth.$endpoint');
+
+/**
+ * A mock OIDC auth provider that currently supports the `authorize` endpoint.
+ */
+export function loader({ context, request, params }: LoaderFunctionArgs) {
+  const { endpoint } = params;
+
+  switch (endpoint) {
+    case 'authorize':
+      return handleAuthorizeRequest({ context, request, params });
+  }
+
+  log.warn('Invalid endpoint requested: [%s]', endpoint);
+  return new Response(null, { status: 404 });
+}
+
+/**
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
+ */
+function handleAuthorizeRequest({ request, params }: LoaderFunctionArgs) {
+  const { MOCK_AUTH_ALLOWED_REDIRECTS } = getEnv(); // used to prevent phishing attacks
+
+  const searchParamsSchema = z.object({
+    clientId: z.string().min(1).max(64),
+    codeChallenge: z.string().min(43).max(128),
+    codeChallengeMethod: z.enum(['S256']),
+    nonce: z.string().min(8).max(64),
+    redirectUri: z.string().refine((val) => MOCK_AUTH_ALLOWED_REDIRECTS.includes(val)),
+    responseType: z.enum(['code']),
+    scope: z.enum(['openid profile']),
+    state: z.string().min(8).max(256),
+  });
+
+  const searchParams = new URL(request.url).searchParams;
+
+  const result = searchParamsSchema.safeParse({
+    clientId: searchParams.get('client_id'),
+    codeChallenge: searchParams.get('code_challenge'),
+    codeChallengeMethod: searchParams.get('code_challenge_method'),
+    nonce: searchParams.get('nonce'),
+    redirectUri: searchParams.get('redirect_uri'),
+    responseType: searchParams.get('response_type'),
+    scope: searchParams.get('scope'),
+    state: searchParams.get('state'),
+  });
+
+  if (!result.success) {
+    return new Response(JSON.stringify(result.error.flatten().fieldErrors), { status: 400 });
+  }
+
+  const redirectUri = new URL(result.data.redirectUri);
+  redirectUri.searchParams.set('code', generateRandomString(16));
+  redirectUri.searchParams.set('state', result.data.state);
+
+  return redirect(redirectUri.toString());
+}

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -64,6 +64,12 @@ const serverEnv = z.object({
   AUTH_ENABLED: z.string().transform(toBoolean).default('false'),
   JAVASCRIPT_ENABLED: z.string().transform(toBoolean).default('true'),
   MOCKS_ENABLED: z.string().transform(toBoolean).default('false'),
+
+  // mocks settings
+  MOCK_AUTH_ALLOWED_REDIRECTS: z
+    .string()
+    .transform((val) => val.split(',').map((val) => val.trim()))
+    .default('http://localhost:3000/auth/callback/raoidc'),
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;


### PR DESCRIPTION
### Description

This is an incremental PR that adds a mock OIDC authorization endpoint to be used when mocking an RAOIDC login. Future PRs will build upon this to fully implement a mocked login flow.

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)

### Checklist
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Sorry.. There's no easy way to test this right now.
