### PR TITLE
AB#2659 -- Fix broken login redirects

### DIFF
--- a/frontend/app/routes/auth.$.tsx
+++ b/frontend/app/routes/auth.$.tsx
@@ -62,7 +62,7 @@ async function handleRaoidcLoginRequest({ params, request }: LoaderFunctionArgs)
   const { origin, searchParams } = new URL(request.url);
   const returnUrl = searchParams.get('returnto');
 
-  if (!returnUrl?.startsWith('/')) {
+  if (returnUrl && !returnUrl.startsWith('/')) {
     log.warn('Invalid return URL [%s]', returnUrl);
     return new Response(null, { status: 400 });
   }


### PR DESCRIPTION
### Description

Fixes an issue where, when hitting `/auth/login` (without a `returnto` parameter), the application was returning a 400 error. 

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)