### PR TITLE
AB#2861 -- Removing use of readonly/hidden fields to set home address as mailing address

### DIFF
--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -41,7 +41,7 @@
         "cancel": "Cancel"
       }
     },
-"address-accuracy": {
+    "address-accuracy": {
       "page-title": "Home Address Accuracy",
       "breadcrumbs": {
         "home": "Home",
@@ -55,7 +55,7 @@
       "requested-change": "Requested change:",
       "re-enter-address": "Re-enter your address"
     },
-"suggested": {
+    "suggested": {
       "page-title:": "Suggested address",
       "breadcrumbs": {
         "home": "Home",
@@ -98,7 +98,7 @@
         "mailing-address-change": "Change mailing address"
       },
       "copy-home-address": "Copy home address",
-      "copy-home-address-note": "We have the following home address on file, which will be used as your mailing address:",   
+      "copy-home-address-note": "We have the following home address on file, which will be used as your mailing address:",
       "field": {
         "address": "Address",
         "city": "City",
@@ -114,7 +114,7 @@
         "cancel": "Cancel"
       }
     },
-"address-accuracy": {
+    "address-accuracy": {
       "page-title": "Mailing Address Accuracy",
       "breadcrumbs": {
         "home": "Home",

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -25,7 +25,7 @@
         "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "home-address-change": "(FR) Change home address"
-      },   
+      },
       "field": {
         "address": "(FR) Adddress",
         "city": "(FR) City",
@@ -41,7 +41,7 @@
         "cancel": "(FR) Cancel"
       }
     },
-"address-accuracy": {
+    "address-accuracy": {
       "page-title": "(FR) Home Address Accuracy",
       "breadcrumbs": {
         "home": "(FR) Home",
@@ -55,7 +55,7 @@
       "requested-change": "(FR) Requested change:",
       "re-enter-address": "(FR) Re-enter your address"
     },
-"suggested": {
+    "suggested": {
       "page-title:": "(FR) Suggested address",
       "breadcrumbs": {
         "home": "(FR) Home",
@@ -97,8 +97,8 @@
         "personal-information": "(FR) Personal information",
         "mailing-address-change": "(FR) Change mailing address"
       },
-      "copy-home-address": "(FR) Copy home address",      
-      "copy-home-address-note": "(FR) We have the following home address on file, which will be used as your mailing address:",   
+      "copy-home-address": "(FR) Copy home address",
+      "copy-home-address-note": "(FR) We have the following home address on file, which will be used as your mailing address:",
       "field": {
         "address": "(FR) Address",
         "city": "(FR) City",
@@ -114,7 +114,7 @@
         "cancel": "(FR) Cancel"
       }
     },
-"address-accuracy": {
+    "address-accuracy": {
       "page-title": "(FR) Mailing Address Accuracy",
       "breadcrumbs": {
         "home": "(FR) Home",


### PR DESCRIPTION
### Description
This PR is a follow-up to https://github.com/DTS-STN/canadian-dental-care-plan/pull/308 and resolves https://github.com/DTS-STN/canadian-dental-care-plan/pull/308#discussion_r1483359315. The `hidden` and `readonly` input fields that held the home address data have been removed. 

The `action` function is now responsible for seeing if the "Copy home address" checkbox is checked, and if so, using the home address on file as the new mailing address.

Some cleanup was also done, such as removing `key` from all input fields because we no longer need to check if the "Copy home address" checkbox is checked to populate the address form with the home address.

### Related Azure Boards Work Items
[AB#2861](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2861)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Run the application locally. 
- Navigate to `/personal-information/mailing-address/edit`. 
- Check the "Copy home address" checkbox. There are no `hidden` or `readonly` input fields.