### PR TITLE
Refactor address service to use `moize`

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/_gcweb-app.personal-information._index';
 
-vi.mock('~/services/user-service.server.ts', () => ({
+vi.mock('~/services/user-service.server', () => ({
   userService: {
     getUserId: vi.fn().mockReturnValue('00000000-0000-0000-0000-000000000000'),
     getUserInfo: vi.fn().mockReturnValue({
@@ -15,7 +15,8 @@ vi.mock('~/services/user-service.server.ts', () => ({
     }),
   },
 }));
-vi.mock('~/services/lookup-service.server.ts', () => ({
+
+vi.mock('~/services/lookup-service.server', () => ({
   lookupService: {
     getAllPreferredLanguages: vi.fn().mockReturnValue([
       {
@@ -36,8 +37,9 @@ vi.mock('~/services/lookup-service.server.ts', () => ({
     }),
   },
 }));
-vi.mock('~/services/address-service.server.ts', () => ({
-  addressService: {
+
+vi.mock('~/services/address-service.server', () => ({
+  getAddressService: vi.fn().mockReturnValue({
     getAddressInfo: vi.fn().mockReturnValue({
       address: 'address',
       city: 'mega-city',
@@ -45,12 +47,12 @@ vi.mock('~/services/address-service.server.ts', () => ({
       postalCode: 'postal code',
       country: 'super country',
     }),
-  },
+  }),
 }));
+
 describe('_gcweb-app.personal-information._index', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
   });
 
   describe('loader()', () => {

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -3,7 +3,7 @@ import { redirect } from '@remix-run/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.confirm';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 
@@ -24,22 +24,21 @@ vi.mock('~/services/user-service.server', () => ({
 }));
 
 vi.mock('~/services/address-service.server', () => ({
-  addressService: {
+  getAddressService: vi.fn().mockReturnValue({
     getAddressInfo: vi.fn(),
     updateAddressInfo: vi.fn(),
-  },
+  }),
 }));
 
 describe('_gcweb-app.personal-information.home-address.confirm', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
   });
 
   describe('loader()', () => {
     it('should return homeAddressInfo and newHomeAddress objects', async () => {
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
-      vi.mocked(addressService.getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
+      vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
       vi.mocked((await sessionService.getSession()).get).mockResolvedValue({ address: '123 Fake Home St.', city: 'city', country: 'country' });
 
       const response = await loader({

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
@@ -3,15 +3,15 @@ import { redirect } from '@remix-run/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.edit';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 
 vi.mock('~/services/address-service.server', () => ({
-  addressService: {
+  getAddressService: vi.fn().mockReturnValue({
     getAddressInfo: vi.fn(),
     updateAddressInfo: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock('~/services/session-service.server', () => ({
@@ -33,13 +33,12 @@ vi.mock('~/services/user-service.server', () => ({
 describe('_gcweb-app.personal-information.home-address.edit', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
   });
 
   describe('loader()', () => {
     it('should return addressInfo', async () => {
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
-      vi.mocked(addressService.getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
+      vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/address/edit'),
@@ -55,7 +54,7 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
     });
 
     it('should throw 404 response if addressInfo is not found', async () => {
-      vi.mocked(addressService.getAddressInfo).mockResolvedValue(null);
+      vi.mocked(getAddressService().getAddressInfo).mockResolvedValue(null);
 
       try {
         await loader({

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { lookupService } from '~/services/lookup-service.server';
 import { userService } from '~/services/user-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -30,8 +30,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
   const preferredLanguage = userInfo.preferredLanguage && (await lookupService.getPreferredLanguage(userInfo?.preferredLanguage));
 
-  const homeAddressInfo = userInfo.homeAddress && (await addressService.getAddressInfo(userId, userInfo?.homeAddress));
-  const mailingAddressInfo = userInfo.mailingAddress && (await addressService.getAddressInfo(userId, userInfo?.mailingAddress));
+  const homeAddressInfo = userInfo.homeAddress && (await getAddressService().getAddressInfo(userId, userInfo?.homeAddress));
+  const mailingAddressInfo = userInfo.mailingAddress && (await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress));
 
   return json({ user: userInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo });
 }

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -4,7 +4,7 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -25,7 +25,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
-  const homeAddressInfo = await addressService.getAddressInfo(userId, userInfo?.homeAddress ?? '');
+  const homeAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
 
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const newHomeAddress = await session.get('newHomeAddress');
@@ -37,7 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
   const session = await sessionService.getSession(request.headers.get('Cookie'));
 
-  await addressService.updateAddressInfo(userId, userInfo?.homeAddress ?? '', session.get('newHomeAddress'));
+  await getAddressService().updateAddressInfo(userId, userInfo?.homeAddress ?? '', session.get('newHomeAddress'));
 
   return redirect('/personal-information');
 }

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -10,7 +10,7 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputField } from '~/components/input-field';
 import { type InputOptionProps } from '~/components/input-option';
 import { InputSelect } from '~/components/input-select';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -31,7 +31,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
-  const addressInfo = await addressService.getAddressInfo(userId, userInfo?.homeAddress ?? '');
+  const addressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
 
   if (!userInfo) {
     throw new Response(null, { status: 404 });

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
@@ -4,7 +4,7 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -25,7 +25,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
-  const mailingAddressInfo = await addressService.getAddressInfo(userId, userInfo?.mailingAddress ?? '');
+  const mailingAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
 
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const newMailingAddress = await session.get('newMailingAddress');
@@ -37,7 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
   const session = await sessionService.getSession(request.headers.get('Cookie'));
 
-  await addressService.updateAddressInfo(userId, userInfo?.mailingAddress ?? '', session.get('newMailingAddress'));
+  await getAddressService().updateAddressInfo(userId, userInfo?.mailingAddress ?? '', session.get('newMailingAddress'));
 
   return redirect('/personal-information');
 }

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
@@ -8,7 +8,7 @@ import { z } from 'zod';
 
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { addressService } from '~/services/address-service.server';
+import { getAddressService } from '~/services/address-service.server';
 import { sessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -29,8 +29,8 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
-  const addressInfo = await addressService.getAddressInfo(userId, userInfo?.mailingAddress ?? '');
-  const homeAddressInfo = await addressService.getAddressInfo(userId, userInfo?.homeAddress ?? '');
+  const addressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
+  const homeAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
 
   if (!userInfo) {
     throw new Response(null, { status: 404 });

--- a/frontend/app/services/address-service.server.ts
+++ b/frontend/app/services/address-service.server.ts
@@ -1,8 +1,11 @@
 import jsonpatch from 'fast-json-patch';
+import moize from 'moize';
 import { z } from 'zod';
 
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('address-service.server');
 
 const addressDtoSchema = z.object({
   addressApartmentUnitNumber: z.string().optional(),
@@ -25,28 +28,27 @@ const addressInfoSchema = z.object({
 
 export type AddressInfo = z.infer<typeof addressInfoSchema>;
 
-function toAddressInfo(addressDto: AddressDto): AddressInfo {
-  return {
-    address: addressDto.addressApartmentUnitNumber ? addressDto.addressApartmentUnitNumber + ' ' + addressDto.addressStreet : addressDto.addressStreet,
-    city: addressDto.addressCity,
-    province: addressDto.addressProvince,
-    postalCode: addressDto.addressPostalZipCode,
-    country: addressDto.addressCountry,
-  };
-}
+/**
+ * Return a singleton instance (by means of memomization) of the address service.
+ */
+export const getAddressService = moize(createAddressService, { onCacheAdd: () => log.info('Creating new address service') });
 
 function createAddressService() {
-  const logger = getLogger('address-service.server');
   const { INTEROP_API_BASE_URI } = getEnv();
 
   async function getAddressInfo(userId: string, addressId: string) {
     const url = `${INTEROP_API_BASE_URI}/users/${userId}/addresses/${addressId}`;
     const response = await fetch(url);
 
-    if (response.ok) return toAddressInfo(addressDtoSchema.parse(await response.json()));
-    if (response.status === 404) return null;
+    if (response.ok) {
+      return toAddressInfo(addressDtoSchema.parse(await response.json()));
+    }
 
-    logger.error('%j', {
+    if (response.status === 404) {
+      return null;
+    }
+
+    log.error('%j', {
       message: 'Failed to fetch address',
       status: response.status,
       statusText: response.statusText,
@@ -57,25 +59,19 @@ function createAddressService() {
     throw new Error(`Failed to fetch data. address: ${response.status}, Status Text: ${response.statusText}`);
   }
 
-  function toAddressDto(addressForm: AddressInfo): AddressDto {
-    return {
-      addressApartmentUnitNumber: String(addressForm.address?.match(/[\d|-]+/)),
-      addressStreet: addressForm.address?.substring(addressForm.address?.indexOf(' ') + 1),
-      addressCity: addressForm.city,
-      addressProvince: addressForm.province,
-      addressPostalZipCode: addressForm.postalCode,
-      addressCountry: addressForm.country,
-    };
-  }
-
   async function updateAddressInfo(userId: string, addressId: string, addressInfo: AddressInfo) {
     const curentAddressDto = await getAddressInfo(userId, addressId);
     const addressDto = toAddressDto(addressInfo);
 
-    if (!curentAddressDto) return;
+    if (!curentAddressDto) {
+      return;
+    }
 
     const patch = jsonpatch.compare(curentAddressDto, { ...curentAddressDto, ...addressDto });
-    if (patch.length === 0) return;
+
+    if (patch.length === 0) {
+      return;
+    }
 
     const url = `${INTEROP_API_BASE_URI}/users/${userId}/addresses/${addressId}`;
     const response = await fetch(url, {
@@ -84,7 +80,7 @@ function createAddressService() {
     });
 
     if (!response.ok) {
-      logger.error('%j', {
+      log.error('%j', {
         message: 'Failed to fetch address',
         status: response.status,
         statusText: response.statusText,
@@ -95,7 +91,27 @@ function createAddressService() {
       throw new Error(`Failed to fetch address. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
   }
+
   return { getAddressInfo, updateAddressInfo };
 }
 
-export const addressService = createAddressService();
+function toAddressDto(addressForm: AddressInfo): AddressDto {
+  return {
+    addressApartmentUnitNumber: String(addressForm.address?.match(/[\d|-]+/)),
+    addressStreet: addressForm.address?.substring(addressForm.address?.indexOf(' ') + 1),
+    addressCity: addressForm.city,
+    addressProvince: addressForm.province,
+    addressPostalZipCode: addressForm.postalCode,
+    addressCountry: addressForm.country,
+  };
+}
+
+function toAddressInfo(addressDto: AddressDto): AddressInfo {
+  return {
+    address: addressDto.addressApartmentUnitNumber ? `${addressDto.addressApartmentUnitNumber} ${addressDto.addressStreet}` : addressDto.addressStreet,
+    city: addressDto.addressCity,
+    province: addressDto.addressProvince,
+    postalCode: addressDto.addressPostalZipCode,
+    country: addressDto.addressCountry,
+  };
+}


### PR DESCRIPTION
### Description

Refactor the address service module to use moize.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and verify that an address is displayed on the personal info page.
