### PR TITLE
Fix collapsible style

### DIFF
--- a/frontend/__tests__/components/collapsible.test.tsx
+++ b/frontend/__tests__/components/collapsible.test.tsx
@@ -20,6 +20,7 @@ describe('Collapsible Details', () => {
 
     const collapsibleDetailsSummaryElement = getByText(additionalProps.summary);
     expect(collapsibleDetailsSummaryElement.tagName).toBe('SPAN');
-    expect(collapsibleDetailsSummaryElement.id).toBe(additionalProps.id + '-summary-header');
+    expect(collapsibleDetailsSummaryElement.parentElement?.tagName).toBe('SUMMARY');
+    expect(collapsibleDetailsSummaryElement.parentElement?.id).toBe(additionalProps.id + '-summary');
   });
 });

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -11,25 +11,19 @@ export interface CollapsibleSummaryProps extends ComponentProps<'summary'> {
   id: string;
 }
 
-export function CollapsibleSummary({ id, children, className, ...props }: CollapsibleSummaryProps) {
-  const headerId = `${id}-header`;
-
+export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
   return (
-    <summary {...props}>
-      <span id={headerId} className={cn('inline text-blue-900 underline', className)}>
-        {children}
-      </span>
+    <summary className={cn('cursor-pointer text-blue-900 underline', className)} {...props}>
+      <span className="ml-4">{children}</span>
     </summary>
   );
 }
 
 export function CollapsibleDetails({ children, id, className, summary, ...props }: CollapsibleDetailsProps) {
-  const detailsId = `${id}-details`;
   const summaryId = `${id}-summary`;
   const contentId = `${id}-content`;
-
   return (
-    <details id={detailsId} {...props}>
+    <details {...props}>
       <CollapsibleSummary id={summaryId}>{summary}</CollapsibleSummary>
       <div id={contentId} className={cn('mt-2 border-l-[6px] border-gray-400 px-6 py-4', className)}>
         {children}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix collapsible style to match figma. The summary marker was black instead of using the summary text color.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Before
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/56ce8225-1192-4422-a761-c9965295af97)

After
![Screenshot 2024-03-05 131130](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/4726eec0-a632-4e99-b860-fecc268cecc1)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`