### PR TITLE
AB#2659 -- Add required search params to RAOIDC logout

### DIFF
--- a/frontend/__tests__/utils/string-utils.test.ts
+++ b/frontend/__tests__/utils/string-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { expandTemplate } from '~/utils/string-utils';
+
+describe('expandTemplate', () => {
+  it('should expand a template', () => {
+    const template = '{greeting}, {subject}!';
+    const variables = { greeting: 'Hello', subject: 'world' };
+
+    expect(expandTemplate(template, variables)).toEqual('Hello, world!');
+  });
+
+  it('should expand a template and not throw an error if a variable is not defined', () => {
+    const template = '{greeting}, {subject}!';
+    const variables = { greeting: 'Hello' };
+
+    expect(expandTemplate(template, variables)).toEqual('Hello, {subject}!');
+  });
+
+  it('should expand a template and not throw an error if extra variables are defined', () => {
+    const template = '{greeting}, {subject}!';
+    const variables = { greeting: 'Hello', subject: 'world', extra: 'variable' };
+
+    expect(expandTemplate(template, variables)).toEqual('Hello, world!');
+  });
+});

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Expand the given string template using the provided variables.
+ * A string template uses handlebar notation to denote placeholders. For example:
+ *
+ * expandTemplate('{greeting}, {subject}!', { greeting: 'Hello', subject: 'world' }) → 'Hello, world!
+ */
+export function expandTemplate(template: string, variables: Record<string, string>) {
+  return Object.entries(variables).reduce((t, [key, value]) => t.replace(`{${key}}`, value), template);
+}


### PR DESCRIPTION
### Description

RAOIDC logout requires a specific set of search params. These params will be added by using substitution variables in the `AUTH_LOGOUT_REDIRECT_URL` like this: `AUTH_LOGOUT_REDIRECT_URL=https://auth.example.com/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}`

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)
- [AB#2915](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2915)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
