### PR TITLE
AB#2929 change content-disposition header for letter download

### DIFF
--- a/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
+++ b/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
@@ -25,7 +25,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       headers: {
         'Content-Type': 'application/octet-stream',
         'Content-Length': pdfResponse.headers.get('Content-Length') ?? '',
-        'Content-Disposition': `attachment; filename="${params.referenceId}.pdf"`,
+        'Content-Disposition': `inline; filename="${params.referenceId}.pdf"`,
       },
     });
   }


### PR DESCRIPTION
### Description
Instead of having letters downloaded upon clicking the link in `/letters`, letters will now be viewable in the browser, with the option to download passed on to the user.

### Related Azure Boards Work Items
[AB#2929](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_boards/board/t/LiteBrite/Stories?System.IterationPath=Canada%20Dental%20Care%20Plan%5CSprint%203)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`