### PR TITLE
Adding exit-application page.

### DIFF
--- a/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
@@ -48,9 +48,9 @@ export default function ApplyFlowTaxFiling() {
       <p>{t('apply:exit-application.click-back')}</p>
       <div className="flex flex-wrap items-center gap-3">
         <Form method="post" noValidate>
-          <ButtonLink variant="alternative" id="back-button" to={`/apply/${id}/review-information`}>
-            {t('apply:exit-application.back-btn')}
+          <ButtonLink id="back-button" to={`/apply/${id}/review-information`}>
             <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+            {t('apply:exit-application.back-btn')}
           </ButtonLink>
           <Button variant="primary">{t('apply:exit-application.exit-btn')}</Button>
         </Form>

--- a/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
@@ -1,0 +1,62 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from '@remix-run/node';
+import { Form, MetaFunction, useLoaderData } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import { Button, ButtonLink } from '~/components/buttons';
+import { getApplyFlow } from '~/routes-flow/apply-flow';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData } from '~/utils/route-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  pageIdentifier: 'CDCP-00XX',
+  pageTitleI18nKey: 'apply:exit-application.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta((args) => {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  return [{ title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) }];
+});
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const applyFlow = getApplyFlow();
+  const { id } = await applyFlow.loadState({ request, params });
+
+  return json({ id });
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const applyFlow = getApplyFlow();
+  const { id } = await applyFlow.loadState({ request, params });
+  //TODO: Add apply form logic
+  const sessionResponseInit = await applyFlow.clearState({ request, params });
+  return redirect(`/apply`, sessionResponseInit);
+}
+
+export default function ApplyFlowTaxFiling() {
+  const { id } = useLoaderData<typeof loader>();
+
+  const { t } = useTranslation(handle.i18nNamespaces);
+
+  return (
+    <>
+      <p>{t('apply:exit-application.are-you-sure')}</p>
+      <p>{t('apply:exit-application.click-back')}</p>
+      <div className="mt-6 flex">
+        <Form method="post" noValidate>
+          <ButtonLink id="back-button" to={`/apply/${id}/review-information`} className="mr-4 w-28 bg-white font-semibold">
+            {t('apply:exit-application.back-btn')}
+            <FontAwesomeIcon icon={faChevronLeft} className="ml-2 size-4" />
+          </ButtonLink>
+          <Button variant="primary" className="w-28 font-semibold">
+            {t('apply:exit-application.exit-btn')}
+          </Button>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/exit-application.tsx
@@ -31,7 +31,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  await applyFlow.loadState({ request, params });
   //TODO: Add apply form logic
   const sessionResponseInit = await applyFlow.clearState({ request, params });
   return redirect(`/apply`, sessionResponseInit);
@@ -43,20 +43,18 @@ export default function ApplyFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   return (
-    <>
+    <div className="space-y-6">
       <p>{t('apply:exit-application.are-you-sure')}</p>
       <p>{t('apply:exit-application.click-back')}</p>
-      <div className="mt-6 flex">
+      <div className="flex flex-wrap items-center gap-3">
         <Form method="post" noValidate>
-          <ButtonLink id="back-button" to={`/apply/${id}/review-information`} className="mr-4 w-28 bg-white font-semibold">
+          <ButtonLink variant="alternative" id="back-button" to={`/apply/${id}/review-information`}>
             {t('apply:exit-application.back-btn')}
-            <FontAwesomeIcon icon={faChevronLeft} className="ml-2 size-4" />
+            <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           </ButtonLink>
-          <Button variant="primary" className="w-28 font-semibold">
-            {t('apply:exit-application.exit-btn')}
-          </Button>
+          <Button variant="primary">{t('apply:exit-application.exit-btn')}</Button>
         </Form>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
@@ -265,7 +265,7 @@ export default function ReviewInformation() {
       <div className="flex flex-wrap items-center gap-3">
         <ButtonLink to={`/apply/${id}/exit-application`} variant="alternative">
           {t('apply:review-information.exit-button')}
-          <FontAwesomeIcon icon={faX} className="h-3 w-3 pl-2" />
+          <FontAwesomeIcon icon={faX} className="ms-3 block size-4" />
         </ButtonLink>
         <Form method="post">
           <Button id="confirm-button" variant="green">

--- a/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
@@ -264,7 +264,8 @@ export default function ReviewInformation() {
       <p className="mb-4">{t('apply:review-information.submit-p-false-info')}</p>
       <div className="flex flex-wrap items-center gap-3">
         <ButtonLink to={`/apply/${id}/exit-application`} variant="alternative">
-          <span className="font-semibold">{t('apply:review-information.exit-button')}</span> <FontAwesomeIcon icon={faX} className="h-3 w-3 pl-2" />
+          {t('apply:review-information.exit-button')}
+          <FontAwesomeIcon icon={faX} className="h-3 w-3 pl-2" />
         </ButtonLink>
         <Form method="post">
           <Button id="confirm-button" variant="green">

--- a/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/review-information.tsx
@@ -262,12 +262,12 @@ export default function ReviewInformation() {
       <h2 className="mb-5 mt-8 text-2xl font-semibold">{t('apply:review-information.submit-app-title')}</h2>
       <p className="mb-4">{t('apply:review-information.submit-p-proceed')}</p>
       <p className="mb-4">{t('apply:review-information.submit-p-false-info')}</p>
-      <div className="flex">
-        <ButtonLink to={`/apply/${id}/exit-application`} className="mr-4 rounded  border border-sky-900 bg-white">
+      <div className="flex flex-wrap items-center gap-3">
+        <ButtonLink to={`/apply/${id}/exit-application`} variant="alternative">
           <span className="font-semibold">{t('apply:review-information.exit-button')}</span> <FontAwesomeIcon icon={faX} className="h-3 w-3 pl-2" />
         </ButtonLink>
         <Form method="post">
-          <Button id="confirm-button" variant="green" className="font-semibold">
+          <Button id="confirm-button" variant="green">
             {t('apply:review-information.submit-button')}
           </Button>
         </Form>

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -304,6 +304,7 @@
     }
   },
   "review-information": {
+    "read-carefully": "Please review this information carefully. The information provided will be used by Sun Life to create your member account and will be reflected on your member card.",
     "page-title": "Review Information",
     "page-sub-title": "Applicant Information",
     "dob-title": "Date of birth",
@@ -315,21 +316,21 @@
     "martial-title": "Martial status",
     "martial-change": "Change martial status",
     "spouse-title": "Spouse / Commom-law information",
-    "contact-info-title": "Contact Information",
-    "phone-title": "Telephone number",
+    "personal-info-title": "Personal Information",
+    "phone-title": "Phone number",
     "phone-change": "Change phone number",
-    "alt-phone-title": "Alternate telephone number",
+    "alt-phone-title": "Alternate phone number",
     "alt-phone-change": "Change alternate phone number",
     "mailing-title": "Mailing address",
     "mailing-change": "Change mailing address",
     "home-title": "Home address",
     "home-change": "Change home address",
-    "comm-prefs-title": "Communication preferences",
+    "comm-title": "Communication",
     "comm-electronic": "Electronic",
     "comm-mail": "Postal mail",
     "comm-pref-title": "Communication preference",
     "comm-pref-change": "Change communication preference",
-    "lang-pref-title": "Language preferences",
+    "lang-pref-title": "Language preference",
     "lang-pref-change": "Change language preference",
     "dental-title": "Access to dental insurance",
     "dental-private-title": "Access to dental insurance",
@@ -339,11 +340,10 @@
     "dental-has-access": "Has access to the following:",
     "dental-has-no-access": "No access to dental benefits",
     "submit-app-title": "Submit your application",
-    "submit-p-one": "By submitting the application, you confirm that the information provided is accurate to the best of your knowledge.",
-    "submit-p-two": "Submitting false information for you and your family may result in you being removed from the plan and have to repay the full cost of care received through CDCP.",
-    "print-app-title": "Print application",
-    "submit-p-three": "Keep a record of your application so that you can refer back to it.",
-    "submit-button": "Submit Application"
+    "submit-p-proceed": "By proceeding with this application, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "Submitting false information for you and your family may result in you being removed from the plan and have to repay the full cost of care received through CDCP.",
+    "submit-button": "Submit Application",
+    "exit-button": "Exit application"
   },
   "terms-and-conditions": {
     "terms-and-conditions": {
@@ -400,5 +400,12 @@
         }
       }
     }
+  },
+  "exit-application": {
+    "page-title": "Exit Application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and your information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit"
   }
 }

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -304,6 +304,7 @@
     }
   },
   "review-information": {
+    "read-carefully": "(FR) Please review this information carefully. The information provided will be used by Sun Life to create your member account and will be reflected on your member card.",
     "page-title": "(FR) Review Information",
     "page-sub-title": "(FR) Applicant Information",
     "dob-title": "(FR) Date of birth",
@@ -315,21 +316,21 @@
     "martial-title": "(FR) Martial status",
     "martial-change": "(FR) Change martial status",
     "spouse-title": "(FR) Spouse / Commom-law information",
-    "contact-info-title": "(FR) Contact Information",
-    "phone-title": "(FR) Telephone number",
+    "personal-info-title": "(FR) Personal Information",
+    "phone-title": "(FR) Phone number",
     "phone-change": "(FR) Change phone number",
-    "alt-phone-title": "(FR) Alternate telephone number",
+    "alt-phone-title": "(FR) Alternate phone number",
     "alt-phone-change": "(FR) Change alternate phone number",
     "mailing-title": "(FR) Mailing address",
     "mailing-change": "(FR) Change mailing address",
     "home-title": "(FR) Home address",
     "home-change": "(FR) Change home address",
-    "comm-prefs-title": "(FR) Communication preferences",
+    "comm-title": "(FR) Communication",
     "comm-electronic": "(FR) Electronic",
     "comm-mail": "(FR) Postal mail",
     "comm-pref-title": "(FR) Communication preference",
     "comm-pref-change": "(FR) Change communication preference",
-    "lang-pref-title": "(FR) Language preferences",
+    "lang-pref-title": "(FR) Language preference",
     "lang-pref-change": "(FR) Change language preference",
     "dental-title": "(FR) Access to dental insurance",
     "dental-private-title": "(FR) Access to dental insurance",
@@ -339,11 +340,10 @@
     "dental-has-access": "(FR) Has access to the following:",
     "dental-has-no-access": "No access to dental benefits",
     "submit-app-title": "(FR) Submit your application",
-    "submit-p-one": "(FR) By submitting the application, you confirm that the information provided is accurate to the best of your knowledge.",
-    "submit-p-two": "(FR) Submitting false information for you and your family may result in you being removed from the plan and have to repay the full cost of care received through CDCP.",
-    "print-app-title": "(FR) Print application",
-    "submit-p-three": "(FR) Keep a record of your application so that you can refer back to it.",
-    "submit-button": "(FR) Submit Application"
+    "submit-p-proceed": "(FR) By proceeding with this application, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "(FR) Submitting false information for you and your family may result in you being removed from the plan and have to repay the full cost of care received through CDCP.",
+    "submit-button": "(FR) Submit Application",
+    "exit-button": "(FR) Exit application"
   },
   "terms-and-conditions": {
     "terms-and-conditions": {
@@ -400,5 +400,12 @@
         }
       }
     }
+  },
+  "exit-application": {
+    "page-title": "Exit Application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and your information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit"
   }
 }


### PR DESCRIPTION
### Description
Completing design changes by adding 11.1 (exit-application page)

### Related Azure Boards Work Items
[AB#3001](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3001)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Navigate to apply/{id}/review-information
- Scroll down and click on exit application
- test both the back and the exit button on the `exit-application` page