### PR TITLE
Fixing i18n key on suggested address page

### DIFF
--- a/frontend/public/locales/en/personal-information.json
+++ b/frontend/public/locales/en/personal-information.json
@@ -55,7 +55,7 @@
       "re-enter-address": "Re-enter your address"
     },
     "suggested": {
-      "page-title:": "Suggested address",
+      "page-title": "Suggested address",
       "subtitle": "Please verify the suggested address.",
       "breadcrumbs": {
         "personal-information": "Personal information",

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -69,7 +69,7 @@
       "re-enter-address": "(FR) If neither of these addresses is correct, you should re-enter your address",
       "note": "(FR) Please note: Your address is compared against Canada Post information for accuracy. However, in some cases, the system may not be able to verify the address’s accuracy. Use this address if you are certain it is correct.",
       "continue": "(FR) Continue",
-      "Cancel": "(FR) Cancel",
+      "cancel": "(FR) Cancel",
       "edit": "(FR) Return to edit page"
     },
     "confirm": {

--- a/frontend/public/locales/fr/personal-information.json
+++ b/frontend/public/locales/fr/personal-information.json
@@ -55,7 +55,7 @@
       "re-enter-address": "(FR) Re-enter your address"
     },
     "suggested": {
-      "page-title:": "(FR) Suggested address",
+      "page-title": "(FR) Suggested address",
       "subtitle": "(FR) Please verify the suggested address.",
       "breadcrumbs": {
         "personal-information": "(FR) Personal information",


### PR DESCRIPTION
### Description
As per title

### Related Azure Boards Work Items
[AB#2867](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2867)

### Screenshots (if applicable)
Before:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/9e0c456c-bea9-4cd9-b9eb-0f361f8801ee)

After:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/9be03c95-4606-4511-982a-75235fe6c1a0)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and go to `/personal-information/home-address/suggested`