### PR TITLE
modify faker db to ensure at leasta single pdf is consistently generated on db schema update

### DIFF
--- a/frontend/__tests__/services/cct-service.server.test.ts
+++ b/frontend/__tests__/services/cct-service.server.test.ts
@@ -53,17 +53,17 @@ describe('cct-service.server.ts', () => {
   });
 
   it('it should return a 200 response when given a valid referenceID', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'eznjdZ6zeD');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
     expect(response.status).toBe(200);
   });
 
   it('it should return "application/pdf" as a the response content-type when given a valid referenceId', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'eznjdZ6zeD');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
     expect(response.headers.get('content-type')).toBe('application/pdf');
   });
 
   it('it should return a ReadableStream when given a valid referenceId', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'eznjdZ6zeD');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
     expectTypeOf(response.body).toMatchTypeOf<ReadableStream<Uint8Array> | null>();
   });
 

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -238,7 +238,9 @@ const seededLetterTypes = [
 const numberOfLetters = faker.number.int({ min: 10, max: 20 }); // Adjust min and max as needed
 for (let i = 0; i < numberOfLetters; i++) {
   // seed avaliable pdf
-  const seededPDF = db.pdf.create();
+  // if i===0 create a pdf with a hardcoded reference ID to prevent unit tests from needing to be updated
+  // (relevant when the db schema changes since faker will re-run with new randomly generated values)
+  const seededPDF = i === 0 ? db.pdf.create({ referenceId: '0000000000' }) : db.pdf.create();
 
   db.letter.create({
     userId: defaultUser.id,


### PR DESCRIPTION
### Description
This idea could be pure cheese on my part, but it solves the problem of having to change some of the unit tests when there is a schema change in `db.ts`. 

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`