### PR TITLE
AB#2770 -- Adding InputSelect and InputOption components

### DIFF
--- a/frontend/app/components/input-option.tsx
+++ b/frontend/app/components/input-option.tsx
@@ -1,0 +1,18 @@
+import { type ComponentProps } from 'react';
+
+export interface InputOptionProps extends ComponentProps<'option'> {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export function InputOption(props: InputOptionProps) {
+  const { label, value, id, ...restProps } = props;
+  const inputOptionTestId = `input-option-${id}-test`;
+
+  return (
+    <option value={value} id={id} data-testid={inputOptionTestId} {...restProps}>
+      {label}
+    </option>
+  );
+}

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -1,0 +1,80 @@
+import { type ComponentProps, type ReactNode, forwardRef } from 'react';
+
+import clsx from 'clsx';
+
+import { InputError } from './input-error';
+import { InputHelp } from './input-help';
+import { InputLabel } from './input-label';
+import { InputOption } from './input-option';
+
+export interface InputSelectProps extends Omit<ComponentProps<'select'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
+  errorMessage?: string;
+  helpMessage?: ReactNode;
+  helpMessageSecondary?: ReactNode;
+  id: string;
+  label: string;
+  name: string;
+  options: ComponentProps<typeof InputOption>[];
+}
+
+const InputSelect = forwardRef<HTMLSelectElement, InputSelectProps>((props, ref) => {
+  const { errorMessage, helpMessage, helpMessageSecondary, id, label, options, className, required, ...restInputProps } = props;
+
+  const inputErrorId = `input-${id}-error`;
+  const inputHelpMessageId = `input-${id}-help`;
+  const inputHelpMessageSecondaryId = `input-${id}-help-secondary`;
+  const inputLabelId = `input-${id}-label`;
+  const inputTestId = `input-${id}-test`;
+  const inputWrapperId = `input-${id}`;
+
+  function getAriaDescribedby() {
+    const ariaDescribedby = [];
+    if (helpMessage) ariaDescribedby.push(inputHelpMessageId);
+    if (helpMessageSecondary) ariaDescribedby.push(inputHelpMessageSecondaryId);
+    return ariaDescribedby.length > 0 ? ariaDescribedby.join(' ') : undefined;
+  }
+
+  return (
+    <div id={inputWrapperId} data-testid={inputWrapperId} className="form-group">
+      <InputLabel id={inputLabelId} htmlFor={id} required={required}>
+        {label}
+      </InputLabel>
+      {errorMessage && (
+        <InputError id={inputErrorId} className="mb-1.5">
+          {errorMessage}
+        </InputError>
+      )}
+      {helpMessage && (
+        <InputHelp id={inputHelpMessageId} className="mb-1.5" data-testid="input-select-help">
+          {helpMessage}
+        </InputHelp>
+      )}
+      <select
+        ref={ref}
+        aria-describedby={getAriaDescribedby()}
+        aria-errormessage={errorMessage && inputErrorId}
+        aria-invalid={!!errorMessage}
+        aria-labelledby={inputLabelId}
+        aria-required={required}
+        className={clsx('form-control', className)}
+        data-testid={inputTestId}
+        id={id}
+        required={required}
+        {...restInputProps}
+      >
+        {options.map(({ value, ...restProps }) => (
+          <InputOption value={value} key={value} {...restProps} />
+        ))}
+      </select>
+      {helpMessageSecondary && (
+        <InputHelp id={inputHelpMessageSecondaryId} className="mt-1.5" data-testid="input-textarea-help-secondary">
+          {helpMessageSecondary}
+        </InputHelp>
+      )}
+    </div>
+  );
+});
+
+InputSelect.displayName = 'InputSelect';
+
+export { InputSelect };

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -8,6 +8,8 @@ import { z } from 'zod';
 
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
+import { type InputOptionProps } from '~/components/input-option';
+import { InputSelect } from '~/components/input-select';
 import { addressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
@@ -89,6 +91,14 @@ export default function PersonalInformationHomeAddressEdit() {
     country: actionData?.formData.country ?? addressInfo?.country,
     postalCode: actionData?.formData.postalCode ?? addressInfo?.postalCode,
   };
+
+  // TODO remove this and get countries from lookup service
+  const countries: InputOptionProps[] = [
+    { label: 'Canada', value: 'Canada', id: 'ca' },
+    { label: 'Mexico', value: 'Mexico', id: 'mx' },
+    { label: 'United States', value: 'United States', id: 'us' },
+  ];
+
   /**
    * Gets an error message based on the provided internationalization (i18n) key.
    *
@@ -129,7 +139,7 @@ export default function PersonalInformationHomeAddressEdit() {
         <InputField id="city" label={t('personal-information:home-address.edit.field.city')} name="city" required defaultValue={defaultValues.city} errorMessage={errorMessages.city} />
         <InputField id="province" label={t('personal-information:home-address.edit.field.province')} name="province" defaultValue={defaultValues.province} errorMessage={errorMessages.province} />
         <InputField id="postalCode" label={t('personal-information:home-address.edit.field.postal-code')} name="postalCode" defaultValue={defaultValues.postalCode} errorMessage={errorMessages.postalCode} />
-        <InputField id="country" label={t('personal-information:home-address.edit.field.country')} name="country" required defaultValue={defaultValues.country} errorMessage={errorMessages.country} />
+        <InputSelect id="country" label={t('personal-information:home-address.edit.field.country')} name="country" defaultValue={defaultValues.country} required options={countries} errorMessage={errorMessages.country} />
 
         <div className="flex flex-wrap gap-3">
           <button id="change-button" className="btn btn-primary btn-lg">


### PR DESCRIPTION
### Description
This PR introduces re-usable and accessible components for `<select>` and `<option>` and is based off similar form components that currently exist in the application.

The corresponding components, `InputSelect` and `InputOption`, are will eventually be used to render a drop-down of countries and provinces/states within the home and mailing address forms (among other forms).

### Related Azure Boards Work Items
[AB#2770](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2770)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/8443569b-d902-419b-bcd5-7af609f771c7)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and navigate to `/personal-information/home-address/edit`.
The "Country" field uses a `InputSelect`.

### Additional Notes
Unit tests will be added in a subsequent PR.