### PR TITLE
Sorting countries in address form component rather than in mock; Updating mocks for French translation to verify sorting

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -124,19 +124,19 @@ for (let i = 0; i < numberOfLetters; i++) {
 db.country.create({
   countryId: 'CAN',
   nameEnglish: 'Canada',
-  nameFrench: '(FR) Canada',
+  nameFrench: 'Canada',
 });
 
 db.country.create({
   countryId: 'USA',
-  nameEnglish: 'USA',
-  nameFrench: '(FR) USA',
+  nameEnglish: 'United States of America',
+  nameFrench: "États-Unis d'Amérique",
 });
 
 db.country.create({
   countryId: 'MEX',
   nameEnglish: 'Mexico',
-  nameFrench: '(FR) Mexico',
+  nameFrench: 'Mexique',
 });
 
 // seed province list
@@ -144,49 +144,56 @@ db.region.create({
   provinceTerritoryStateId: 'ON',
   countryId: 'CAN',
   nameEnglish: 'Ontario',
-  nameFrench: '(FR) Ontario',
+  nameFrench: 'Ontario',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'MB',
   countryId: 'CAN',
   nameEnglish: 'Manitoba',
-  nameFrench: '(FR) Manitoba',
+  nameFrench: 'Manitoba',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'QC',
   countryId: 'CAN',
   nameEnglish: 'Quebec',
-  nameFrench: '(FR) Quebec',
+  nameFrench: 'Québec',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'NS',
   countryId: 'CAN',
   nameEnglish: 'Nova Scotia',
-  nameFrench: '(FR) Nova Scotia',
+  nameFrench: 'Nouvelle-Écosse',
+});
+
+db.region.create({
+  provinceTerritoryStateId: 'NL',
+  countryId: 'CAN',
+  nameEnglish: 'Newfoundland and Labrador',
+  nameFrench: 'Terre-Neuve-et-Labrador',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'PE',
   countryId: 'CAN',
   nameEnglish: 'Prince Edward Island',
-  nameFrench: '(FR) Prince Edward Island',
+  nameFrench: 'Île-du-Prince-Édouard',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'UT',
   countryId: 'USA',
   nameEnglish: 'Utah',
-  nameFrench: '(FR) Utah',
+  nameFrench: 'Utah',
 });
 
 db.region.create({
   provinceTerritoryStateId: 'NY',
   countryId: 'USA',
   nameEnglish: 'New York',
-  nameFrench: '(FR) New York',
+  nameFrench: 'État de New York',
 });
 
 export { db };

--- a/frontend/app/mocks/lookup-api.server.ts
+++ b/frontend/app/mocks/lookup-api.server.ts
@@ -41,7 +41,7 @@ export function getLookupApiMockHandlers() {
     http.get('https://api.example.com/lookups/countries', ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       const countryList = db.country.getAll();
-      return HttpResponse.json(countryList.sort((a, b) => (a.countryId < b.countryId ? -1 : 1)));
+      return HttpResponse.json(countryList);
     }),
 
     //

--- a/frontend/app/routes/_app+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/_app+/personal-information+/home-address+/edit.tsx
@@ -139,24 +139,26 @@ export default function PersonalInformationHomeAddressEdit() {
     postalCode: actionData?.formData.postalCode ?? addressInfo?.postalCode ?? '',
   };
 
-  const countries: InputOptionProps[] = countryList.map((country) => {
-    return {
-      label: i18n.language === 'fr' ? country.nameFrench : country.nameEnglish,
-      value: country.countryId,
-      id: country.countryId,
-    };
-  }) as InputOptionProps[];
+  const countries: InputOptionProps[] = countryList
+    .map((country) => {
+      return {
+        children: i18n.language === 'fr' ? country.nameFrench : country.nameEnglish,
+        value: country.countryId,
+        id: country.countryId,
+      };
+    })
+    .sort((country1, country2) => country1.children.localeCompare(country2.children));
 
-  //populate region/province/state list with selected country or current address country
+  // populate region/province/state list with selected country or current address country
   const regions: InputOptionProps[] = (selectedCountry ? countryRegions : regionList.filter((region) => region.countryId === defaultValues.country))
     .map((region) => {
       return {
-        label: i18n.language === 'fr' ? region.nameFrench : region.nameEnglish,
+        children: i18n.language === 'fr' ? region.nameFrench : region.nameEnglish,
         value: region.provinceTerritoryStateId,
         id: region.provinceTerritoryStateId,
       };
     })
-    .sort((r1, r2) => r1.label.localeCompare(r2.label)) as InputOptionProps[];
+    .sort((region1, region2) => region1.children.localeCompare(region2.children));
 
   /**
    * Gets an error message based on the provided internationalization (i18n) key.

--- a/frontend/app/routes/_app+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/_app+/personal-information+/mailing-address+/edit.tsx
@@ -146,24 +146,26 @@ export default function PersonalInformationMailingAddressEdit() {
     postalCode: actionData?.formData.postalCode ?? addressInfo?.postalCode,
   };
 
-  const countries: InputOptionProps[] = countryList.map((country) => {
-    return {
-      label: i18n.language === 'fr' ? country.nameFrench : country.nameEnglish,
-      value: country.countryId,
-      id: country.countryId,
-    };
-  }) as InputOptionProps[];
+  const countries: InputOptionProps[] = countryList
+    .map((country) => {
+      return {
+        children: i18n.language === 'fr' ? country.nameFrench : country.nameEnglish,
+        value: country.countryId,
+        id: country.countryId,
+      };
+    })
+    .sort((country1, country2) => country1.children.localeCompare(country2.children));
 
-  //populate region/province/state list with selected country or current address country
+  // populate region/province/state list with selected country or current address country
   const regions: InputOptionProps[] = (selectedCountry ? countryRegions : regionList.filter((region) => region.countryId === defaultValues.country))
     .map((region) => {
       return {
-        label: i18n.language === 'fr' ? region.nameFrench : region.nameEnglish,
+        children: i18n.language === 'fr' ? region.nameFrench : region.nameEnglish,
         value: region.provinceTerritoryStateId,
         id: region.provinceTerritoryStateId,
       };
     })
-    .sort((r1, r2) => r1.label.localeCompare(r2.label)) as InputOptionProps[];
+    .sort((region1, region2) => region1.children.localeCompare(region2.children));
 
   /**
    * Gets an error message based on the provided internationalization (i18n) key.


### PR DESCRIPTION
### Description
As per title.

Also made changes to how the `InputOptionProps[]` for `regions` and `countries` are populated to remove the use of `as InputOptionProps[]`.

Also added "Newfoundland and Labrador" to the DB mock so that the Suggested Address page renders the province because the corrected address coming from the WSAddress mock is a Newfoundland address.

### Screenshots (if applicable)
For the Suggested Address page...

**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/2c265617-2563-4da8-8c82-4ff367fc4a17)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/de51c44a-23bf-42ff-a144-ab5a2ce46ad9)

For the Country dropdown...

**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/e9c33426-5b93-4d0c-991a-0fb70d0521aa)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/c61efbea-fad5-474b-a6f4-c3db8c3f8b72)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

1. Run application locally
2. Make a home address change
3. Verify sorted "Province/State" and "Country" dropdown
4. Hit "Continue"
5. Verify Suggested address has a province