### PR TITLE
[gitops] AB#2659 -- Add RASCL logout endpoint

### DIFF
--- a/gitops/overlays/dev/configs/frontend-config.conf
+++ b/gitops/overlays/dev/configs/frontend-config.conf
@@ -16,6 +16,7 @@ REDIS_URL=redis://redis-dev
 #
 AUTH_LOGOUT_REDIRECT_URL=https://cdcp-dev.dev-dp.dts-stn.com/
 AUTH_RAOIDC_CLIENT_ID=CDCP
+AUTH_RASCL_LOGOUT_URL=https://cdcp-dev.dev-dp.dts-stn.com/
 
 #
 # RAOIDC mock confuguration

--- a/gitops/overlays/int/configs/frontend-config.conf
+++ b/gitops/overlays/int/configs/frontend-config.conf
@@ -17,5 +17,6 @@ REDIS_URL=redis://redis-int
 AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
 AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
 AUTH_RAOIDC_CLIENT_ID=CDCP
+AUTH_RASCL_LOGOUT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/rascl/Support/GlobalLogout.aspx
 
 SCCH_BASE_URI=https://secure-client-hub-staging.bdm.dshp-phdn.net

--- a/gitops/overlays/staging/configs/frontend-config.conf
+++ b/gitops/overlays/staging/configs/frontend-config.conf
@@ -17,5 +17,6 @@ REDIS_URL=redis://redis-staging
 AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
 AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
 AUTH_RAOIDC_CLIENT_ID=CDCP
+AUTH_RASCL_LOGOUT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/rascl/Support/GlobalLogout.aspx
 
 SCCH_BASE_URI=https://secure-client-hub-staging.bdm.dshp-phdn.net


### PR DESCRIPTION
### Description

This PR adds the RASCL logout endpoints to the `dev` and `staging` environments in preparation for an upcoming PR to fix broken logouts.

### Related Azure Boards Work Items

- [AB#2659](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2659)
