### PR TITLE
Fix broken declaration file

### DIFF
--- a/frontend/app/components/toaster.tsx
+++ b/frontend/app/components/toaster.tsx
@@ -54,7 +54,8 @@ interface SnackbarProps extends ComponentProps<typeof MaterialDesignContent> {}
 const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(({ className, message, ...props }, ref) => {
   const ns = useI18nNamespaces();
   const { t } = useTranslation(ns);
-  const translatedMessage = t(message, { defaultValue: message });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const translatedMessage = t(message as any, { defaultValue: message });
   return <MaterialDesignContent ref={ref} className={cn('!rounded-lg !border', className)} message={translatedMessage} {...props} />;
 });
 

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -1,4 +1,5 @@
-import type communicationPreference from '../public/locales/en/communication-preferences.json';
+import type communicationPreference from '../public/locales/en/communication-preference.json';
+import type dataUnavailable from '../public/locales/en/data-unavailable.json';
 import type demographicsOralHealthQuestions from '../public/locales/en/demographics-oral-health-questions.json';
 import type dentalInsuranceQuestion from '../public/locales/en/dental-insurance-question.json';
 import type gcweb from '../public/locales/en/gcweb.json';
@@ -7,8 +8,6 @@ import type intake from '../public/locales/en/intake.json';
 import type letters from '../public/locales/en/letters.json';
 import type personalInformation from '../public/locales/en/personal-information.json';
 import type reviewInformation from '../public/locales/en/review-information.json';
-import type dataUnavailable from '../public/locales/en/udata-unavailable.json';
-import type updatePhoneNumber from '../public/locales/en/update-phone-number.json';
 import type { PublicEnv } from '~/utils/env.server';
 
 /**
@@ -30,7 +29,6 @@ declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: false;
     resources: {
-      'access-question': typeof accessQuestion;
       'communication-preference': typeof communicationPreference;
       'data-unavailable': typeof dataUnavailable;
       'demographics-oral-health-questions': typeof demographicsOralHealthQuestions;
@@ -40,7 +38,6 @@ declare module 'i18next' {
       intake: typeof intake;
       letters: typeof letters;
       'personal-information': typeof personalInformation;
-      'update-phone-number': typeof updatePhoneNumber;
       'review-information': typeof reviewInformation;
     };
   }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

Since we have `"skipLibCheck": true,` in `tsconfig.json` file. The declartion files are not validated. I had to set it to `false` then fix it then set it back to `true`. At the moment, there is no way to only skip-lib-check `node_modules`.
https://github.com/microsoft/TypeScript/issues/30511