### PR TITLE
Disable vitest globals

### DIFF
--- a/frontend/__tests__/components/address.test.tsx
+++ b/frontend/__tests__/components/address.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
 
 import { Address } from '~/components/address';
 
@@ -10,13 +11,13 @@ describe('Address', () => {
   it('should render country when not a Canadian address', async () => {
     render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" />);
     const actual = screen.getByTestId('address-id');
-    expect(actual).toHaveTextContent('USA');
+    expect(actual.textContent).toBe('123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should not render country when address is Canadian', async () => {
     render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />);
     const actual = screen.getByTestId('address-id');
-    expect(actual).not.toHaveTextContent('Canada');
+    expect(actual.textContent).toBe('123 Fake Street\nOttawa ON  K2K 2K2');
   });
 
   it('should not have any a11y issues', async () => {

--- a/frontend/__tests__/components/anchor-link.test.tsx
+++ b/frontend/__tests__/components/anchor-link.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AnchorLink, type AnchorLinkProps } from '~/components/anchor-link';
 import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';

--- a/frontend/__tests__/components/input-field.test.tsx
+++ b/frontend/__tests__/components/input-field.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { InputField } from '~/components/input-field';
 

--- a/frontend/__tests__/components/input-help.test.tsx
+++ b/frontend/__tests__/components/input-help.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { InputHelp } from '~/components/input-help';
 

--- a/frontend/__tests__/components/input-label.test.tsx
+++ b/frontend/__tests__/components/input-label.test.tsx
@@ -1,6 +1,6 @@
 import { getByTestId, render, screen } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { InputLabel } from '~/components/input-label';
 

--- a/frontend/__tests__/components/input-textarea.test.tsx
+++ b/frontend/__tests__/components/input-textarea.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { InputTextarea } from '~/components/input-textarea';
 

--- a/frontend/__tests__/components/language-switcher.test.tsx
+++ b/frontend/__tests__/components/language-switcher.test.tsx
@@ -5,7 +5,7 @@ import { createRemixStub } from '@remix-run/testing';
 
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { useTranslation } from 'react-i18next';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
 import { getClientEnv } from '~/utils/env';

--- a/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
@@ -38,17 +38,14 @@ vi.mock('~/services/lookup-service.server.ts', () => ({
 }));
 vi.mock('~/services/address-service.server.ts', () => ({
   addressService: {
-    getAddressInfo: vi.fn().mockReturnValue(
-      {
-        address: "address",
-        city: "mega-city",
-        province: "mega province",
-        postalCode: "postal code",
-        country: "super country",
-      }
-    )
-
-  }
+    getAddressInfo: vi.fn().mockReturnValue({
+      address: 'address',
+      city: 'mega-city',
+      province: 'mega province',
+      postalCode: 'postal code',
+      country: 'super country',
+    }),
+  },
 }));
 describe('_gcweb-app.personal-information._index', () => {
   afterEach(() => {
@@ -97,19 +94,19 @@ describe('_gcweb-app.personal-information._index', () => {
         },
         preferredLanguage: { id: 'fr', nameEn: 'French', nameFr: 'Français' },
         homeAddressInfo: {
-          address: "address",
-          city: "mega-city",
-          province: "mega province",
-          postalCode: "postal code",
-          country: "super country",
+          address: 'address',
+          city: 'mega-city',
+          province: 'mega province',
+          postalCode: 'postal code',
+          country: 'super country',
         },
         mailingAddressInfo: {
-          address: "address",
-          city: "mega-city",
-          province: "mega province",
-          postalCode: "postal code",
-          country: "super country",
-        }
+          address: 'address',
+          city: 'mega-city',
+          province: 'mega province',
+          postalCode: 'postal code',
+          country: 'super country',
+        },
       });
     });
   });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@remix-run/node';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.confirm';
 import { addressService } from '~/services/address-service.server';

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@remix-run/node';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.edit';
 import { addressService } from '~/services/address-service.server';

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@remix-run/node';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.phone-number.confirm';
 import { sessionService } from '~/services/session-service.server';
@@ -67,7 +67,6 @@ describe('_gcweb-app.personal-information.phone-number.confirm', () => {
     });
 
     it('should redirect to homepage page when newPhoneNumber is missing', async () => {
-
       let request = new Request('http://localhost:3000/personal-information/phone-number/confirm', {
         method: 'POST',
       });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@remix-run/node';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.phone-number.edit';
 import { userService } from '~/services/user-service.server';

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { loader } from '~/routes/_gcweb-app.personal-information.preferred-language.confirm';
 import { lookupService } from '~/services/lookup-service.server';
 import { userService } from '~/services/user-service.server';

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.edit.test.tsx
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { loader } from '~/routes/_gcweb-app.personal-information.preferred-language.edit';
 import { lookupService } from '~/services/lookup-service.server';
 import { userService } from '~/services/user-service.server';

--- a/frontend/__tests__/services/session-service.server.test.ts
+++ b/frontend/__tests__/services/session-service.server.test.ts
@@ -1,7 +1,7 @@
 /* eslint @typescript-eslint/no-unused-vars: ["error", { "varsIgnorePattern": "^_" }] */
 import { createFileSessionStorage, createSessionStorage } from '@remix-run/node';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { redisService } from '~/services/redis-service.server';
 import { getEnv } from '~/utils/env.server';

--- a/frontend/__tests__/services/wsaddress-service.server.test.ts
+++ b/frontend/__tests__/services/wsaddress-service.server.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { describe, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expectTypeOf, it, vi } from 'vitest';
 
 import type { ParseWSAddressResponseDTO, ValidateWSAddressResponseDTO } from '~/services/wsaddress-service.server';
 import { getWSAddressService } from '~/services/wsaddress-service.server';

--- a/frontend/__tests__/setup-test-env.ts
+++ b/frontend/__tests__/setup-test-env.ts
@@ -1,9 +1,22 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
 
 import { JSDOM } from 'jsdom';
+import { afterEach } from 'vitest';
 
 // Workaround: For some reason FormData is not set to jsdom's by default
 const jsdom = new JSDOM(`<!doctype html>`);
 const { FormData } = jsdom.window;
 window.FormData = FormData;
 global.FormData = FormData;
+
+/**
+ * Jest has their globals API enabled by default. Vitest does not. We can either enable globals via the globals
+ * configuration setting or update your code to use imports from the vitest module instead.
+ *
+ * We decided to keep globals disabled.
+ * @see https://vitest.dev/guide/migration.html#globals-as-a-default
+ */
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/__tests__/types.d.test.ts
+++ b/frontend/__tests__/types.d.test.ts
@@ -1,3 +1,5 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
 import { type ExtractFuncParm, type ExtractLast, type RemoveLast, type ToFunc, type ToIntersection, type ToTuple, type ToTupleArray } from '~/types';
 
 describe('ToFunc<T> utility type', () => {

--- a/frontend/__tests__/utils/link-utils.test.tsx
+++ b/frontend/__tests__/utils/link-utils.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from '@testing-library/react';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
 

--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -3,23 +3,25 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Outlet, json } from '@remix-run/react';
 import { createRemixStub } from '@remix-run/testing';
 
+import { describe, expect, it } from 'vitest';
+
 import type { BuildInfo } from '~/utils/route-utils';
 import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey } from '~/utils/route-utils';
 
 describe('coalesce<T> reducer', () => {
-  test('expect undefined from two undefined values', () => {
+  it('expect undefined from two undefined values', () => {
     expect(coalesce(undefined, undefined)).toBeUndefined();
   });
 
-  test('expect previous from previous and undefined', () => {
+  it('expect previous from previous and undefined', () => {
     expect(coalesce('previous', undefined)).toBe('previous');
   });
 
-  test('expect current from undefined and current', () => {
+  it('expect current from undefined and current', () => {
     expect(coalesce(undefined, 'current')).toBe('current');
   });
 
-  test('expect current from previous and current', () => {
+  it('expect current from previous and current', () => {
     expect(coalesce('previous', 'current')).toBe('current');
   });
 });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,13 +11,12 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "paths": {
-      "~/*": ["./app/*"],
+      "~/*": ["./app/*"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "ES2022",
-    "types": ["vitest/globals"],
-  },
+    "target": "ES2022"
+  }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,13 +8,11 @@ export default defineConfig({
   test: {
     pool: 'forks',
     testTimeout: 50000,
-    globals: true,
     // happy-dom doesn't support button submit or FormData
     // https://github.com/capricorn86/happy-dom/issues/527
     // https://github.com/capricorn86/happy-dom/issues/585
     environment: 'jsdom',
     setupFiles: ['./__tests__/setup-test-env.ts'],
-    include: [...configDefaults.include, '**/*.test-d.ts(x)'],
     exclude: [...configDefaults.exclude, '**/build/**', '**/e2e/**'],
     coverage: {
       exclude: [...(configDefaults.coverage.exclude ?? []), '**/build/**', '**/e2e/**'],


### PR DESCRIPTION
### Description

Decided to keep vitest globals disabled.

https://vitest.dev/guide/migration.html#globals-as-a-default

> Jest has their [globals API](https://jestjs.io/docs/api) enabled by default. Vitest does not. You can either enable globals via [the globals configuration setting](https://vitest.dev/config/#globals) or update your code to use imports from the vitest module instead.
> 
> If you decide to keep globals disabled, be aware that common libraries like [testing-library](https://testing-library.com/) will not run auto DOM [cleanup](https://testing-library.com/docs/svelte-testing-library/api/#cleanup).

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run `npm run test:unit -- run`

### Additional Notes

Still need to find a way to remove `@types/jest` from the global TS scope. `@types/jest` is imported from `@testing-library/**` packages.