### PR TITLE
Fixing broken e2e test (and typos)

### DIFF
--- a/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.edit.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal informaiton home address edit page', () => {
+test.describe('personal information home address edit page', () => {
   test('should navigate to home address edit page', async ({ page }) => {
     await test.step('navigate', async () => {
       await page.goto('/personal-information/home-address/edit');

--- a/frontend/e2e/_gcweb-app.personal-information.home-address.suggested.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.home-address.suggested.spec.ts
@@ -1,24 +1,24 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal informaiton home address edit page', () => {
-  test('should navigate to home address edit page', async ({ page }) => {
+test.describe('personal information home address suggested page', () => {
+  test('should navigate to home address suggested page', async ({ page }) => {
     await page.goto('/personal-information/home-address/edit');
     await page.locator('button#change-button').click();
-    await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+    await expect(page).toHaveURL(/.*personal-information\/home-address\/suggested/);
   });
 
-  test('should navigate back to the edit page after clicking the cancel button', async ({ page }) => {
+  test('should navigate back to the personal information page after clicking the cancel button', async ({ page }) => {
     await test.step('navigate to confirm page', async () => {
       await page.goto('/personal-information/home-address/edit');
       await page.locator('button#change-button').click();
-      await expect(page).toHaveURL(/.*personal-information\/home-address\/confirm/);
+      await expect(page).toHaveURL(/.*personal-information\/home-address\/suggested/);
     });
     await test.step('click cancel', async () => {
       await page.locator('a#cancel-button').click();
     });
-    await test.step('return to edit page', async () => {
-      await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
+    await test.step('return to personal information page', async () => {
+      await expect(page).toHaveURL(/.*personal-information/);
     });
   });
 

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.confirm.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal informaiton mailing edit page', () => {
+test.describe('personal information mailing edit page', () => {
   test('should navigate to mailing edit page', async ({ page }) => {
     await page.goto('/personal-information/mailing-address/edit');
     await page.locator('button#change-button').click();

--- a/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.mailing-address.edit.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal informaiton mailing address edit page', () => {
+test.describe('personal information mailing address edit page', () => {
   test('should navigate to mailing address edit page', async ({ page }) => {
     await test.step('navigate', async () => {
       await page.goto('/personal-information/mailing-address/edit');

--- a/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
+++ b/frontend/e2e/_gcweb-app.personal-information.phone-number.edit.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
-test.describe('personal informaiton phone number edit page', () => {
+test.describe('personal information phone number edit page', () => {
   test('should navigate to phone number edit page', async ({ page }) => {
     await test.step('navigate', async () => {
       await page.goto('/personal-information/phone-number/edit');


### PR DESCRIPTION
### Description
As per title. I forgot to fix an e2e test as a result of https://github.com/DTS-STN/canadian-dental-care-plan/pull/464

Mock WSAddress API results in the user being taken to the Suggested Address page by default instead of the Confirm page, so I have renamed the e2e test file and fixed the corresponding broken test.

### Related Azure Boards Work Items
Somewhat related to [AB#2705](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2705)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/6b9c455b-9859-4a95-abc8-3584757ecb21)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run `npm run test:e2e` and verify no broken tests in `frontend\e2e\_gcweb-app.personal-information.home-address.suggested.spec.ts`