### PR TITLE
Displaying toast component when home and mailing addresses are changed (and icon changes to personal information page)

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -1,5 +1,4 @@
-import { redirect } from '@remix-run/node';
-
+import { redirectWithSuccess } from 'remix-toast';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/_gcweb-app.personal-information.home-address.confirm';
@@ -106,14 +105,14 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
   });
 
   describe('action()', () => {
-    it('should redirect to personal information page when updating user info is successful', async () => {
+    it('should redirect with toast message to personal information page when updating user info is successful', async () => {
       const response = await action({
         request: new Request('http://localhost:3000/personal-information/home-address/confirm', { method: 'POST' }),
         context: {},
         params: {},
       });
 
-      expect(response).toEqual(redirect('/personal-information'));
+      expect(response).toEqual(await redirectWithSuccess('/personal-information', 'personal-information:home-address.confirm.updated-notification'));
     });
   });
 });

--- a/frontend/app/routes/_gcweb-app.personal-information._index.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information._index.tsx
@@ -67,7 +67,7 @@ export default function PersonalInformationIndex() {
             </Link>
           }
           title={t('personal-information:index.home-address')}
-          icon="glyphicon-map-marker"
+          icon="glyphicon-home"
         >
           {homeAddressInfo && (
             <Address
@@ -87,7 +87,7 @@ export default function PersonalInformationIndex() {
             </Link>
           }
           title={t('personal-information:index.mailing-address')}
-          icon="glyphicon-map-marker"
+          icon="glyphicon-envelope"
         >
           {mailingAddressInfo && (
             <Address

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.confirm.tsx
@@ -1,7 +1,8 @@
-import { type ActionFunctionArgs, type LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { type ActionFunctionArgs, type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Form, Link, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
+import { redirectWithSuccess } from 'remix-toast';
 
 import { Address } from '~/components/address';
 import { getAddressService } from '~/services/address-service.server';
@@ -46,7 +47,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
   await getAddressService().updateAddressInfo(userId, userInfo?.homeAddress ?? '', session.get('newHomeAddress'));
 
-  return redirect('/personal-information');
+  // TODO remove new home address from session and handle case when it is missing
+  return redirectWithSuccess('/personal-information', 'personal-information:home-address.confirm.updated-notification');
 }
 
 export default function PersonalInformationHomeAddressConfirm() {

--- a/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.mailing-address.confirm.tsx
@@ -1,7 +1,8 @@
-import { type ActionFunctionArgs, type LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { type ActionFunctionArgs, type LoaderFunctionArgs, json } from '@remix-run/node';
 import { Form, Link, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
+import { redirectWithSuccess } from 'remix-toast';
 
 import { Address } from '~/components/address';
 import { getAddressService } from '~/services/address-service.server';
@@ -47,7 +48,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
   await getAddressService().updateAddressInfo(userId, userInfo?.mailingAddress ?? '', session.get('newMailingAddress'));
 
-  return redirect('/personal-information');
+  // TODO remove new mailing address from session and handle case when it is missing
+  return redirectWithSuccess('/personal-information', 'personal-information:mailing-address.confirm.updated-notification');
 }
 
 export default function PersonalInformationMailingAddressConfirm() {

--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -81,7 +81,8 @@
       "button": {
         "confirm": "Confirm",
         "cancel": "Cancel"
-      }
+      },
+      "updated-notification": "Home address updated"
     }
   },
   "mailing-address": {
@@ -133,7 +134,8 @@
       "button": {
         "confirm": "Confirm",
         "cancel": "Cancel"
-      }
+      },
+      "updated-notification": "Mailing address updated"
     }
   },
   "phone-number": {

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -81,7 +81,8 @@
       "button": {
         "confirm": "(FR) Confirm",
         "cancel": "(FR) Cancel"
-      }
+      },
+      "updated-notification": "(FR) Home address updated"
     }
   },
   "mailing-address": {
@@ -133,7 +134,8 @@
       "button": {
         "confirm": "(FR) Confirm",
         "cancel": "(FR) Cancel"
-      }
+      },
+      "updated-notification": "(FR) Mailing address updated"
     }
   },
   "phone-number": {


### PR DESCRIPTION
### Description
- Displaying toast component when home and mailing addresses are changed
- Updated icons for home and mailing address on personal information index page so they don't have the same one

### Related Azure Boards Work Items
[AB#2851](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2851)

### Screenshots (if applicable)
Toast component for when home address is changes (mailing address is similar except for the text):
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/0a346ee8-1a8c-4d36-80f4-1a5cc73045ca)

Icons on Personal Information index page:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/aa2c04d5-b714-4d44-b01a-882401867e17)

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and make a home or mailing address change. 

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->