### PR TITLE
Add k8s readiness endpoint

### DIFF
--- a/frontend/app/routes/api.readyz.ts
+++ b/frontend/app/routes/api.readyz.ts
@@ -1,0 +1,11 @@
+import type { LoaderFunctionArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+
+/**
+ * A basic readiness endpoint to be used by kubernetes container probes
+ *
+ * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+ */
+export function loader({ request }: LoaderFunctionArgs) {
+  return json({ ready: true });
+}


### PR DESCRIPTION
```
❯ curl --include http://localhost:3000/api/readyz
HTTP/1.1 200 OK
content-type: application/json; charset=utf-8
Vary: Accept-Encoding
Date: Thu, 22 Feb 2024 12:49:38 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{ "ready": true }
```