### PR TITLE
Set address font-style to not italic

### DIFF
--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -15,8 +15,8 @@ function formatAddress(address: string, city: string, country: string, provinceS
   const isNotCanadianAddress = 'canada' !== country.toLowerCase();
 
   // prettier-ignore
-  const lines = [`${address}`, 
-    `${city}${provinceState ? ` ${provinceState}` : ''}${postalZipCode ? `  ${postalZipCode}` : ''}`, 
+  const lines = [`${address}`,
+    `${city}${provinceState ? ` ${provinceState}` : ''}${postalZipCode ? `  ${postalZipCode}` : ''}`,
     `${isNotCanadianAddress ? country : ''}`];
 
   return lines
@@ -30,7 +30,7 @@ export function Address(props: AddressProps) {
   const formattedAddress = formatAddress(address, city, country, provinceState, postalZipCode);
 
   return (
-    <address className={clsx('mb-0 whitespace-pre-wrap', className)} data-testid="address-id" {...restProps}>
+    <address className={clsx('mb-0 whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...restProps}>
       {formattedAddress}
     </address>
   );


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Set address font-style to not italic. Use agant default is italic and CCSG says that people with dyslexia or other reading disorders may find it difficult to read italicized text.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/3bd13c4c-2d08-4cdb-be74-4d4aef3ab7d5)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Got to `/personal-information` and the addresses font-style should be normal.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

https://design.canada.ca/style-guide/#wp4-2