### PR TITLE
AB#2705 -- Removing outstanding TODOs for suggested address flow

### DIFF
--- a/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
+++ b/frontend/__tests__/routes/_gcweb-app.personal-information.home-address.confirm.test.tsx
@@ -67,14 +67,17 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
   });
 
   describe('loader()', () => {
-    it('should return homeAddressInfo and newHomeAddress objects', async () => {
+    it('should return all necessary address objects and countries/regions list', async () => {
       const userService = getUserService();
       const sessionService = await getSessionService();
       const session = await sessionService.getSession(new Request('https://example.com/'));
 
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', firstName: 'John', lastName: 'Maverick' });
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue({ address: '111 Fake Home St', city: 'city', country: 'country' });
-      vi.mocked(session.get).mockResolvedValue({ address: '123 Fake Home St.', city: 'city', country: 'country' });
+      vi.mocked(session.get)
+        .mockReturnValueOnce({ address: '123 Fake Home St.', city: 'city', country: 'country' }) // return value for session.get('newHomeAddress')
+        .mockReturnValueOnce(true) // return value for session.get('useSuggestedAddress')
+        .mockReturnValueOnce({ address: '123 Fake Suggested St.', city: 'city', country: 'country' }); // return value for session.get('suggestedAddress')
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/home-address/confirm'),
@@ -106,6 +109,8 @@ describe('_gcweb-app.personal-information.home-address.confirm', () => {
             nameFr: '(FR) sample',
           },
         ],
+        useSuggestedAddress: true,
+        suggestedAddress: { address: '123 Fake Suggested St.', city: 'city', country: 'country' },
       });
     });
   });

--- a/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
+++ b/frontend/app/routes/_gcweb-app.personal-information.home-address.suggested.tsx
@@ -7,11 +7,9 @@ import { useTranslation } from 'react-i18next';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { InputRadios } from '~/components/input-radios';
-import { getAddressService } from '~/services/address-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
-import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('personal-information');
@@ -31,23 +29,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request);
 
-  const userService = getUserService();
   const sessionService = await getSessionService();
-  const userId = await userService.getUserId();
-  const userInfo = await userService.getUserInfo(userId);
-  const homeAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
+  const session = await sessionService.getSession(request);
+  const homeAddressInfo = session.get('newHomeAddress');
+  const suggestedAddressInfo = session.get('suggestedAddress');
 
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
-
-  //
-  // TODO
-  // CHANGE THE SOURCE OF THE SUGGESTED ADDRESS TO WHAT WS ADDRESS SERVICE IS RETURNING INSTEAD OF MAILING ADDRESS
-  //
-  const suggestedAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
-  const session = await sessionService.getSession(request);
-  session.set('homeAddress', homeAddressInfo);
-  session.set('suggestedAddress', suggestedAddressInfo);
 
   return json({ homeAddressInfo, suggestedAddressInfo, countryList, regionList });
 }
@@ -56,24 +44,13 @@ export async function action({ request }: ActionFunctionArgs) {
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request);
 
-  const userService = getUserService();
   const sessionService = await getSessionService();
-  const userId = await userService.getUserId();
-  const userInfo = await userService.getUserInfo(userId);
-  const homeAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.homeAddress ?? '');
-  //
-  // TODO
-  // CHANGE THE SOURCE OF THE SUGGESTED ADDRESS TO WHAT WS ADDRESS SERVICE IS RETURNING INSTEAD OF MAILING ADDRESS
-  //
-  const suggestedAddressInfo = await getAddressService().getAddressInfo(userId, userInfo?.mailingAddress ?? '');
-  const formDataRadio = Object.fromEntries(await request.formData());
-  //retrieve selected address, store it in the session and then redirect to the confirm page...
   const session = await sessionService.getSession(request);
-  if (formDataRadio.selectedAddress === 'home') {
-    session.set('newHomeAddress', homeAddressInfo);
-  } else {
-    session.set('newHomeAddress', suggestedAddressInfo);
-  }
+
+  const formDataRadio = Object.fromEntries(await request.formData());
+  const useSuggestedAddress = formDataRadio.selectedAddress === 'suggested';
+  session.set('useSuggestedAddress', useSuggestedAddress);
+
   return redirect('/personal-information/home-address/confirm', {
     headers: {
       'Set-Cookie': await sessionService.commitSession(session),

--- a/frontend/app/services/wsaddress-service.server.ts
+++ b/frontend/app/services/wsaddress-service.server.ts
@@ -41,12 +41,12 @@ export const getWSAddressService = moize.promise(createWSAddressService, { onCac
 async function createWSAddressService() {
   const { INTEROP_API_BASE_URI } = getEnv();
 
-  async function correctAddress({ address, city, province, postalCode, country }: { address: string; city: string; province: string; postalCode: string; country: string }) {
+  async function correctAddress({ address, city, province, postalCode, country }: { address: string; city: string; province?: string; postalCode?: string; country: string }) {
     const searchParams = new URLSearchParams({
       addressLine: address,
       city,
-      province,
-      postalCode,
+      ...(province && { province }),
+      ...(postalCode && { postalCode }),
       country,
       formatResult: 'true',
       language: 'English', // TODO confirm that we should always have this as "English"

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
@@ -44,7 +44,7 @@ test.describe('personal informaiton home address edit page', () => {
     });
   });
 
-  test('should redirect to home address confirm page', async ({ page }) => {
+  test('should redirect to home address suggested page', async ({ page }) => {
     await test.step('navigate', async () => {
       await page.goto('/personal-information/home-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
@@ -55,8 +55,8 @@ test.describe('personal informaiton home address edit page', () => {
       await page.locator('button#change-button').click();
     });
 
-    await test.step('detect home address confirm page', async () => {
-      await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+    await test.step('detect home address suggested page', async () => {
+      await expect(page).toHaveURL(/.*personal-information\/home-address\/suggested/);
     });
   });
 


### PR DESCRIPTION
### Description
The following TODOs have been addressed in this PR:
- `WSAddressService` is now used in the `action(..)` for the Edit Home Address route
- The source of the suggested address is now what `WSAddressService` returns (instead of the mailing address)

Additional changes:
- Unit tests to increase coverage for the Edit Home Address route (as well as fixing unit tests as a result of new changes)
- Changing Confirm page to display the Suggested Address if applicable
- Introducing an interface for the return value of `correctAddress(..)` within `WSAddressService`

### Related Azure Boards Work Items
[AB#2705](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2705)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application and make a home address change. You should be redirected to the Suggested address form by default.

### Additional Notes
Approximately 50 of the 127 lines added in this PR are copy and paste x2 unit tests.