### PR TITLE
AB#2659 -- Fix broken nonce

### DIFF
--- a/frontend/__tests__/utils/raoidc-utils.server.test.ts
+++ b/frontend/__tests__/utils/raoidc-utils.server.test.ts
@@ -30,7 +30,7 @@ describe('raoidc-utils.server', () => {
 
   describe('random string generation utils', () => {
     it('should generate a random nonce', () => {
-      expect(generateRandomNonce().length).toEqual(16);
+      expect(generateRandomNonce().length).toEqual(32);
     });
 
     it('should generate a random code verifier and a code challenge', () => {

--- a/frontend/app/utils/raoidc-utils.server.ts
+++ b/frontend/app/utils/raoidc-utils.server.ts
@@ -358,7 +358,7 @@ export function generateRandomCodeVerifier(len = 64) {
 /**
  * Generate a random nonce string.
  */
-export function generateRandomNonce(len = 16) {
+export function generateRandomNonce(len = 32) {
   return generateRandomString(len);
 }
 


### PR DESCRIPTION
### Description

RAOIDC requires a minimum nonce size of 32 characters. Oops.

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)