### PR TITLE
AB#2977 - Integrating hCaptcha on intake index page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -40,6 +40,17 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 ENABLED_FEATURES=doc-upload,email-alerts,update-personal-info,view-applications,view-letters,view-messages
 
 
+# hCaptcha secret key -- used for server-side verifification
+# (required; use the example below)
+HCAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000
+# hCaptcha site key -- used to integrate hCaptcha to a webpage
+# (required; use the example below)
+HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
+# hCaptcha verify URL -- used to verify hCaptcha tokens
+# (required; use the example below)
+HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
+
+
 # i18n language cookie name
 # (optional; default: __CDCP//lang)
 LANG_COOKIE_NAME=__CDCP//lang

--- a/frontend/__tests__/utils/csp-utils.server.test.ts
+++ b/frontend/__tests__/utils/csp-utils.server.test.ts
@@ -27,12 +27,12 @@ describe('csp.server', () => {
 
       expect(csp).toContain(`base-uri 'none';`);
       expect(csp).toContain(`default-src 'none';`);
-      expect(csp).toContain(`connect-src 'self';`);
+      expect(csp).toContain(`connect-src 'self' https://hcaptcha.com https://*.hcaptcha.com;`);
       expect(csp).toContain(`font-src 'self' fonts.gstatic.com;`);
-      expect(csp).toContain(`frame-src 'self';`);
+      expect(csp).toContain(`frame-src 'self' https://hcaptcha.com https://*.hcaptcha.com;`);
       expect(csp).toContain(`img-src 'self' data:;`);
-      expect(csp).toContain(`script-src 'strict-dynamic' 'nonce-${nonce}';`);
-      expect(csp).toContain(`style-src 'self'`);
+      expect(csp).toContain(`script-src 'strict-dynamic' 'nonce-${nonce}' https://hcaptcha.com https://*.hcaptcha.com;`);
+      expect(csp).toContain(`style-src 'self' 'unsafe-inline' https://hcaptcha.com https://*.hcaptcha.com`);
     });
 
     it('should allow HMR websocket connections when NODE_ENV=development', () => {
@@ -41,7 +41,7 @@ describe('csp.server', () => {
       const nonce = '1234567890ABCDEF';
       const csp = generateContentSecurityPolicy(nonce);
 
-      expect(csp).toContain(`connect-src 'self' ws://localhost:3001;`);
+      expect(csp).toContain(`connect-src 'self' https://hcaptcha.com https://*.hcaptcha.com ws://localhost:3001;`);
     });
   });
 });

--- a/frontend/app/routes/_public+/intake+/_index.tsx
+++ b/frontend/app/routes/_public+/intake+/_index.tsx
@@ -1,24 +1,58 @@
-import { ActionFunctionArgs, redirect } from '@remix-run/node';
-import { Form } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { Form, useLoaderData } from '@remix-run/react';
 
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { randomUUID } from 'crypto';
+import { z } from 'zod';
 
 import { Button } from '~/components/buttons';
 import { getIntakeFlow } from '~/routes-flow/intake-flow';
+import { getHCaptchaService } from '~/services/hcaptcha-service.server';
+import { getEnv } from '~/utils/env.server';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { HCAPTCHA_SITE_KEY } = getEnv();
+  return { siteKey: HCAPTCHA_SITE_KEY };
+}
 
 export async function action({ request }: ActionFunctionArgs) {
+  const formDataSchema = z.object({
+    'h-captcha-response': z.string().min(1, { message: 'Please indicate that you are human.' }),
+  });
+
+  const formData = Object.fromEntries(await request.formData());
+  const parsedDataResult = formDataSchema.safeParse(formData);
+
+  if (!parsedDataResult.success) {
+    return json({
+      errors: parsedDataResult.error.flatten(),
+      formData: formData as Partial<z.infer<typeof formDataSchema>>,
+    });
+  }
+
+  const hCaptchaService = await getHCaptchaService();
+  const hCaptchaResponse = parsedDataResult.data['h-captcha-response'];
+  const hCaptchaResult = await hCaptchaService.verifyHCaptchaResponse(hCaptchaResponse);
+
+  // TODO handle the hCaptchaResult (eg. log the result or redirect to another page)
+  console.log(hCaptchaResult);
+
   const intakeFlow = getIntakeFlow();
   const id = randomUUID().toString();
   const sessionResponseInit = await intakeFlow.start({ id, request });
+
   return redirect(`/intake/${id}/personal-info`, sessionResponseInit);
 }
 
 export default function IntakeIndex() {
+  const { siteKey } = useLoaderData<typeof loader>();
+
   return (
     <>
       <h3>Intake Form Index</h3>
       <p>Privacy Statements</p>
       <Form method="post" noValidate>
+        <HCaptcha sitekey={siteKey} />
         <Button>Accept and start intake flow!</Button>
       </Form>
     </>

--- a/frontend/app/services/hcaptcha-service.server.ts
+++ b/frontend/app/services/hcaptcha-service.server.ts
@@ -1,0 +1,44 @@
+import moize from 'moize';
+
+import { getEnv } from '~/utils/env.server';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('hcaptcha-service.server');
+
+/**
+ * Return a singleton instance (by means of memomization) of the hCaptcha service.
+ */
+export const getHCaptchaService = moize(createHCaptchaService, { onCacheAdd: () => log.info('Creating new hCaptcha service') });
+
+function createHCaptchaService() {
+  const { HCAPTCHA_SECRET_KEY, HCAPTCHA_VERIFY_URL } = getEnv();
+
+  /**
+   * Verify the user response (ie. the "h-captcha-response" token).
+   *
+   * @see https://docs.hcaptcha.com/#verify-the-user-response-server-side
+   */
+  async function verifyHCaptchaResponse(hCaptchaResponse: string) {
+    const url = new URL(HCAPTCHA_VERIFY_URL);
+    url.searchParams.set('response', hCaptchaResponse);
+    url.searchParams.set('secret', HCAPTCHA_SECRET_KEY);
+
+    const response = await fetch(url, { method: 'POST' });
+
+    if (!response.ok) {
+      log.error('%j', {
+        message: 'Failed to verify hCaptcha',
+        status: response.status,
+        statusText: response.statusText,
+        url: HCAPTCHA_VERIFY_URL,
+        responseBody: await response.text(),
+      });
+
+      throw new Error(`Failed to verify hCaptcha: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  return { verifyHCaptchaResponse };
+}

--- a/frontend/app/utils/csp-utils.server.ts
+++ b/frontend/app/utils/csp-utils.server.ts
@@ -15,15 +15,15 @@ export function generateContentSecurityPolicy(nonce: string) {
     // prettier-ignore
     `base-uri 'none'`,
     `default-src 'none'`,
-    `connect-src 'self'` + (isDevelopment ? ' ws://localhost:3001' : ''),
+    `connect-src 'self' https://hcaptcha.com https://*.hcaptcha.com` + (isDevelopment ? ' ws://localhost:3001' : ''),
     `font-src 'self' fonts.gstatic.com`,
     `form-action 'self'`,
     `frame-ancestors 'self'`,
-    `frame-src 'self'`,
+    `frame-src 'self' https://hcaptcha.com https://*.hcaptcha.com`,
     `img-src 'self' data:`,
-    `script-src 'strict-dynamic' 'nonce-${nonce}'`,
+    `script-src 'strict-dynamic' 'nonce-${nonce}' https://hcaptcha.com https://*.hcaptcha.com`,
     // unsafe-inline is required by remix-toast 💩
-    `style-src 'self' 'unsafe-inline'`,
+    `style-src 'self' 'unsafe-inline' https://hcaptcha.com https://*.hcaptcha.com`,
   ].join('; ');
 
   log.debug(`Generated content security policy: [${contentSecurityPolicy}]`);

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -57,6 +57,11 @@ const serverEnv = z.object({
   AUTH_RAOIDC_PROXY_URL: z.string().trim().transform(emptyToUndefined).optional(),
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
+  // hCaptcha settings
+  HCAPTCHA_SECRET_KEY: z.string().trim().min(1),
+  HCAPTCHA_SITE_KEY: z.string().trim().min(1),
+  HCAPTCHA_VERIFY_URL: z.string().url(),
+
   // language cookie settings
   LANG_COOKIE_NAME: z.string().default('__CDCP//lang'),
   LANG_COOKIE_DOMAIN: z.string().optional(),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@hcaptcha/react-hcaptcha": "^1.10.1",
         "@mswjs/data": "^0.16.1",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
@@ -1519,6 +1520,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hcaptcha/loader": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-1.2.3.tgz",
+      "integrity": "sha512-tJVkPpvWZ9kIXMAFeH/7B8iIDNN+kpFLBVgtJQgtWa1cAN0bUve2VPuc/UTVa0NUh7tsmd6oAg/C0VUplMt2UQ=="
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.10.1.tgz",
+      "integrity": "sha512-P0en4gEZAecah7Pt3WIaJO2gFlaLZKkI0+Tfdg8fNqsDxqT9VytZWSkH4WAkiPRULK1QcGgUZK+J56MXYmPifw==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@hcaptcha/loader": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@hcaptcha/react-hcaptcha": "^1.10.1",
     "@mswjs/data": "^0.16.1",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",


### PR DESCRIPTION
### Description
- Adding hCaptcha component library (see https://github.com/hCaptcha/react-hcaptcha)
- Adding environment variables for site key, secret key and site verification endpoint
- Adding `hcaptcha-service` for calling site verification endpoint

References:
- https://docs.hcaptcha.com/

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977) 

### Screenshots (if applicable)
**hCaptcha on screen:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/8068b264-1854-4ea9-be82-48867df8102b)

**`/siteverify` response:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/2d297a8e-2429-4107-9cd9-ea85b4957dd8)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and navigate to `/intake`.
Click on the hCaptcha to verify you are a human and start an intake application.
The console will log the `/siteverify` response.

### Additional Notes
The message "This hCaptcha is for testing only..." is because we are running on `localhost`. See https://docs.hcaptcha.com/#local-development.

Unit tests will come in a subsequent PR.