### PR TITLE
refactor e2e test locators

### DIFF
--- a/frontend/e2e/_app+/data-unavailable.spec.ts
+++ b/frontend/e2e/_app+/data-unavailable.spec.ts
@@ -1,0 +1,15 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('data unavailblepage', () => {
+  test('should navigate data unavailable page', async ({ page }) => {
+    await page.goto('/data-unavailable');
+    await expect(page).toHaveURL('/data-unavailable');
+  });
+
+  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+    await page.goto('/data-unavailable');
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/frontend/e2e/_app+/letters+/_index.spec.ts
+++ b/frontend/e2e/_app+/letters+/_index.spec.ts
@@ -9,7 +9,7 @@ test.describe('letters page', () => {
 
   test('it should sort letters oldest to newest', async ({ page }) => {
     await page.goto('/letters');
-    const selectLocator = page.locator('select#sort-order');
+    const selectLocator = page.getByRole('combobox', { name: 'filter by' });
     await expect(selectLocator).toHaveValue('desc');
     await selectLocator.selectOption('asc');
     await expect(page).toHaveURL(/\/letters?.*sort=asc/);
@@ -21,7 +21,7 @@ test.describe('letters page', () => {
     // in chromium, however, this isn't the case. Instead, the pdf will fire a download event
     await page.goto('/letters');
     const downloadPromise = page.waitForEvent('download');
-    await page.locator('a[href$="/download"]').first().click();
+    await page.getByRole('main').getByRole('listitem').first().getByRole('link').click();
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toMatch(/\.pdf$/);
   });

--- a/frontend/e2e/_app+/personal-information+/home-address+/edit.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/home-address+/edit.spec.ts
@@ -21,19 +21,19 @@ test.describe('personal information home address edit page', () => {
     });
 
     await test.step('submit invalid form data', async () => {
-      await page.locator('input#address').evaluate((e) => ((e as HTMLInputElement).required = false));
-      await page.locator('input#address').fill('');
-      await page.locator('button#change-button').click();
+      await page.getByRole('textbox', { name: 'address' }).evaluate((e) => ((e as HTMLInputElement).required = false));
+      await page.getByRole('textbox', { name: 'address' }).fill('');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect errors summary presence', async () => {
-      const errorSummary = page.locator('section#error-summary');
+      const errorSummary = page.getByRole('alert').first();
       await expect(errorSummary).toBeInViewport();
       await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {
-      const input = page.locator('input#address');
+      const input = page.getByRole('textbox', { name: 'address' });
       const errorMessage = await input.evaluate((element) => (element as HTMLInputElement).validationMessage);
       expect(errorMessage).toEqual(expect.anything());
     });
@@ -51,8 +51,8 @@ test.describe('personal information home address edit page', () => {
     });
 
     await test.step('enter and submit form data', async () => {
-      await page.locator('input#address').fill('123 New Address Avenue');
-      await page.locator('button#change-button').click();
+      await page.getByRole('textbox', { name: 'address' }).fill('123 New Address Avenue');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect home address suggested page', async () => {
@@ -67,7 +67,7 @@ test.describe('personal information home address edit page', () => {
     });
 
     await test.step('click cancel', async () => {
-      await page.locator('a#cancel-button').click();
+      await page.getByRole('link', { name: 'cancel' }).click();
     });
 
     await test.step('detect personal information page', async () => {

--- a/frontend/e2e/_app+/personal-information+/home-address+/suggested.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/home-address+/suggested.spec.ts
@@ -4,18 +4,18 @@ import { expect, test } from '@playwright/test';
 test.describe('personal information home address suggested page', () => {
   test('should navigate to home address suggested page', async ({ page }) => {
     await page.goto('/personal-information/home-address/edit');
-    await page.locator('button#change-button').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/home-address\/suggested/);
   });
 
   test('should navigate back to the personal information page after clicking the cancel button', async ({ page }) => {
     await test.step('navigate to confirm page', async () => {
       await page.goto('/personal-information/home-address/edit');
-      await page.locator('button#change-button').click();
+      await page.getByRole('button', { name: 'change' }).click();
       await expect(page).toHaveURL(/.*personal-information\/home-address\/suggested/);
     });
     await test.step('click cancel', async () => {
-      await page.locator('a#cancel-button').click();
+      await page.getByRole('link', { name: 'cancel' }).click();
     });
     await test.step('return to personal information page', async () => {
       await expect(page).toHaveURL(/.*personal-information/);

--- a/frontend/e2e/_app+/personal-information+/mailing-address+/confirm.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/mailing-address+/confirm.spec.ts
@@ -4,18 +4,18 @@ import { expect, test } from '@playwright/test';
 test.describe('personal information mailing confirm page', () => {
   test('should navigate to mailing confirm page', async ({ page }) => {
     await page.goto('/personal-information/mailing-address/edit');
-    await page.locator('button#change-button').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
   });
 
   test('should navigate back to the edit page after clicking the cancel button', async ({ page }) => {
     await test.step('navigate to confirm page', async () => {
       await page.goto('/personal-information/mailing-address/edit');
-      await page.locator('button#change-button').click();
+      await page.getByRole('button', { name: 'change' }).click();
       await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
     });
     await test.step('click cancel', async () => {
-      await page.locator('a#cancel-button').click();
+      await page.getByRole('link', { name: 'cancel' }).click();
     });
     await test.step('return to edit page', async () => {
       await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
@@ -24,7 +24,7 @@ test.describe('personal information mailing confirm page', () => {
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/personal-information/mailing-address/edit');
-    await page.locator('button#change-button').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/mailing-address\/confirm/);
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);

--- a/frontend/e2e/_app+/personal-information+/mailing-address+/edit.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/mailing-address+/edit.spec.ts
@@ -21,8 +21,8 @@ test.describe('personal information mailing address edit page', () => {
     });
 
     await test.step('click copy home address checkbox', async () => {
-      await page.locator('input#input-checkbox-copy-home-address').click();
-      await expect(page.locator('input#address')).not.toBeAttached();
+      await page.getByRole('checkbox', { name: 'copy home address' }).click();
+      await expect(page.getByRole('textbox', { name: 'address' })).not.toBeAttached();
     });
 
     await test.step('detect any accessibility issues', async () => {
@@ -38,19 +38,19 @@ test.describe('personal information mailing address edit page', () => {
     });
 
     await test.step('submit invalid form data', async () => {
-      await page.locator('input#address').evaluate((e) => ((e as HTMLInputElement).required = false));
-      await page.locator('input#address').fill('');
-      await page.locator('button#change-button').click();
+      await page.getByRole('textbox', { name: 'address' }).evaluate((e) => ((e as HTMLInputElement).required = false));
+      await page.getByRole('textbox', { name: 'address' }).fill('');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect errors summary presence', async () => {
-      const errorSummary = page.locator('section#error-summary');
+      const errorSummary = page.getByRole('alert').first();
       await expect(errorSummary).toBeInViewport();
       await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {
-      const input = page.locator('input#address');
+      const input = page.getByRole('textbox', { name: 'address' });
       const errorMessage = await input.evaluate((element) => (element as HTMLInputElement).validationMessage);
       expect(errorMessage).toEqual(expect.anything());
     });
@@ -68,8 +68,8 @@ test.describe('personal information mailing address edit page', () => {
     });
 
     await test.step('enter and submit form data', async () => {
-      await page.locator('input#address').fill('123 New Address Avenue');
-      await page.locator('button#change-button').click();
+      await page.getByRole('textbox', { name: 'address' }).fill('123 New Address Avenue');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect mailing address confirm page', async () => {
@@ -84,7 +84,7 @@ test.describe('personal information mailing address edit page', () => {
     });
 
     await test.step('click cancel', async () => {
-      await page.locator('a#cancel-button').click();
+      await page.getByRole('link', { name: 'cancel' }).click();
     });
 
     await test.step('detect personal information page', async () => {

--- a/frontend/e2e/_app+/personal-information+/phone-number+/confirm.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/phone-number+/confirm.spec.ts
@@ -6,13 +6,13 @@ test.describe('phone number change confirmation page', () => {
     await page.goto('/personal-information/phone-number/edit');
     await expect(page).toHaveURL('/personal-information/phone-number/edit');
 
-    await page.locator('button#submit').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/phone-number\/confirm/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/personal-information/phone-number/edit');
-    await page.locator('button#submit').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/phone-number\/confirm/);
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();

--- a/frontend/e2e/_app+/personal-information+/phone-number+/edit.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/phone-number+/edit.spec.ts
@@ -21,18 +21,18 @@ test.describe('personal information phone number edit page', () => {
     });
 
     await test.step('submit invalid form data', async () => {
-      await page.locator('input#phoneNumber').fill('ASDF');
-      await page.locator('button#submit').click();
+      await page.getByRole('textbox', { name: 'phone number' }).fill('ASDF');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect errors summary presence', async () => {
-      const errorSummary = page.locator('section#error-summary');
+      const errorSummary = page.getByRole('alert').first();
       await expect(errorSummary).toBeInViewport();
       await expect(errorSummary).toBeFocused();
     });
 
     await test.step('detect form errors', async () => {
-      const input = page.locator('input#phoneNumber');
+      const input = page.getByRole('textbox', { name: 'phone number' });
       const errorMessage = await input.evaluate((element) => (element as HTMLInputElement).validationMessage);
       expect(errorMessage).toEqual(expect.anything());
     });
@@ -50,8 +50,8 @@ test.describe('personal information phone number edit page', () => {
     });
 
     await test.step('enter and submit form data', async () => {
-      await page.locator('input#phoneNumber').fill('(506) 555-5555');
-      await page.locator('button#submit').click();
+      await page.getByRole('textbox', { name: 'phone number' }).fill('(506) 555-5555');
+      await page.getByRole('button', { name: 'change' }).click();
     });
 
     await test.step('detect phone number confirm page', async () => {
@@ -66,7 +66,7 @@ test.describe('personal information phone number edit page', () => {
     });
 
     await test.step('click cancel', async () => {
-      await page.locator('a#cancel').click();
+      await page.getByRole('link', { name: 'cancel' }).click();
     });
 
     await test.step('detect personal information page', async () => {

--- a/frontend/e2e/_app+/personal-information+/preferred-language+/confirm.spec.ts
+++ b/frontend/e2e/_app+/personal-information+/preferred-language+/confirm.spec.ts
@@ -4,13 +4,13 @@ import { expect, test } from '@playwright/test';
 test.describe('preferred language confirm page', async () => {
   test('should navigate to page and render', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-    await page.locator('button#change-button').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/preferred-language\/confirm/);
   });
 
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
     await page.goto('/personal-information/preferred-language/edit');
-    await page.locator('button#change-button').click();
+    await page.getByRole('button', { name: 'change' }).click();
     await expect(page).toHaveURL(/.*personal-information\/preferred-language\/confirm/);
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();


### PR DESCRIPTION
### Description
Last week e2e tests were changed to have element locators use css selectors as a convention.  However, the playwright documentation asserts the following [re:locators](https://playwright.dev/docs/locators#locate-by-role):

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/b539471e-6d0b-49bd-82eb-83849cf5c891)

In short: this PR aligns the e2e tests with the playwright documentation (and in some cases reverts the locators back to their original `getByRole()`.
zure-boards-work-items
-->


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`