### PR TITLE
AB#2935: add session timeout variables into env

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -81,7 +81,7 @@ SESSION_COOKIE_SAME_SITE=lax
 SESSION_COOKIE_SECRET=0123456789ABCDEF
 # session cookie max age in seconds
 # (optional; default: 600)
-SESSION_COOKIE_MAX_AGE_SECONDS=600
+SESSION_COOKIE_MAX_AGE_SECONDS=1200
 # session cookie httpOnly flag
 # (optional; default: true)
 SESSION_COOKIE_HTTP_ONLY=true
@@ -91,7 +91,12 @@ SESSION_COOKIE_SECURE=true
 # location of session files when using file storage
 # (optional; default: ./node_modules/.cache/sessions/)
 SESSION_FILE_DIR=./node_modules/.cache/sessions/
-
+# the time before a user is considered idle in seconds
+# (optional; default: 1140)
+SESSION_TIMEOUT_SECONDS=1140
+# how long before idle to emit the onPrompt event in seconds
+# (optional; default: 300)
+SESSION_TIMEOUT_PROMPT_SECONDS=300
 
 # redis server URL
 # (optional; default: redis://localhost)

--- a/frontend/__tests__/components/client-env.test.tsx
+++ b/frontend/__tests__/components/client-env.test.tsx
@@ -12,6 +12,8 @@ describe('<ClientEnv>', () => {
       I18NEXT_DEBUG: true,
       LANG_QUERY_PARAM: 'locale',
       SCCH_BASE_URI: 'http://www.example.com',
+      SESSION_TIMEOUT_SECONDS: 120,
+      SESSION_TIMEOUT_PROMPT_SECONDS: 30,
     };
 
     const { container } = render(<ClientEnv env={env} nonce={nonce} />);

--- a/frontend/app/components/session-timeout.tsx
+++ b/frontend/app/components/session-timeout.tsx
@@ -8,6 +8,7 @@ import { useIdleTimer } from 'react-idle-timer';
 
 import { Button } from '~/components/buttons';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
+import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('gcweb');
@@ -18,6 +19,8 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
   const { t } = useTranslation(i18nNamespaces);
   const [modalOpen, setModalOpen] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState('');
+  const { SESSION_TIMEOUT_SECONDS: timeoutParam } = getClientEnv();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS: timeoutPromptParam } = getClientEnv();
   const navigate = useNavigate();
 
   const handleOnIdle = () => {
@@ -28,8 +31,8 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
   const { reset, getRemainingTime } = useIdleTimer({
     onIdle: handleOnIdle,
     onPrompt: () => setModalOpen(true),
-    promptBeforeIdle: promptBeforeIdle ?? 5 * 60 * 1000, //5 minutes
-    timeout: timeout ?? 20 * 60 * 1000, //20 minutes
+    promptBeforeIdle: promptBeforeIdle ?? timeoutPromptParam * 1000,
+    timeout: timeout ?? timeoutParam * 1000,
   });
 
   const handleOnIdleContinueSession = async () => {
@@ -69,6 +72,7 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <p>{Math.ceil(getRemainingTime() / 1000)} seconds remaining</p>
     </div>
   );
 };

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -67,6 +67,14 @@ const serverEnv = z.object({
   SESSION_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),
   SESSION_COOKIE_SECURE: z.string().transform(toBoolean).default('true'),
   SESSION_FILE_DIR: z.string().trim().min(1).default('./node_modules/cache/sessions/'),
+  SESSION_TIMEOUT_SECONDS: z.coerce
+    .number()
+    .min(0)
+    .default(19 * 60),
+  SESSION_TIMEOUT_PROMPT_SECONDS: z.coerce
+    .number()
+    .min(0)
+    .default(5 * 60),
 
   // redis server configuration
   REDIS_URL: z.string().trim().min(1).default('redis://localhost'),
@@ -91,6 +99,8 @@ const publicEnv = serverEnv.pick({
   I18NEXT_DEBUG: true,
   LANG_QUERY_PARAM: true,
   SCCH_BASE_URI: true,
+  SESSION_TIMEOUT_SECONDS: true,
+  SESSION_TIMEOUT_PROMPT_SECONDS: true,
 });
 
 export type PublicEnv = z.infer<typeof publicEnv>;


### PR DESCRIPTION
### Description

1. add SESSION_TIMEOUT into env
2. add SESSION_TIMEOUT_PROMPT into env

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`