### PR TITLE
AB#3022 - Handle document title in MetaFunction

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -17,7 +17,7 @@ import { getBuildInfoService } from '~/services/build-info-service.server';
 import tailwindStyleSheet from '~/tailwind.css';
 import { getPublicEnv } from '~/utils/env.server';
 import type { FeatureName } from '~/utils/env.server';
-import { useDocumentTitleI18nKey, useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
+import { useI18nNamespaces } from '~/utils/route-utils';
 import { useAlternateLanguages, useCanonicalURL } from '~/utils/seo-utils';
 
 export const links: LinksFunction = () => [
@@ -51,7 +51,6 @@ export default function App() {
   const { env, origin, toast } = useLoaderData<typeof loader>();
   const ns = useI18nNamespaces();
   const { i18n } = useTranslation(ns);
-  const documentTitle = useDocumentTitle();
   const canonicalURL = useCanonicalURL(origin);
   const alternateLanguages = useAlternateLanguages(origin);
 
@@ -60,7 +59,6 @@ export default function App() {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{documentTitle}</title>
         <Meta />
         <link rel="canonical" href={canonicalURL} />
         {alternateLanguages.map(({ href, hrefLang }) => (
@@ -91,21 +89,4 @@ export function useFeature(feature: FeatureName) {
   // we must explicitly specify which loader to use
   const loaderData = useRouteLoaderData<typeof loader>('root');
   return loaderData?.env.ENABLED_FEATURES.includes(feature);
-}
-
-/**
- * Get the translated document title based on internationalization keys,
- * or undefined if no key is provided.
- *
- * This hook initializes the translation function and retrieves
- * internationalization keys for the document title and page title. It returns
- * the translated document title or undefined if no key is provided.
- */
-function useDocumentTitle() {
-  const ns = useI18nNamespaces();
-  const { t } = useTranslation(ns);
-  const documentTitleI18nKey = useDocumentTitleI18nKey();
-  const pageTitleI18nKey = usePageTitleI18nKey();
-  const i18nKey = documentTitleI18nKey ?? pageTitleI18nKey;
-  return i18nKey && (t(i18nKey) as string); // as string otherwise it's typeof any
 }

--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -1,11 +1,20 @@
+import { MetaFunction } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
 import { NotFoundError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/application-layout';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
-  documentTitleI18nKey: 'gcweb:not-found.document-title',
   i18nNamespaces: [...layoutI18nNamespaces],
   pageIdentifier: 'CDCP-0404',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('gcweb:not-found.document-title') }) }];
+});
 
 export async function loader() {
   return new Response(null, { status: 404 });

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -1,17 +1,21 @@
-import { Link } from '@remix-run/react';
+import { Link, MetaFunction } from '@remix-run/react';
 
 import { ButtonLink } from '~/components/buttons';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('gcweb'),
-  documentTitleI18nKey: 'gcweb:header.application-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction = mergeMeta((args) => {
+  return [{ title: 'Canadian Dental Care Plan | Régime canadien de soins dentaires - Canada.ca' }];
+});
 
 export default function RootIndex() {
   return (
-    <main role="main" className="flex h-svh bg-splash-page bg-cover bg-center" property="mainContentOfPage">
+    <main role="main" className="bg-splash-page flex h-svh bg-cover bg-center" property="mainContentOfPage">
       <div className="m-auto w-[300px] bg-white md:w-[400px] lg:w-[500px]">
         <div className="p-8">
           <h1 className="sr-only">Canadian Dental Care Plan | Régime canadien de soins dentaires</h1>

--- a/frontend/app/routes/_protected+/data-unavailable.tsx
+++ b/frontend/app/routes/_protected+/data-unavailable.tsx
@@ -1,6 +1,6 @@
 import { json } from '@remix-run/node';
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -8,16 +8,20 @@ import { InlineLink } from '~/components/inline-link';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('data-unavailable');
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'data-unavailable:page-title' }],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('data-unavailable', 'gcweb'),
   pageIdentifier: 'CDCP-0099',
   pageTitleI18nKey: 'data-unavailable:page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('data-unavailable:page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -29,7 +33,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function DataUnavailable() {
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { SCCH_BASE_URI } = useLoaderData<typeof loader>();
   const doyouqualify = <InlineLink to={t('do-you-qualify.href')} />;
   const howtoapply = <InlineLink to={t('how-to-apply.href')} />;
@@ -39,17 +43,17 @@ export default function DataUnavailable() {
   return (
     <>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="service-eligible" components={{ doyouqualify }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="service-eligible" components={{ doyouqualify }} />
       </p>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="more-information" components={{ howtoapply }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="more-information" components={{ howtoapply }} />
       </p>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="other-enquiry" components={{ contactus }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="other-enquiry" components={{ contactus }} />
       </p>
       <p className="mb-8">{t('service-delay')}</p>
 
-      <Trans ns={i18nNamespaces} i18nKey="my-dashboard" components={{ mydashboard }} />
+      <Trans ns={handle.i18nNamespaces} i18nKey="my-dashboard" components={{ mydashboard }} />
     </>
   );
 }

--- a/frontend/app/routes/_protected+/home.tsx
+++ b/frontend/app/routes/_protected+/home.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps, ReactNode } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { Link, useLoaderData } from '@remix-run/react';
+import { Link, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -10,13 +10,19 @@ import { useFeature } from '~/root';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('index'),
+  i18nNamespaces: getTypedI18nNamespaces('index', 'gcweb'),
   pageIdentifier: 'CDCP-0001',
   pageTitleI18nKey: 'index:page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('index:page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();

--- a/frontend/app/routes/_protected+/letters+/_index.tsx
+++ b/frontend/app/routes/_protected+/letters+/_index.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from 'react';
 
 import { json } from '@remix-run/node';
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData, useSearchParams } from '@remix-run/react';
+import { MetaFunction, useLoaderData, useSearchParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -14,14 +14,20 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'letters:index.page-title' }],
-  i18nNamespaces: getTypedI18nNamespaces('letters'),
+  i18nNamespaces: getTypedI18nNamespaces('letters', 'gcweb'),
   pageIdentifier: 'CDCP-0002',
   pageTitleI18nKey: 'letters:index.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('letters:index.page-title') }) }];
+});
 
 const orderEnumSchema = z.enum(['asc', 'desc']);
 

--- a/frontend/app/routes/_protected+/personal-information+/_index.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/_index.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import { json } from '@remix-run/node';
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -14,14 +14,20 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'personal-information:index.page-title' }],
-  i18nNamespaces: getTypedI18nNamespaces('personal-information'),
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0002',
   pageTitleI18nKey: 'personal-information:index.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:index.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   if (!featureEnabled('update-personal-info')) {

--- a/frontend/app/routes/_protected+/personal-information+/home-address+/address-accuracy.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/home-address+/address-accuracy.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -10,8 +10,7 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
   breadcrumbs: [
@@ -19,10 +18,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:home-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.address-accuracy.page-title' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0013',
   pageTitleI18nKey: 'personal-information:home-address.address-accuracy.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:home-address.address-accuracy.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -50,7 +54,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PersonalInformationHomeAddressAccuracy() {
   const { newHomeAddress, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_protected+/personal-information+/home-address+/confirm.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/home-address+/confirm.tsx
@@ -1,6 +1,6 @@
 import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { redirectWithSuccess } from 'remix-toast';
@@ -13,8 +13,7 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
   breadcrumbs: [
@@ -22,10 +21,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:home-address.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.confirm.breadcrumbs.address-change-confirm' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0005',
   pageTitleI18nKey: 'personal-information:home-address.confirm.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:home-address.confirm.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -68,7 +72,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PersonalInformationHomeAddressConfirm() {
   const { homeAddressInfo, newHomeAddress, useSuggestedAddress, suggestedAddress, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   // TODO extract to util for all address routes to use
   function getCountryName(countryId: string) {

--- a/frontend/app/routes/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/home-address+/edit.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -20,9 +20,8 @@ import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getWSAddressService } from '~/services/wsaddress-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information', 'gcweb');
 
 export const handle = {
   breadcrumbs: [
@@ -30,10 +29,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:home-address.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.edit.breadcrumbs.home-address-change' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0004',
   pageTitleI18nKey: 'personal-information:home-address.edit.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:home-address.edit.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -119,7 +123,7 @@ export default function PersonalInformationHomeAddressEdit() {
   const { addressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const [selectedCountry, setSelectedCountry] = useState('');
   const [countryRegions, setCountryRegions] = useState<RegionInfo[]>([]);
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const errorSummaryId = 'error-summary';
 
   useEffect(() => {

--- a/frontend/app/routes/_protected+/personal-information+/home-address+/suggested.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/home-address+/suggested.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -11,8 +11,7 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
   breadcrumbs: [
@@ -20,10 +19,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:home-address.suggested.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:home-address.suggested.breadcrumbs.suggested-address' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0008',
   pageTitleI18nKey: 'personal-information:home-address.suggested.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:home-address.suggested.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -60,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function HomeAddressSuggested() {
   const { homeAddressInfo, suggestedAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -10,8 +10,7 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
   breadcrumbs: [
@@ -19,10 +18,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:mailing-address.address-accuracy.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.address-accuracy.page-title' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0014',
   pageTitleI18nKey: 'personal-information:mailing-address.address-accuracy.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:mailing-address.address-accuracy.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -50,7 +54,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PersonalInformationMailingAddressAccuracy() {
   const { newMailingAddress, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_protected+/personal-information+/mailing-address+/confirm.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/mailing-address+/confirm.tsx
@@ -1,6 +1,6 @@
 import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { redirectWithSuccess } from 'remix-toast';
@@ -13,8 +13,7 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
   breadcrumbs: [
@@ -22,10 +21,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:mailing-address.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.confirm.breadcrumbs.address-change-confirm' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0005',
   pageTitleI18nKey: 'personal-information:mailing-address.confirm.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:mailing-address.confirm.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -64,7 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PersonalInformationMailingAddressConfirm() {
   const { mailingAddressInfo, newMailingAddress, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   return (
     <>
       <p className="mb-8 text-lg text-gray-500">{t('personal-information:mailing-address.confirm.subtitle')}</p>

--- a/frontend/app/routes/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -21,9 +21,8 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information', 'gcweb');
 
 export const handle = {
   breadcrumbs: [
@@ -31,10 +30,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:mailing-address.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:mailing-address.edit.breadcrumbs.mailing-address-change' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0004',
   pageTitleI18nKey: 'personal-information:mailing-address.edit.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:mailing-address.edit.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -121,7 +125,7 @@ export default function PersonalInformationMailingAddressEdit() {
   const { addressInfo, homeAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const [selectedCountry, setSelectedCountry] = useState('');
   const [countryRegions, setCountryRegions] = useState<RegionInfo[]>([]);
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const errorSummaryId = 'error-summary';
   const [copyAddressChecked, setCopyAddressChecked] = useState(false);
 

--- a/frontend/app/routes/_protected+/personal-information+/phone-number+/confirm.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/phone-number+/confirm.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { redirectWithSuccess } from 'remix-toast';
@@ -10,9 +10,8 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
@@ -20,10 +19,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:phone-number.confirm.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:phone-number.confirm.breadcrumbs.confirm-phone-number' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0009',
   pageTitleI18nKey: 'personal-information:phone-number.confirm.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:phone-number.confirm.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -71,7 +75,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PhoneNumberConfirm() {
   const loaderData = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   return (
     <>
       <p className="mb-8 text-lg text-gray-500">{t('personal-information:phone-number.confirm.subtitle')}</p>

--- a/frontend/app/routes/_protected+/personal-information+/phone-number+/edit.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/phone-number+/edit.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useTranslation } from 'react-i18next';
@@ -15,19 +15,24 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('personal-information', 'gcweb');
 export const handle = {
   breadcrumbs: [
     // prettier-ignore
     { labelI18nKey: 'personal-information:phone-number.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:phone-number.edit.breadcrumbs.change-phone-number' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0008',
   pageTitleI18nKey: 'personal-information:phone-number.edit.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:phone-number.edit.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -81,7 +86,7 @@ export default function PhoneNumberEdit() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   const defaultValues = {
     phoneNumber: actionData?.formData.phoneNumber ?? userInfo.phoneNumber ?? '',

--- a/frontend/app/routes/_protected+/personal-information+/preferred-language+/confirm.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/preferred-language+/confirm.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { redirectWithSuccess } from 'remix-toast';
@@ -11,9 +11,8 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information');
 
 export const handle = {
   breadcrumbs: [
@@ -21,10 +20,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.preferred-language-edit', to: '/personal-information/preferred-language/edit' },
     { labelI18nKey: 'personal-information:preferred-language.confirm.breadcrumbs.preferred-language-confirm' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-00010',
   pageTitleI18nKey: 'personal-information:preferred-language.confirm.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:preferred-language.confirm.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -73,7 +77,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PreferredLanguageConfirm() {
   const { preferredLanguage } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   return (
     <>
       <p className="mb-8 text-lg text-gray-500">{t('personal-information:preferred-language.confirm.subtitle')}</p>

--- a/frontend/app/routes/_protected+/personal-information+/preferred-language+/edit.tsx
+++ b/frontend/app/routes/_protected+/personal-information+/preferred-language+/edit.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -12,9 +12,8 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('personal-information', 'gcweb');
 
 export const handle = {
   breadcrumbs: [
@@ -22,10 +21,15 @@ export const handle = {
     { labelI18nKey: 'personal-information:preferred-language.edit.breadcrumbs.personal-information', to: '/personal-information' },
     { labelI18nKey: 'personal-information:preferred-language.edit.page-title' },
   ],
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('personal-information', 'gcweb'),
   pageIdentifier: 'CDCP-0012',
   pageTitleI18nKey: 'personal-information:preferred-language.edit.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('personal-information:preferred-language.edit.page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
@@ -72,7 +76,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function PreferredLanguageEdit() {
   const { userInfo, preferredLanguages } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/applicant-information.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -13,17 +13,21 @@ import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
 export const applyIdParamSchema = z.string().uuid();
 
-const i18nNamespaces = getTypedI18nNamespaces('apply');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'apply:applicant-information.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('apply:applicant-information.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -64,7 +68,7 @@ export default function ApplyFlowApplicationInformation() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   /**
    * Gets an error message based on the provided internationalization (i18n) key.

--- a/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,15 +9,19 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:application-delegate.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:application-delegate.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -28,7 +32,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ApplyFlowApplicationDelegate() {
   const { id } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   const contactServiceCanada = <InlineLink to={t('application-delegate.contact-service-canada-href')} />;
   const preparingToApply = <InlineLink to={t('application-delegate.preparing-to-apply-href')} />;
@@ -37,10 +41,10 @@ export default function ApplyFlowApplicationDelegate() {
   return (
     <div className="mt-6">
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
       </p>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="application-delegate.prepare-to-apply" components={{ preparingToApply }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="application-delegate.prepare-to-apply" components={{ preparingToApply }} />
       </p>
       <div className="flex flex-wrap items-center gap-3">
         <ButtonLink type="button" variant="alternative" to={`/apply/${id}/type-of-application`}>

--- a/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -15,15 +15,19 @@ import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('communication-preference');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('communication-preference', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'communication-preference:page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('communication-preference:page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
@@ -98,7 +102,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function ApplyFlowCommunicationPreferencePage() {
   const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, id, state } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [emailMethodChecked, setEmailMethodChecked] = useState(state?.preferredMethod === communicationMethodEmail.id);
 
   const actionData = useActionData<typeof action>();

--- a/frontend/app/routes/_public+/apply+/$id+/confirm.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/confirm.tsx
@@ -2,24 +2,28 @@ import type { ReactNode } from 'react';
 
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import { InlineLink } from '~/components/inline-link';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('apply');
 
 export const applyIdParamSchema = z.string().uuid();
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
   pageIdentifier: 'CDCP-0013',
   pageTitleI18nKey: 'apply:confirm.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('apply:confirm.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   //TODO: Get User/apply form information
@@ -75,7 +79,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ApplyFlowConfirm() {
   const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   const mscaLink = <InlineLink to={t('confirm.msca-link')} />;
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} />;
@@ -87,7 +91,7 @@ export default function ApplyFlowConfirm() {
       <span>TODO: Contextual Alert Information</span>
       <h2 className="mt-8 text-3xl font-semibold">{t('confirm.keep-copy')}</h2>
       <p className="mt-4">
-        <Trans ns={i18nNamespaces} i18nKey="confirm.print-copy-text" />
+        <Trans ns={handle.i18nNamespaces} i18nKey="confirm.print-copy-text" />
       </p>
       <button
         className="mt-8 inline-flex w-44 items-center justify-center rounded bg-gray-800 px-5 py-2.5 align-middle font-lato text-xl font-semibold text-white outline-offset-2 hover:bg-gray-900"
@@ -101,23 +105,23 @@ export default function ApplyFlowConfirm() {
       <h2 className="mt-8 text-3xl font-semibold">{t('confirm.whats-next')}</h2>
       <p className="mt-4">{t('confirm.begin-process')}</p>
       <p className="mt-4">
-        <Trans ns={i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
       </p>
       <p className="mt-4">{t('confirm.use-code')}</p>
       <h2 className="mt-8 text-3xl font-semibold">{t('confirm.register-msca-title')}</h2>
       <p className="mt-4">
-        <Trans ns={i18nNamespaces} i18nKey="confirm.register-msca-text" components={{ mscaLink }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="confirm.register-msca-text" components={{ mscaLink }} />
       </p>
       <p className="mt-4">{t('confirm.msca-notify')}</p>
       <h2 className="mt-8 text-3xl font-semibold">{t('confirm.how-insurance')}</h2>
       <p className="mt-4">{t('confirm.eligible-text')}</p>
       <p className="mt-4">
-        <Trans ns={i18nNamespaces} i18nKey="confirm.more-info-cdcp" components={{ moreInfoLink }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="confirm.more-info-cdcp" components={{ moreInfoLink }} />
       </p>
 
       <p className="mt-4">{t('confirm.ineligible-text')}</p>
       <p className="mt-4">
-        <Trans ns={i18nNamespaces} i18nKey="confirm.more-info-service" components={{ dentalContactUsLink }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="confirm.more-info-service" components={{ dentalContactUsLink }} />
       </p>
 
       <h2 className="mt-8 text-3xl font-semibold">{t('confirm.application-summ')}</h2>

--- a/frontend/app/routes/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/date-of-birth.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,15 +16,19 @@ import { InputSelect } from '~/components/input-select';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { yearsBetween } from '~/utils/apply-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:date-of-birth.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:date-of-birth.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -61,7 +65,7 @@ export default function ApplyFlowDateOfBirth() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   useEffect(() => {
     if (actionData?.formData && hasErrors(actionData.formData)) {

--- a/frontend/app/routes/_public+/apply+/$id+/demographics-part1.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics-part1.tsx
@@ -1,6 +1,6 @@
 import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -11,14 +11,18 @@ import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('demographics-oral-health-questions', 'gcweb');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('demographics-oral-health-questions', 'gcweb'),
   pageIdentifier: 'CDCP-1111',
   pageTitleI18nKey: 'demographics-oral-health-questions:part1.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('demographics-oral-health-questions:part1.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const bornTypes = await getLookupService().getAllBornTypes();
@@ -34,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function DemographicsPart1() {
   const { bornTypes, disabilityTypes } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   return (
     <>

--- a/frontend/app/routes/_public+/apply+/$id+/demographics-part2.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics-part2.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -17,14 +17,18 @@ import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('demographics-oral-health-questions', 'gcweb');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('demographics-oral-health-questions', 'gcweb'),
   pageIdentifier: 'CDCP-1112',
   pageTitleI18nKey: 'demographics-oral-health-questions:part2.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('demographics-oral-health-questions:part2.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { OTHER_GENDER_TYPE_ID } = getEnv();
@@ -77,7 +81,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function DemographicsPart2() {
   const { otherGenderCode, genderTypes, mouthPainTypes, lastTimeDentistVisitTypes, avoidedDentalCostTypes, id, state } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [otherGenderChecked, setOtherGenderChecked] = useState(state?.gender === otherGenderCode.id);
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';

--- a/frontend/app/routes/_public+/apply+/$id+/demographics.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/demographics.tsx
@@ -1,6 +1,6 @@
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,13 +9,19 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonLink } from '~/components/buttons';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('demographics-oral-health-questions');
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('demographics-oral-health-questions', 'gcweb'),
   pageIdentifier: 'CDCP-1110',
   pageTitleI18nKey: 'demographics-oral-health-questions:optional-demographic-oral-health-questions.page-title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('demographics-oral-health-questions:optional-demographic-oral-health-questions.page-title') }) }];
+});
+
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
   const { id, state } = await applyFlow.loadState({ request, params });
@@ -35,7 +41,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export default function Demographics() {
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { id } = useLoaderData<typeof loader>();
 
   return (

--- a/frontend/app/routes/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/dental-insurance.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -12,14 +12,18 @@ import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('dental-insurance-question');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('dental-insurance-question', 'gcweb'),
   pageIdentifier: 'CDCP-1115',
   pageTitleI18nKey: 'dental-insurance-question:title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('dental-insurance-question:title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -53,19 +57,19 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function AccessToDentalInsuranceQuestion() {
   const { options, state } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   const helpMessage = (
     <>
       <ul className="mb-4 list-disc">
         <li>
-          <Trans ns={i18nNamespaces} i18nKey="dental-insurance-question:list.employer" />
+          <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance-question:list.employer" />
         </li>
         <li>
-          <Trans ns={i18nNamespaces} i18nKey="dental-insurance-question:list.pension" />
+          <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance-question:list.pension" />
         </li>
         <li>
-          <Trans ns={i18nNamespaces} i18nKey="dental-insurance-question:list.dental-coverage" />
+          <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance-question:list.dental-coverage" />
         </li>
         <li className="list-none">
           <Details id={t('dental-insurance-question:detail.additional-info.title')} title={t('dental-insurance-question:detail.additional-info.title')}>
@@ -75,7 +79,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 <li>{t('dental-insurance-question:detail.additional-info.list.opted')}</li>
                 <li>{t('dental-insurance-question:detail.additional-info.list.cannot-opt')}</li>
               </ul>
-              <Trans ns={i18nNamespaces} i18nKey="dental-insurance-question:detail.additional-info.not-eligible" />
+              <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance-question:detail.additional-info.not-eligible" />
             </div>
           </Details>
         </li>

--- a/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,15 +9,19 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:dob-eligibility.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -28,7 +32,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ApplyFlowFileYourTaxes() {
   const { id } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   const eligibilityInfo = <InlineLink to={t('dob-eligibility.eligibility-info-href')} />;
 
@@ -36,7 +40,7 @@ export default function ApplyFlowFileYourTaxes() {
     <div className="mt-6">
       <p className="mb-6">{t('dob-eligibility.ineligible-to-apply')}</p>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
       </p>
       <div className="flex flex-wrap items-center gap-3">
         <ButtonLink type="button" variant="alternative" to={`/apply/${id}/date-of-birth`}>

--- a/frontend/app/routes/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -2,7 +2,7 @@ import { Fragment, useState } from 'react';
 
 import { json, redirect } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -12,14 +12,18 @@ import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-
-const i18nNamespaces = getTypedI18nNamespaces('provincial-territorial');
+import { mergeMeta } from '~/utils/meta-utils';
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('provincial-territorial', 'gcweb'),
   pageIdentifier: 'CDCP-1115',
   pageTitleI18nKey: 'provincial-territorial:title',
 };
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('provincial-territorial:title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -54,7 +58,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function AccessToDentalInsuranceQuestion() {
   const { federalSocialPrograms, federalDentalBenefits, state } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [checked, setChecked] = useState(state.dentalBenefit?.federalBenefit ?? '');
 
   return (
@@ -71,7 +75,7 @@ export default function AccessToDentalInsuranceQuestion() {
               children: (
                 <Fragment key={option.code}>
                   <strong>{getNameByLanguage(i18n.language, option)}</strong>,&nbsp;
-                  {option.code === 'yes' ? <Trans ns={i18nNamespaces} i18nKey="provincial-territorial:federal-benefits.option-yes" /> : <Trans ns={i18nNamespaces} i18nKey="provincial-territorial:federal-benefits.option-no" />}
+                  {option.code === 'yes' ? <Trans ns={handle.i18nNamespaces} i18nKey="provincial-territorial:federal-benefits.option-yes" /> : <Trans ns={handle.i18nNamespaces} i18nKey="provincial-territorial:federal-benefits.option-no" />}
                 </Fragment>
               ),
               value: option.code,

--- a/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,15 +9,19 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:file-your-taxes.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -28,7 +32,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ApplyFlowFileYourTaxes() {
   const { id } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   const taxInfo = <InlineLink to={t('file-your-taxes.tax-info-href')} />;
 
@@ -38,7 +42,7 @@ export default function ApplyFlowFileYourTaxes() {
       <p className="mb-6">{t('file-your-taxes.tax-not-filed')}</p>
       <p className="mb-6">{t('file-your-taxes.unable-to-assess')}</p>
       <p className="mb-6">
-        <Trans ns={i18nNamespaces} i18nKey="file-your-taxes.tax-info" components={{ taxInfo }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="file-your-taxes.tax-info" components={{ taxInfo }} />
       </p>
       <p className="mb-6">{t('file-your-taxes.apply-after')}</p>
 

--- a/frontend/app/routes/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/partner-information.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -13,17 +13,21 @@ import { InputField } from '~/components/input-field';
 import { InputSelect } from '~/components/input-select';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
 export const applyIdParamSchema = z.string().uuid();
 
-const i18nNamespaces = getTypedI18nNamespaces('apply');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'apply:partner-information.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('apply:partner-information.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -65,7 +69,7 @@ export default function ApplyFlowApplicationInformation() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
 
   /**
    * Gets an error message based on the provided internationalization (i18n) key.

--- a/frontend/app/routes/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/personal-information.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useTranslation } from 'react-i18next';
@@ -17,17 +17,22 @@ import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { RegionInfo, getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('apply');
 const validPostalCode = new RegExp('^[ABCEGHJKLMNPRSTVXYabceghjklmnprstvxy]\\d[A-Za-z] \\d[A-Za-z]\\d{1}$');
 const validZipCode = new RegExp('^\\d{5}$');
 
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'apply:personal-information.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('apply:personal-information.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -169,7 +174,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function ApplyFlowPersonalInformation() {
   const { id, state, countryList, regionList } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(state?.mailingCountry);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<RegionInfo[]>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(state?.copyMailingAddress === 'on');

--- a/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import { json } from '@remix-run/node';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { redirectWithSuccess } from 'remix-toast';
@@ -12,15 +12,19 @@ import { Button } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('review-information');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('review-information', 'gcweb'),
   pageIdentifier: 'CDCP-0002',
   pageTitleI18nKey: 'review-information:page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('review-information:page-title') }) }];
+});
 
 export async function loader({ request }: LoaderFunctionArgs) {
   //TODO: Get User/apply form information
@@ -83,7 +87,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function ReviewInformation() {
   const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance } = useLoaderData<typeof loader>();
-  const { i18n, t } = useTranslation(i18nNamespaces);
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
   return (
     <>
       <h2 className="text-2xl font-semibold">{t('review-information:page-sub-title')}</h2>

--- a/frontend/app/routes/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/tax-filing.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,15 +13,19 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:tax-filing.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:tax-filing.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -58,7 +62,7 @@ export default function ApplyFlowTaxFiling() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   useEffect(() => {
     if (actionData?.formData && hasErrors(actionData.formData)) {

--- a/frontend/app/routes/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { MetaFunction, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -10,14 +10,18 @@ import { CollapsibleDetails } from '~/components/collapsible';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('terms-and-conditions');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('terms-and-conditions', 'gcweb'),
   pageTitleI18nKey: 'terms-and-conditions:terms-and-conditions.index.page-heading',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('terms-and-conditions:terms-and-conditions.index.page-heading') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -40,7 +44,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function TermsAndConditions() {
   const { id } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   const hcaptchaTermsOfService = <InlineLink to="https://www.hcaptcha.com/terms" />;
   const infosource = <InlineLink to="https://www.canada.ca/en/employment-social-development/corporate/transparency/access-information/reports/infosource.html?utm_campaign=not-applicable&utm_medium=vanity-url&utm_source=canada-ca_infosource-esdc" />;
@@ -71,7 +75,7 @@ export default function TermsAndConditions() {
           <li>{t('terms-and-conditions:terms-and-conditions.index.terms-and-conditions-of-use-terms-of-use-of-the-online-application-bullet-inactive')}</li>
           <li>{t('terms-and-conditions:terms-and-conditions.index.terms-and-conditions-of-use-terms-of-use-of-the-online-application-bullet-msdc')}</li>
           <li>
-            <Trans ns={i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.terms-and-conditions-of-use-terms-of-use-of-the-online-application-bullet-antibot" components={{ hcaptchaTermsOfService }} />
+            <Trans ns={handle.i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.terms-and-conditions-of-use-terms-of-use-of-the-online-application-bullet-antibot" components={{ hcaptchaTermsOfService }} />
           </li>
         </ul>
 
@@ -100,13 +104,13 @@ export default function TermsAndConditions() {
         </ul>
 
         <p className="mb-6">
-          <Trans ns={i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-three" components={{ infosource }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-three" components={{ infosource }} />
         </p>
         <p className="mb-6">
-          <Trans ns={i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-four" components={{ microsoftDataPrivacyPolicy }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-four" components={{ microsoftDataPrivacyPolicy }} />
         </p>
         <p className="mb-6">
-          <Trans ns={i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-five" components={{ fileacomplaint }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-how-we-protect-your-privacy-text-part-five" components={{ fileacomplaint }} />
         </p>
 
         <h2 className="font-bold"> {t('terms-and-conditions:terms-and-conditions.index.privacy-notice-statement-who-we-can-share-your-information-with-heading')}</h2>

--- a/frontend/app/routes/_public+/apply+/$id+/type-of-application.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/type-of-application.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
-import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Form, MetaFunction, useActionData, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,15 +13,19 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('eligibility');
-
 export const handle = {
-  i18nNamespaces,
+  i18nNamespaces: getTypedI18nNamespaces('eligibility', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
   pageTitleI18nKey: 'eligibility:type-of-application.page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('eligibility:type-of-application.page-title') }) }];
+});
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
@@ -58,7 +62,7 @@ export default function ApplyFlowTypeOfApplication() {
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
-  const { t } = useTranslation(i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
 
   useEffect(() => {
     if (actionData?.formData && hasErrors(actionData.formData)) {

--- a/frontend/app/routes/_public+/apply+/_index.tsx
+++ b/frontend/app/routes/_public+/apply+/_index.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useRef } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { Form, useLoaderData, useSubmit } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { Form, MetaFunction, useLoaderData, useSubmit } from '@remix-run/react';
 
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { randomUUID } from 'crypto';

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -48,8 +48,6 @@ export type Breadcrumbs = z.infer<typeof breadcrumbsSchema>;
 
 export type BuildInfo = z.infer<typeof buildInfoSchema>;
 
-export type DocumentTitleI18nKey = z.infer<typeof i18nKeySchema>;
-
 export type I18nNamespaces = z.infer<typeof i18nNamespacesSchema>;
 
 export type PageIdentifier = z.infer<typeof pageIdentifierSchema>;
@@ -61,7 +59,6 @@ export type PageTitleI18nKey = z.infer<typeof i18nKeySchema>;
  */
 export interface RouteHandleData extends Record<string, unknown | undefined> {
   breadcrumbs?: Breadcrumbs;
-  documentTitleI18nKey?: PageTitleI18nKey;
   i18nNamespaces?: I18nNamespaces;
   pageIdentifier?: PageIdentifier;
   pageTitleI18nKey?: PageTitleI18nKey;
@@ -81,14 +78,6 @@ export function useBuildInfo() {
   return useMatches()
     .map(({ data }) => data as { buildInfo?: BuildInfo } | undefined)
     .map((data) => buildInfoSchema.safeParse(data?.buildInfo))
-    .map((result) => (result.success ? result.data : undefined))
-    .reduce(coalesce);
-}
-
-export function useDocumentTitleI18nKey() {
-  return useMatches()
-    .map(({ handle }) => handle as RouteHandleData | undefined)
-    .map((handle) => i18nKeySchema.safeParse(handle?.documentTitleI18nKey))
     .map((result) => (result.success ? result.data : undefined))
     .reduce(coalesce);
 }

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -1,4 +1,10 @@
 {
+  "meta": {
+    "title": {
+      "default": "Canadian Dental Care Plan - Canada.ca",
+      "template": "{{title}} - Canadian Dental Care Plan - Canada.ca"
+    }
+  },
   "nav": {
     "skip-to-content": "Skip to main content",
     "skip-to-about": "Skip to About this site"

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -1,4 +1,10 @@
 {
+  "meta": {
+    "title": {
+      "default": "Régime canadien de soins dentaires - Canada.ca",
+      "template": "{{title}} - Régime canadien de soins dentaires - Canada.ca"
+    }
+  },
   "nav": {
     "skip-to-content": "Passer au contenu principal",
     "skip-to-about": "Passer à « À propos de ce site »"
@@ -38,7 +44,7 @@
     "canada-ca": "(FR) Canada.ca",
     "benefits": "(FR) Benefits",
     "dental-coverage": "(FR) Dental coverage",
-    "canadian-dental-care-plan": "(FR) Canadian Dental Care Plan"
+    "canadian-dental-care-plan": "Régime canadien de soins dentaires"
   },
   "page-details": {
     "page-details": "Détails de la page",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Manage the document title within MetaFunction for enhanced flexibility. This approach allows for the document title to typically include the suffix `Canadian Dental Care Plan - Canada.ca` in English and `Régime canadien de soins dentaires - Canada.ca` in French, 99% of the time. MetaFunction possesses the capability to utilize loader data as required.

https://remix.run/docs/en/main/route/meta

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3022](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3022)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Splash Page
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/3c2b9ac9-3929-431e-92be-28c81db14cbf)

Apply - T&C Page
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/4fae5577-923d-4c14-a07f-6d5f5000c0e3)

Letters Page
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/1062c604-b501-4f8d-b8ff-24a5d34589f3)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Browser pages and the document title should be set and toggling the language should change it.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

The document title content will be reviewed later.