### PR TITLE
change contrast ratio on toast

### DIFF
--- a/frontend/app/components/toaster.tsx
+++ b/frontend/app/components/toaster.tsx
@@ -16,5 +16,5 @@ export function Toaster({ toast }: ToasterProps) {
     }
   }, [toast]);
 
-  return <SnackbarProvider anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }} />;
+  return <SnackbarProvider className="bg-green-700" anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }} />;
 }


### PR DESCRIPTION
The contrast ratio on the toast was failing WCAG 2.1 contrast test.

Before

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/8c3d0086-d0ef-4329-98ed-1031cb8001e2)

After

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/f5a5eb51-fefe-43f3-83a6-16993627acaf)
