### PR TITLE
Minor i18n fixup

### DIFF
--- a/frontend/app/routes/_public+/apply+/$id+/_route.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/_route.tsx
@@ -2,6 +2,14 @@ import { useEffect } from 'react';
 
 import { Outlet, useNavigate } from '@remix-run/react';
 
+import { handle as layoutHandle } from '~/routes/_public+/apply+/_layout';
+import { RouteHandleData } from '~/utils/route-utils';
+
+export const handle = {
+  // ensure that the parent layout's i18n namespaces are loaded
+  i18nNamespaces: [...layoutHandle.i18nNamespaces],
+} as const satisfies RouteHandleData;
+
 /**
  * The parent route of all /apply/{id}/* routes, used to
  * redirect to /apply if the flow has not yet been initialized.


### PR DESCRIPTION
The `/apply/{id}` route should load the i18n namespace from the layout to ensure that it is always available.