### PR TITLE
AB#2903: integrate address forms with country list and province list

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information._index.test.tsx
@@ -35,6 +35,25 @@ vi.mock('~/services/lookup-service.server', () => ({
       nameEn: 'French',
       nameFr: 'Français',
     }),
+    getAllCountries: vi.fn().mockReturnValue([
+      {
+        code: 'SUP',
+        nameEn: 'super country',
+        nameFr: '(FR) super country',
+      },
+    ]),
+    getAllRegions: vi.fn().mockReturnValue([
+      {
+        code: 'SP',
+        country: {
+          code: 'SUP',
+          nameEn: 'super country',
+          nameFr: '(FR) super country',
+        },
+        nameEn: 'sample',
+        nameFr: '(FR) sample',
+      },
+    ]),
   }),
 }));
 
@@ -109,6 +128,25 @@ describe('_gcweb-app.personal-information._index', () => {
           postalCode: 'postal code',
           country: 'super country',
         },
+        countryList: [
+          {
+            code: 'SUP',
+            nameEn: 'super country',
+            nameFr: '(FR) super country',
+          },
+        ],
+        regionList: [
+          {
+            code: 'SP',
+            country: {
+              code: 'SUP',
+              nameEn: 'super country',
+              nameFr: '(FR) super country',
+            },
+            nameEn: 'sample',
+            nameFr: '(FR) sample',
+          },
+        ],
       });
     });
   });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -7,10 +7,37 @@ import { getAddressService } from '~/services/address-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 
+vi.mock('~/services/lookup-service.server', () => ({
+  getLookupService: vi.fn().mockReturnValue({
+    getAllCountries: vi.fn().mockReturnValue([
+      {
+        code: 'SUP',
+        nameEn: 'super country',
+        nameFr: '(FR) super country',
+      },
+    ]),
+    getAllRegions: vi.fn().mockReturnValue([
+      {
+        code: 'SP',
+        country: {
+          code: 'SUP',
+          nameEn: 'super country',
+          nameFr: '(FR) super country',
+        },
+        nameEn: 'sample',
+        nameFr: '(FR) sample',
+      },
+    ]),
+  }),
+}));
+
 vi.mock('~/services/session-service.server', () => ({
   getSessionService: vi.fn().mockResolvedValue({
+    commitSession: vi.fn(),
     getSession: vi.fn().mockReturnValue({
+      has: vi.fn(),
       get: vi.fn(),
+      unset: vi.fn(),
     }),
   }),
 }));
@@ -19,7 +46,6 @@ vi.mock('~/services/user-service.server', () => ({
   getUserService: vi.fn().mockReturnValue({
     getUserId: vi.fn().mockReturnValue('some-id'),
     getUserInfo: vi.fn(),
-    updateUserInfo: vi.fn(),
   }),
 }));
 
@@ -37,12 +63,13 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
 
   describe('loader()', () => {
     it('should return homeAddressInfo and newHomeAddress objects', async () => {
-      const sessionService = await getSessionService();
       const userService = getUserService();
+      const sessionService = await getSessionService();
+      const session = await sessionService.getSession();
 
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
-      vi.mocked((await sessionService.getSession()).get).mockResolvedValue({ address: '123 Fake Home St.', city: 'city', country: 'country' });
+      vi.mocked(session.get).mockResolvedValue({ address: '123 Fake Home St.', city: 'city', country: 'country' });
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/home-address/confirm'),
@@ -55,6 +82,25 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
       expect(data).toEqual({
         homeAddressInfo: { address: '111 Fake Home St', city: 'city', country: 'country' },
         newHomeAddress: { address: '123 Fake Home St.', city: 'city', country: 'country' },
+        countryList: [
+          {
+            code: 'SUP',
+            nameEn: 'super country',
+            nameFr: '(FR) super country',
+          },
+        ],
+        regionList: [
+          {
+            code: 'SP',
+            country: {
+              code: 'SUP',
+              nameEn: 'super country',
+              nameFr: '(FR) super country',
+            },
+            nameEn: 'sample',
+            nameFr: '(FR) sample',
+          },
+        ],
       });
     });
   });

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -25,7 +25,7 @@ const db = factory({
     addressCity: faker.location.city,
     addressProvince: () => faker.location.state({ abbreviated: true }),
     addressPostalZipCode: faker.location.zipCode,
-    addressCountry: () => 'Canada',
+    addressCountry: () => 'CAN',
   },
   preferredLanguage: {
     id: primaryKey(String),
@@ -103,7 +103,7 @@ db.pdf.create({
 
 // seed country list
 const countryCanada = db.country.create({
-  code: 'CDN',
+  code: 'CAN',
   nameEn: 'Canada',
   nameFr: '(FR) Canada',
 });
@@ -125,7 +125,7 @@ db.region.create({
   code: 'ON',
   country: countryCanada,
   nameEn: 'Ontario',
-  nameFr: '(FR) COntario',
+  nameFr: '(FR) Ontario',
 });
 
 db.region.create({
@@ -140,6 +140,20 @@ db.region.create({
   country: countryCanada,
   nameEn: 'Quebec',
   nameFr: '(FR) Quebec',
+});
+
+db.region.create({
+  code: 'NS',
+  country: countryCanada,
+  nameEn: 'Nova Scotia',
+  nameFr: '(FR) Nova Scotia',
+});
+
+db.region.create({
+  code: 'PE',
+  country: countryCanada,
+  nameEn: 'Prince Edward Island',
+  nameFr: '(FR) Prince Edward Island',
 });
 
 db.region.create({

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -25,6 +25,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userService = getUserService();
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
+  const countryList = await getLookupService().getAllCountries();
+  const regionList = await getLookupService().getAllRegions();
 
   if (!userInfo) {
     throw new Response(null, { status: 404 });
@@ -34,11 +36,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const homeAddressInfo = userInfo.homeAddress && (await getAddressService().getAddressInfo(userId, userInfo?.homeAddress));
   const mailingAddressInfo = userInfo.mailingAddress && (await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress));
 
-  return json({ user: userInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo });
+  return json({ user: userInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, countryList, regionList });
 }
 
 export default function PersonalInformationIndex() {
-  const { user, preferredLanguage, homeAddressInfo, mailingAddressInfo } = useLoaderData<typeof loader>();
+  const { user, preferredLanguage, homeAddressInfo, mailingAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(i18nNamespaces);
   return (
     <>
@@ -67,11 +69,16 @@ export default function PersonalInformationIndex() {
           title={t('personal-information:index.home-address')}
           icon="glyphicon-map-marker"
         >
-          {homeAddressInfo ? (
-            <Address address={homeAddressInfo.address} city={homeAddressInfo.city} provinceState={homeAddressInfo.province} postalZipCode={homeAddressInfo.postalCode} country={homeAddressInfo.country} />
-          ) : (
-            <p>{t('personal-information:index.no-address-on-file')}</p>
+          {homeAddressInfo && (
+            <Address
+              address={homeAddressInfo?.address}
+              city={homeAddressInfo?.city}
+              provinceState={regionList.find((region) => region.code === homeAddressInfo.province)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn']}
+              postalZipCode={homeAddressInfo?.postalCode}
+              country={countryList.find((country) => country.code === homeAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
+            />
           )}
+          {!homeAddressInfo && <p>{t('personal-information:index.no-address-on-file')}</p>}
         </PersonalInformationSection>
         <PersonalInformationSection
           footer={
@@ -82,11 +89,16 @@ export default function PersonalInformationIndex() {
           title={t('personal-information:index.mailing-address')}
           icon="glyphicon-map-marker"
         >
-          {mailingAddressInfo ? (
-            <Address address={mailingAddressInfo.address} city={mailingAddressInfo.city} provinceState={mailingAddressInfo.province} postalZipCode={mailingAddressInfo.postalCode} country={mailingAddressInfo.country} />
-          ) : (
-            <p>{t('personal-information:index.no-address-on-file')}</p>
+          {mailingAddressInfo && (
+            <Address
+              address={mailingAddressInfo?.address}
+              city={mailingAddressInfo?.city}
+              provinceState={regionList.find((region) => region.code === mailingAddressInfo.province)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn']}
+              postalZipCode={mailingAddressInfo?.postalCode}
+              country={countryList.find((country) => country.code === mailingAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
+            />
           )}
+          {!mailingAddressInfo && <p>{t('personal-information:index.no-address-on-file')}</p>}
         </PersonalInformationSection>
         <PersonalInformationSection
           footer={

--- a/frontend/app/services/address-service.server.ts
+++ b/frontend/app/services/address-service.server.ts
@@ -60,14 +60,15 @@ function createAddressService() {
   }
 
   async function updateAddressInfo(userId: string, addressId: string, addressInfo: AddressInfo) {
-    const curentAddressDto = await getAddressInfo(userId, addressId);
-    const addressDto = toAddressDto(addressInfo);
+    const currentAddressInfo = await getAddressInfo(userId, addressId);
 
-    if (!curentAddressDto) {
+    if (!currentAddressInfo) {
       return;
     }
+    const currentAddressDto = toAddressDto(currentAddressInfo);
+    const addressDto = toAddressDto(addressInfo);
 
-    const patch = jsonpatch.compare(curentAddressDto, { ...curentAddressDto, ...addressDto });
+    const patch = jsonpatch.compare(currentAddressDto, { ...currentAddressDto, ...addressDto });
 
     if (patch.length === 0) {
       return;
@@ -100,8 +101,8 @@ function toAddressDto(addressForm: AddressInfo): AddressDto {
     addressApartmentUnitNumber: String(addressForm.address?.match(/[\d|-]+/)),
     addressStreet: addressForm.address?.substring(addressForm.address?.indexOf(' ') + 1),
     addressCity: addressForm.city,
-    addressProvince: addressForm.province,
-    addressPostalZipCode: addressForm.postalCode,
+    addressProvince: addressForm.province ?? '',
+    addressPostalZipCode: addressForm.postalCode ?? '',
     addressCountry: addressForm.country,
   };
 }

--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -20,16 +20,13 @@ const countrySchema = z.object({
 
 const regionSchema = z.object({
   code: z.string(),
-  country: z.object({
-    code: z.string(),
-    nameEn: z.string(),
-    nameFr: z.string(),
-  }),
+  country: countrySchema,
   nameEn: z.string(),
   nameFr: z.string(),
 });
 
 export type PreferredLanguageInfo = z.infer<typeof preferredLanguageSchema>;
+export type RegionInfo = z.infer<typeof regionSchema>;
 
 /**
  * Return a singleton instance (by means of memomization) of the lookup service.

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -41,7 +41,7 @@
         "cancel": "Cancel"
       }
     },
-    "address-accuracy": {
+"address-accuracy": {
       "page-title": "Home Address Accuracy",
       "breadcrumbs": {
         "home": "Home",
@@ -55,7 +55,7 @@
       "requested-change": "Requested change:",
       "re-enter-address": "Re-enter your address"
     },
-    "suggested": {
+"suggested": {
       "page-title:": "Suggested address",
       "breadcrumbs": {
         "home": "Home",
@@ -97,6 +97,8 @@
         "personal-information": "Personal information",
         "mailing-address-change": "Change mailing address"
       },
+      "copy-home-address": "Copy home address",
+      "copy-home-address-note": "We have the following home address on file, which will be used as your mailing address:",   
       "field": {
         "address": "Address",
         "city": "City",
@@ -112,7 +114,7 @@
         "cancel": "Cancel"
       }
     },
-    "address-accuracy": {
+"address-accuracy": {
       "page-title": "Mailing Address Accuracy",
       "breadcrumbs": {
         "home": "Home",

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -25,7 +25,7 @@
         "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "home-address-change": "(FR) Change home address"
-      },
+      },   
       "field": {
         "address": "(FR) Adddress",
         "city": "(FR) City",
@@ -41,7 +41,7 @@
         "cancel": "(FR) Cancel"
       }
     },
-    "address-accuracy": {
+"address-accuracy": {
       "page-title": "(FR) Home Address Accuracy",
       "breadcrumbs": {
         "home": "(FR) Home",
@@ -55,7 +55,7 @@
       "requested-change": "(FR) Requested change:",
       "re-enter-address": "(FR) Re-enter your address"
     },
-    "suggested": {
+"suggested": {
       "page-title:": "(FR) Suggested address",
       "breadcrumbs": {
         "home": "(FR) Home",
@@ -97,6 +97,8 @@
         "personal-information": "(FR) Personal information",
         "mailing-address-change": "(FR) Change mailing address"
       },
+      "copy-home-address": "(FR) Copy home address",      
+      "copy-home-address-note": "(FR) We have the following home address on file, which will be used as your mailing address:",   
       "field": {
         "address": "(FR) Address",
         "city": "(FR) City",
@@ -112,7 +114,7 @@
         "cancel": "(FR) Cancel"
       }
     },
-    "address-accuracy": {
+"address-accuracy": {
       "page-title": "(FR) Mailing Address Accuracy",
       "breadcrumbs": {
         "home": "(FR) Home",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

1. integrate home-address edit and confirm with country list and province list
2. integrate mailing-address edit and confirm with country list and province list

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/132592996/44eff144-7237-4163-8cd0-24751cf1d09d)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/132592996/e47fa6b0-76f2-4e56-90a3-b29fe8611b79)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`