### PR TITLE
mock cct-service.server to decouple unit tests from db.ts

### DIFF
--- a/frontend/__tests__/services/cct-service.server.test.ts
+++ b/frontend/__tests__/services/cct-service.server.test.ts
@@ -17,6 +17,10 @@ vi.mock('~/utils/env.server.ts', () => ({
   }),
 }));
 
+vi.mock('~/mocks/cct-api.server.ts', () => ({
+  getPdfEntity: vi.fn().mockReturnValue({ id: '0000000000' }),
+}));
+
 const handlers = [
   http.get('https://api.example.com/cctws/OnDemand/api/GetPdfByLetterId', async ({ request }) => {
     const url = new URL(request.url);
@@ -53,21 +57,23 @@ describe('cct-service.server.ts', () => {
   });
 
   it('it should return a 200 response when given a valid referenceID', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'v37j3ykKVI');
     expect(response.status).toBe(200);
   });
 
   it('it should return "application/pdf" as a the response content-type when given a valid referenceId', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'v37j3ykKVI');
     expect(response.headers.get('content-type')).toBe('application/pdf');
   });
 
   it('it should return a ReadableStream when given a valid referenceId', async () => {
-    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', '0000000000');
+    const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'v37j3ykKVI');
     expectTypeOf(response.body).toMatchTypeOf<ReadableStream<Uint8Array> | null>();
   });
 
   it('it should return a 404 when given an invalid referenceID', async () => {
+    const cctApiService = await import('~/mocks/cct-api.server');
+    cctApiService.getPdfEntity = (await vi.importActual<typeof import('~/mocks/cct-api.server')>('~/mocks/cct-api.server.ts')).getPdfEntity;
     const response = await cctService.getPdf('00000000-0000-0000-0000-000000000000', 'invalidReferenceId');
     expect(response.status).toBe(404);
   });

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -219,9 +219,7 @@ const seededLetterTypes = [
 const numberOfLetters = faker.number.int({ min: 10, max: 20 }); // Adjust min and max as needed
 for (let i = 0; i < numberOfLetters; i++) {
   // seed avaliable pdf
-  // if i===0 create a pdf with a hardcoded reference ID to prevent unit tests from needing to be updated
-  // (relevant when the db schema changes since faker will re-run with new randomly generated values)
-  const seededPDF = i === 0 ? db.pdf.create({ referenceId: '0000000000' }) : db.pdf.create();
+  const seededPDF = db.pdf.create();
 
   db.letter.create({
     userId: defaultUser.id,


### PR DESCRIPTION
### Description
Decouple the db from the unit tests, specifically in `cct-service.service`.  Devs shouldn't need to update the unit tests when there are changes to the db schema.  

### Related Azure Boards Work Items
[AB#3033](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3033)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`