### PR TITLE
Remove session cookie max age

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -79,9 +79,6 @@ SESSION_COOKIE_SAME_SITE=lax
 # session cookie encryption secret
 # (optional; default: a random UUID)
 SESSION_COOKIE_SECRET=0123456789ABCDEF
-# session cookie max age in seconds
-# (optional; default: 600)
-SESSION_COOKIE_MAX_AGE_SECONDS=1200
 # session cookie httpOnly flag
 # (optional; default: true)
 SESSION_COOKIE_HTTP_ONLY=true

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -32,8 +32,7 @@ if (ENABLED_MOCKS.length > 0) {
  * for the root loader, we can use the handleDataRequest function to effectively
  * 'touch' the session, extending it by the default session lifetime.
  *
- * Extending the session lifetime will update the expires/maxage field of the
- * session cookie, and will also update the TTL value of the session data when
+ * Extending the session lifetime  update the TTL value of the session data when
  * using Redis as a backing store.
  *
  * @see https://remix.run/docs/en/main/file-conventions/entry.server#handledatarequest

--- a/frontend/app/services/session-service.server.ts
+++ b/frontend/app/services/session-service.server.ts
@@ -43,7 +43,6 @@ async function createSessionService() {
   const sessionCookie = createCookie(env.SESSION_COOKIE_NAME, {
     path: env.SESSION_COOKIE_PATH,
     domain: env.SESSION_COOKIE_DOMAIN,
-    maxAge: env.SESSION_COOKIE_MAX_AGE_SECONDS,
     sameSite: env.SESSION_COOKIE_SAME_SITE,
     secrets: [env.SESSION_COOKIE_SECRET],
     secure: env.SESSION_COOKIE_SECURE,

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -63,7 +63,6 @@ const serverEnv = z.object({
   SESSION_COOKIE_PATH: z.string().trim().min(1).default('/'),
   SESSION_COOKIE_SAME_SITE: z.enum(['lax', 'strict', 'none']).default('lax'),
   SESSION_COOKIE_SECRET: z.string().trim().min(16).default(randomUUID()),
-  SESSION_COOKIE_MAX_AGE_SECONDS: z.coerce.number().default(1200),
   SESSION_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),
   SESSION_COOKIE_SECURE: z.string().transform(toBoolean).default('true'),
   SESSION_FILE_DIR: z.string().trim().min(1).default('./node_modules/cache/sessions/'),


### PR DESCRIPTION
### Description

Remove cookie max age setting in preparation for upcoming session changes.

Since our session backing store will be Redis, there is no reason to set a max age on the session cookie (redis will expire the data automatically). Also, removing the cookie max age removes the need to "touch" the cookie whenever a request is made, which will lead to simpler session handling in the application.

### Related Azure Boards Work Items

- [AB#2673](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2673)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
