### PR TITLE
Rename lang and toast cookies

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -36,8 +36,8 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 
 # i18n language cookie name
-# (optional; default: _gc_lang)
-LANG_COOKIE_NAME=_gc_lang
+# (optional; default: __CDCP//lang)
+LANG_COOKIE_NAME=__CDCP//lang
 # i18n language cookie domain
 # (optional; default: undefined)
 LANG_COOKIE_DOMAIN=localhost

--- a/frontend/app/components/toaster.tsx
+++ b/frontend/app/components/toaster.tsx
@@ -18,6 +18,7 @@ export interface ToasterProps {
 export function Toaster({ toast }: ToasterProps) {
   setToastCookieOptions({
     // TODO :: GjB :: make these configurable
+    name: '__CDCP//toast',
     sameSite: 'lax',
     secure: true,
   });

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -47,7 +47,7 @@ const serverEnv = z.object({
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
   // language cookie settings
-  LANG_COOKIE_NAME: z.string().default('_gc_lang'),
+  LANG_COOKIE_NAME: z.string().default('__CDCP//lang'),
   LANG_COOKIE_DOMAIN: z.string().optional(),
   LANG_COOKIE_PATH: z.string().default('/'),
   LANG_COOKIE_HTTP_ONLY: z.string().transform(toBoolean).default('true'),


### PR DESCRIPTION
### Description

Rename lang and toast cookies to match the convention used by the session cookie

### Checklist

- [X] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
