### PR TITLE
Move lookup API mocks to their own module

### DIFF
--- a/frontend/app/mocks/lookup-api.server.ts
+++ b/frontend/app/mocks/lookup-api.server.ts
@@ -1,0 +1,77 @@
+import { HttpResponse, http } from 'msw';
+import { z } from 'zod';
+
+import { db } from '~/mocks/db';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('lookup-api.server');
+
+/**
+ * Server-side MSW mocks for the lookup API.
+ */
+export function getLookupApiMockHandlers() {
+  log.info('Initializing lookup API mock handlers');
+
+  return [
+    //
+    // Handler for GET request to retrieve all preferred languages
+    //
+    http.get('https://api.example.com/lookups/preferred-languages', ({ request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      const preferredLanguageList = db.preferredLanguage.getAll();
+      return HttpResponse.json(preferredLanguageList);
+    }),
+
+    //
+    // Handler for GET requests to retrieve preferred languages by id
+    //
+    http.get('https://api.example.com/lookups/preferred-languages/:id', ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      const preferredLanguageEntity = getPreferredLanguageEntity(params.id);
+      return HttpResponse.json({
+        id: preferredLanguageEntity.id,
+        nameEn: preferredLanguageEntity.nameEn,
+        nameFr: preferredLanguageEntity.nameFr,
+      });
+    }),
+
+    //
+    // Handler for GET request to retrieve all countries
+    //
+    http.get('https://api.example.com/lookups/countries', ({ request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      const countryList = db.country.getAll();
+      return HttpResponse.json(countryList.sort((a, b) => (a.code < b.code ? -1 : 1)));
+    }),
+
+    //
+    // Handler for GET request to retrieve all countries
+    //
+    http.get('https://api.example.com/lookups/regions', ({ request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      const provinceList = db.region.getAll();
+      return HttpResponse.json(provinceList);
+    }),
+  ];
+}
+
+/**
+ * Retrieves a preferred language entity based on the provided preferred language ID.
+ *
+ * @param id - The preferred language ID to look up in the database.
+ * @returns The preferred language entity if found, otherwise throws a 404 error.
+ */
+function getPreferredLanguageEntity(id: string | readonly string[]) {
+  const parsedPreferredLanguageId = z.string().safeParse(id);
+  const parsedPreferredLanguage = !parsedPreferredLanguageId.success
+    ? undefined
+    : db.preferredLanguage.findFirst({
+        where: { id: { equals: parsedPreferredLanguageId.data } },
+      });
+
+  if (!parsedPreferredLanguage) {
+    throw new HttpResponse('No Preferred Language found', { status: 404, headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  return parsedPreferredLanguage;
+}

--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -3,28 +3,8 @@ import { setupServer } from 'msw/node';
 import { z } from 'zod';
 
 import { db } from '~/mocks/db';
+import { getLookupApiMockHandlers } from '~/mocks/lookup-api.server';
 import { getPowerPlatformApiMockHandlers } from '~/mocks/power-platform-api.server';
-
-/**
- * Retrieves a preferred language entity based on the provided preferred language ID.
- *
- * @param id - The preferred language ID to look up in the database.
- * @returns The preferred language entity if found, otherwise throws a 404 error.
- */
-function getPreferredLanguageEntity(id: string | readonly string[]) {
-  const parsedPreferredLanguageId = z.string().safeParse(id);
-  const parsedPreferredLanguage = !parsedPreferredLanguageId.success
-    ? undefined
-    : db.preferredLanguage.findFirst({
-        where: { id: { equals: parsedPreferredLanguageId.data } },
-      });
-
-  if (!parsedPreferredLanguage) {
-    throw new HttpResponse('No Preferred Language found', { status: 404, headers: { 'Content-Type': 'text/plain' } });
-  }
-
-  return parsedPreferredLanguage;
-}
 
 /**
  * Retrieves a PDF entity based on the provided referenceId ID.
@@ -51,42 +31,6 @@ function getPdfEntity(referenceId: string | readonly string[]) {
 }
 
 const handlers = [
-  /**
-   * Handler for GET request to retrieve all preferred languages
-   */
-  http.get('https://api.example.com/lookups/preferred-languages', () => {
-    const preferredLanguageList = db.preferredLanguage.getAll();
-    return HttpResponse.json(preferredLanguageList);
-  }),
-
-  /**
-   * Handler for GET requests to retrieve preferred languages by id
-   */
-  http.get('https://api.example.com/lookups/preferred-languages/:id', ({ params }) => {
-    const preferredLanguageEntity = getPreferredLanguageEntity(params.id);
-    return HttpResponse.json({
-      id: preferredLanguageEntity.id,
-      nameEn: preferredLanguageEntity.nameEn,
-      nameFr: preferredLanguageEntity.nameFr,
-    });
-  }),
-
-  /**
-   * Handler for GET request to retrieve all countries
-   */
-  http.get('https://api.example.com/lookups/countries', () => {
-    const countryList = db.country.getAll();
-    return HttpResponse.json(countryList.sort((a, b) => (a.code < b.code ? -1 : 1)));
-  }),
-
-  /**
-   * Handler for GET request to retrieve all countries
-   */
-  http.get('https://api.example.com/lookups/regions', () => {
-    const provinceList = db.region.getAll();
-    return HttpResponse.json(provinceList);
-  }),
-
   /**
    * Handler for POST requests to WSAddress parse service
    */
@@ -166,4 +110,4 @@ const handlers = [
   }),
 ];
 
-export const server = setupServer(...handlers, ...getPowerPlatformApiMockHandlers());
+export const server = setupServer(...handlers, ...getLookupApiMockHandlers(), ...getPowerPlatformApiMockHandlers());


### PR DESCRIPTION
### Description

This PR moves the lookup API mocks into their own module. In a future PR I plan to allow for enabling/disabling mocks on a per-service level, this PR will make it easier to do that.

### Checklist
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

The code was copy/pasted from one file to another and a single line of logging was added to each mocked endpoint. Please keep this in mind when reviewing; my intention wasn't to update any code, but simply move it to a new module.

Marking as *draft* until #284 is merged.