### PR TITLE
Fixing broken breadcrumb links

### DIFF
--- a/frontend/app/components/layouts/application-layout.tsx
+++ b/frontend/app/components/layouts/application-layout.tsx
@@ -245,15 +245,25 @@ function Breadcrumbs({ layout }: { layout: 'protected' | 'public' }) {
               })}
             </>
           )}
-          {layout === 'public' &&
-            breadcrumbs.map(({ labelI18nKey, to }, index) => {
-              return (
-                <li key={labelI18nKey} property="itemListElement" typeof="ListItem" className="flex items-center">
-                  {index !== 0 && <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />}
-                  <Breadcrumb to={to}>{t(labelI18nKey)}</Breadcrumb>
-                </li>
-              );
-            })}
+          {layout === 'public' && (
+            <>
+              <li property="itemListElement" typeof="ListItem" className="flex items-center">
+                <Breadcrumb to={t('gcweb:breadcrumbs.canada-ca-url')}>{t('gcweb:breadcrumbs.canada-ca')}</Breadcrumb>
+              </li>
+              <li property="itemListElement" typeof="ListItem" className="flex items-center">
+                <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />
+                <Breadcrumb to={t('gcweb:breadcrumbs.benefits-url')}>{t('gcweb:breadcrumbs.benefits')}</Breadcrumb>
+              </li>
+              <li property="itemListElement" typeof="ListItem" className="flex items-center">
+                <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />
+                <Breadcrumb to={t('gcweb:breadcrumbs.dental-coverage-url')}>{t('gcweb:breadcrumbs.dental-coverage')}</Breadcrumb>
+              </li>
+              <li property="itemListElement" typeof="ListItem" className="flex items-center">
+                <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />
+                <Breadcrumb to={t('gcweb:breadcrumbs.canadian-dental-care-plan-url')}>{t('gcweb:breadcrumbs.canadian-dental-care-plan')}</Breadcrumb>
+              </li>
+            </>
+          )}
         </ol>
       </div>
     </nav>

--- a/frontend/app/routes/_public+/apply+/_layout.tsx
+++ b/frontend/app/routes/_public+/apply+/_layout.tsx
@@ -5,14 +5,7 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
-  breadcrumbs: [
-    // prettier-ignore
-    { labelI18nKey: 'apply:breadcrumbs.canada-ca', to: 'apply:breadcrumbs.canada-ca-url'},
-    { labelI18nKey: 'apply:breadcrumbs.benefits', to: 'apply:breadcrumbs.benefits-url' },
-    { labelI18nKey: 'apply:breadcrumbs.dental-coverage', to: 'apply:breadcrumbs.dental-coverage-url' },
-    { labelI18nKey: 'apply:breadcrumbs.canadian-dental-care-plan', to: 'apply:breadcrumbs.canadian-dental-care-plan-url' },
-  ],
-  i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces, 'apply'),
+  i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
 } as const satisfies RouteHandleData;
 
 export function ErrorBoundary() {

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -16,16 +16,6 @@
       "marital-status": "Marital status must be provided"
     }
   },
-  "breadcrumbs": {
-    "canada-ca": "Canada.ca",
-    "canada-ca-url": "https://www.canada.ca/en.html",
-    "benefits": "Benefits",
-    "benefits-url": "https://www.canada.ca/en/services/benefits.html",
-    "dental-coverage": "Dental coverage",
-    "dental-coverage-url": "https://www.canada.ca/en/services/benefits/dental.html",
-    "canadian-dental-care-plan": "Canadian Dental Care Plan",
-    "canadian-dental-care-plan-url": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-  },
   "communication-preference": {
     "page-title": "Communication preferences",
     "note": "If eligible, we will share your membership information with Sun Life Assurance Company of Canada (Sun Life), who will be responsible for handling member enrolment and administering claims processing and benefits for the Canadian Dental Care Plan.",

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -40,7 +40,15 @@
   },
   "breadcrumbs": {
     "you-are-here": "You are here:",
-    "home": "Home"
+    "home": "Home",
+    "canada-ca": "Canada.ca",
+    "canada-ca-url": "https://www.canada.ca/en.html",
+    "benefits": "Benefits",
+    "benefits-url": "https://www.canada.ca/en/services/benefits.html",
+    "dental-coverage": "Dental coverage",
+    "dental-coverage-url": "https://www.canada.ca/en/services/benefits/dental.html",
+    "canadian-dental-care-plan": "Canadian Dental Care Plan",
+    "canadian-dental-care-plan-url": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
   "page-details": {
     "page-details": "Page details",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -16,16 +16,6 @@
       "marital-status": "(FR) Marital status must be provided"
     }
   },
-  "breadcrumbs": {
-    "canada-ca": "Canada.ca",
-    "canada-ca-url": "https://www.canada.ca/fr.html",
-    "benefits": "Prestations",
-    "benefits-url": "https://www.canada.ca/fr/services/prestations.html",
-    "dental-coverage": "Couverture dentaire",
-    "dental-coverage-url": "https://www.canada.ca/fr/services/prestations/dentaire.html",
-    "canadian-dental-care-plan": "Régime canadien de soins dentaires ",
-    "canadian-dental-care-plan-url": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-  },
   "communication-preference": {
     "page-title": "Préférences en matière de communication",
     "note": "Si vous êtes admissible, nous communiquerons les détails liés à votre adhésion à la Sun Life du Canada, compagnie d'assurance-vie, qui sera responsable du traitement de l'adhésion des membres et de la gestion des demandes de règlement et des prestations du Régime canadien de soins dentaires.",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -40,7 +40,15 @@
   },
   "breadcrumbs": {
     "you-are-here": "Vous êtes ici\u00a0:",
-    "home": "Accueil"
+    "home": "Accueil",
+    "canada-ca": "Canada.ca",
+    "canada-ca-url": "https://www.canada.ca/fr.html",
+    "benefits": "Prestations",
+    "benefits-url": "https://www.canada.ca/fr/services/prestations.html",
+    "dental-coverage": "Couverture dentaire",
+    "dental-coverage-url": "https://www.canada.ca/fr/services/prestations/dentaire.html",
+    "canadian-dental-care-plan": "Régime canadien de soins dentaires ",
+    "canadian-dental-care-plan-url": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
   "page-details": {
     "page-details": "Détails de la page",


### PR DESCRIPTION
### Description
May not be best solution going forward but open to any future refactoring as this PR is just to get the breadcrumbs to work.

Current solution doesn't allow any public pages to specify their own set of breadcrumbs, which currently is not needed since all breadcrumbs are the same for these pages :shrug: 

Also uses `gcweb` namespace for CDCP application breadcrumbs... :shrug: x2

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/d5bbdf28-9112-441d-9170-7fc7a4d44dda)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/fa702eac-c949-4494-b52b-0026cd9e9faa)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/d5bbdf28-9112-441d-9170-7fc7a4d44dda)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/27d8eaa4-0a23-421e-9fa4-c22cbf9a9eeb)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`