### PR TITLE
AB#2770 -- Refactoring Address component to remove React warnings

### DIFF
--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -10,7 +10,7 @@ export interface AddressProps extends ComponentProps<'address'> {
   country: string;
 }
 
-function formatAddress({ address, city, provinceState, postalZipCode, country }: AddressProps): string {
+function formatAddress(address: string, city: string, country: string, provinceState?: string, postalZipCode?: string) {
   // TODO 'canada' shouldn't be hardcoded as we may deal with different values of the country field such as abbreviations
   const isNotCanadianAddress = 'canada' !== country.toLowerCase();
 
@@ -26,8 +26,8 @@ function formatAddress({ address, city, provinceState, postalZipCode, country }:
 }
 
 export function Address(props: AddressProps) {
-  const { className, ...restProps } = props;
-  const formattedAddress = formatAddress(props);
+  const { address, city, provinceState, postalZipCode, country, className, ...restProps } = props;
+  const formattedAddress = formatAddress(address, city, country, provinceState, postalZipCode);
 
   return (
     <address className={clsx('mb-0 whitespace-pre-wrap', className)} data-testid="address-id" {...restProps}>


### PR DESCRIPTION
### Description
Currently, any page that uses the `<Address>` component would result in the following warning in Developer Tools console:
> Warning: React does not recognize the `provinceState`/`postalZipCode` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `provincestate`/`postalzipcode` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

This warning is because the `Address` component was accepting custom props through `AddressProps` but these custom props were not de-structured and thus, passed to the `<address>` HTML element through `restProps`.

This PR fixes the above issue.

### Related Azure Boards Work Items
[AB#2770](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2770)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Run the application locally.
- Navigate to the Personal Information page
- Open Developer Tools console and verify that there is no React warning