### PR TITLE
Change the scrollIntoViewOptions

### DIFF
--- a/frontend/app/utils/link-utils.ts
+++ b/frontend/app/utils/link-utils.ts
@@ -12,6 +12,6 @@ export function scrollAndFocusFromAnchorLink(href: string): void {
   const targetElement = document.querySelector<HTMLElement>(hash);
   if (!targetElement) return;
 
-  targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  targetElement.scrollIntoView({ behavior: 'smooth' });
   targetElement.focus();
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->
Change the scrollIntoViewOptions to use the block default value of `start`. Using `center` made the H1 scrolling at a weird place.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Tab untile you see the `Skip to main content` skip link and click. It should scrool the H1 at the start.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

~~I need to figure why pressing `Enter` doesn't work for the skip links.~~ Seems to be good now. 😕 