### PR TITLE
Fix session timeout dialog

### DIFF
--- a/frontend/app/components/dialog.tsx
+++ b/frontend/app/components/dialog.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X as XIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { cn } from '~/utils/tw-utils';
 
@@ -13,29 +15,35 @@ const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay ref={ref} className={cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80', className)} {...props} />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 sm:rounded-lg',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none"></DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(({ className, children, ...props }, ref) => {
+  const { t } = useTranslation(['gcweb']);
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-white data-[state=open]:text-black">
+          <XIcon className="h-4 w-4" />
+          <span className="sr-only">{t('dialog.close')}</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={cn('flex flex-col space-y-1.5', className)} {...props} />;
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
 DialogHeader.displayName = 'DialogHeader';
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
@@ -47,8 +55,8 @@ const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Tit
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-black', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export { Dialog, DialogPortal, DialogOverlay, DialogClose, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };
+export { Dialog, DialogPortal, DialogOverlay, DialogTrigger, DialogClose, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };

--- a/frontend/app/components/dropdown-menu.tsx
+++ b/frontend/app/components/dropdown-menu.tsx
@@ -36,7 +36,7 @@ const DropdownMenuSubContent = React.forwardRef<React.ElementRef<typeof Dropdown
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={clsx(
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 text-black/[.87] shadow-lg',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 text-black/[.87] shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -50,7 +50,7 @@ const DropdownMenuContent = React.forwardRef<React.ElementRef<typeof DropdownMen
       ref={ref}
       sideOffset={sideOffset}
       className={clsx(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 text-black/[.87] shadow-md',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 text-black/[.87] shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/frontend/app/components/session-timeout.tsx
+++ b/frontend/app/components/session-timeout.tsx
@@ -3,24 +3,20 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
-import type { IIdleTimerProps } from 'react-idle-timer';
-import { useIdleTimer } from 'react-idle-timer';
+import { IIdleTimerProps, useIdleTimer } from 'react-idle-timer';
 
 import { Button } from '~/components/buttons';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
-import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
-export interface SessionTimeoutProps extends Pick<IIdleTimerProps, 'promptBeforeIdle'>, Pick<IIdleTimerProps, 'timeout'> {}
+export interface SessionTimeoutProps extends Required<Pick<IIdleTimerProps, 'promptBeforeIdle' | 'timeout'>> {}
 
 const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
   const { t } = useTranslation(i18nNamespaces);
   const [modalOpen, setModalOpen] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState('');
-  const { SESSION_TIMEOUT_SECONDS: timeoutParam } = getClientEnv();
-  const { SESSION_TIMEOUT_PROMPT_SECONDS: timeoutPromptParam } = getClientEnv();
   const navigate = useNavigate();
 
   const handleOnIdle = () => {
@@ -31,15 +27,24 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
   const { reset, getRemainingTime } = useIdleTimer({
     onIdle: handleOnIdle,
     onPrompt: () => setModalOpen(true),
-    promptBeforeIdle: promptBeforeIdle ?? timeoutPromptParam * 1000,
-    timeout: timeout ?? timeoutParam * 1000,
+    promptBeforeIdle,
+    timeout,
   });
 
-  const handleOnIdleContinueSession = async () => {
+  const handleOnIdleContinueSession = useCallback(async () => {
     await fetch('/api/refresh-session');
     setModalOpen(false);
     reset();
-  };
+  }, [reset]);
+
+  const handleOnDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        handleOnIdleContinueSession();
+      }
+    },
+    [handleOnIdleContinueSession],
+  );
 
   const tick = useCallback(() => {
     const minutes = Math.floor(getRemainingTime() / 60_000);
@@ -55,25 +60,22 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
   }, [tick]);
 
   return (
-    <div>
-      <Dialog open={modalOpen && timeRemaining.length > 0}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t('session-timeout.header')}</DialogTitle>
-          </DialogHeader>
-          {t('session-timeout.description', { timeRemaining })}
-          <DialogFooter>
-            <Button id="end-session-button" variant="default" size="sm" onClick={handleOnIdle}>
-              {t('session-timeout.end-session')}
-            </Button>
-            <Button id="continue-session-button" variant="primary" size="sm" onClick={handleOnIdleContinueSession}>
-              {t('session-timeout.continue-session')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <p>{Math.ceil(getRemainingTime() / 1000)} seconds remaining</p>
-    </div>
+    <Dialog open={modalOpen && timeRemaining.length > 0} onOpenChange={handleOnDialogOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('session-timeout.header')}</DialogTitle>
+        </DialogHeader>
+        {t('session-timeout.description', { timeRemaining })}
+        <DialogFooter>
+          <Button id="end-session-button" variant="default" size="sm" onClick={handleOnIdle}>
+            {t('session-timeout.end-session')}
+          </Button>
+          <Button id="continue-session-button" variant="primary" size="sm" onClick={handleOnIdleContinueSession}>
+            {t('session-timeout.continue-session')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -85,7 +85,7 @@ export default function App() {
         <Suspense>
           <Outlet />
           <Toaster toast={toast} />
-          <SessionTimeout />
+          <SessionTimeout promptBeforeIdle={env.SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={env.SESSION_TIMEOUT_SECONDS * 1000} />
         </Suspense>
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -84,6 +84,7 @@
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "tailwindcss": "^3.4.1",
+        "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.3.3",
         "vite": "^5.1.3",
         "vite-tsconfig-paths": "^4.3.1",
@@ -13712,6 +13713,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,6 +101,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.3.3",
     "vite": "^5.1.3",
     "vite-tsconfig-paths": "^4.3.1",

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -73,5 +73,8 @@
     "description": "Your session will expire automatically in {{timeRemaining}}. Select \"Continue Session\" to extend your session.",
     "end-session": "End session now",
     "header": "Session timeout warning"
+  },
+  "dialog": {
+    "close": "Close"
   }
 }

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -73,5 +73,8 @@
     "description": "Votre session expirera automatiquement dans {{timeRemaining}}. Sélectionnez «\u00a0Continuer la session\u00a0» pour prolonger votre session.",
     "end-session": "Mettre fin à la session",
     "header": "Avertissement d'expiration de la session"
+  },
+  "dialog": {
+    "close": "Fermer"
   }
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -18,5 +18,5 @@ export default {
     },
     extend: {},
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 } satisfies Config;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Address the session timeout dialog issues. The close button in the dialog lacked styling and visibility, although users could still navigate to it using the TAB key. Additionally, the ESC key action wasn't set up to allow users to continue the session when pressed.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/9ca7eea1-7312-4365-9aae-322ed9227e38)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Configure the following .env variables (testing purposes only):

```
SESSION_TIMEOUT_SECONDS=60
SESSION_TIMEOUT_PROMPT_SECONDS=55
```

Wait for the session timeout dialog to open then test the keyboard navigation. Close button should be visible and `ESC` keyboard key should work.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

Added missing tailwind plugin [tailwindcss-animate](https://github.com/jamiebuilds/tailwindcss-animate) used by shadcn/ui.