### PR TITLE
Make acquiring a session slightly easier

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -65,7 +65,7 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
     it('should return homeAddressInfo and newHomeAddress objects', async () => {
       const userService = getUserService();
       const sessionService = await getSessionService();
-      const session = await sessionService.getSession();
+      const session = await sessionService.getSession(new Request('https://example.com/'));
 
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });

--- a/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.phone-number.confirm.test.tsx
@@ -34,7 +34,7 @@ describe('_gcweb-app.personal-information.phone-number.confirm', () => {
   describe('loader()', () => {
     it('should return userInfo and newPhoneNumber', async () => {
       const sessionService = await getSessionService();
-      const session = await sessionService.getSession();
+      const session = await sessionService.getSession(new Request('https://example.com/'));
       const userService = getUserService();
 
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', phoneNumber: '(111) 222-3333' });
@@ -59,7 +59,7 @@ describe('_gcweb-app.personal-information.phone-number.confirm', () => {
   describe('action()', () => {
     it('should redirect to the personal information on success', async () => {
       const sessionService = await getSessionService();
-      const session = await sessionService.getSession();
+      const session = await sessionService.getSession(new Request('https://example.com/'));
 
       vi.mocked(session.has).mockResolvedValueOnce(true);
 

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
@@ -23,7 +23,7 @@ export const handle = {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   if (!session.has('newHomeAddress')) return redirect('/');
   const newHomeAddress = await session.get('newHomeAddress');
   return json({ newHomeAddress });

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -32,7 +32,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const regionList = await getLookupService().getAllRegions();
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   const newHomeAddress = await session.get('newHomeAddress');
   return json({ homeAddressInfo, newHomeAddress, countryList, regionList });
 }
@@ -42,7 +42,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
 
   await getAddressService().updateAddressInfo(userId, userInfo?.homeAddress ?? '', session.get('newHomeAddress'));
 

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -74,7 +74,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   session.set('newHomeAddress', parsedDataResult.data);
 
   return redirect('/personal-information/home-address/confirm', {

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
@@ -37,7 +37,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // CHANGE THE SOURCE OF THE SUGGESTED ADDRESS TO WHAT WS ADDRESS SERVICE IS RETURNING INSTEAD OF MAILING ADDRESS
   //
   const suggestedAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   session.set('homeAddress', homeAddressInfo);
   session.set('suggestedAddress', suggestedAddressInfo);
 
@@ -57,7 +57,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const suggestedAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
   const formDataRadio = Object.fromEntries(await request.formData());
   //retrieve selected address, store it in the session and then redirect to the confirm page...
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   if (formDataRadio.selectedAddress === 'home') {
     session.set('newHomeAddress', homeAddressInfo);
   } else {

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
@@ -23,7 +23,7 @@ export const handle = {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   if (!session.has('newMailingAddress')) return redirect('/');
   const newMailingAddress = await session.get('newMailingAddress');
   return json({ newMailingAddress });

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
@@ -32,7 +32,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const regionList = await getLookupService().getAllRegions();
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   const newMailingAddress = await session.get('newMailingAddress');
   return json({ mailingAddressInfo, newMailingAddress, countryList, regionList });
 }
@@ -43,7 +43,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userInfo = await userService.getUserInfo(userId);
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
 
   await getAddressService().updateAddressInfo(userId, userInfo?.mailingAddress ?? '', session.get('newMailingAddress'));
 

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
@@ -81,7 +81,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
 
   const { copyHomeAddress } = formData as Partial<z.infer<typeof copyHomeAddressSchema>>;
   if (copyHomeAddress) {

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
@@ -27,7 +27,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   if (!session.has('newPhoneNumber')) return redirect('/');
 
   return json({ userInfo, newPhoneNumber: await session.get('newPhoneNumber') });
@@ -41,7 +41,7 @@ export async function action({ request }: ActionFunctionArgs) {
   if (!userInfo) return redirect('/');
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   if (!session.has('newPhoneNumber')) return redirect('/');
 
   userInfo.phoneNumber = session.get('newPhoneNumber');

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
@@ -56,7 +56,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   session.set('newPhoneNumber', parsedDataResult.data.phoneNumber);
 
   return redirect('/personal-information/phone-number/confirm', {

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
@@ -28,7 +28,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   const preferredLanguageSession = await session.get('preferredLanguage');
   const preferredLanguage = await getLookupService().getPreferredLanguage(preferredLanguageSession);
   return json({ userInfo, preferredLanguage });
@@ -38,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userService = getUserService();
   const userId = await userService.getUserId();
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   const preferredLanguageSession = await session.get('preferredLanguage');
   await userService.updateUserInfo(userId, { preferredLanguage: preferredLanguageSession });
   return redirect('/personal-information');

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -51,7 +51,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   session.set('preferredLanguage', parsedDataResult.data.preferredLanguage);
 
   return redirect('/personal-information/preferred-language/confirm', {

--- a/frontend/app/routes/auth.$.tsx
+++ b/frontend/app/routes/auth.$.tsx
@@ -68,7 +68,7 @@ async function handleRaoidcLoginRequest({ params, request }: LoaderFunctionArgs)
 
   log.debug('Storing [codeVerifier] and [state] in session for future validation');
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   // set as flash values so they're removed after the first get()
   session.flash('codeVerifier', codeVerifier);
   session.flash('returnUrl', returnUrl ?? '/');
@@ -88,7 +88,7 @@ async function handleRaoidcCallbackRequest({ params, request }: LoaderFunctionAr
 
   const raoidcService = await getRaoidcService();
   const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request.headers.get('Cookie'));
+  const session = await sessionService.getSession(request);
   const codeVerifier = session.get('codeVerifier');
   const returnUrl = session.get('returnUrl') ?? '/';
   const state = session.get('state');


### PR DESCRIPTION
### Description

Make acquiring a session a little less boilerplate-y.

**Before:** `sessionService.getSession(request.headers.get('Cookie'))`
**After:** `sessionService.getSession(request)`

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Attempt to change phone number or address, notice the data persists from the edit page to the confirm page (this is handled in session).
