### PR TITLE
Fix global error logging

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -48,6 +48,17 @@ export async function handleDataRequest(response: Response, { request }: LoaderF
   return response;
 }
 
+/**
+ * Log any errors using the application logger (Remix will log using console.error() by default, which we don't want).
+ *
+ * @see https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
+ */
+export function handleError(error: unknown, { request }: LoaderFunctionArgs | ActionFunctionArgs) {
+  if (!request.signal.aborted) {
+    log.error(error);
+  }
+}
+
 export default async function handleRequest(request: Request, responseStatusCode: number, responseHeaders: Headers, remixContext: EntryContext) {
   const handlerFnName = isbot(request.headers.get('user-agent')) ? 'onAllReady' : 'onShellReady';
   log.debug(`Handling [${request.method}] request to [${request.url}] with handler function [${handlerFnName}]`);

--- a/frontend/app/utils/logging.server.ts
+++ b/frontend/app/utils/logging.server.ts
@@ -29,7 +29,7 @@ export const getLogger = (category: string) => {
     format: format.combine(
       format.timestamp(),
       format.splat(),
-      format.printf((info) => `${info.timestamp} ${info.level.toUpperCase().padStart(7)} --- [${formatCategory(category, 25)}]: ${info.message}`),
+      format.printf((info) => `${info.timestamp} ${info.level.toUpperCase().padStart(7)} --- [${formatCategory(category, 25)}]: ${info.stack ?? info.message}`),
     ),
     transports: [new transports.Console()],
   });


### PR DESCRIPTION
### Description

Log uncaught errors using the application logger instead of Remix's default `console.error()`.

### Screenshots

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/f7dc2f89-294c-4311-aed9-f31fcf561ff3)

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Hit <http://localhost:3000/error> and look at the server console. Or, look at the screenshot above and trust me that it works.
