### PR TITLE
Move CCT mocks to their own module

### DIFF
--- a/frontend/app/mocks/cct-api.server.ts
+++ b/frontend/app/mocks/cct-api.server.ts
@@ -1,0 +1,67 @@
+import { HttpResponse, http } from 'msw';
+import { z } from 'zod';
+
+import { db } from '~/mocks/db';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('cct-api.server');
+
+/**
+ * Server-side MSW mocks for the CCT API.
+ */
+export function getCCTApiMockHandlers() {
+  log.info('Initializing CCT API mock handlers');
+
+  return [
+    //
+    // Handler for GET requests to retrieve pdf
+    //
+    http.get('https://api.example.com/cct/letters/:referenceId', async ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      const encoder = new TextEncoder();
+      const pdfEntity = getPdfEntity(params.referenceId);
+      const stream = new ReadableStream({
+        start(controller) {
+          // Encode the string chunks using "TextEncoder".
+          controller.enqueue(encoder.encode('Gums'));
+          controller.enqueue(encoder.encode('n'));
+          controller.enqueue(encoder.encode('roses'));
+          controller.enqueue(encoder.encode(pdfEntity?.id));
+          controller.close();
+        },
+      });
+
+      // Send the mocked response immediately.
+      return new HttpResponse(stream, {
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': `attachment, filename=${pdfEntity.referenceId}.pdf`,
+        },
+      });
+    }),
+  ];
+}
+
+/**
+ * Retrieves a PDF entity based on the provided referenceId ID.
+ *
+ * @param id - The reference Id to look up in the database.
+ * @returns The PDF entity if found, otherwise throws a 404 error.
+ */
+function getPdfEntity(referenceId: string | readonly string[]) {
+  const parsedReferenceId = z.string().safeParse(referenceId);
+  if (!parsedReferenceId) {
+    throw new HttpResponse('Invalid referenceId: ' + referenceId, { status: 400, headers: { 'Content-Type': 'text/plain' } });
+  }
+  const parsedPdfEntity = !parsedReferenceId.success
+    ? undefined
+    : db.pdf.findFirst({
+        where: { id: { equals: parsedReferenceId.data } },
+      });
+
+  if (!parsedPdfEntity) {
+    throw new HttpResponse('No PDF found with the provided referenceId: ' + referenceId, { status: 404, headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  return parsedPdfEntity;
+}

--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -1,62 +1,8 @@
-import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { z } from 'zod';
 
-import { db } from '~/mocks/db';
+import { getCCTApiMockHandlers } from '~/mocks/cct-api.server';
 import { getLookupApiMockHandlers } from '~/mocks/lookup-api.server';
 import { getPowerPlatformApiMockHandlers } from '~/mocks/power-platform-api.server';
 import { getWSAddressApiMockHandlers } from '~/mocks/wsaddress-api.server';
 
-/**
- * Retrieves a PDF entity based on the provided referenceId ID.
- *
- * @param id - The reference Id to look up in the database.
- * @returns The PDF entity if found, otherwise throws a 404 error.
- */
-function getPdfEntity(referenceId: string | readonly string[]) {
-  const parsedReferenceId = z.string().safeParse(referenceId);
-  if (!parsedReferenceId) {
-    throw new HttpResponse('Invalid referenceId: ' + referenceId, { status: 400, headers: { 'Content-Type': 'text/plain' } });
-  }
-  const parsedPdfEntity = !parsedReferenceId.success
-    ? undefined
-    : db.pdf.findFirst({
-        where: { id: { equals: parsedReferenceId.data } },
-      });
-
-  if (!parsedPdfEntity) {
-    throw new HttpResponse('No PDF found with the provided referenceId: ' + referenceId, { status: 404, headers: { 'Content-Type': 'text/plain' } });
-  }
-
-  return parsedPdfEntity;
-}
-
-const handlers = [
-  /**
-   * Handler for GET requests to retrieve pdf
-   */
-  http.get('https://api.example.com/cct/letters/:referenceId', async ({ params }) => {
-    const encoder = new TextEncoder();
-    const pdfEntity = getPdfEntity(params.referenceId);
-    const stream = new ReadableStream({
-      start(controller) {
-        // Encode the string chunks using "TextEncoder".
-        controller.enqueue(encoder.encode('Gums'));
-        controller.enqueue(encoder.encode('n'));
-        controller.enqueue(encoder.encode('proses'));
-        controller.enqueue(encoder.encode(pdfEntity?.id));
-        controller.close();
-      },
-    });
-
-    // Send the mocked response immediately.
-    return new HttpResponse(stream, {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        'Content-Disposition': `attachment, filename=${pdfEntity.referenceId}.pdf`,
-      },
-    });
-  }),
-];
-
-export const server = setupServer(...handlers, ...getLookupApiMockHandlers(), ...getPowerPlatformApiMockHandlers(), ...getWSAddressApiMockHandlers());
+export const server = setupServer(...getCCTApiMockHandlers(), ...getLookupApiMockHandlers(), ...getPowerPlatformApiMockHandlers(), ...getWSAddressApiMockHandlers());


### PR DESCRIPTION
### Description

This PR moves the WSAddress API mocks into their own module. In a future PR I plan to allow for enabling/disabling mocks on a per-service level, this PR will make it easier to do that.

### Checklist
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

The code was copy/pasted from one file to another and a single line of logging was added to each mocked endpoint. Please keep this in mind when reviewing; my intention wasn't to update any code, but simply move it to a new module.

Marking as *draft* until #286 is merged.