### PR TITLE
Add `remix-flat-routes`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,6 +83,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.11",
+        "remix-flat-routes": "^0.6.4",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.3.3",
@@ -2816,6 +2817,33 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/v1-route-convention": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/v1-route-convention/-/v1-route-convention-0.1.4.tgz",
+      "integrity": "sha512-fVTr9YlNLWfaiM/6Y56sOtcY8x1bBJQHY0sDWO5+Z/vjJ2Ni7fe2fwrzs1jUFciMPXqBQdFGePnkuiYLz3cuUA==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^7.4.3"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^1.15.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@remix-run/v1-route-convention/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@remix-run/web-blob": {
@@ -12807,6 +12835,49 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remix-flat-routes": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/remix-flat-routes/-/remix-flat-routes-0.6.4.tgz",
+      "integrity": "sha512-/0bTfaNSd2O3ak+cCLAlmHIsgm7YWiaBiu5ENUyuSWSNwF/KaHuKFhcHHhozPevQ8ROgCZG9tNbWzH6ktJoprA==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/v1-route-convention": "^0.1.3",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^5.1.0"
+      },
+      "bin": {
+        "migrate-flat-routes": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^1.15.0 || ^2"
+      }
+    },
+    "node_modules/remix-flat-routes/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/remix-flat-routes/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/remix-toast": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,6 +100,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
+    "remix-flat-routes": "^0.6.4",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.3.3",

--- a/frontend/remix.config.js
+++ b/frontend/remix.config.js
@@ -1,8 +1,11 @@
+import { flatRoutes } from 'remix-flat-routes';
+
 /**
  * @type {import('@remix-run/dev').AppConfig}
  */
 export default {
   cacheDirectory: './node_modules/.cache/remix',
-  ignoredRouteFiles: ['**/.*'],
+  ignoredRouteFiles: ['**/.*'], // let remix-flat-routes handle routing
+  routes: async (defineRoutes) => flatRoutes('routes', defineRoutes),
   serverDependenciesToBundle: ['react-idle-timer'],
 };


### PR DESCRIPTION
### Description

The `routes/` folder in the project is getting a little cluttered and hard to navigate. I think we can fix this using nested folders via `remix-flat-routes`.

This PR adds `remix-flat-routes` but makes no changes to any of the existing routes.

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

Future PRs will be used to refactor the routes into an easier to navigate folder structure.