### PR TITLE
AB#2659 -- Refactor RAOIDC token exchange

### DIFF
--- a/frontend/app/routes/auth.$.tsx
+++ b/frontend/app/routes/auth.$.tsx
@@ -102,9 +102,9 @@ async function handleRaoidcCallbackRequest({ params, request }: LoaderFunctionAr
   const redirectUri = generateCallbackUri(new URL(request.url).origin, 'raoidc');
 
   log.debug('Storing auth tokens and userinfo in session');
-  const { auth, user_info: userInfo } = await raoidcService.handleCallback(request, codeVerifier, state, redirectUri);
-  session.set('auth', auth);
-  session.set('userInfo', userInfo);
+  const { idToken, userInfoToken } = await raoidcService.handleCallback(request, codeVerifier, state, redirectUri);
+  session.set('idToken', idToken);
+  session.set('userInfoToken', userInfoToken);
 
   log.debug('RAOIDC login successful; redirecting to [%s]', returnUrl);
   return redirect(returnUrl, {

--- a/frontend/app/services/raoidc-service.server.ts
+++ b/frontend/app/services/raoidc-service.server.ts
@@ -92,10 +92,10 @@ async function createRaoidcService() {
       privateKeyId: privateKeyId,
     };
 
-    const authTokenSet = await fetchAccessToken(serverMetadata, jwkSet, authCode, client, codeVerifier, redirectUri, fetchFn);
-    const userInfo = await fetchUserInfo(serverMetadata.userinfo_endpoint, authTokenSet.access_token, client, fetchFn);
+    const { accessToken, idToken } = await fetchAccessToken(serverMetadata, jwkSet, authCode, client, codeVerifier, redirectUri, fetchFn);
+    const userInfoToken = await fetchUserInfo(serverMetadata.userinfo_endpoint, accessToken, client, fetchFn);
 
-    return { auth: authTokenSet, user_info: userInfo };
+    return { accessToken, idToken, userInfoToken };
   }
 
   /**


### PR DESCRIPTION
### Description

Since the RAOIDC access token is only ever used to fetch the user info from the `userinfo` endpoint, there is no need to persist it in session.

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and hit `/auth/login`. If everything works the application will perform a mock login and return back to the home page without any error.
