### PR TITLE
AB#2659 -- add RAOIDC session check support

### DIFF
--- a/frontend/app/mocks/raoidc.server.ts
+++ b/frontend/app/mocks/raoidc.server.ts
@@ -5,7 +5,7 @@ import { HttpResponse, http } from 'msw';
 import { privateKeyPemToCryptoKey, publicKeyPemToCryptoKey } from '~/utils/crypto-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
-import { type AuthTokenSet, type UserinfoTokenSet } from '~/utils/raoidc-utils.server';
+import { type AuthTokenSet, type JWKSet, type ServerMetadata, type UserinfoTokenSet } from '~/utils/raoidc-utils.server';
 
 const log = getLogger('raoidc.server');
 
@@ -47,6 +47,15 @@ export function getRaoidcMockHandlers() {
     http.get(`${AUTH_RAOIDC_BASE_URL}/userinfo`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       return HttpResponse.json(await getUserInfo());
+    }),
+
+    //
+    // RAOIDC `/validatesession` endpoint mock
+    // (note: this is not a standard OIDC endpoint)
+    //
+    http.get(`${AUTH_RAOIDC_BASE_URL}/validatesession`, async ({ request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      return HttpResponse.json(getSessionStatus());
     }),
   ];
 }
@@ -177,9 +186,12 @@ async function getJwks() {
         ...publicJwk,
       },
     ],
-  };
+  } as JWKSet;
 }
 
+/**
+ * Returns mock OIDC server metadata.
+ */
 function getOpenidConfiguration(authBaseUrl: string) {
   return {
     issuer: 'GC-ECAS-MOCK',
@@ -199,5 +211,13 @@ function getOpenidConfiguration(authBaseUrl: string) {
     userinfo_signing_alg_values_supported: ['RS256', 'RS512'],
     userinfo_encryption_alg_values_supported: ['RSA-OAEP-256'],
     userinfo_encryption_enc_values_supported: ['A256GCM'],
-  };
+  } as ServerMetadata;
+}
+
+/**
+ * Performs a mock session validation.
+ * 'true' means the session is valid
+ */
+function getSessionStatus() {
+  return true;
 }


### PR DESCRIPTION
### Description

RAOIDC exposes a `/../validatesession` endpoint that must be used to validate whether or not a user's authentication session is still active. This endpoint will return `true` if the session is still active, and `false` if the session is no longer active (ie: if the user logged out or timed out).

This PR adds support for calling RAOIDC's `/../validatesession` endpoint, and provides a mock that can be used during local development, or when RAOIDC is not available.

Note that the code to actually perform session validation on each request will come in a subsequent PR. It is not included here in order to keep this PR small(er).

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
