### PR TITLE
Add ability to use protected or public layout.

### DIFF
--- a/frontend/app/components/layouts/application-layout.tsx
+++ b/frontend/app/components/layouts/application-layout.tsx
@@ -20,17 +20,20 @@ export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
 export interface ApplicationLayoutProps {
   children?: ReactNode;
-  showAccountMenu?: boolean;
+  layout: 'protected' | 'public';
 }
 
 /**
  * GCWeb Application page template.
  * see: https://wet-boew.github.io/GCWeb/templates/application/application-docs-en.html
  */
-export default function ApplicationLayout({ children, showAccountMenu }: ApplicationLayoutProps) {
+export default function ApplicationLayout({ children, layout }: ApplicationLayoutProps) {
   return (
     <>
-      <PageHeader showAccountMenu={showAccountMenu} />
+      <SkipNavigationLinks />
+      {layout === 'protected' && <ProtectedPageHeader />}
+      {layout === 'public' && <PublicPageHeader />}
+      <Breadcrumbs />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
         <AppPageTitle />
         {children}
@@ -82,73 +85,33 @@ function NavigationMenu() {
   );
 }
 
-interface PageHeaderProps {
-  showAccountMenu?: boolean;
-}
-
-function PageHeader({ showAccountMenu }: PageHeaderProps) {
-  const { i18n, t } = useTranslation(i18nNamespaces);
-
-  /**
-   * handleOnSkipLinkClick is the click event handler for the anchor link.
-   * It prevents the default anchor link behavior, scrolls to and focuses
-   * on the target element specified by 'anchorElementId', and invokes
-   * the optional 'onClick' callback.
-   */
-  function handleOnSkipLinkClick(e: MouseEvent<HTMLAnchorElement>) {
-    e.preventDefault();
-    scrollAndFocusFromAnchorLink(e.currentTarget.href);
-  }
+function ProtectedPageHeader() {
+  const { t } = useTranslation(i18nNamespaces);
 
   return (
-    <>
-      <div id="skip-to-content">
-        {[
-          { to: '#wb-cont', children: t('gcweb:nav.skip-to-content') },
-          { to: '#wb-info', children: t('gcweb:nav.skip-to-about') },
-        ].map(({ to, children }) => (
-          <ButtonLink key={to} to={to} onClick={handleOnSkipLinkClick} variant="primary" className="absolute z-10 mx-2 -translate-y-full transition-all focus:mt-2 focus:translate-y-0">
-            {children}
-          </ButtonLink>
-        ))}
-      </div>
-      <header>
-        <div id="wb-bnr" className="border border-b border-gray-200 bg-gray-50">
-          <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
-            <div property="publisher" typeof="GovernmentOrganization">
-              <Link to={t('gcweb:header.govt-of-canada.href')} property="url">
-                <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
+    <header>
+      <PageHeaderBrand />
+      <section className="bg-gray-700 text-white">
+        <div className="sm:container">
+          <div className="flex flex-col items-stretch justify-between sm:flex-row sm:items-center">
+            <h2 className="p-4 font-lato text-xl font-semibold sm:p-0 sm:py-3 sm:text-2xl">
+              <Link to="/" className="hover:underline">
+                {t('gcweb:header.application-title')}
               </Link>
-              <meta property="name" content={t('gcweb:header.govt-of-canada.text')} />
-              <meta property="areaServed" typeof="Country" content="Canada" />
-              <link property="logo" href="/assets/wmms-blk.svg" />
-            </div>
-            <section id="wb-lng">
-              <h2 className="sr-only">{t('gcweb:header.language-selection')}</h2>
-              <LanguageSwitcher>
-                <span className="hidden md:block">{t('gcweb:language-switcher.alt-lang')}</span>
-                <abbr title={t('gcweb:language-switcher.alt-lang')} className="cursor-help uppercase md:hidden">
-                  {t('gcweb:language-switcher.alt-lang-abbr')}
-                </abbr>
-              </LanguageSwitcher>
-            </section>
+            </h2>
+            <NavigationMenu />
           </div>
         </div>
-        <section className="bg-gray-700 text-white">
-          <div className="sm:container">
-            <div className="flex flex-col items-stretch justify-between sm:flex-row sm:items-center">
-              <h2 className="p-4 font-lato text-xl font-semibold sm:p-0 sm:py-3 sm:text-2xl">
-                <Link to="/" className="hover:underline">
-                  {t('gcweb:header.application-title')}
-                </Link>
-              </h2>
-              {showAccountMenu && <NavigationMenu />}
-            </div>
-          </div>
-        </section>
-      </header>
-      <Breadcrumbs />
-    </>
+      </section>
+    </header>
+  );
+}
+
+function PublicPageHeader() {
+  return (
+    <header className="border-b-[3px] border-slate-700">
+      <PageHeaderBrand />
+    </header>
   );
 }
 
@@ -286,16 +249,17 @@ function Breadcrumbs() {
 
 export interface NotFoundErrorProps {
   error?: unknown;
-  showAccountMenu?: boolean;
+  layout: 'protected' | 'public';
 }
 
-export function NotFoundError({ error, showAccountMenu }: NotFoundErrorProps) {
+export function NotFoundError({ error, layout }: NotFoundErrorProps) {
   const { t } = useTranslation(i18nNamespaces);
   const home = <InlineLink to="/" />;
 
   return (
     <>
-      <PageHeader showAccountMenu={showAccountMenu} />
+      {layout === 'protected' && <ProtectedPageHeader />}
+      {layout === 'public' && <PublicPageHeader />}
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
         <PageTitle>
           <span>{t('gcweb:not-found.page-title')}</span>
@@ -316,16 +280,17 @@ export function NotFoundError({ error, showAccountMenu }: NotFoundErrorProps) {
 
 export interface ServerErrorProps {
   error: unknown;
-  showAccountMenu?: boolean;
+  layout: 'protected' | 'public';
 }
 
-export function ServerError({ error, showAccountMenu }: ServerErrorProps) {
+export function ServerError({ error, layout }: ServerErrorProps) {
   const { t } = useTranslation(i18nNamespaces);
   const home = <InlineLink to="/" />;
 
   return (
     <>
-      <PageHeader showAccountMenu={showAccountMenu} />
+      {layout === 'protected' && <ProtectedPageHeader />}
+      {layout === 'public' && <PublicPageHeader />}
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
         <PageTitle>
           <span>{t('gcweb:server-error.page-title')}</span>
@@ -342,5 +307,60 @@ export function ServerError({ error, showAccountMenu }: ServerErrorProps) {
       </main>
       <PageFooter />
     </>
+  );
+}
+
+export function SkipNavigationLinks() {
+  const { t } = useTranslation(i18nNamespaces);
+
+  /**
+   * handleOnSkipLinkClick is the click event handler for the anchor link.
+   * It prevents the default anchor link behavior, scrolls to and focuses
+   * on the target element specified by 'anchorElementId', and invokes
+   * the optional 'onClick' callback.
+   */
+  function handleOnSkipLinkClick(e: MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    scrollAndFocusFromAnchorLink(e.currentTarget.href);
+  }
+
+  return (
+    <div id="skip-to-content">
+      {[
+        { to: '#wb-cont', children: t('gcweb:nav.skip-to-content') },
+        { to: '#wb-info', children: t('gcweb:nav.skip-to-about') },
+      ].map(({ to, children }) => (
+        <ButtonLink key={to} to={to} onClick={handleOnSkipLinkClick} variant="primary" className="absolute z-10 mx-2 -translate-y-full transition-all focus:mt-2 focus:translate-y-0">
+          {children}
+        </ButtonLink>
+      ))}
+    </div>
+  );
+}
+
+export function PageHeaderBrand() {
+  const { i18n, t } = useTranslation(i18nNamespaces);
+  return (
+    <div id="wb-bnr">
+      <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
+        <div property="publisher" typeof="GovernmentOrganization">
+          <Link to={t('gcweb:header.govt-of-canada.href')} property="url">
+            <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
+          </Link>
+          <meta property="name" content={t('gcweb:header.govt-of-canada.text')} />
+          <meta property="areaServed" typeof="Country" content="Canada" />
+          <link property="logo" href="/assets/wmms-blk.svg" />
+        </div>
+        <section id="wb-lng">
+          <h2 className="sr-only">{t('gcweb:header.language-selection')}</h2>
+          <LanguageSwitcher>
+            <span className="hidden md:block">{t('gcweb:language-switcher.alt-lang')}</span>
+            <abbr title={t('gcweb:language-switcher.alt-lang')} className="cursor-help uppercase md:hidden">
+              {t('gcweb:language-switcher.alt-lang-abbr')}
+            </abbr>
+          </LanguageSwitcher>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -12,5 +12,5 @@ export async function loader() {
 }
 
 export default function NotFound() {
-  return <NotFoundError />; // delegate rendering to the layout's 404 component
+  return <NotFoundError layout="public" />; // delegate rendering to the layout's 404 component
 }

--- a/frontend/app/routes/_protected+/_layout.tsx
+++ b/frontend/app/routes/_protected+/_layout.tsx
@@ -13,17 +13,17 @@ export function ErrorBoundary() {
   if (isRouteErrorResponse(error)) {
     switch (error.status) {
       case 404: {
-        return <NotFoundError error={error} showAccountMenu />;
+        return <NotFoundError error={error} layout="protected" />;
       }
     }
   }
 
-  return <ServerError error={error} showAccountMenu />;
+  return <ServerError error={error} layout="protected" />;
 }
 
 export default function Layout() {
   return (
-    <ApplicationLayout showAccountMenu>
+    <ApplicationLayout layout="protected">
       <Outlet />
     </ApplicationLayout>
   );

--- a/frontend/app/routes/_public+/apply+/_layout.tsx
+++ b/frontend/app/routes/_public+/apply+/_layout.tsx
@@ -13,17 +13,17 @@ export function ErrorBoundary() {
   if (isRouteErrorResponse(error)) {
     switch (error.status) {
       case 404: {
-        return <NotFoundError error={error} />;
+        return <NotFoundError layout="public" error={error} />;
       }
     }
   }
 
-  return <ServerError error={error} />;
+  return <ServerError layout="public" error={error} />;
 }
 
 export default function Layout() {
   return (
-    <ApplicationLayout>
+    <ApplicationLayout layout="public">
       <Outlet />
     </ApplicationLayout>
   );


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3003](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3003)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Protected Layout
![localhost_3000_personal-information (4)](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/366e495f-3ced-4241-b433-ee854b34a5e0)

Public Layout
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/f0e69e9f-13b5-4f78-ae48-7517091ab949)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`