### PR TITLE
[gitops] Configure session timeouts

### DIFF
--- a/gitops/overlays/dev/configs/frontend-config.conf
+++ b/gitops/overlays/dev/configs/frontend-config.conf
@@ -10,8 +10,9 @@ ENABLED_MOCKS=cct,lookup,power-platform,raoidc,wsaddress
 #
 SESSION_STORAGE_TYPE=redis
 REDIS_URL=redis://redis-dev
-SESSION_TIMEOUT_SECONDS=60
-SESSION_TIMEOUT_PROMPT_SECONDS=30
+# 4 minutes and 19 minutes, respectively
+SESSION_TIMEOUT_PROMPT_SECONDS=240
+SESSION_TIMEOUT_SECONDS=1140
 
 #
 # RAOIDC configuration


### PR DESCRIPTION
Set session timeouts in `dev` to:

- 15m to fire warning
- 19m to end session