### PR TITLE
Remove unnecessary awaits

### DIFF
--- a/frontend/app/routes-flow/intake-flow.ts
+++ b/frontend/app/routes-flow/intake-flow.ts
@@ -68,11 +68,11 @@ async function loadState({ params, request, fallbackRedirectUrl = '/intake' }: L
 
   const sessionName = getSessionName(id.data);
 
-  if (!(await session.has(sessionName))) {
+  if (!session.has(sessionName)) {
     throw redirect(fallbackRedirectUrl, 302);
   }
 
-  const sessionState = await session.get(sessionName);
+  const sessionState = session.get(sessionName);
   const state = intakeStateSchema.parse(sessionState);
 
   return { id: id.data, state };
@@ -97,7 +97,7 @@ async function saveState({ params, request, state }: SaveStateArgs) {
   const session = await sessionService.getSession(request);
 
   const sessionName = getSessionName(id);
-  await session.set(sessionName, newState);
+  session.set(sessionName, newState);
 
   return {
     headers: {
@@ -123,7 +123,7 @@ async function clearState({ params, request }: ClearStateArgs) {
   const session = await sessionService.getSession(request);
 
   const sessionName = getSessionName(id);
-  await session.unset(sessionName);
+  session.unset(sessionName);
 
   return {
     headers: {
@@ -150,7 +150,7 @@ async function start({ id, request }: StartArgs) {
   const session = await sessionService.getSession(request);
 
   const sessionName = getSessionName(parsedId);
-  await session.set(sessionName, initialState);
+  session.set(sessionName, initialState);
 
   return {
     headers: {

--- a/frontend/app/routes/_protected+/personal-information+/home-address+/address-accuracy.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/home-address+/address-accuracy.tsx
@@ -30,9 +30,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request);
-  if (!session.has('newHomeAddress')) return redirect('/');
-  const newHomeAddress = await session.get('newHomeAddress');
 
+  if (!session.has('newHomeAddress')) {
+    return redirect('/');
+  }
+
+  const newHomeAddress = session.get('newHomeAddress');
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
 

--- a/frontend/app/routes/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
@@ -30,9 +30,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request);
-  if (!session.has('newMailingAddress')) return redirect('/');
-  const newMailingAddress = await session.get('newMailingAddress');
 
+  if (!session.has('newMailingAddress')) {
+    return redirect('/');
+  }
+
+  const newMailingAddress = session.get('newMailingAddress');
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
 

--- a/frontend/app/routes/_protected+/personal-information+/mailing-address+/confirm.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/mailing-address+/confirm.tsx
@@ -40,7 +40,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request);
-  const newMailingAddress = await session.get('newMailingAddress');
+  const newMailingAddress = session.get('newMailingAddress');
+
   return json({ mailingAddressInfo, newMailingAddress, countryList, regionList });
 }
 


### PR DESCRIPTION
### Description

Remove unnecessary `await` keywords because Remix doesn't return promises when accessing session data.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
