### PR TITLE
Memoize build info feature

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -7,43 +7,26 @@ import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderD
 import { useTranslation } from 'react-i18next';
 import { getToast } from 'remix-toast';
 
-import SessionTimeout from './components/session-timeout';
-import { Toaster } from './components/toaster';
-// import cdcpStyleSheet from '~/cdcp.css';
 import { ClientEnv } from '~/components/client-env';
 import { NonceContext } from '~/components/nonce-context';
+import SessionTimeout from '~/components/session-timeout';
+import { Toaster } from '~/components/toaster';
 import fontNotoSansStyleSheet from '~/fonts/noto-sans.css';
+import { getBuildInfoService } from '~/services/build-info-service.server';
 import tailwindStyleSheet from '~/tailwind.css';
-import { readBuildInfo } from '~/utils/build-info.server';
 import { getPublicEnv } from '~/utils/env.server';
 import { useDocumentTitleI18nKey, useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: fontNotoSansStyleSheet },
   { rel: 'stylesheet', href: tailwindStyleSheet },
-  // { rel: 'stylesheet', href: cdcpStyleSheet },
 ];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const buildInfo = readBuildInfo('build-info.json');
-  const publicEnv = getPublicEnv();
+  const buildInfoService = getBuildInfoService();
   const { toast, headers } = await getToast(request);
 
-  return json(
-    {
-      buildInfo: buildInfo ?? {
-        buildDate: '2000-01-01T00:00:00Z',
-        buildId: '0000',
-        buildRevision: '00000000',
-        buildVersion: '0.0.0-00000000-0000',
-      },
-      env: publicEnv,
-      toast,
-    },
-    {
-      headers,
-    },
-  );
+  return json({ buildInfo: buildInfoService.getBuildInfo(), env: getPublicEnv(), toast }, { headers });
 }
 
 /**

--- a/frontend/app/services/build-info-service.server.ts
+++ b/frontend/app/services/build-info-service.server.ts
@@ -1,0 +1,20 @@
+import moize from 'moize';
+
+import { BuildInfo, readBuildInfo } from '~/utils/build-info.server';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('build-info-service.server');
+
+export const getBuildInfoService = moize(createBuildInfoService, { onCacheAdd: () => log.info('Creating new buildinfo service') });
+
+const defaultBuildInfo: BuildInfo = {
+  buildDate: '2000-01-01T00:00:00Z',
+  buildId: '0000',
+  buildRevision: '00000000',
+  buildVersion: '0.0.0-00000000-0000',
+};
+
+function createBuildInfoService() {
+  const buildInfo = readBuildInfo('build-info.json') ?? defaultBuildInfo;
+  return { getBuildInfo: () => buildInfo };
+}


### PR DESCRIPTION
### Description

This PR stops rhe build info feature from hitting the disk for every request (looking for build-info.json).

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
