### PR TITLE
Updating breadcrumb URLs for CDCP Application

### DIFF
--- a/frontend/app/routes/_public+/apply+/_layout.tsx
+++ b/frontend/app/routes/_public+/apply+/_layout.tsx
@@ -6,10 +6,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 export const handle = {
   breadcrumbs: [
     // prettier-ignore
-    { labelI18nKey: 'gcweb:breadcrumbs.canada-ca'},
-    { labelI18nKey: 'gcweb:breadcrumbs.benefits' },
-    { labelI18nKey: 'gcweb:breadcrumbs.dental-coverage' },
-    { labelI18nKey: 'gcweb:breadcrumbs.canadian-dental-care-plan', to: '/' },
+    { labelI18nKey: 'apply:breadcrumbs.canada-ca', to: 'apply:breadcrumbs.canada-ca-url'},
+    { labelI18nKey: 'apply:breadcrumbs.benefits', to: 'apply:breadcrumbs.benefits-url' },
+    { labelI18nKey: 'apply:breadcrumbs.dental-coverage', to: 'apply:breadcrumbs.dental-coverage-url' },
+    { labelI18nKey: 'apply:breadcrumbs.canadian-dental-care-plan', to: 'apply:breadcrumbs.canadian-dental-care-plan-url' },
   ],
   i18nNamespaces: [...layoutI18nNamespaces],
 } as const satisfies RouteHandleData;

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -1,4 +1,14 @@
 {
+  "breadcrumbs": {
+    "canada-ca": "Canada.ca",
+    "canada-ca-url": "https://www.canada.ca/en.html",
+    "benefits": "Benefits",
+    "benefits-url": "https://www.canada.ca/en/services/benefits.html",
+    "dental-coverage": "Dental coverage",
+    "dental-coverage-url": "https://www.canada.ca/en/services/benefits/dental.html",
+    "canadian-dental-care-plan": "Canadian Dental Care Plan",
+    "canadian-dental-care-plan-url": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
   "applicant-information": {
     "page-title": "Applicant Information",
     "form-instructions": "Please provide your legal name (as indicated on your SIN card/letter). We will use the information you provided to verify your identity. Any information that does not match the information on your SIN appliation may cause delay in the processing of your application.",

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -40,11 +40,7 @@
   },
   "breadcrumbs": {
     "you-are-here": "You are here:",
-    "home": "Home",
-    "canada-ca": "Canada.ca",
-    "benefits": "Benefits",
-    "dental-coverage": "Dental coverage",
-    "canadian-dental-care-plan": "Canadian Dental Care Plan"
+    "home": "Home"
   },
   "page-details": {
     "page-details": "Page details",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -1,4 +1,14 @@
 {
+  "breadcrumbs": {
+    "canada-ca": "Canada.ca",
+    "canada-ca-url": "https://www.canada.ca/fr.html",
+    "benefits": "Prestations",
+    "benefits-url": "https://www.canada.ca/fr/services/prestations.html",
+    "dental-coverage": "Couverture dentaire",
+    "dental-coverage-url": "https://www.canada.ca/fr/services/prestations/dentaire.html",
+    "canadian-dental-care-plan": "Régime canadien de soins dentaires ",
+    "canadian-dental-care-plan-url": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
   "applicant-information": {
     "page-title": "(FR) Applicant Information",
     "form-instructions": "(FR) Please provide your legal name (as indicated on your SIN card/letter). We will use the information you provided to verify your identity. Any information that does not match the information on your SIN appliation may cause delay in the processing of your application.",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -40,11 +40,7 @@
   },
   "breadcrumbs": {
     "you-are-here": "Vous êtes ici\u00a0:",
-    "home": "Accueil",
-    "canada-ca": "(FR) Canada.ca",
-    "benefits": "(FR) Benefits",
-    "dental-coverage": "(FR) Dental coverage",
-    "canadian-dental-care-plan": "Régime canadien de soins dentaires"
+    "home": "Accueil"
   },
   "page-details": {
     "page-details": "Détails de la page",


### PR DESCRIPTION
### Description
...to match Figma

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/de86411a-b6a5-4795-9f30-30a40836fbcf)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/fb581c31-39b7-4061-ac8e-fd28a8bbb902)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/apply`. Breadcrumbs in English and French should navigate to appropriate pages.