### PR TITLE
[gitops] AB#2659 -- config mock RAOIDC endpoint

### DIFF
--- a/gitops/overlays/dev/configs/frontend-config.conf
+++ b/gitops/overlays/dev/configs/frontend-config.conf
@@ -6,3 +6,6 @@ REDIS_URL=redis://redis-dev
 
 AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
 AUTH_RAOIDC_CLIENT_ID=CDCP
+
+# Temporary mock RAOIDC endpoint (remove once RAOIDC integration is complete)
+MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-dev.dev-dp.dts-stn.com/auth/callback/raoidc


### PR DESCRIPTION
PR #259 added a mock OIDC authorization endpoint to the application. This PR configures our dev callback URL as an allowed redirect to be used with that mock endpoint.