### PR TITLE
[gitops] AB#2659 -- Add search params to RAOIDC logout (int)

### DIFF
--- a/gitops/overlays/int/configs/frontend-config.conf
+++ b/gitops/overlays/int/configs/frontend-config.conf
@@ -14,7 +14,7 @@ REDIS_URL=redis://redis-int
 #
 # RAOIDC configuration
 #
-AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout
+AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
 AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
 AUTH_RAOIDC_CLIENT_ID=CDCP
 


### PR DESCRIPTION
### Description

Add the required search params to the RAOIDC logout URL in int.

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)
- [AB#2915](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2915)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
