### PR TITLE
Set cookies to `samesite: lax`

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -48,8 +48,8 @@ LANG_COOKIE_PATH=/
 # (optional; default: true)
 LANG_COOKIE_HTTP_ONLY=true
 # i18n language cookie samesite value
-# (optional; default: strict)
-LANG_COOKIE_SAME_SITE=strict
+# (optional; default: lax)
+LANG_COOKIE_SAME_SITE=lax
 # i18n language cookie secure flag
 # (optional; default: true)
 LANG_COOKIE_SECURE=true
@@ -74,8 +74,8 @@ SESSION_COOKIE_DOMAIN=localhost
 # (optional; default: /)
 SESSION_COOKIE_PATH=/
 # session cookie samesite value
-# (optional; default: strict)
-SESSION_COOKIE_SAME_SITE=strict
+# (optional; default: lax)
+SESSION_COOKIE_SAME_SITE=lax
 # session cookie encryption secret
 # (optional; default: a random UUID)
 SESSION_COOKIE_SECRET=0123456789ABCDEF

--- a/frontend/__tests__/utils/locale-utils.server.test.ts
+++ b/frontend/__tests__/utils/locale-utils.server.test.ts
@@ -42,7 +42,7 @@ describe('locale-utils.server', () => {
         LANG_COOKIE_DOMAIN: 'example.com',
         LANG_COOKIE_PATH: '/',
         LANG_COOKIE_HTTP_ONLY: true,
-        LANG_COOKIE_SAME_SITE: 'strict',
+        LANG_COOKIE_SAME_SITE: 'lax',
         LANG_COOKIE_SECURE: true,
       });
 

--- a/frontend/app/components/toaster.tsx
+++ b/frontend/app/components/toaster.tsx
@@ -17,7 +17,7 @@ export interface ToasterProps {
 export function Toaster({ toast }: ToasterProps) {
   setToastCookieOptions({
     // TODO :: GjB :: make these configurable
-    sameSite: 'strict',
+    sameSite: 'lax',
     secure: true,
   });
 

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -51,7 +51,7 @@ const serverEnv = z.object({
   LANG_COOKIE_DOMAIN: z.string().optional(),
   LANG_COOKIE_PATH: z.string().default('/'),
   LANG_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),
-  LANG_COOKIE_SAME_SITE: z.enum(['lax', 'strict', 'none']).default('strict'),
+  LANG_COOKIE_SAME_SITE: z.enum(['lax', 'strict', 'none']).default('lax'),
   LANG_COOKIE_SECURE: z.string().transform(toBoolean).default('true'),
   LANG_QUERY_PARAM: z.string().default('lang'),
 
@@ -61,7 +61,7 @@ const serverEnv = z.object({
   SESSION_COOKIE_NAME: z.string().trim().min(1).default('__CDCP//session'),
   SESSION_COOKIE_DOMAIN: z.string().trim().min(1).optional(),
   SESSION_COOKIE_PATH: z.string().trim().min(1).default('/'),
-  SESSION_COOKIE_SAME_SITE: z.enum(['lax', 'strict', 'none']).default('strict'),
+  SESSION_COOKIE_SAME_SITE: z.enum(['lax', 'strict', 'none']).default('lax'),
   SESSION_COOKIE_SECRET: z.string().trim().min(16).default(randomUUID()),
   SESSION_COOKIE_MAX_AGE: z.coerce.number().default(1200),
   SESSION_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),


### PR DESCRIPTION
### Description

Because the domain is not being set during cookie creation, `samesite: lax` needs to be configured for our cookies.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
