### PR TITLE
Make apply form multi-tab/multi-window safe

### DIFF
--- a/frontend/app/routes/_public+/apply+/$id+/_route.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/_route.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { Outlet, useNavigate } from '@remix-run/react';
+
+/**
+ * The parent route of all /apply/{id}/* routes, used to
+ * redirect to /apply if the flow has not yet been initialized.
+ */
+export default function Route() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // redirect to start if the flow has not yet been initialized
+    const flowState = sessionStorage.getItem('flow.state');
+    if (flowState !== 'active') navigate('/apply');
+  }, [navigate]);
+
+  return <Outlet />;
+}

--- a/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
@@ -51,7 +51,7 @@ export default function ApplyFlowApplicationDelegate() {
           {t('application-delegate.back-btn')}
           <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
-        <ButtonLink type="submit" variant="primary" to="/">
+        <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('application-delegate.return-btn')}
         </ButtonLink>
       </div>

--- a/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
 import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';

--- a/frontend/app/routes/_public+/apply+/$id+/demographics-part1.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics-part1.tsx
@@ -1,5 +1,5 @@
-import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
 import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/app/routes/_public+/apply+/$id+/demographics-part2.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics-part2.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
 import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/app/routes/_public+/apply+/$id+/demographics.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics.tsx
@@ -28,6 +28,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   return json({ id, state });
 }
+
 export async function action({ request, params }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
   const { id, state } = await applyFlow.loadState({ request, params });
@@ -37,6 +38,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     params,
     state,
   });
+
   return redirect(`/apply/${id}/demographics-part1`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/dental-insurance.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
-import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
 import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';

--- a/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
@@ -47,7 +47,7 @@ export default function ApplyFlowFileYourTaxes() {
           {t('dob-eligibility.back-btn')}
           <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
-        <ButtonLink type="submit" variant="primary" to="/">
+        <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('dob-eligibility.return-btn')}
         </ButtonLink>
       </div>

--- a/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
@@ -51,7 +51,7 @@ export default function ApplyFlowFileYourTaxes() {
           {t('file-your-taxes.back-btn')}
           <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
-        <ButtonLink type="submit" variant="primary" to="/">
+        <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('file-your-taxes.return-btn')}
         </ButtonLink>
       </div>

--- a/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
-import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
 import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';

--- a/frontend/app/routes/_public+/apply+/_index.tsx
+++ b/frontend/app/routes/_public+/apply+/_index.tsx
@@ -65,6 +65,8 @@ export default function ApplyIndex() {
 
       captchaRef.current.resetCaptcha();
     }
+
+    sessionStorage.setItem('flow.state', 'active');
   }
 
   return (


### PR DESCRIPTION
### Description

This PR addresses data clobbering issues that could occur when users fill out the application form across multiple tabs.

Here's what it does:

- **prevents data clobbering:** When a user opens the application form in a new tab (by middle-clicking, copying/pasting the URL, etc.), they'll be redirected back to the beginning of the form. This ensures each tab holds independent data and prevents accidental overwriting from other tabs.
- **stops accidental resubmissions:** Users won't be able to use the browser's back button to revisit and resubmit a previously submitted form. This helps avoid duplicate submissions and data inconsistencies.

### Related Azure Boards Work Items

- [AB#2973](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2973)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- navigate to <http://localhost:3000/apply> and begin the application flow
- on any page after the initial start page, open the form in another tab (middle click, copy/paste URL, etc)
- verify that you are bounced back to the application form's start