### PR TITLE
Refactor redis service to use `moize`

### DIFF
--- a/frontend/__tests__/services/session-service.server.test.ts
+++ b/frontend/__tests__/services/session-service.server.test.ts
@@ -3,7 +3,7 @@ import { createFileSessionStorage, createSessionStorage } from '@remix-run/node'
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { redisService } from '~/services/redis-service.server';
+import { getRedisService } from '~/services/redis-service.server';
 import { getEnv } from '~/utils/env.server';
 
 vi.mock('@remix-run/node', () => ({
@@ -14,11 +14,11 @@ vi.mock('@remix-run/node', () => ({
 }));
 
 vi.mock('~/services/redis-service.server', () => ({
-  redisService: {
+  getRedisService: vi.fn().mockResolvedValue({
     set: vi.fn(),
     get: vi.fn(),
     del: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock('~/utils/env.server', () => ({
@@ -55,6 +55,7 @@ describe('session-service.server tests', () => {
 
   describe('getSessionService() -- redis-backed session storage tests', () => {
     it('should call redisService.set() when creating redis-backed session storage', async () => {
+      const redisService = await getRedisService();
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
       const { sessionService: _sessionService } = await import('~/services/session-service.server');
       const strategy = vi.mocked(createSessionStorage).mock.calls[0][0];
@@ -63,7 +64,8 @@ describe('session-service.server tests', () => {
       expect(redisService.set).toHaveBeenCalled();
     });
 
-    it('should call redisService.get() when reading from redis-backed session storage', async () => {
+    it('should call redisService().get() when reading from redis-backed session storage', async () => {
+      const redisService = await getRedisService();
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
       vi.mocked(redisService.get).mockResolvedValue('"value"');
       const { sessionService: _sessionService } = await import('~/services/session-service.server');
@@ -72,15 +74,17 @@ describe('session-service.server tests', () => {
       expect(redisService.get).toHaveBeenCalled();
     });
 
-    it('should call redisService.set() when updating redis-backed session storage', async () => {
+    it('should call redisService().set() when updating redis-backed session storage', async () => {
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
+      const redisService = await getRedisService();
       const { sessionService: _sessionService } = await import('~/services/session-service.server');
       const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
       await sessionStrategy.updateData('id', 'value');
       expect(redisService.set).toHaveBeenCalled();
     });
 
-    it('should call redisService.del() when deleting from redis-backed session storage', async () => {
+    it('should call redisService().del() when deleting from redis-backed session storage', async () => {
+      const redisService = await getRedisService();
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
       const { sessionService: _sessionService } = await import('~/services/session-service.server');
       const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];

--- a/frontend/app/services/session-service.server.ts
+++ b/frontend/app/services/session-service.server.ts
@@ -25,7 +25,7 @@ import { createCookie, createFileSessionStorage, createSessionStorage } from '@r
 
 import { randomUUID } from 'node:crypto';
 
-import { redisService } from '~/services/redis-service.server';
+import { getRedisService } from '~/services/redis-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
@@ -63,20 +63,24 @@ function createSessionService() {
       cookie: sessionCookie,
       createData: async (data) => {
         log.debug(`Creating new session storage slot with id=[${sessionId}]`);
-        await redisService.set(sessionId, JSON.stringify(data), setCommandOptions);
+        const redisService = await getRedisService();
+        redisService.set(sessionId, JSON.stringify(data), setCommandOptions);
         return sessionId;
       },
       readData: async (id) => {
         log.debug(`Reading session data for session id=[${id}]`);
+        const redisService = await getRedisService();
         return JSON.parse(await redisService.get(id));
       },
       updateData: async (id, data) => {
         log.debug(`Updating session data for session id=[${id}]`);
-        await redisService.set(id, JSON.stringify(data), setCommandOptions);
+        const redisService = await getRedisService();
+        redisService.set(id, JSON.stringify(data), setCommandOptions);
       },
       deleteData: async (id) => {
         log.debug(`Deleting all session data for session id=[${id}]`);
-        await redisService.del(id);
+        const redisService = await getRedisService();
+        redisService.del(id);
       },
     });
   }


### PR DESCRIPTION
### Description

Refactor the redis service module to use moize.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
