### PR TITLE
add initial beefed up e2e tests

### DIFF
--- a/frontend/e2e/_gcweb-app.$.spec.ts
+++ b/frontend/e2e/_gcweb-app.$.spec.ts
@@ -3,16 +3,13 @@ import { expect, test } from '@playwright/test';
 
 test.describe('not found page', () => {
   test('should navigate to not found page', async ({ page }) => {
-    await page.goto('/personal-info');
-
-    await expect(page.locator('h1')).toHaveText("We couldn't find that web page (Error 404)");
+    await page.goto('/page-does-not-exist');
+    await expect(page).toHaveURL('/page-does-not-exist');
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/personal-info');
-
+    await page.goto('/page-does-not-exist');
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });

--- a/frontend/e2e/_gcweb-app._index.spec.ts
+++ b/frontend/e2e/_gcweb-app._index.spec.ts
@@ -4,15 +4,12 @@ import { expect, test } from '@playwright/test';
 test.describe('homepage', () => {
   test('should navigate to index', async ({ page }) => {
     await page.goto('/');
-
-    await expect(page.locator('h1')).toHaveText(/home/i);
+    await expect(page).toHaveURL('/');
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/');
-
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });

--- a/frontend/e2e/_gcweb-app.letters._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.letters._index.spec.ts
@@ -4,15 +4,34 @@ import { expect, test } from '@playwright/test';
 test.describe('letters page', () => {
   test('should navigate to letters page', async ({ page }) => {
     await page.goto('/letters');
+    await expect(page).toHaveURL('/letters');
+  });
 
-    await expect(page.locator('h1')).toHaveText('Letters');
+  test('it should sort list in ascending order by date', async ({ page }) => {
+    await page.goto('/letters');
+    await page.locator('select').selectOption('asc');
+    await expect(page).toHaveURL('/letters?sort=asc');
+  });
+
+  test('it should sort list in descending order by date', async ({ page }) => {
+    await page.goto('/letters');
+    await page.locator('select').selectOption('desc');
+    await expect(page).toHaveURL('/letters?sort=desc');
+  });
+
+  test('it should click on a pdf and successfully download', async ({ page }) => {
+    // note: the default behaviour in the browser is to open the pdf in the tab
+    // in chromium, however, this isn't the case. Instead, the pdf will fire a download event
+    await page.goto('/letters');
+    const downloadPromise = page.waitForEvent('download');
+    await page.locator('a[href$="/download"]').first().click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/.pdf/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/letters');
-
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.confirm.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+// TODO: beef up
+
+test.describe('personal informaiton home address edit page', () => {
+  test('should navigate to home address edit page', async ({ page }) => {
+    await page.goto('/personal-information/home-address/edit');
+    await page.locator('button#change-button').click();
+    await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/letters');
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
@@ -1,14 +1,16 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal information view page', () => {
-  test('should navigate to personal information view page', async ({ page }) => {
-    await page.goto('/personal-information');
-    await expect(page).toHaveURL('/personal-information');
+// TODO: beef up
+
+test.describe('personal informaiton home address edit page', () => {
+  test('should navigate to home address edit page', async ({ page }) => {
+    await page.goto('/personal-information/home-address/edit');
+    await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/personal-information');
+    await page.goto('/letters');
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+// TODO: beef up
+
+test.describe('personal informaiton mailing edit page', () => {
+  test('should navigate to mailing edit page', async ({ page }) => {
+    await page.goto('/personal-information/mailing-address/edit');
+    await page.locator('button#change-button').click();
+    await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/letters');
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
@@ -1,14 +1,16 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal information view page', () => {
-  test('should navigate to personal information view page', async ({ page }) => {
-    await page.goto('/personal-information');
-    await expect(page).toHaveURL('/personal-information');
+// TODO: beef up
+
+test.describe('personal informaiton mailing address edit page', () => {
+  test('should navigate to mailing address edit page', async ({ page }) => {
+    await page.goto('/personal-information/mailing-address/edit');
+    await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/personal-information');
+    await page.goto('/letters');
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.confirm.spec.ts
@@ -4,7 +4,9 @@ import { expect, test } from '@playwright/test';
 test.describe('phone number change confirmation page', () => {
   test('should navigate to phone number change confirmation page', async ({ page }) => {
     await page.goto('/personal-information/phone-number/edit');
-    await page.locator('button', { hasText: /change/i }).click();
+    await expect(page).toHaveURL('/personal-information/phone-number/edit');
+
+    await page.locator('button#submit').click();
     await expect(page).toHaveURL(/.*personal-information\/phone-number\/confirm/);
   });
 

--- a/frontend/e2e/_gcweb-app.personal-information.preferred-language.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.preferred-language.confirm.spec.ts
@@ -4,13 +4,13 @@ import { expect, test } from '@playwright/test';
 test.describe('preferred language confirm page', async () => {
   test('should navigate to page and render', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-    await page.locator('button', { hasText: /change/i }).click();
+    await page.locator('button#change-button').click();
     await expect(page).toHaveURL(/.*personal-information\/preferred-language\/confirm/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-    await page.locator('button', { hasText: /change/i }).click();
+    await page.locator('button#change-button').click();
     await expect(page).toHaveURL(/.*personal-information\/preferred-language\/confirm/);
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();

--- a/frontend/e2e/_gcweb-app.personal-information.preferred-language.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.preferred-language.edit.spec.ts
@@ -4,15 +4,12 @@ import { expect, test } from '@playwright/test';
 test.describe('preferred language edit page', async () => {
   test('should navigate to page and render', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-
-    await expect(page.locator('h1')).toHaveText('Change preferred language');
+    await expect(page).toHaveURL('/personal-information/preferred-language/edit');
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
### Description
This is part of an incremental PR that aims to beef up the current e2e tests.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
