### PR TITLE
Move WSAddress mocks to their own module

### DIFF
--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { db } from '~/mocks/db';
 import { getLookupApiMockHandlers } from '~/mocks/lookup-api.server';
 import { getPowerPlatformApiMockHandlers } from '~/mocks/power-platform-api.server';
+import { getWSAddressApiMockHandlers } from '~/mocks/wsaddress-api.server';
 
 /**
  * Retrieves a PDF entity based on the provided referenceId ID.
@@ -32,58 +33,6 @@ function getPdfEntity(referenceId: string | readonly string[]) {
 
 const handlers = [
   /**
-   * Handler for POST requests to WSAddress parse service
-   */
-  http.post('https://api.example.com/address/parse', ({ params }) => {
-    return HttpResponse.json({
-      responseType: 'CA',
-      addressLine: '23 CORONATION ST',
-      city: 'ST JOHNS',
-      province: 'NL',
-      postalCode: 'A1C5B9',
-      streetNumberSuffix: 'streetNumberSuffix',
-      streetDirection: 'streetDirection',
-      unitType: 'unitType',
-      unitNumber: '000',
-      serviceAreaName: 'serviceAreaName',
-      serviceAreaType: 'serviceAreaType',
-      serviceAreaQualifier: '',
-      cityLong: 'cityLong',
-      cityShort: 'cityShort',
-      deliveryInformation: 'deliveryInformation',
-      extraInformation: 'extraInformation',
-      statusCode: 'Valid',
-      canadaPostInformation: [],
-      message: 'message',
-      addressType: 'Urban',
-      streetNumber: '23',
-      streetName: 'CORONATION',
-      streetType: 'ST',
-      serviceType: 'Unknown',
-      serviceNumber: '000',
-      country: 'CAN',
-      warnings: '',
-      functionalMessages: [{ action: 'action', message: 'message' }],
-    });
-  }),
-
-  /**
-   * Handler for POST requests to WSAddress validate service
-   */
-  http.post('https://api.example.com/address/validate', ({ params }) => {
-    return HttpResponse.json({
-      responseType: 'CA',
-      statusCode: 'Valid',
-      functionalMessages: [
-        { action: 'OriginalInput', message: '111 WELLINGTON ST   OTTAWA   ON   K1A0A4   CAN' },
-        { action: 'Information', message: 'Dept = SENAT   Branch = SENAT   Lang = F' },
-      ],
-      message: '',
-      warnings: '',
-    });
-  }),
-
-  /**
    * Handler for GET requests to retrieve pdf
    */
   http.get('https://api.example.com/cct/letters/:referenceId', async ({ params }) => {
@@ -110,4 +59,4 @@ const handlers = [
   }),
 ];
 
-export const server = setupServer(...handlers, ...getLookupApiMockHandlers(), ...getPowerPlatformApiMockHandlers());
+export const server = setupServer(...handlers, ...getLookupApiMockHandlers(), ...getPowerPlatformApiMockHandlers(), ...getWSAddressApiMockHandlers());

--- a/frontend/app/mocks/wsaddress-api.server.ts
+++ b/frontend/app/mocks/wsaddress-api.server.ts
@@ -1,0 +1,68 @@
+import { HttpResponse, http } from 'msw';
+
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('wsaddress-api.server');
+
+/**
+ * Server-side MSW mocks for the WSAddress API.
+ */
+export function getWSAddressApiMockHandlers() {
+  log.info('Initializing WSAddress API mock handlers');
+
+  return [
+    //
+    // Handler for POST requests to WSAddress parse service
+    //
+    http.post('https://api.example.com/address/parse', ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      return HttpResponse.json({
+        responseType: 'CA',
+        addressLine: '23 CORONATION ST',
+        city: 'ST JOHNS',
+        province: 'NL',
+        postalCode: 'A1C5B9',
+        streetNumberSuffix: 'streetNumberSuffix',
+        streetDirection: 'streetDirection',
+        unitType: 'unitType',
+        unitNumber: '000',
+        serviceAreaName: 'serviceAreaName',
+        serviceAreaType: 'serviceAreaType',
+        serviceAreaQualifier: '',
+        cityLong: 'cityLong',
+        cityShort: 'cityShort',
+        deliveryInformation: 'deliveryInformation',
+        extraInformation: 'extraInformation',
+        statusCode: 'Valid',
+        canadaPostInformation: [],
+        message: 'message',
+        addressType: 'Urban',
+        streetNumber: '23',
+        streetName: 'CORONATION',
+        streetType: 'ST',
+        serviceType: 'Unknown',
+        serviceNumber: '000',
+        country: 'CAN',
+        warnings: '',
+        functionalMessages: [{ action: 'action', message: 'message' }],
+      });
+    }),
+
+    //
+    // Handler for POST requests to WSAddress validate service
+    //
+    http.post('https://api.example.com/address/validate', ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      return HttpResponse.json({
+        responseType: 'CA',
+        statusCode: 'Valid',
+        functionalMessages: [
+          { action: 'OriginalInput', message: '111 WELLINGTON ST   OTTAWA   ON   K1A0A4   CAN' },
+          { action: 'Information', message: 'Dept = SENAT   Branch = SENAT   Lang = F' },
+        ],
+        message: '',
+        warnings: '',
+      });
+    }),
+  ];
+}


### PR DESCRIPTION
### Description

This PR moves the WSAddress API mocks into their own module. In a future PR I plan to allow for enabling/disabling mocks on a per-service level, this PR will make it easier to do that.

### Checklist
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

The code was copy/pasted from one file to another and a single line of logging was added to each mocked endpoint. Please keep this in mind when reviewing; my intention wasn't to update any code, but simply move it to a new module.

Marking as *draft* until #285 is merged.