### PR TITLE
[gitops] Bump staging to `v0.0.0-72f218fc-001b7`

### DIFF
--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-51c55fab-001a2
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-72f218fc-001b7
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
Bump staging to latest build (to stop that annoying `/api/readyz` logging).