### PR TITLE
AB#2659 -- Add RASCL logout endpoint

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -30,6 +30,9 @@ AUTH_RAOIDC_CLIENT_ID=CDCP
 # RAOIDC proxy URL -- used to proxy all outgoing RAOIDC calls
 # (optional; default: undefined)
 AUTH_RAOIDC_PROXY_URL=
+# RASCL logout URL -- used when no RAOIDC session is found during logout
+# (required; use the example below)
+AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 
 # i18n language cookie name
@@ -115,5 +118,5 @@ MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc
 # (required; use the example below)
 SCCH_BASE_URI=http://www.example.com
 
-# Community where the documents were generated from, and user belongs. This value is linked to the specific vault database for the given community. 
+# Community where the documents were generated from, and user belongs. This value is linked to the specific vault database for the given community.
 CCT_VAULT_COMMUNITY='SecurityReview'

--- a/frontend/app/routes/auth.$.tsx
+++ b/frontend/app/routes/auth.$.tsx
@@ -67,8 +67,15 @@ async function handleLoginRequest({ request }: LoaderFunctionArgs) {
  * Handler for /auth/logout requests
  */
 async function handleLogoutRequest({ request }: LoaderFunctionArgs) {
+  const { AUTH_RASCL_LOGOUT_URL } = getEnv();
+
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request);
+
+  if (!session.has('idToken')) {
+    log.debug(`User has not authenticated; bypassing RAOIDC logout and redirecting to RASCL logout`);
+    throw redirect(AUTH_RASCL_LOGOUT_URL);
+  }
 
   const idToken: IdToken = session.get('idToken');
   const locale = await getLocale(request);

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -44,6 +44,7 @@ const serverEnv = z.object({
   AUTH_RAOIDC_BASE_URL: z.string().trim().min(1),
   AUTH_RAOIDC_CLIENT_ID: z.string().trim().min(1),
   AUTH_RAOIDC_PROXY_URL: z.string().trim().transform(emptyToUndefined).optional(),
+  AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
   // language cookie settings
   LANG_COOKIE_NAME: z.string().default('_gc_lang'),


### PR DESCRIPTION
### Description

Forward user to the RASCL global logout endpoint when an RAOIDC session is not detected.

### Related Azure Boards Work Items

- AB#2659

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
