### PR TITLE
Add `./tmp/**` to typescript excludes

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["./remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["./tmp/**"],
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### Description

The `./tmp/` folder is often used as a dumping ground in the application. Typescript shouldn't be considering its contents when building/typechecking the project.
