### PR TITLE
Add footer's main band

### DIFF
--- a/frontend/app/components/layouts/application-layout.tsx
+++ b/frontend/app/components/layouts/application-layout.tsx
@@ -172,7 +172,7 @@ function PageDetails() {
   return (
     <section className="mb-8 mt-16">
       <h2 className="sr-only">{t('gcweb:page-details.page-details')}</h2>
-      <dl id="wb-dtmd" className="space-y-1 text-sm text-gray-500">
+      <dl id="wb-dtmd" className="space-y-1">
         {!!pageIdentifier && (
           <div className="flex gap-2">
             <dt>{t('gcweb:page-details.screen-id')}</dt>
@@ -206,10 +206,26 @@ function PageFooter() {
   const { t } = useTranslation(i18nNamespaces);
 
   return (
-    <footer id="wb-info" className="border-t bg-stone-50 py-7">
-      <div className="container">
+    <footer id="wb-info" className="bg-stone-50">
+      <div className="bg-gray-700 text-white">
+        <section className="container py-6">
+          <h2 className="mb-4">My Service Canada Account</h2>
+          <div className="grid gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+            <Link className="hover:underline" to="https://example.com/contact-us">
+              Contact Us
+            </Link>
+            <Link className="hover:underline" to="https://example.com/link-1">
+              [Link1]
+            </Link>
+            <Link className="hover:underline" to="https://example.com/link-2">
+              [Link2]
+            </Link>
+          </div>
+        </section>
+      </div>
+      <div className="container py-7">
         <h2 className="sr-only">{t('gcweb:footer.about-site')}</h2>
-        <div className=" flex items-center justify-between gap-4">
+        <div className="flex items-center justify-between gap-4">
           <nav aria-labelledby="gc-corporate">
             <h3 id="gc-corporate" className="sr-only">
               {t('gcweb:footer.gc-corporate')}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

We were asked to add the footer main band to match MSCA-D footer and also GCDS specs. The footer's main band content will be provided later.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

- [AB#3003](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3003)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/8871bb28-0509-4372-8b6a-1bf3005d5477)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->