### PR TITLE
Rename csp.server.ts to csp-utils.server.ts

### DIFF
--- a/frontend/__tests__/utils/csp-utils.server.test.ts
+++ b/frontend/__tests__/utils/csp-utils.server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { generateContentSecurityPolicy } from '~/utils/csp.server';
+import { generateContentSecurityPolicy } from '~/utils/csp-utils.server';
 import { getEnv } from '~/utils/env.server';
 
 vi.mock('~/utils/env.server', () => ({

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -9,7 +9,7 @@ import { I18nextProvider } from 'react-i18next';
 
 import { NonceProvider, generateNonce } from '~/components/nonce-context';
 import { server } from '~/mocks/node';
-import { generateContentSecurityPolicy } from '~/utils/csp.server';
+import { generateContentSecurityPolicy } from '~/utils/csp-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getNamespaces } from '~/utils/locale-utils';
 import { createLangCookie, getLocale, initI18n } from '~/utils/locale-utils.server';

--- a/frontend/app/utils/csp-utils.server.ts
+++ b/frontend/app/utils/csp-utils.server.ts
@@ -1,10 +1,10 @@
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
-const log = getLogger('csp.server');
+const log = getLogger('csp-utils.server');
 
 /**
- * Generate a strict CSP.
+ * Generate a strict content security policy.
  * @see https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
  */
 export function generateContentSecurityPolicy(nonce: string) {


### PR DESCRIPTION
### Description

Rename `csp.server.ts` to `csp-utils.server.ts` to match application conventions.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
