### PR TITLE
Move 'home' breadcrumb into layout route

### DIFF
--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -5,8 +5,7 @@ import { createRemixStub } from '@remix-run/testing';
 
 import { describe, expect, it } from 'vitest';
 
-import type { BuildInfo } from '~/utils/route-utils';
-import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey } from '~/utils/route-utils';
+import { type Breadcrumbs, type BuildInfo, coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey } from '~/utils/route-utils';
 
 describe('coalesce<T> reducer', () => {
   it('expect undefined from two undefined values', () => {
@@ -43,25 +42,26 @@ describe('useBreadcrumbs()', () => {
     render(<RemixStub />);
 
     const element = await waitFor(() => screen.findByTestId('data'));
-    expect(element.textContent).toEqual('');
+    expect(element.textContent).toEqual('[]');
   });
 
   it('expect correctly coalesced breadcrumbs from useBreadcrumbs() if the loaders provide data', async () => {
+    const breadcrumbs: Breadcrumbs = [
+      { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.personal-information', to: '/personal-information' },
+      { labelI18nKey: 'personal-information:preferred-language.edit.page-title', to: '/personal-information/preferred-language' },
+      { labelI18nKey: 'personal-information:preferred-language.edit.page-title' },
+    ];
+
     const RemixStub = createRemixStub([
       {
         Component: () => <Outlet />,
-        handle: { breadcrumbs: [{ labelI18nKey: 'index:breadcrumbs.home' }] } satisfies RouteHandleData,
+        handle: {
+          breadcrumbs: [{ labelI18nKey: 'gcweb:breadcrumbs.home' }],
+        } satisfies RouteHandleData,
         children: [
           {
             Component: () => <div data-testid="data">{JSON.stringify(useBreadcrumbs())}</div>,
-            handle: {
-              breadcrumbs: [
-                { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.home', to: '/' },
-                { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.personal-information', to: '/personal-information' },
-                { labelI18nKey: 'personal-information:preferred-language.edit.page-title', to: '/personal-information/preferred-language' },
-                { labelI18nKey: 'personal-information:preferred-language.edit.page-title' },
-              ],
-            } satisfies RouteHandleData,
+            handle: { breadcrumbs } satisfies RouteHandleData,
             path: '/',
           },
         ],
@@ -71,9 +71,7 @@ describe('useBreadcrumbs()', () => {
     render(<RemixStub />);
 
     const element = await waitFor(() => screen.findByTestId('data'));
-    expect(element.textContent).toEqual(
-      `[{"labelI18nKey":"personal-information:preferred-language.edit.breadcrumbs.home","to":"/"},{"labelI18nKey":"personal-information:preferred-language.edit.breadcrumbs.personal-information","to":"/personal-information"},{"labelI18nKey":"personal-information:preferred-language.edit.page-title","to":"/personal-information/preferred-language"},{"labelI18nKey":"personal-information:preferred-language.edit.page-title"}]`,
-    );
+    expect(element.textContent).toEqual(JSON.stringify(breadcrumbs));
   });
 });
 

--- a/frontend/app/routes/_gcweb-app._index.tsx
+++ b/frontend/app/routes/_gcweb-app._index.tsx
@@ -12,7 +12,6 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 const i18nNamespaces = getTypedI18nNamespaces('index');
 
 export const handle = {
-  breadcrumbs: [{ labelI18nKey: 'index:breadcrumbs.home' }],
   i18nNamespaces,
   pageIdentifier: 'CDCP-0001',
   pageTitleI18nKey: 'index:page-title',

--- a/frontend/app/routes/_gcweb-app.letters._index.tsx
+++ b/frontend/app/routes/_gcweb-app.letters._index.tsx
@@ -14,7 +14,7 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 const i18nNamespaces = getTypedI18nNamespaces('letters');
 
 export const handle = {
-  breadcrumbs: [{ labelI18nKey: 'letters:index.breadcrumbs.home', to: '/' }, { labelI18nKey: 'letters:index.page-title' }],
+  breadcrumbs: [{ labelI18nKey: 'letters:index.page-title' }],
   i18nNamespaces,
   pageIdentifier: 'CDCP-0002',
   pageTitleI18nKey: 'letters:index.page-title',

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -15,7 +15,7 @@ import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils'
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
-  breadcrumbs: [{ labelI18nKey: 'personal-information:index.breadcrumbs.home', to: '/' }, { labelI18nKey: 'personal-information:index.page-title' }],
+  breadcrumbs: [{ labelI18nKey: 'personal-information:index.page-title' }],
   i18nNamespaces,
   pageIdentifier: 'CDCP-0002',
   pageTitleI18nKey: 'personal-information:index.page-title',

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.address-accuracy.tsx
@@ -12,7 +12,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:home-address.address-accuracy.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:home-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.address-accuracy.page-title' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -14,7 +14,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:home-address.confirm.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:home-address.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.confirm.breadcrumbs.address-change-confirm' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.edit.tsx
@@ -21,7 +21,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:home-address.edit.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:home-address.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.edit.breadcrumbs.home-address-change' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
@@ -17,7 +17,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:home-address.suggested.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:home-address.suggested.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.suggested.breadcrumbs.suggested-address' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.address-accuracy.tsx
@@ -12,7 +12,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:mailing-address.address-accuracy.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:mailing-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.address-accuracy.page-title' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
@@ -14,7 +14,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:mailing-address.confirm.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:mailing-address.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.confirm.breadcrumbs.address-change-confirm' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.edit.tsx
@@ -22,7 +22,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:mailing-address.edit.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:mailing-address.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.edit.breadcrumbs.mailing-address-change' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.confirm.tsx
@@ -13,7 +13,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:phone-number.confirm.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:phone-number.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:phone-number.confirm.breadcrumbs.confirm-phone-number' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.phone-number.edit.tsx
@@ -16,7 +16,7 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:phone-number.edit.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:phone-number.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:phone-number.edit.breadcrumbs.change-phone-number' },
   ],

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.confirm.tsx
@@ -14,7 +14,6 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.home', to: '/' },
     { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.preferred-language-edit', to: '/personal-information/preferred-language/edit' },
     { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.preferred-language-confirm' },

--- a/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.preferred-language.edit.tsx
@@ -15,7 +15,7 @@ const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
-    { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.home', to: '/' },
+    // prettier-ignore
     { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:preferred-language.edit.page-title' },
   ],

--- a/frontend/app/routes/_gcweb-app.tsx
+++ b/frontend/app/routes/_gcweb-app.tsx
@@ -263,32 +263,29 @@ function PageFooter() {
   );
 }
 
-function Breadcrumbs() {
-  const { t } = useTranslation(i18nNamespaces);
-  const { t: breadcrumbsTranslation } = useTranslation(useI18nNamespaces());
-  const breadcrumbs = useBreadcrumbs();
+function Breadcrumb({ children, to }: { children: ReactNode; to?: string }) {
+  // prettier-ignore
+  return to === undefined
+    ? <span property="name">{children}</span>
+    : <Link to={to} property="item" typeof="WebPage"><span property="name">{children}</span></Link>;
+}
 
-  if (breadcrumbs === undefined || breadcrumbs.length === 0) {
-    return <></>;
-  }
+function Breadcrumbs() {
+  const { t } = useTranslation([...i18nNamespaces, ...useI18nNamespaces()]);
+  const breadcrumbs = useBreadcrumbs();
 
   return (
     <nav id="wb-bc" property="breadcrumb" aria-labelledby="breadcrumbs">
       <h2 id="breadcrumbs">{t('gcweb:breadcrumbs.you-are-here')}</h2>
       <div className="container">
         <ol className="breadcrumb" typeof="BreadcrumbList">
+          <li property="itemListElement" typeof="ListItem">
+            <Breadcrumb to={breadcrumbs.length !== 0 ? '/' : undefined}>{t('gcweb:breadcrumbs.home')}</Breadcrumb>
+          </li>
           {breadcrumbs.map(({ labelI18nKey, to }, index) => {
-            const label = breadcrumbsTranslation(labelI18nKey);
             return (
               <li key={index} property="itemListElement" typeof="ListItem">
-                {to ? (
-                  <Link to={to} property="item" typeof="WebPage">
-                    <span property="name">{label}</span>
-                  </Link>
-                ) : (
-                  <span property="name">{label}</span>
-                )}
-                <meta property="position" content={`${index + 1}`} />
+                <Breadcrumb to={to}>{t(labelI18nKey)}</Breadcrumb>
               </li>
             );
           })}

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -56,11 +56,13 @@ export type PageIdentifier = z.infer<typeof pageIdentifierSchema>;
 export type PageTitleI18nKey = z.infer<typeof i18nKeySchema>;
 
 export function useBreadcrumbs() {
-  return useMatches()
-    .map((route) => route?.handle as RouteHandleData | undefined)
-    .map((handle) => breadcrumbsSchema.safeParse(handle?.breadcrumbs))
-    .map((result) => (result.success ? result.data : undefined))
-    .reduce(coalesce);
+  return (
+    useMatches()
+      .map((route) => route?.handle as RouteHandleData | undefined)
+      .map((handle) => breadcrumbsSchema.safeParse(handle?.breadcrumbs))
+      .map((result) => (result.success ? result.data : undefined))
+      .reduce(coalesce) ?? []
+  );
 }
 
 export function useBuildInfo() {

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -33,7 +33,8 @@
     "alt-lang-abbr": "FR"
   },
   "breadcrumbs": {
-    "you-are-here": "You are here:"
+    "you-are-here": "You are here:",
+    "home": "Home"
   },
   "page-details": {
     "page-details": "Page details",

--- a/frontend/public/locales/en/index.json
+++ b/frontend/public/locales/en/index.json
@@ -1,9 +1,6 @@
 {
   "page-title": "Home",
   "welcome": "Welcome {{firstName}} {{lastName}}",
-  "breadcrumbs": {
-    "home": "Home"
-  },
   "personal-info": "Personal information",
   "personal-info-desc": "In this section, you can see and update your personal information.",
   "upload": "Upload document for CDCP",

--- a/frontend/public/locales/en/letters.json
+++ b/frontend/public/locales/en/letters.json
@@ -2,7 +2,6 @@
   "index": {
     "page-title": "Letters",
     "breadcrumbs": {
-      "home": "Home",
       "letters": "Letters"
     },
     "subject": "Subject",

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -2,7 +2,6 @@
   "index": {
     "page-title": "Personal information",
     "breadcrumbs": {
-      "home": "Home",
       "personal-information": "Personal information"
     },
     "on-file": "We have the following information for you on file.",
@@ -22,7 +21,6 @@
     "edit": {
       "page-title": "Change home address",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "home-address-change": "Change home address"
       },
@@ -44,7 +42,6 @@
     "address-accuracy": {
       "page-title": "Home Address Accuracy",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information"
       },
       "cancel": "Cancel",
@@ -58,7 +55,6 @@
     "suggested": {
       "page-title:": "Suggested address",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "suggested-address": "Change home address"
       },
@@ -76,7 +72,6 @@
     "confirm": {
       "page-title": "Confirm",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "address-change-confirm": "Confirm"
       },
@@ -93,7 +88,6 @@
     "edit": {
       "page-title": "Change mailing address",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "mailing-address-change": "Change mailing address"
       },
@@ -117,7 +111,6 @@
     "address-accuracy": {
       "page-title": "Mailing Address Accuracy",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information"
       },
       "cancel": "Cancel",
@@ -131,7 +124,6 @@
     "confirm": {
       "page-title": "Confirm",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "address-change-confirm": "Confirm"
       },
@@ -148,7 +140,6 @@
     "edit": {
       "page-title": "Update phone number",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "change-phone-number": "Change phone number"
       },
@@ -171,7 +162,6 @@
     "confirm": {
       "page-title": "Confirm phone number",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "confirm-phone-number": "Confirm phone number"
       },
@@ -187,7 +177,6 @@
     "edit": {
       "page-title": "Change preferred language",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "preferred-language": "Preferred language",
         "edit": "Edit"
@@ -200,7 +189,6 @@
     "confirm": {
       "page-title": "Confirm preferred language",
       "breadcrumbs": {
-        "home": "Home",
         "personal-information": "Personal information",
         "preferred-language": "Preferred language",
         "preferred-language-edit": "Change preferred language",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -33,7 +33,8 @@
     "alt-lang-abbr": "EN"
   },
   "breadcrumbs": {
-    "you-are-here": "Vous êtes ici\u00a0:"
+    "you-are-here": "Vous êtes ici\u00a0:",
+    "home": "Accueil"
   },
   "page-details": {
     "page-details": "Détails de la page",

--- a/frontend/public/locales/fr/index.json
+++ b/frontend/public/locales/fr/index.json
@@ -1,9 +1,6 @@
 {
   "page-title": "(FR) Home",
   "welcome": "Bienvenue {{firstName}} {{lastName}}",
-  "breadcrumbs": {
-    "home": "(FR) Home"
-  },
   "personal-info": "(FR) Personal information",
   "personal-info-desc": "(FR) In this section, you can see and update your personal information.",
   "upload": "(FR) Upload document for CDCP",

--- a/frontend/public/locales/fr/letters.json
+++ b/frontend/public/locales/fr/letters.json
@@ -2,7 +2,6 @@
   "index": {
     "page-title": "(FR) Letters",
     "breadcrumbs": {
-      "home": "(FR) Home",
       "letters": "(FR) Letters"
     },
     "subject": "(FR) Subject",

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -2,7 +2,6 @@
   "index": {
     "page-title": "(FR) Personal information",
     "breadcrumbs": {
-      "home": "(FR) Home",
       "personal-information": "(FR) Personal information"
     },
     "on-file": "(FR) We have the following information for you on file.",
@@ -22,7 +21,6 @@
     "edit": {
       "page-title": "(FR) Change home address",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "home-address-change": "(FR) Change home address"
       },
@@ -44,7 +42,6 @@
     "address-accuracy": {
       "page-title": "(FR) Home Address Accuracy",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information"
       },
       "cancel": "(FR) Cancel",
@@ -58,7 +55,6 @@
     "suggested": {
       "page-title:": "(FR) Suggested address",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "suggested-address": "(FR) Suggested address"
       },
@@ -76,7 +72,6 @@
     "confirm": {
       "page-title": "(FR) Confirm",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "address-change-confirm": "(FR) Confirm"
       },
@@ -93,7 +88,6 @@
     "edit": {
       "page-title": "(FR) Change mailing address",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "mailing-address-change": "(FR) Change mailing address"
       },
@@ -117,7 +111,6 @@
     "address-accuracy": {
       "page-title": "(FR) Mailing Address Accuracy",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information"
       },
       "cancel": "(FR) Cancel",
@@ -131,7 +124,6 @@
     "confirm": {
       "page-title": "(FR) Confirm",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "address-change-confirm": "(FR) Confirm"
       },
@@ -148,7 +140,6 @@
     "edit": {
       "page-title": "(FR) Update phone number",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "change-phone-number": "(FR) Change phone number"
       },
@@ -171,7 +162,6 @@
     "confirm": {
       "page-title": "(FR) Confirm phone number",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "confirm-phone-number": "(FR) Confirm phone number"
       },
@@ -187,7 +177,6 @@
     "edit": {
       "page-title": "(FR) Change preferred language",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "preferred-language": "(FR) Preferred language",
         "edit": "(FR) Edit"
@@ -200,7 +189,6 @@
     "confirm": {
       "page-title": "(FR) Confirm preferred language",
       "breadcrumbs": {
-        "home": "(FR) Home",
         "personal-information": "(FR) Personal information",
         "preferred-language": "(FR) Preferred language",
         "preferred-language-edit": "(FR) Change preferred language",


### PR DESCRIPTION
## Apologies for the size of this PR. 😞

### Description

This PR moves all of the 'home' breadcrumbs out of the page routes and into the main GCWeb layout route to reduce boilerplate and repetition in the application.

### Related Azure Boards Work Items

- [AB#2848](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2848)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and navigate around. Verify that the breadcrumbs render correctly.
