### PR TITLE
AB#2969 -- Fixed multiple titles appearing on error pages

### DIFF
--- a/frontend/app/routes/_app+/_layout.tsx
+++ b/frontend/app/routes/_app+/_layout.tsx
@@ -297,18 +297,23 @@ function ServerError({ error }: ServerErrorProps) {
   const home = <InlineLink to="/" />;
 
   return (
-    <ApplicationLayout>
-      <PageTitle>
-        {t('gcweb:server-error.page-title')}
-        &#32;<small className="block text-2xl font-normal text-neutral-500">{t('gcweb:server-error.page-subtitle')}</small>
-      </PageTitle>
-      <p className="mb-8 text-lg text-gray-500">{t('gcweb:server-error.page-message')}</p>
-      <ul className="list-disc space-y-2 pl-10">
-        <li>{t('gcweb:server-error.option-01')}</li>
-        <li>
-          <Trans ns={i18nNamespaces} i18nKey="gcweb:server-error.option-02" components={{ home }} />
-        </li>
-      </ul>
-    </ApplicationLayout>
+    <>
+      <PageHeader />
+      <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+        <PageTitle>
+          {t('gcweb:server-error.page-title')}
+          &#32;<small className="block text-2xl font-normal text-neutral-500">{t('gcweb:server-error.page-subtitle')}</small>
+        </PageTitle>
+        <p className="mb-8 text-lg text-gray-500">{t('gcweb:server-error.page-message')}</p>
+        <ul className="list-disc space-y-2 pl-10">
+          <li>{t('gcweb:server-error.option-01')}</li>
+          <li>
+            <Trans ns={i18nNamespaces} i18nKey="gcweb:server-error.option-02" components={{ home }} />
+          </li>
+        </ul>
+        <PageDetails />
+      </main>
+      <PageFooter />
+    </>
   );
 }


### PR DESCRIPTION
### Description
Fixed multiple titles appearing on error pages. Removed layout wrapper from ServerError component (PageTitle was duplicated)

### Related Azure Boards Work Items
AB#2969

### Screenshots (if applicable)
Issue caused by page title rendering in layout:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/9ad838ac-c0b0-4b8c-8d63-3e8159e65930)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [] (N/A) I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
The current link should render an error page with the correct title: http://localhost:3000/personal-information/home-address/confirm

### Additional Notes
N/A