### PR TITLE
Refactor skip links

### DIFF
--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -101,20 +101,14 @@ function PageHeader() {
   }, [showDropdown]);
   return (
     <>
-      <nav>
-        <ul id="wb-tphp">
-          <li className="wb-slc">
-            <AnchorLink anchorElementId="wb-cont" className="wb-sl">
-              {t('gcweb:nav.skip-to-content')}
-            </AnchorLink>
-          </li>
-          <li className="wb-slc visible-sm visible-md visible-lg">
-            <AnchorLink anchorElementId="wb-info" className="wb-sl">
-              {t('gcweb:nav.skip-to-about')}
-            </AnchorLink>
-          </li>
-        </ul>
-      </nav>
+      <div id="skip-to-content" className="wb-slc">
+        <AnchorLink anchorElementId="wb-cont" className="wb-sl">
+          {t('gcweb:nav.skip-to-content')}
+        </AnchorLink>
+        <AnchorLink anchorElementId="wb-info" className="wb-sl">
+          {t('gcweb:nav.skip-to-about')}
+        </AnchorLink>
+      </div>
       <header>
         <div id="wb-bnr" className="container">
           <div className="row">


### PR DESCRIPTION
### Description

Refactor skip links to match WebAIM article

 It fixes e2e a11y axe error: `Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable`. The page have two `nav` elements with no unique aria-label, aria-labelledby, or title to make landmarks distinguishable.

https://webaim.org/techniques/skipnav/

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run `npm run test:e2e`