### PR TITLE
Refactor session service to use `moize`

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -4,15 +4,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.confirm';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 
 vi.mock('~/services/session-service.server', () => ({
-  sessionService: {
+  getSessionService: vi.fn().mockResolvedValue({
     getSession: vi.fn().mockReturnValue({
       get: vi.fn(),
     }),
-  },
+  }),
 }));
 
 vi.mock('~/services/user-service.server', () => ({
@@ -37,6 +37,7 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
 
   describe('loader()', () => {
     it('should return homeAddressInfo and newHomeAddress objects', async () => {
+      const sessionService = await getSessionService();
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
       vi.mocked((await sessionService.getSession()).get).mockResolvedValue({ address: '123 Fake Home St.', city: 'city', country: 'country' });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.edit.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.edit';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 
 vi.mock('~/services/address-service.server', () => ({
@@ -15,12 +15,12 @@ vi.mock('~/services/address-service.server', () => ({
 }));
 
 vi.mock('~/services/session-service.server', () => ({
-  sessionService: {
+  getSessionService: vi.fn().mockResolvedValue({
+    commitSession: vi.fn(),
     getSession: vi.fn().mockReturnValue({
       set: vi.fn(),
     }),
-    commitSession: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock('~/services/user-service.server', () => ({
@@ -70,6 +70,7 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
 
   describe('action()', () => {
     it('should redirect to confirm page', async () => {
+      const sessionService = await getSessionService();
       vi.mocked(sessionService.commitSession).mockResolvedValue('some-set-cookie-header');
 
       const formData = new FormData();

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.edit.test.tsx
@@ -6,12 +6,12 @@ import { action, loader } from '~/routes/_gcweb-app.personal-information.phone-n
 import { userService } from '~/services/user-service.server';
 
 vi.mock('~/services/session-service.server', () => ({
-  sessionService: {
+  getSessionService: vi.fn().mockResolvedValue({
     commitSession: vi.fn(),
     getSession: vi.fn().mockReturnValue({
       set: vi.fn(),
     }),
-  },
+  }),
 }));
 
 vi.mock('~/services/user-service.server', () => ({

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.preferred-language.confirm.test.tsx
@@ -29,12 +29,11 @@ vi.mock('~/utils/env.server', () => ({
 }));
 
 vi.mock('~/services/session-service.server', () => ({
-  createSessionService: vi.fn(),
-  sessionService: {
+  getSessionService: vi.fn().mockResolvedValue({
     getSession: vi.fn().mockReturnValue({
       get: vi.fn(),
     }),
-  },
+  }),
 }));
 
 describe('_gcweb-app.personal-information.preferred-language.confirm', () => {

--- a/frontend/__tests__/services/session-service.server.test.ts
+++ b/frontend/__tests__/services/session-service.server.test.ts
@@ -41,23 +41,32 @@ describe('session-service.server tests', () => {
 
   describe('getSessionService() -- SESSION_STORAGE_TYPE flag tests', () => {
     it('should create a new file-backed session storage when SESSION_STORAGE_TYPE=file', async () => {
+      const { getSessionService } = await import('~/services/session-service.server');
+
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'file' });
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+      const _sessionService = await getSessionService();
+
       expect(createFileSessionStorage).toHaveBeenCalled();
     });
 
     it('should create a new redis-backed session storage when SESSION_STORAGE_TYPE=redis', async () => {
+      const { getSessionService } = await import('~/services/session-service.server');
+
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+      const _sessionService = await getSessionService();
+
       expect(createSessionStorage).toHaveBeenCalled();
     });
   });
 
   describe('getSessionService() -- redis-backed session storage tests', () => {
     it('should call redisService.set() when creating redis-backed session storage', async () => {
+      const { getSessionService } = await import('~/services/session-service.server');
       const redisService = await getRedisService();
+
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+      const _sessionService = await getSessionService();
+
       const strategy = vi.mocked(createSessionStorage).mock.calls[0][0];
       const sessionId = await strategy.createData('value');
       expect(sessionId).toBeDefined();
@@ -65,10 +74,13 @@ describe('session-service.server tests', () => {
     });
 
     it('should call redisService().get() when reading from redis-backed session storage', async () => {
+      const { getSessionService } = await import('~/services/session-service.server');
       const redisService = await getRedisService();
+
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
       vi.mocked(redisService.get).mockResolvedValue('"value"');
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+      const _sessionService = await getSessionService();
+
       const strategy = vi.mocked(createSessionStorage).mock.calls[0][0];
       await strategy.readData('id');
       expect(redisService.get).toHaveBeenCalled();
@@ -76,17 +88,23 @@ describe('session-service.server tests', () => {
 
     it('should call redisService().set() when updating redis-backed session storage', async () => {
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
+      const { getSessionService } = await import('~/services/session-service.server');
       const redisService = await getRedisService();
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+
+      const _sessionService = await getSessionService();
+
       const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
       await sessionStrategy.updateData('id', 'value');
       expect(redisService.set).toHaveBeenCalled();
     });
 
     it('should call redisService().del() when deleting from redis-backed session storage', async () => {
+      const { getSessionService } = await import('~/services/session-service.server');
       const redisService = await getRedisService();
+
       vi.mocked(getEnv, { partial: true }).mockReturnValue({ SESSION_STORAGE_TYPE: 'redis' });
-      const { sessionService: _sessionService } = await import('~/services/session-service.server');
+      const _sessionService = await getSessionService();
+
       const sessionStrategy = vi.mocked(createSessionStorage).mock.calls[0][0];
       await sessionStrategy.deleteData('id');
       expect(redisService.del).toHaveBeenCalled();

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -27,6 +27,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
   const homeAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const newHomeAddress = await session.get('newHomeAddress');
   return json({ homeAddressInfo, newHomeAddress });
@@ -35,6 +36,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
 
   await getAddressService().updateAddressInfo(userId, userInfo?.homeAddress ?? '', session.get('newHomeAddress'));

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -11,7 +11,7 @@ import { InputField } from '~/components/input-field';
 import { type InputOptionProps } from '~/components/input-option';
 import { InputSelect } from '~/components/input-select';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -68,6 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('newHomeAddress', parsedDataResult.data);
 

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -27,6 +27,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
   const mailingAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const newMailingAddress = await session.get('newMailingAddress');
   return json({ mailingAddressInfo, newMailingAddress });
@@ -35,6 +36,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
+
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
 
   await getAddressService().updateAddressInfo(userId, userInfo?.mailingAddress ?? '', session.get('newMailingAddress'));

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { getAddressService } from '~/services/address-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -67,6 +67,7 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('newMailingAddress', parsedDataResult.data);
 

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
@@ -4,7 +4,7 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -24,6 +24,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   if (!session.has('newPhoneNumber')) return redirect('/');
 
@@ -36,6 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
   if (!userInfo) return redirect('/');
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   if (!session.has('newPhoneNumber')) return redirect('/');
 

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -54,6 +54,7 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('newPhoneNumber', parsedDataResult.data.phoneNumber);
 

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
@@ -5,7 +5,7 @@ import { Form, Link, useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 
 import { getLookupService } from '~/services/lookup-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -26,6 +26,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const preferredLanguageSession = await session.get('preferredLanguage');
   const preferredLanguage = await getLookupService().getPreferredLanguage(preferredLanguageSession);
@@ -34,6 +35,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await userService.getUserId();
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const preferredLanguageSession = await session.get('preferredLanguage');
   await userService.updateUserInfo(userId, { preferredLanguage: preferredLanguageSession });

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 import { InputRadios } from '~/components/input-radios';
 import { getLookupService } from '~/services/lookup-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { userService } from '~/services/user-service.server';
 import { PREFERRED_LANGUAGES } from '~/utils/constants';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -49,6 +49,7 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('preferredLanguage', parsedDataResult.data.preferredLanguage);
 

--- a/frontend/app/routes/auth.$.tsx
+++ b/frontend/app/routes/auth.$.tsx
@@ -3,7 +3,7 @@ import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { z } from 'zod';
 
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { sessionService } from '~/services/session-service.server';
+import { getSessionService } from '~/services/session-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 import { generateCallbackUri, generateRandomString } from '~/utils/raoidc-utils.server';
@@ -54,6 +54,7 @@ async function handleRaoidcLoginRequest({ params, request }: LoaderFunctionArgs)
   const { authUrl, codeVerifier, state } = raoidcService.generateSigninRequest(redirectUri);
 
   // codeVerifier and state will have to be validated in the callback handler
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   session.set('codeVerifier', codeVerifier);
   session.set('state', state);
@@ -71,6 +72,7 @@ async function handleRaoidcLoginRequest({ params, request }: LoaderFunctionArgs)
 async function handleRaoidcCallbackRequest({ params, request }: LoaderFunctionArgs) {
   log.debug('Handling RAOIDC callback request');
   const raoidcService = await getRaoidcService();
+  const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
   const codeVerifier = session.get('codeVerifier');
   const state = session.get('state');


### PR DESCRIPTION
# Apologies for the size of this PR 😞

### Description

Refactor the session service module to use `moize`.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and attempt to change address or phone number. Notice that the changed value persists across different pages of the flow.
