### PR TITLE
replaced chunk streaming with stream response body for pdf downloads

### DIFF
--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -78,8 +78,8 @@ export function getPowerPlatformApiMockHandlers() {
      * Handler for GET requests to retrieve letters details.
      */
     http.get('https://api.example.com/users/:userId/letters', ({ params, request }) => {
-      const url = new URL(request.url)
-      const sortParam = url.searchParams.get('sort') ?? 'asc'
+      const url = new URL(request.url);
+      const sortParam = url.searchParams.get('sort') ?? 'asc';
       const sort = sortParam === 'desc' ? 'desc' : 'asc';
       const letterEntities = getLetterEntities(params.userId, sort);
 
@@ -144,8 +144,8 @@ function getLetterEntities(userId: string | readonly string[], sortOrder: 'asc' 
           },
         },
         orderBy: {
-          dateSent: sortOrder
-        }
+          dateSent: sortOrder,
+        },
       });
 
   return letterEntities;

--- a/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
+++ b/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
@@ -17,30 +17,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   }
 
   if (pdfResponse.ok) {
-    const readableStream = new ReadableStream({
-      async start(controller) {
-        const reader = pdfResponse.body?.getReader();
-        async function readChunk() {
-          if (!reader) controller.close();
-          else {
-            try {
-              const { done, value } = await reader.read();
-              if (done) {
-                controller.close();
-                return;
-              }
-              controller.enqueue(value);
-            } catch (error) {
-              console.error('Error reading file:', error);
-              controller.error(error);
-            }
-          }
-        }
-        await readChunk();
-      },
-    });
-
-    return new Response(readableStream, {
+    return new Response(pdfResponse.body, {
       headers: {
         'Content-Type': 'application/octet-stream',
         'Content-Length': pdfResponse.headers.get('Content-Length') ?? '',


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->
Replaced stream encoding in letters download with `pdfResponse.body` to fix latency issue.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->
AB#2894, AB#2895, AB#2896, AB#2897

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->
Fixed lag between opening pdfs.