### PR TITLE
remove preventDefault from anchor-link

### DIFF
--- a/frontend/app/components/anchor-link.tsx
+++ b/frontend/app/components/anchor-link.tsx
@@ -23,12 +23,10 @@ export function AnchorLink(props: AnchorLinkProps) {
 
   /**
    * handleOnSkipLinkClick is the click event handler for the anchor link.
-   * It prevents the default anchor link behavior, scrolls to and focuses
-   * on the target element specified by 'anchorElementId', and invokes
-   * the optional 'onClick' callback.
+   * It scrolls to, and focuses, on the target element specified by 'anchorElementId',
+   * and invokes the optional 'onClick' callback.
    */
   function handleOnSkipLinkClick(e: MouseEvent<HTMLAnchorElement>) {
-    e.preventDefault();
     scrollAndFocusFromAnchorLink(e.currentTarget.href);
     onClick?.(e);
   }


### PR DESCRIPTION
When using keyboard navigation and tabbing through the page, when the skip-link for navigating to `wb-cont` is pressed, nothing happens and the skip link remains in place.

On Canada.ca, if you follow the same procedure, the skip link correctly navigates to `wb-cont` and the skip-link disappears from view as expected.  

I'm not sure what the reason for having the `event.preventDefault()` is for in this case, but I believe it can be removed (or optionally toggled by adding a flag in the component props if needed).