### PR TITLE
AB#2935 -- Call `/api/refresh-session` to extend session

### DIFF
--- a/frontend/app/components/session-timeout.tsx
+++ b/frontend/app/components/session-timeout.tsx
@@ -3,10 +3,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
-import { useIdleTimer } from 'react-idle-timer';
 import type { IIdleTimerProps } from 'react-idle-timer';
+import { useIdleTimer } from 'react-idle-timer';
 
-import { Button } from './buttons';
+import { Button } from '~/components/buttons';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
@@ -32,7 +32,8 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
     timeout: timeout ?? 20 * 60 * 1000, //20 minutes
   });
 
-  const handleOnIdleContinueSession = () => {
+  const handleOnIdleContinueSession = async () => {
+    await fetch('/api/refresh-session');
     setModalOpen(false);
     reset();
   };

--- a/frontend/app/routes/api.refresh-session.ts
+++ b/frontend/app/routes/api.refresh-session.ts
@@ -1,0 +1,23 @@
+/**
+ * An API route that can be used to refresh the user's server-side session.
+ */
+import { LoaderFunctionArgs } from '@remix-run/node';
+
+import { getSessionService } from '~/services/session-service.server';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('routes/api.refresh-session');
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  log.debug('Touching session to extend its lifetime');
+
+  const sessionService = await getSessionService();
+  const session = await sessionService.getSession(request);
+
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Set-Cookie': await sessionService.commitSession(session),
+    },
+  });
+}


### PR DESCRIPTION
### Description

Extend-session dialog was not actually extending session.

### Related Azure Boards Work Items

- [AB#2935](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2935)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Let extend-session dialog pop up (you can reconfigure the timers to make this happen quicker)
- Click the continue session button
- Notice an XHR request made to `/api/refresh-session` that contains the session cookie
