### PR TITLE
[gitops] Bump staging version

### DIFF
--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-b669e229-0018c
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-51c55fab-001a2
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
Bump staging version to `0.0.0-51c55fab-001a2` in preparation for upcoming PR that will enable liveness/readiness probes.