### PR TITLE
'Home' breadcrumb shows on protected pages only

### DIFF
--- a/frontend/app/components/layouts/application-layout.tsx
+++ b/frontend/app/components/layouts/application-layout.tsx
@@ -33,7 +33,7 @@ export default function ApplicationLayout({ children, layout }: ApplicationLayou
       <SkipNavigationLinks />
       {layout === 'protected' && <ProtectedPageHeader />}
       {layout === 'public' && <PublicPageHeader />}
-      <Breadcrumbs />
+      <Breadcrumbs layout={layout} />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
         <AppPageTitle />
         {children}
@@ -219,7 +219,7 @@ function Breadcrumb({ children, to }: { children: ReactNode; to?: string }) {
     : <InlineLink to={to} property="item" typeof="WebPage"><span property="name">{children}</span></InlineLink>;
 }
 
-function Breadcrumbs() {
+function Breadcrumbs({ layout }: { layout: 'protected' | 'public' }) {
   const { t } = useTranslation([...i18nNamespaces, ...useI18nNamespaces()]);
   const breadcrumbs = useBreadcrumbs();
 
@@ -230,17 +230,30 @@ function Breadcrumbs() {
       </h2>
       <div className="container mt-4">
         <ol className="flex flex-wrap items-center gap-x-3 gap-y-1" typeof="BreadcrumbList">
-          <li property="itemListElement" typeof="ListItem">
-            <Breadcrumb to={breadcrumbs.length !== 0 ? '/' : undefined}>{t('gcweb:breadcrumbs.home')}</Breadcrumb>
-          </li>
-          {breadcrumbs.map(({ labelI18nKey, to }) => {
-            return (
-              <li key={labelI18nKey} property="itemListElement" typeof="ListItem" className="flex items-center">
-                <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />
-                <Breadcrumb to={to}>{t(labelI18nKey)}</Breadcrumb>
+          {layout === 'protected' && (
+            <>
+              <li property="itemListElement" typeof="ListItem">
+                <Breadcrumb to={breadcrumbs.length !== 0 ? '/home' : undefined}>{t('gcweb:breadcrumbs.home')}</Breadcrumb>
               </li>
-            );
-          })}
+              {breadcrumbs.map(({ labelI18nKey, to }) => {
+                return (
+                  <li key={labelI18nKey} property="itemListElement" typeof="ListItem" className="flex items-center">
+                    <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />
+                    <Breadcrumb to={to}>{t(labelI18nKey)}</Breadcrumb>
+                  </li>
+                );
+              })}
+            </>
+          )}
+          {layout === 'public' &&
+            breadcrumbs.map(({ labelI18nKey, to }, index) => {
+              return (
+                <li key={labelI18nKey} property="itemListElement" typeof="ListItem" className="flex items-center">
+                  {index !== 0 && <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />}
+                  <Breadcrumb to={to}>{t(labelI18nKey)}</Breadcrumb>
+                </li>
+              );
+            })}
         </ol>
       </div>
     </nav>

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -15,7 +15,7 @@ export const meta: MetaFunction = mergeMeta((args) => {
 
 export default function RootIndex() {
   return (
-    <main role="main" className="bg-splash-page flex h-svh bg-cover bg-center" property="mainContentOfPage">
+    <main role="main" className="flex h-svh bg-splash-page bg-cover bg-center" property="mainContentOfPage">
       <div className="m-auto w-[300px] bg-white md:w-[400px] lg:w-[500px]">
         <div className="p-8">
           <h1 className="sr-only">Canadian Dental Care Plan | Régime canadien de soins dentaires</h1>


### PR DESCRIPTION
### Description
The "Home" breadcrumb should not show in the public CDCP application intake form. It should only appear on the protected pages.

### Screenshots (if applicable)
#### Public pages
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/1cca3195-47a3-4d84-b9c2-2e001d518314)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/5d0184ae-f4f6-4dac-8bf8-201cea5060e9)

#### Protected pages (no changes)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/1157ac37-c8ed-46ae-b76d-b736a5bbeb44)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally. Navigate to `/apply`. The "Home" breadcrumb should be gone. 
Navigate to `/letters`. The "Home" breadcrumb should exist.