### PR TITLE
AB#2868 -- Created routes for address to handle invalid WSAddress response

### DIFF
--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
@@ -1,0 +1,74 @@
+import { type ActionFunctionArgs, type LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { Form, Link, useLoaderData } from '@remix-run/react';
+
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+import { Address } from '~/components/address';
+import { getSessionService } from '~/services/session-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'personal-information:home-address.address-accuracy.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'personal-information:home-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
+    { labelI18nKey: 'personal-information:home-address.address-accuracy.page-title' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0013',
+  pageTitleI18nKey: 'personal-information:home-address.address-accuracy.page-title',
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const sessionService = await getSessionService();
+  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const newHomeAddress = await session.get('newHomeAddress');
+  return json({ newHomeAddress });
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  return redirect('/personal-information/home-address/confirm');
+}
+
+export default function PersonalInformationHomeAddressAccuracy() {
+  const { newHomeAddress } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
+  return (
+    <>
+      <Form method="post">
+        <section className="alert alert-warning mt-4">
+          <h3>{t('personal-information:home-address.address-accuracy.invalid-address')}</h3>
+          <p>{t('personal-information:home-address.address-accuracy.invalid-address-info')}</p>
+        </section>
+        <p>{t('personal-information:home-address.address-accuracy.note')}</p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <section className="panel panel-info flex flex-col">
+            <header className="panel-heading">
+              <h2 className="h3 panel-title">
+                <span className={clsx('glyphicon', 'glyphicon-map-marker', 'pull-right')} aria-hidden="true"></span>
+                {t('personal-information:home-address.address-accuracy.requested-change')}
+              </h2>
+            </header>
+            <div className="panel-body">
+              {newHomeAddress && <Address address={newHomeAddress?.address} city={newHomeAddress?.city} provinceState={newHomeAddress?.province} postalZipCode={newHomeAddress?.postalCode} country={newHomeAddress?.country} />}
+              {!newHomeAddress && <p>{t('personal-information:index.no-address-on-file')}</p>}
+            </div>
+          </section>
+        </div>
+        <Link id="cancel-button" to="/personal-information/home-address/edit" className="text-base font-bold">
+          {t('personal-information:home-address.address-accuracy.re-enter-address')}
+        </Link>
+        <div className="my-4 flex flex-wrap gap-3">
+          <button id="confirm-button" className="btn btn-primary btn-lg">
+            {t('personal-information:home-address.address-accuracy.continue')}
+          </button>
+          <Link id="cancel-button" to="/personal-information/" className="btn btn-default btn-lg">
+            {t('personal-information:home-address.address-accuracy.cancel')}
+          </Link>
+        </div>
+      </Form>
+    </>
+  );
+}

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
@@ -24,6 +24,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
+  if (!session.has('newHomeAddress')) return redirect('/');
   const newHomeAddress = await session.get('newHomeAddress');
   return json({ newHomeAddress });
 }
@@ -39,7 +40,7 @@ export default function PersonalInformationHomeAddressAccuracy() {
     <>
       <Form method="post">
         <section className="alert alert-warning mt-4">
-          <h3>{t('personal-information:home-address.address-accuracy.invalid-address')}</h3>
+          <h2>{t('personal-information:home-address.address-accuracy.invalid-address')}</h2>
           <p>{t('personal-information:home-address.address-accuracy.invalid-address-info')}</p>
         </section>
         <p>{t('personal-information:home-address.address-accuracy.note')}</p>
@@ -52,8 +53,7 @@ export default function PersonalInformationHomeAddressAccuracy() {
               </h2>
             </header>
             <div className="panel-body">
-              {newHomeAddress && <Address address={newHomeAddress?.address} city={newHomeAddress?.city} provinceState={newHomeAddress?.province} postalZipCode={newHomeAddress?.postalCode} country={newHomeAddress?.country} />}
-              {!newHomeAddress && <p>{t('personal-information:index.no-address-on-file')}</p>}
+              <Address address={newHomeAddress?.address} city={newHomeAddress?.city} provinceState={newHomeAddress?.province} postalZipCode={newHomeAddress?.postalCode} country={newHomeAddress?.country} />
             </div>
           </section>
         </div>

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
@@ -24,6 +24,7 @@ export const handle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request.headers.get('Cookie'));
+  if (!session.has('newMailingAddress')) return redirect('/');
   const newMailingAddress = await session.get('newMailingAddress');
   return json({ newMailingAddress });
 }
@@ -39,7 +40,7 @@ export default function PersonalInformationMailingAddressAccuracy() {
     <>
       <Form method="post">
         <section className="alert alert-warning mt-4">
-          <h3>{t('personal-information:mailing-address.address-accuracy.invalid-address')}</h3>
+          <h2>{t('personal-information:mailing-address.address-accuracy.invalid-address')}</h2>
           <p>{t('personal-information:mailing-address.address-accuracy.invalid-address-info')}</p>
         </section>
         <p>{t('personal-information:mailing-address.address-accuracy.note')}</p>
@@ -52,8 +53,7 @@ export default function PersonalInformationMailingAddressAccuracy() {
               </h2>
             </header>
             <div className="panel-body">
-              {newMailingAddress && <Address address={newMailingAddress?.address} city={newMailingAddress?.city} provinceState={newMailingAddress?.province} postalZipCode={newMailingAddress?.postalCode} country={newMailingAddress?.country} />}
-              {!newMailingAddress && <p>{t('personal-information:index.no-address-on-file')}</p>}
+              <Address address={newMailingAddress?.address} city={newMailingAddress?.city} provinceState={newMailingAddress?.province} postalZipCode={newMailingAddress?.postalCode} country={newMailingAddress?.country} />
             </div>
           </section>
         </div>

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
@@ -1,0 +1,74 @@
+import { type ActionFunctionArgs, type LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { Form, Link, useLoaderData } from '@remix-run/react';
+
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+import { Address } from '~/components/address';
+import { getSessionService } from '~/services/session-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+
+const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+
+export const handle = {
+  breadcrumbs: [
+    { labelI18nKey: 'personal-information:mailing-address.address-accuracy.breadcrumbs.home', to: '/' },
+    { labelI18nKey: 'personal-information:mailing-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
+    { labelI18nKey: 'personal-information:mailing-address.address-accuracy.page-title' },
+  ],
+  i18nNamespaces,
+  pageIdentifier: 'CDCP-0014',
+  pageTitleI18nKey: 'personal-information:mailing-address.address-accuracy.page-title',
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const sessionService = await getSessionService();
+  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const newMailingAddress = await session.get('newMailingAddress');
+  return json({ newMailingAddress });
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  return redirect('/personal-information/mailing-address/confirm');
+}
+
+export default function PersonalInformationMailingAddressAccuracy() {
+  const { newMailingAddress } = useLoaderData<typeof loader>();
+  const { t } = useTranslation(i18nNamespaces);
+  return (
+    <>
+      <Form method="post">
+        <section className="alert alert-warning mt-4">
+          <h3>{t('personal-information:mailing-address.address-accuracy.invalid-address')}</h3>
+          <p>{t('personal-information:mailing-address.address-accuracy.invalid-address-info')}</p>
+        </section>
+        <p>{t('personal-information:mailing-address.address-accuracy.note')}</p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <section className="panel panel-info !m-0 flex flex-col">
+            <header className="panel-heading">
+              <h2 className="h3 panel-title">
+                <span className={clsx('glyphicon', 'glyphicon-map-marker', 'pull-right')} aria-hidden="true"></span>
+                {t('personal-information:mailing-address.address-accuracy.requested-change')}
+              </h2>
+            </header>
+            <div className="panel-body">
+              {newMailingAddress && <Address address={newMailingAddress?.address} city={newMailingAddress?.city} provinceState={newMailingAddress?.province} postalZipCode={newMailingAddress?.postalCode} country={newMailingAddress?.country} />}
+              {!newMailingAddress && <p>{t('personal-information:index.no-address-on-file')}</p>}
+            </div>
+          </section>
+        </div>
+        <Link id="cancel-button" to="/personal-information/mailing-address/edit" className="text-base font-bold">
+          {t('personal-information:mailing-address.address-accuracy.re-enter-address')}
+        </Link>
+        <div className="flex flex-wrap gap-3">
+          <button id="confirm-button" className="btn btn-primary btn-lg">
+            {t('personal-information:mailing-address.address-accuracy.continue')}
+          </button>
+          <Link id="cancel-button" to="/personal-information/" className="btn btn-default btn-lg">
+            {t('personal-information:mailing-address.address-accuracy.cancel')}
+          </Link>
+        </div>
+      </Form>
+    </>
+  );
+}

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -41,6 +41,20 @@
         "cancel": "Cancel"
       }
     },
+    "address-accuracy": {
+      "page-title": "Home Address Accuracy",
+      "breadcrumbs": {
+        "home": "Home",
+        "personal-information": "Personal information"
+      },
+      "cancel": "Cancel",
+      "continue": "Continue",
+      "invalid-address": "Unable to verify address",
+      "invalid-address-info": "Your address is compared against Canada Post information for accuracy. However, in some cases, the system may not be able to verify the address’s accuracy. Use this address if you are certain it is correct.",
+      "note": "Please note: Choose \"Continue\" if the home address is correct or choose \"Re-enter address\" if changes are required",
+      "requested-change": "Requested change:",
+      "re-enter-address": "Re-enter your address"
+    },
     "suggested": {
       "page-title:": "Suggested address",
       "breadcrumbs": {
@@ -97,6 +111,20 @@
         "change": "Change",
         "cancel": "Cancel"
       }
+    },
+    "address-accuracy": {
+      "page-title": "Mailing Address Accuracy",
+      "breadcrumbs": {
+        "home": "Home",
+        "personal-information": "Personal information"
+      },
+      "cancel": "Cancel",
+      "continue": "Continue",
+      "invalid-address": "Unable to verify address",
+      "invalid-address-info": "Your address is compared against Canada Post information for accuracy. However, in some cases, the system may not be able to verify the address’s accuracy. Use this address if you are certain it is correct.",
+      "note": "Please note: Choose \"Continue\" if the mailing address is correct or choose \"Re-enter address\" if changes are required",
+      "requested-change": "Requested change:",
+      "re-enter-address": "Re-enter your address"
     },
     "confirm": {
       "page-title": "Confirm",

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -41,6 +41,20 @@
         "cancel": "(FR) Cancel"
       }
     },
+    "address-accuracy": {
+      "page-title": "(FR) Home Address Accuracy",
+      "breadcrumbs": {
+        "home": "(FR) Home",
+        "personal-information": "(FR) Personal information"
+      },
+      "cancel": "(FR) Cancel",
+      "continue": "(FR) Continue",
+      "invalid-address": "(FR) Unable to verify address",
+      "invalid-address-info": "(FR) Your address is compared against Canada Post information for accuracy. However, in some cases, the system may not be able to verify the address’s accuracy. Use this address if you are certain it is correct.",
+      "note": "(FR) Please note: Choose \"Continue\" if the home address is correct or choose \"Re-enter address\" if changes are required",
+      "requested-change": "(FR) Requested change:",
+      "re-enter-address": "(FR) Re-enter your address"
+    },
     "suggested": {
       "page-title:": "(FR) Suggested address",
       "breadcrumbs": {
@@ -97,6 +111,20 @@
         "change": "(FR) Change",
         "cancel": "(FR) Cancel"
       }
+    },
+    "address-accuracy": {
+      "page-title": "(FR) Mailing Address Accuracy",
+      "breadcrumbs": {
+        "home": "(FR) Home",
+        "personal-information": "(FR) Personal information"
+      },
+      "cancel": "(FR) Cancel",
+      "continue": "(FR) Continue",
+      "invalid-address": "(FR) Unable to verify address",
+      "invalid-address-info": "(FR) Your address is compared against Canada Post information for accuracy. However, in some cases, the system may not be able to verify the address’s accuracy. Use this address if you are certain it is correct.",
+      "note": "(FR) Please note: Choose \"Continue\" if the mailing address is correct or choose \"Re-enter address\" if changes are required",
+      "requested-change": "(FR) Requested change:",
+      "re-enter-address": "(FR) Re-enter your address"
     },
     "confirm": {
       "page-title": "(FR) Confirm",


### PR DESCRIPTION
### Description
Created "invalid" address routes for when WSAddress is unable to validate an address (user is prompted to correct address or continue if it is a real address).

### Related Azure Boards Work Items
[AB#2868](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2868)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/6c34deb6-7522-4894-980b-071872a045a2)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Change the redirect in home/mailing address edit pages to redirect to the appropriate invalid page to view the page.

### Additional Notes
Page will be linked in a future PR when WSAddress is available (or additional runtime api mock are created to simulate the endpoint)