### PR TITLE
AB#3018 -- OWASP ZAP fixes

### DIFF
--- a/frontend/__tests__/utils/security-utils.server.test.ts
+++ b/frontend/__tests__/utils/security-utils.server.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { generateContentSecurityPolicy } from '~/utils/csp-utils.server';
 import { getEnv } from '~/utils/env.server';
+import { generateContentSecurityPolicy, generatePermissionsPolicy } from '~/utils/security-utils.server';
 
 vi.mock('~/utils/env.server', () => ({
   getEnv: vi.fn(),
@@ -13,7 +13,7 @@ vi.mock('~/utils/logging.server', () => ({
   }),
 }));
 
-describe('csp.server', () => {
+describe('security-utils.server', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -42,6 +42,20 @@ describe('csp.server', () => {
       const csp = generateContentSecurityPolicy(nonce);
 
       expect(csp).toContain(`connect-src 'self' https://hcaptcha.com https://*.hcaptcha.com ws://localhost:3001;`);
+    });
+  });
+
+  describe('generatePermissionsPolicy', () => {
+    it('should generate a secure permissions policy', () => {
+      const permissionsPolicy = generatePermissionsPolicy();
+
+      expect(permissionsPolicy).toContain('camera=()');
+      expect(permissionsPolicy).toContain('display-capture=()');
+      expect(permissionsPolicy).toContain('fullscreen=()');
+      expect(permissionsPolicy).toContain('geolocation=()');
+      expect(permissionsPolicy).toContain('microphone=()');
+      expect(permissionsPolicy).toContain('publickey-credentials-get=()');
+      expect(permissionsPolicy).toContain('screen-wake-lock=()');
     });
   });
 });

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -11,11 +11,11 @@ import { NonceProvider, generateNonce } from '~/components/nonce-context';
 import { server } from '~/mocks/node';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getSessionService } from '~/services/session-service.server';
-import { generateContentSecurityPolicy } from '~/utils/csp-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getNamespaces } from '~/utils/locale-utils';
 import { createLangCookie, getLocale, initI18n } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
+import { generateContentSecurityPolicy, generatePermissionsPolicy } from '~/utils/security-utils.server';
 
 // instrumentation should be started as early as possible to ensure proper initialization
 const instrumentationService = getInstrumentationService();
@@ -80,10 +80,12 @@ export default async function handleRequest(request: Request, responseStatusCode
 
   const nonce = generateNonce(32);
   const contentSecurityPolicy = generateContentSecurityPolicy(nonce);
+  const permissionsPolicy = generatePermissionsPolicy();
 
   // @see: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html
   responseHeaders.set('Content-Security-Policy', contentSecurityPolicy);
   responseHeaders.set('Content-Type', 'text/html; charset=UTF-8');
+  responseHeaders.set('Permissions-Policy', permissionsPolicy);
   responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   responseHeaders.set('X-Content-Type-Options', 'nosniff');
   responseHeaders.set('X-Frame-Options', 'deny');

--- a/frontend/app/utils/security-utils.server.ts
+++ b/frontend/app/utils/security-utils.server.ts
@@ -29,3 +29,23 @@ export function generateContentSecurityPolicy(nonce: string) {
   log.debug(`Generated content security policy: [${contentSecurityPolicy}]`);
   return contentSecurityPolicy;
 }
+
+/**
+ * Generate a secure permissions policy.
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#permissions-policy-formerly-feature-policy
+ */
+export function generatePermissionsPolicy() {
+  // prettier-ignore
+  const permissionsPolicy = [
+    'camera=()',
+    'display-capture=()',
+    'fullscreen=()',
+    'geolocation=()',
+    'microphone=()',
+    'publickey-credentials-get=()',
+    'screen-wake-lock=()',
+  ].join(', ');
+
+  log.debug(`Generated content security policy: [${permissionsPolicy}]`);
+  return permissionsPolicy;
+}


### PR DESCRIPTION
### Description

This PR fixes the "permissions policy header not set" OWASP ZAP alert found in our nightly ZAP scans.

### Related Azure Boards Work Items

- [AB#3018](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3018)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
