### PR TITLE
Move 404 page and fix layout handle's `satisfies`

### DIFF
--- a/frontend/app/routes/_protected+/_layout.tsx
+++ b/frontend/app/routes/_protected+/_layout.tsx
@@ -3,9 +3,9 @@ import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
 import ApplicationLayout, { ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/application-layout';
 import type { RouteHandleData } from '~/utils/route-utils';
 
-export const handle: RouteHandleData = {
+export const handle = {
   i18nNamespaces: [...layoutI18nNamespaces],
-} as const;
+} as const satisfies RouteHandleData;
 
 export function ErrorBoundary() {
   const error = useRouteError();

--- a/frontend/app/routes/_public+/$.tsx
+++ b/frontend/app/routes/_public+/$.tsx
@@ -7,11 +7,9 @@ import { PageTitle } from '~/components/page-title';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('gcweb');
-
 export const handle = {
   documentTitleI18nKey: 'gcweb:not-found.document-title',
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('gcweb'),
   pageIdentifier: 'CDCP-0404',
 } as const satisfies RouteHandleData;
 
@@ -20,22 +18,19 @@ export async function loader() {
 }
 
 export default function NotFound() {
-  const { t } = useTranslation(i18nNamespaces);
-
-  // (content will be added by <Trans>)
-  // eslint-disable-next-line jsx-a11y/anchor-has-content
+  const { t } = useTranslation(handle.i18nNamespaces);
   const home = <InlineLink to="/" />;
 
   return (
     <>
       <PageTitle>
-        {t('gcweb:not-found.page-title')}
-        &#32;<small className="block text-2xl font-normal text-neutral-500">{t('gcweb:not-found.page-subtitle')}</small>
+        <span>{t('gcweb:not-found.page-title')}</span>
+        <small className="block text-2xl font-normal text-neutral-500">{t('gcweb:not-found.page-subtitle')}</small>
       </PageTitle>
       <p className="mb-8 text-lg text-gray-500">{t('gcweb:not-found.page-message')}</p>
       <ul className="list-disc space-y-2 pl-10">
         <li>
-          <Trans ns={i18nNamespaces} i18nKey="gcweb:not-found.page-link" components={{ home }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="gcweb:not-found.page-link" components={{ home }} />
         </li>
       </ul>
     </>

--- a/frontend/app/routes/_public+/_layout.tsx
+++ b/frontend/app/routes/_public+/_layout.tsx
@@ -3,9 +3,9 @@ import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
 import ApplicationLayout, { ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/application-layout';
 import type { RouteHandleData } from '~/utils/route-utils';
 
-export const handle: RouteHandleData = {
+export const handle = {
   i18nNamespaces: [...layoutI18nNamespaces],
-} as const;
+} as const satisfies RouteHandleData;
 
 export function ErrorBoundary() {
   const error = useRouteError();


### PR DESCRIPTION
### Description

Move 404 page to public routes. A future PR might add a 404 page for protected routes.

### Related Azure Boards Work Items

- [AB#3003](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3003)

### Screenshots

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/221b3b98-41b0-4c35-83b1-1790250081bb)

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Visit <http://localhost:3000/dimebag-darrell>