### PR TITLE
add remaining e2e tests

### DIFF
--- a/frontend/e2e/_gcweb-app.letters._index.spec.ts
+++ b/frontend/e2e/_gcweb-app.letters._index.spec.ts
@@ -7,16 +7,13 @@ test.describe('letters page', () => {
     await expect(page).toHaveURL('/letters');
   });
 
-  test('it should sort list in ascending order by date', async ({ page }) => {
+  test('it should sort letters oldest to newest', async ({ page }) => {
     await page.goto('/letters');
-    await page.locator('select').selectOption('asc');
-    await expect(page).toHaveURL('/letters?sort=asc');
-  });
-
-  test('it should sort list in descending order by date', async ({ page }) => {
-    await page.goto('/letters');
-    await page.locator('select').selectOption('desc');
-    await expect(page).toHaveURL('/letters?sort=desc');
+    const selectLocator = page.locator('select#sort-order');
+    await expect(selectLocator).toHaveValue('desc');
+    await selectLocator.selectOption('asc');
+    await expect(page).toHaveURL(/\/letters?.*sort=asc/);
+    await expect(selectLocator).toHaveValue('asc');
   });
 
   test('it should click on a pdf and successfully download', async ({ page }) => {

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.confirm.spec.ts
@@ -1,13 +1,25 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-// TODO: beef up
-
 test.describe('personal informaiton home address edit page', () => {
   test('should navigate to home address edit page', async ({ page }) => {
     await page.goto('/personal-information/home-address/edit');
     await page.locator('button#change-button').click();
     await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+  });
+
+  test('should navigate back to the edit page after clicking the cancel button', async ({ page }) => {
+    await test.step('navigate to confirm page', async () => {
+      await page.goto('/personal-information/home-address/edit');
+      await page.locator('button#change-button').click();
+      await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+    });
+    await test.step('click cancel', async () => {
+      await page.locator('a#cancel-button').click();
+    });
+    await test.step('return to edit page', async () => {
+      await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
+    });
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
@@ -28,8 +28,8 @@ test.describe('personal informaiton home address edit page', () => {
 
     await test.step('detect errors summary presence', async () => {
       const errorSummary = page.locator('section#error-summary');
-      await expect(errorSummary).toBeInViewport({ timeout: 10000 });
-      await expect(errorSummary).toBeFocused({ timeout: 10000 });
+      await expect(errorSummary).toBeInViewport();
+      await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
@@ -1,13 +1,25 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-// TODO: beef up
-
 test.describe('personal informaiton mailing edit page', () => {
   test('should navigate to mailing edit page', async ({ page }) => {
     await page.goto('/personal-information/mailing-address/edit');
     await page.locator('button#change-button').click();
     await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
+  });
+
+  test('should navigate back to the edit page after clicking the cancel button', async ({ page }) => {
+    await test.step('navigate to confirm page', async () => {
+      await page.goto('/personal-information/mailing-address/edit');
+      await page.locator('button#change-button').click();
+      await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
+    });
+    await test.step('click cancel', async () => {
+      await page.locator('a#cancel-button').click();
+    });
+    await test.step('return to edit page', async () => {
+      await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
+    });
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
@@ -45,8 +45,8 @@ test.describe('personal informaiton mailing address edit page', () => {
 
     await test.step('detect errors summary presence', async () => {
       const errorSummary = page.locator('section#error-summary');
-      await expect(errorSummary).toBeInViewport({ timeout: 10000 });
-      await expect(errorSummary).toBeFocused({ timeout: 10000 });
+      await expect(errorSummary).toBeInViewport();
+      await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
@@ -27,8 +27,8 @@ test.describe('personal informaiton phone number edit page', () => {
 
     await test.step('detect errors summary presence', async () => {
       const errorSummary = page.locator('section#error-summary');
-      await expect(errorSummary).toBeInViewport({ timeout: 10000 });
-      await expect(errorSummary).toBeFocused({ timeout: 10000 });
+      await expect(errorSummary).toBeInViewport();
+      await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ const port = process.env.PORT ?? '3000';
 export default defineConfig({
   testDir: './e2e',
   timeout: 15 * 1000,
-  expect: { timeout: 5 * 1000 },
+  expect: { timeout: 10 * 1000 },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
### Description
Last PR for the e2e tests that I wanted to put in.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
- timeouts are still randomly happening, but when I do `npx playwright test --debug` and manually step through the tests, they don't fail. 