### PR TITLE
AB#2912 -- Added correction endpoint to WSAddress service

### DIFF
--- a/frontend/__tests__/services/wsaddress-service.server.test.ts
+++ b/frontend/__tests__/services/wsaddress-service.server.test.ts
@@ -2,12 +2,35 @@ import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expectTypeOf, it, vi } from 'vitest';
 
-import type { ParseWSAddressResponseDTO, ValidateWSAddressResponseDTO } from '~/services/wsaddress-service.server';
+import type { CorrectWSAddressResponseDTO, ParseWSAddressResponseDTO, ValidateWSAddressResponseDTO } from '~/services/wsaddress-service.server';
 import { getWSAddressService } from '~/services/wsaddress-service.server';
 
 //TODO: add invalid request tests when changing to use Interop's WSAddress endpoint instead of MSW
 
 const handlers = [
+  /**
+   * Handler for POST requests to WSAddress correction service
+   */
+  http.post('https://api.example.com/address/correction', ({ params, request }) => {
+    return HttpResponse.json({
+      responseType: 'CA',
+      addressLine: '23 Coronation St',
+      city: "St. John's",
+      province: 'NL',
+      postalCode: 'A1C5B9',
+      deliveryInformation: 'deliveryInformation',
+      extraInformation: 'extraInformation',
+      statusCode: 'Valid',
+      country: 'CAN',
+      message: '',
+      warnings: '',
+      functionalMessages: [
+        { action: 'OriginalInput', message: '111 WELLINGTON ST   OTTAWA   ON   K1A0A4   CAN' },
+        { action: 'Information', message: 'Dept = SENAT   Branch = SENAT   Lang = F' },
+      ],
+    });
+  }),
+
   /**
    * Handler for POST requests to WSAddress parse service
    */
@@ -76,6 +99,13 @@ describe('wsaddress-service.server tests', () => {
   });
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('correctWSAddress()', () => {
+    it('should correct an address successfully', async () => {
+      const result = await wsAddressService.correctWSAddress({ addressLine: 'addr 123', city: 'ABC', country: 'CAN', language: 'EN', postalCode: 'A1B2C3', province: 'ON', formatResult: true });
+      expectTypeOf(result).toMatchTypeOf<CorrectWSAddressResponseDTO>();
+    });
   });
 
   describe('validateWSAddress()', () => {

--- a/frontend/app/mocks/wsaddress-api.server.ts
+++ b/frontend/app/mocks/wsaddress-api.server.ts
@@ -12,6 +12,30 @@ export function getWSAddressApiMockHandlers() {
 
   return [
     //
+    // Handler for POST requests to WSAddress correction service
+    //
+    http.post('https://api.example.com/address/correction', ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+      return HttpResponse.json({
+        responseType: 'CA',
+        addressLine: '23 Coronation St',
+        city: "St. John's",
+        province: 'NL',
+        postalCode: 'A1C5B9',
+        deliveryInformation: 'deliveryInformation',
+        extraInformation: 'extraInformation',
+        statusCode: 'Valid',
+        country: 'CAN',
+        message: '',
+        warnings: '',
+        functionalMessages: [
+          { action: 'OriginalInput', message: '111 WELLINGTON ST   OTTAWA   ON   K1A0A4   CAN' },
+          { action: 'Information', message: 'Dept = SENAT   Branch = SENAT   Lang = F' },
+        ],
+      });
+    }),
+
+    //
     // Handler for POST requests to WSAddress parse service
     //
     http.post('https://api.example.com/address/parse', ({ params, request }) => {


### PR DESCRIPTION
### Description
Added in the initial address correction endpoint call for the wsaddress-service (Including MSW endpoint mock and unit test)

### Related Azure Boards Work Items
[AB#2912](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2912)

### Screenshots (if applicable)
N/A

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e` (no tests found?)

### Test Instructions
Run unit tests to confirm the 'correction' service result/return conforms to the correction response DTO type.

### Additional Notes
N/A