### PR TITLE
change content-type on pdf letter download

### DIFF
--- a/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
+++ b/frontend/app/routes/_gcweb-app.letters.$referenceId.download.tsx
@@ -23,7 +23,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   if (pdfResponse.ok) {
     return new Response(pdfResponse.body, {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Content-Type': 'application/pdf',
         'Content-Length': pdfResponse.headers.get('Content-Length') ?? '',
         'Content-Disposition': `inline; filename="${params.referenceId}.pdf"`,
       },


### PR DESCRIPTION
This is a followup to #377 since I made and oopsie and forgot to change the content-type as well.  I've tested that the PDF now opens in all common browsers (Edge, FireFox, Chrome). 