### PR TITLE
AB#3022 Add robots meta tags

### DIFF
--- a/frontend/__tests__/utils/meta-utils.test.ts
+++ b/frontend/__tests__/utils/meta-utils.test.ts
@@ -1,0 +1,123 @@
+import { MetaArgs } from '@remix-run/node';
+
+import { describe, expect, it } from 'vitest';
+
+import { mergeMeta } from '~/utils/meta-utils';
+
+describe('mergeMeta', () => {
+  it('should merge parent meta with leaf meta', () => {
+    // Mock data
+    const parentMetaFn = () => [
+      { name: 'description', content: 'Parent description' },
+      { name: 'keywords', content: 'Parent keywords' },
+    ];
+
+    const leafMetaFn = () => [
+      { name: 'description', content: 'Leaf description' },
+      { name: 'author', content: 'Leaf author' },
+    ];
+
+    const args: MetaArgs = {
+      data: undefined,
+      location: {
+        hash: '',
+        key: '',
+        pathname: '/',
+        search: '',
+        state: {},
+      },
+      matches: [
+        {
+          data: undefined,
+          id: 'parent',
+          meta: parentMetaFn(),
+          params: {},
+          pathname: '/',
+        },
+      ],
+      params: {},
+    };
+
+    // Call the mergeMeta function
+    const mergedMetaFn = mergeMeta(leafMetaFn);
+    const mergedMeta = mergedMetaFn(args);
+
+    // Assertions
+    expect(mergedMeta).toEqual([
+      { name: 'description', content: 'Leaf description' },
+      { name: 'author', content: 'Leaf author' },
+      { name: 'keywords', content: 'Parent keywords' },
+    ]);
+  });
+
+  it('should handle merging when parent meta not found', () => {
+    // Mock data
+    const parentMetaFn = () => [];
+    const leafMetaFn = () => [{ name: 'description', content: 'Leaf description' }];
+
+    const args: MetaArgs = {
+      data: undefined,
+      location: {
+        hash: '',
+        key: '',
+        pathname: '/',
+        search: '',
+        state: {},
+      },
+      matches: [
+        {
+          data: undefined,
+          id: 'parent',
+          meta: parentMetaFn(),
+          params: {},
+          pathname: '/',
+        },
+      ],
+      params: {},
+    };
+
+    // Call the mergeMeta function
+    const mergedMetaFn = mergeMeta(leafMetaFn);
+    const mergedMeta = mergedMetaFn(args);
+
+    // Assertions
+    expect(mergedMeta).toEqual([{ name: 'description', content: 'Leaf description' }]);
+  });
+
+  it('should handle merging when meta properties are different', () => {
+    // Mock data
+    const parentMetaFn = () => [{ name: 'description', content: 'Parent description' }];
+    const leafMetaFn = () => [{ property: 'og:description', content: 'Leaf OG description' }];
+
+    const args: MetaArgs = {
+      data: undefined,
+      location: {
+        hash: '',
+        key: '',
+        pathname: '/',
+        search: '',
+        state: {},
+      },
+      matches: [
+        {
+          data: undefined,
+          id: 'parent',
+          meta: parentMetaFn(),
+          params: {},
+          pathname: '/',
+        },
+      ],
+      params: {},
+    };
+
+    // Call the mergeMeta function
+    const mergedMetaFn = mergeMeta(leafMetaFn);
+    const mergedMeta = mergedMetaFn(args);
+
+    // Assertions
+    expect(mergedMeta).toEqual([
+      { property: 'og:description', content: 'Leaf OG description' },
+      { name: 'description', content: 'Parent description' },
+    ]);
+  });
+});

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useContext } from 'react';
 
-import type { LinksFunction, LoaderFunctionArgs } from '@remix-run/node';
+import type { LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData, useRouteLoaderData } from '@remix-run/react';
 
@@ -25,6 +25,10 @@ export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: fontNotoSansStyleSheet },
   { rel: 'stylesheet', href: tailwindStyleSheet },
 ];
+
+export const meta: MetaFunction<typeof loader> = (args) => {
+  return [{ name: 'robots', content: 'noindex' }];
+};
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const buildInfoService = getBuildInfoService();

--- a/frontend/app/routes/_public+/apply+/_index.tsx
+++ b/frontend/app/routes/_public+/apply+/_index.tsx
@@ -1,4 +1,4 @@
-import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { Form, useLoaderData } from '@remix-run/react';
 
 import HCaptcha from '@hcaptcha/react-hcaptcha';
@@ -9,11 +9,16 @@ import { Button } from '~/components/buttons';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getHCaptchaService } from '~/services/hcaptcha-service.server';
 import { getEnv } from '~/utils/env.server';
+import { mergeMeta } from '~/utils/meta-utils';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { HCAPTCHA_SITE_KEY } = getEnv();
   return { siteKey: HCAPTCHA_SITE_KEY };
 }
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  return [{ name: 'robots', content: 'index' }];
+});
 
 export async function action({ request }: ActionFunctionArgs) {
   const formDataSchema = z.object({

--- a/frontend/app/utils/meta-utils.ts
+++ b/frontend/app/utils/meta-utils.ts
@@ -1,0 +1,31 @@
+import { LoaderFunction, MetaFunction } from '@remix-run/node';
+
+/**
+ * Merging helper {@link https://remix.run/docs/en/main/route/meta#meta-merging-helper}
+ *
+ * If you can't avoid the merge problem with global meta or index routes, we've created
+ * a helper that you can put in your app that can override and append to parent meta easily.
+ */
+export const mergeMeta = <Loader extends LoaderFunction | unknown = unknown, ParentsLoaders extends Record<string, LoaderFunction | unknown> = Record<string, unknown>>(
+  leafMetaFn: MetaFunction<Loader, ParentsLoaders>,
+): MetaFunction<Loader, ParentsLoaders> => {
+  return (args) => {
+    const leafMeta = leafMetaFn(args);
+
+    return args.matches.reduceRight((acc, match) => {
+      for (const parentMeta of match.meta) {
+        const index = acc.findIndex((meta) => {
+          // prettier-ignore
+          return ('name' in meta && 'name' in parentMeta && meta.name === parentMeta.name)
+            || ('property' in meta && 'property' in parentMeta && meta.property === parentMeta.property)
+            || ('title' in meta && 'title' in parentMeta);
+        });
+        if (index == -1) {
+          // Parent meta not found in acc, so add it
+          acc.push(parentMeta);
+        }
+      }
+      return acc;
+    }, leafMeta);
+  };
+};


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Include robots meta tags. The default value for the content of all pages' meta tags is set to `noindex`. Page routes must explicitly specify `index` if they are to be indexed by search engines. The `/apply` route is configured to be indexed.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3022](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3022)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Go through pages and they should have the following `robots` meta:

```html
<meta name="robots" content="noindex">
```

Except for `/apply` that should be:

```html
<meta name="robots" content="index">
```

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

[Remix's Meta Merging Helper](https://remix.run/docs/en/main/route/meta#meta-merging-helper)