### PR TITLE
AB#2705 -- Refactoring wsaddress-service to correctly consume (mocked) API

### DIFF
--- a/frontend/app/services/wsaddress-service.server.ts
+++ b/frontend/app/services/wsaddress-service.server.ts
@@ -6,166 +6,34 @@ import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('wsaddress-service.server');
 
-export interface CorrectWSAddressRequestDTO {
-  addressLine: string;
-  city: string;
-  province: string;
-  postalCode: string;
-  country: string;
-  formatResult: boolean;
-  language: string;
-}
-
-export interface CorrectWSAddressResponseDTO {
-  responseType?: string;
-  addressLine?: string;
-  city?: string;
-  province?: string;
-  postalCode?: string;
-  deliveryInformation?: string;
-  extraInformation?: string;
-  statusCode?: string;
-  country?: string;
-  message?: string;
-  warnings?: string;
-  functionalMessages?: { action: string; message: string }[];
-}
-
-export interface ParseWSAddressRequestDTO {
-  addressLine: string;
-  city: string;
-  province: string;
-  postalCode: string;
-  country: string;
-  geographicScope: string;
-  parseType: string;
-  language: string;
-}
-
-export interface ParseWSAddressResponseDTO {
-  responseType?: string;
-  addressLine?: string;
-  city?: string;
-  province?: string;
-  postalCode?: string;
-  streetNumberSuffix?: string;
-  streetDirection?: string;
-  unitType?: string;
-  unitNumber?: string;
-  serviceAreaName?: string;
-  serviceAreaType?: string;
-  serviceAreaQualifier?: string;
-  cityLong?: string;
-  cityShort?: string;
-  deliveryInformation?: string;
-  extraInformation?: string;
-  statusCode?: string;
-  canadaPostInformation?: string[];
-  message?: string;
-  addressType?: string;
-  streetNumber?: string;
-  streetName?: string;
-  streetType?: string;
-  serviceType?: string;
-  serviceNumber?: string;
-  country?: string;
-  warnings?: string;
-  functionalMessages?: { action: string; message: string }[];
-}
-
-export interface ValidateWSAddressRequestDTO {
-  addressLine: string;
-  city: string;
-  province: string;
-  postalCode: string;
-  country: string;
-  language: string;
-}
-
-export interface ValidateWSAddressResponseDTO {
-  responseType?: string;
-  statusCode?: string;
-  functionalMessages?: { action: string; message: string }[];
-  message?: string;
-  warnings?: string;
-}
-
-//TODO: Update validation schema when changing to use Interop's WSAddress endpoint instead of MSW
-const correctWSAddressResponseSchema = z.object({
-  responseType: z.string().optional(),
-  addressLine: z.string().optional(),
-  city: z.string().optional(),
-  province: z.string().optional(),
-  postalCode: z.string().optional(),
-  deliveryInformation: z.string().optional(),
-  extraInformation: z.string().optional(),
-  statusCode: z.string().optional(),
-  country: z.string().optional(),
-  message: z.string().optional(),
-  warnings: z.string().optional(),
-  functionalMessages: z
-    .array(
-      z.object({
-        action: z.string(),
-        message: z.string(),
-      }),
-    )
-    .optional(),
+const correctAddressResponseSchema = z.object({
+  'wsaddr:CorrectionResults': z.object({
+    'nc:AddressFullText': z.string().optional(),
+    'nc:AddressCityName': z.string().optional(),
+    'nc:ProvinceCode': z.string().optional(),
+    'nc:AddressPostalCode': z.string().optional(),
+    'nc:CountryCode': z.string().optional(),
+    'wsaddr:StatusCode': z.string(),
+  }),
 });
 
-//TODO: Update validation schema when changing to use Interop's WSAddress endpoint instead of MSW
-const parseWSAddressResponseSchema = z.object({
-  responseType: z.string().optional(),
-  addressLine: z.string().optional(),
-  city: z.string().optional(),
-  province: z.string().optional(),
-  postalCode: z.string().optional(),
-  streetNumberSuffix: z.string().optional(),
-  streetDirection: z.string().optional(),
-  unitType: z.string().optional(),
-  unitNumber: z.string().optional(),
-  serviceAreaName: z.string().optional(),
-  serviceAreaType: z.string().optional(),
-  serviceAreaQualifier: z.string().optional(),
-  cityLong: z.string().optional(),
-  cityShort: z.string().optional(),
-  deliveryInformation: z.string().optional(),
-  extraInformation: z.string().optional(),
-  statusCode: z.string().optional(),
-  canadaPostInformation: z.array(z.string()).optional(),
-  message: z.string().optional(),
-  addressType: z.string().optional(),
-  streetNumber: z.string().optional(),
-  streetName: z.string().optional(),
-  streetType: z.string().optional(),
-  serviceType: z.string().optional(),
-  serviceNumber: z.string().optional(),
-  country: z.string().optional(),
-  warnings: z.string().optional(),
-  functionalMessages: z
-    .array(
-      z.object({
-        action: z.string(),
-        message: z.string(),
-      }),
-    )
-    .optional(),
+const parseAddressResponseSchema = z.object({
+  'wsaddr:ParsedResults': z.object({
+    'nc:AddressFullText': z.string(),
+    'nc:AddressCityName': z.string(),
+    'can:ProvinceCode': z.string().optional(),
+    'nc:AddressPostalCode': z.string().optional(),
+    'nc:CountryCode': z.string(),
+    'wsaddr:AddressSecondaryUnitNumber': z.string().optional(),
+  }),
 });
 
-//TODO: Update validation schema when changing to use Interop's WSAddress endpoint instead of MSW
-const validateWSAddressResponseSchema = z.object({
-  responseType: z.string().optional(),
-  statusCode: z.string().optional(),
-  functionalMessages: z
-    .array(
-      z.object({
-        action: z.string(),
-        message: z.string(),
-      }),
-    )
-    .optional(),
-  message: z.string().optional(),
-  warnings: z.string().optional(),
+const validateAddressResponseSchema = z.object({
+  'wsaddr:ValidationResults': z.object({
+    'wsaddr:Information': z.object({
+      'wsaddr:StatusCode': z.string(),
+    }),
+  }),
 });
 
 export const getWSAddressService = moize.promise(createWSAddressService, { onCacheAdd: () => log.info('Creating new WSAddress service') });
@@ -173,39 +41,45 @@ export const getWSAddressService = moize.promise(createWSAddressService, { onCac
 async function createWSAddressService() {
   const { INTEROP_API_BASE_URI } = getEnv();
 
-  async function correctWSAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
-    const request: CorrectWSAddressRequestDTO = {
+  async function correctAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
+    const searchParams = new URLSearchParams({
       addressLine: address,
       city,
       province,
       postalCode,
       country,
-      formatResult: true,
+      formatResult: 'true',
       language: 'English', // TODO confirm that we should always have this as "English"
-    };
-    const url = `${INTEROP_API_BASE_URI}/address/correction`;
-    const response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(request),
     });
+    const url = `${INTEROP_API_BASE_URI}/CAN/correct?${searchParams}`;
+    const response = await fetch(url);
 
-    if (response.ok) {
-      return correctWSAddressResponseSchema.parse(await response.json());
+    if (!response.ok) {
+      log.error('%j', {
+        message: 'Failed to correct the address',
+        status: response.status,
+        statusText: response.statusText,
+        url: url,
+        responseBody: await response.text(),
+      });
+
+      throw new Error(`Failed to correct the address. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    log.error('%j', {
-      message: 'Failed to correct the address',
-      status: response.status,
-      statusText: response.statusText,
-      url: url,
-      responseBody: await response.text(),
-    });
-
-    throw new Error(`Failed to correct the address. Status: ${response.status}, Status Text: ${response.statusText}`);
+    const correctAddressResponse = correctAddressResponseSchema.parse(await response.json());
+    const correctionResults = correctAddressResponse['wsaddr:CorrectionResults'];
+    return {
+      status: correctionResults['wsaddr:StatusCode'],
+      address: correctionResults['nc:AddressFullText'],
+      city: correctionResults['nc:AddressCityName'],
+      province: correctionResults['nc:ProvinceCode'],
+      postalCode: correctionResults['nc:AddressPostalCode'],
+      country: correctionResults['nc:CountryCode'],
+    };
   }
 
-  async function parseWSAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
-    const request: ParseWSAddressRequestDTO = {
+  async function parseAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
+    const searchParams = new URLSearchParams({
       addressLine: address,
       city,
       province,
@@ -214,57 +88,62 @@ async function createWSAddressService() {
       geographicScope: 'Canada', // TODO figure out a way to map this - value can also be "Foreign"
       parseType: 'parseOnly', // only parse the address - do not correct or validate it
       language: 'English', // TODO confirm that we should always have this as "English"
-    };
-    const url = `${INTEROP_API_BASE_URI}/address/parse`;
-    const response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(request),
     });
+    const url = `${INTEROP_API_BASE_URI}/CAN/parse?${searchParams}`;
+    const response = await fetch(url);
 
-    if (response.ok) {
-      return parseWSAddressResponseSchema.parse(await response.json());
+    if (!response.ok) {
+      log.error('%j', {
+        message: 'Failed to parse the address',
+        status: response.status,
+        statusText: response.statusText,
+        url: url,
+        responseBody: await response.text(),
+      });
+
+      throw new Error(`Failed to parse the address. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    log.error('%j', {
-      message: 'Failed to parse the address',
-      status: response.status,
-      statusText: response.statusText,
-      url: url,
-      responseBody: await response.text(),
-    });
-
-    throw new Error(`Failed to parse the address. Status: ${response.status}, Status Text: ${response.statusText}`);
+    const parseAddressResponse = parseAddressResponseSchema.parse(await response.json());
+    const parsedResults = parseAddressResponse['wsaddr:ParsedResults'];
+    return {
+      apartmentUnitNumber: parsedResults['wsaddr:AddressSecondaryUnitNumber'],
+      address: parsedResults['nc:AddressFullText'],
+      city: parsedResults['nc:AddressCityName'],
+      province: parsedResults['can:ProvinceCode'],
+      postalCode: parsedResults['nc:AddressPostalCode'],
+      country: parsedResults['nc:CountryCode'],
+    };
   }
 
-  async function validateWSAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
-    const request: ValidateWSAddressRequestDTO = {
+  async function validateAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
+    const searchParams = new URLSearchParams({
       addressLine: address,
       city,
       province,
       postalCode,
       country,
       language: 'English', // TODO confirm that we should always have this as "English"
-    };
-    const url = `${INTEROP_API_BASE_URI}/address/validate`;
-    const response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(request),
     });
+    const url = `${INTEROP_API_BASE_URI}/CAN/validate?${searchParams}`;
+    const response = await fetch(url);
 
-    if (response.ok) {
-      return validateWSAddressResponseSchema.parse(await response.json());
+    if (!response.ok) {
+      log.error('%j', {
+        message: 'Failed to validate the address',
+        status: response.status,
+        statusText: response.statusText,
+        url: url,
+        responseBody: await response.text(),
+      });
+
+      throw new Error(`Failed to validate the address. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    log.error('%j', {
-      message: 'Failed to validate the address',
-      status: response.status,
-      statusText: response.statusText,
-      url: url,
-      responseBody: await response.text(),
-    });
-
-    throw new Error(`Failed to validate the address. Status: ${response.status}, Status Text: ${response.statusText}`);
+    const validateAddressResponse = validateAddressResponseSchema.parse(await response.json());
+    const isValid = 'Valid' === validateAddressResponse['wsaddr:ValidationResults']['wsaddr:Information']['wsaddr:StatusCode'];
+    return isValid;
   }
 
-  return { correctWSAddress, parseWSAddress, validateWSAddress };
+  return { correctAddress, parseAddress, validateAddress };
 }


### PR DESCRIPTION
### Description

This PR is a continuation of https://github.com/DTS-STN/canadian-dental-care-plan/pull/420.

#### `wsaddress-service.server.ts` changes:
- Functions now call `GET` with query parameters (as per mock API changes) instead of `POST` with request body
- Functions map from API's (NIEM'd) fields to a more developer-friendly domain entity
- Superfluous DTOs and Zod schemas have been removed

#### `wsaddress-service.server.test.ts` changes:
- Removing use of `handler`s and MSW's `setupServer(..)` as these uses are more suitable for integration tests rather than unit tests
- Mocking `fetch(..)` calls with (NIEM'd) responses
- Adding unit tests for when API response is not a `200 - OK` to obtain 100% unit test coverage 

### Related Azure Boards Work Items
[AB#2705](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2705)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the unit associated unit test for the service changes

### Additional Notes
Sorry for the large(r) pull request. Please let me know if you would like to break it down into smaller PRs.