### PR TITLE
Fix azure board bot problem

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -3,9 +3,11 @@
 
 ### Related Azure Boards Work Items
 <!--
-  Mention any Azure Boards work items that are related to this pull request. Reference them using the work item ID. For example: "AB#123".
-
+  Mention any Azure Boards work items that are related to this pull request.
   https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/
+
+  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
+  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
 -->
 
 ### Screenshots (if applicable)


### PR DESCRIPTION
### Description
Fix azure board bot problem. The bot's trying to link the `Related Azure Boards Work Items` example with ID 123 but fails, which is normal.

### Related Azure Boards Work Items

_N/A_

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/403c52e4-a3a6-4219-9702-a7159f23595f)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->

_N/A_

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

_N/A_

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

_N/A_