### PR TITLE
Switch to manual routing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -93,7 +93,6 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.12",
-        "remix-flat-routes": "^0.6.4",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.4.2",
@@ -3369,33 +3368,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/v1-route-convention": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/v1-route-convention/-/v1-route-convention-0.1.4.tgz",
-      "integrity": "sha512-fVTr9YlNLWfaiM/6Y56sOtcY8x1bBJQHY0sDWO5+Z/vjJ2Ni7fe2fwrzs1jUFciMPXqBQdFGePnkuiYLz3cuUA==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^7.4.3"
-      },
-      "peerDependencies": {
-        "@remix-run/dev": "^1.15.0 || ^2.0.0"
-      }
-    },
-    "node_modules/@remix-run/v1-route-convention/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@remix-run/web-blob": {
@@ -13497,49 +13469,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remix-flat-routes": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/remix-flat-routes/-/remix-flat-routes-0.6.4.tgz",
-      "integrity": "sha512-/0bTfaNSd2O3ak+cCLAlmHIsgm7YWiaBiu5ENUyuSWSNwF/KaHuKFhcHHhozPevQ8ROgCZG9tNbWzH6ktJoprA==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/v1-route-convention": "^0.1.3",
-        "fs-extra": "^11.1.1",
-        "minimatch": "^5.1.0"
-      },
-      "bin": {
-        "migrate-flat-routes": "dist/cli.js"
-      },
-      "peerDependencies": {
-        "@remix-run/dev": "^1.15.0 || ^2"
-      }
-    },
-    "node_modules/remix-flat-routes/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/remix-flat-routes/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/remix-toast": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,7 +110,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.12",
-    "remix-flat-routes": "^0.6.4",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.4.2",

--- a/frontend/remix.config.js
+++ b/frontend/remix.config.js
@@ -1,11 +1,85 @@
-import { flatRoutes } from 'remix-flat-routes';
+/**
+ * @type {import('@remix-run/dev').AppConfig['routes']}
+ * @see https://remix.run/docs/en/main/discussion/routes#manual-route-configuration
+ */
+const routesFn = (defineRoutes) => {
+  return defineRoutes((route) => {
+    //
+    // API routes
+    //
+    route('/api/readyz', 'routes/api+/readyz.ts');
+    route('/api/refresh-session', 'routes/_protected+/api+/refresh-session.ts');
+    route('/api/switch-language', 'routes/api+/switch-language.ts');
+
+    //
+    // Auth routes
+    //
+    route('/.well-known/jwks.json', 'routes/[.]well-known.jwks[.]json.tsx');
+    route('/auth/*', 'routes/_protected+/auth+/$.tsx');
+
+    //
+    // Unprotected routes
+    //
+    route('/', 'routes/_index.tsx', { index: true });
+    route('/apply', 'routes/_public+/apply+/_layout.tsx', () => {
+      route('', 'routes/_public+/apply+/_index.tsx', { index: true });
+      route(':id', 'routes/_public+/apply+/$id+/_route.tsx', () => {
+        route('applicant-information', 'routes/_public+/apply+/$id+/applicant-information.tsx');
+        route('application-delegate', 'routes/_public+/apply+/$id+/application-delegate.tsx');
+        route('communication-preference', 'routes/_public+/apply+/$id+/communication-preference.tsx');
+        route('confirm', 'routes/_public+/apply+/$id+/confirm.tsx');
+        route('date-of-birth', 'routes/_public+/apply+/$id+/date-of-birth.tsx');
+        route('demographics-part1', 'routes/_public+/apply+/$id+/demographics-part1.tsx');
+        route('demographics-part2', 'routes/_public+/apply+/$id+/demographics-part2.tsx');
+        route('demographics', 'routes/_public+/apply+/$id+/demographics.tsx');
+        route('dental-insurance', 'routes/_public+/apply+/$id+/dental-insurance.tsx');
+        route('dob-eligibility', 'routes/_public+/apply+/$id+/dob-eligibility.tsx');
+        route('federal-provincial-territorial-benefits', 'routes/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx');
+        route('file-your-taxes', 'routes/_public+/apply+/$id+/file-your-taxes.tsx');
+        route('partner-information', 'routes/_public+/apply+/$id+/partner-information.tsx');
+        route('personal-information', 'routes/_public+/apply+/$id+/personal-information.tsx');
+        route('review-information', 'routes/_public+/apply+/$id+/review-information.tsx');
+        route('tax-filing', 'routes/_public+/apply+/$id+/tax-filing.tsx');
+        route('terms-and-conditions', 'routes/_public+/apply+/$id+/terms-and-conditions.tsx');
+        route('type-of-application', 'routes/_public+/apply+/$id+/type-of-application.tsx');
+      });
+    });
+
+    //
+    // Protected routes
+    //
+    route('', 'routes/_protected+/_layout.tsx', () => {
+      route('/data-unavailable', 'routes/_protected+/data-unavailable.tsx');
+      route('/error', 'routes/_protected+/error.tsx');
+      route('/home', 'routes/_protected+/home.tsx');
+      route('/letters/', 'routes/_protected+/letters+/_index.tsx', { index: true });
+      route('/letters/:referenceId/download', 'routes/_protected+/letters+/$referenceId.download.tsx');
+      route('/personal-information/', 'routes/_protected+/personal-information+/_index.tsx', { index: true });
+      route('/personal-information/home-address/address-accuracy', 'routes/_protected+/personal-information+/home-address+/address-accuracy.tsx');
+      route('/personal-information/home-address/confirm', 'routes/_protected+/personal-information+/home-address+/confirm.tsx');
+      route('/personal-information/home-address/edit', 'routes/_protected+/personal-information+/home-address+/edit.tsx');
+      route('/personal-information/home-address/suggested', 'routes/_protected+/personal-information+/home-address+/suggested.tsx');
+      route('/personal-information/mailing-address/address-accuracy', 'routes/_protected+/personal-information+/mailing-address+/address-accuracy.tsx');
+      route('/personal-information/mailing-address/confirm', 'routes/_protected+/personal-information+/mailing-address+/confirm.tsx');
+      route('/personal-information/mailing-address/edit', 'routes/_protected+/personal-information+/mailing-address+/edit.tsx');
+      route('/personal-information/phone-number/confirm', 'routes/_protected+/personal-information+/phone-number+/confirm.tsx');
+      route('/personal-information/phone-number/edit', 'routes/_protected+/personal-information+/phone-number+/edit.tsx');
+      route('/personal-information/preferred-language/confirm', 'routes/_protected+/personal-information+/preferred-language+/confirm.tsx');
+      route('/personal-information/preferred-language/edit', 'routes/_protected+/personal-information+/preferred-language+/edit.tsx');
+    });
+
+    //
+    // Catch-all 404 page
+    //
+    route('*', 'routes/$.tsx');
+  });
+};
 
 /**
  * @type {import('@remix-run/dev').AppConfig}
  */
 export default {
   cacheDirectory: './node_modules/.cache/remix',
-  ignoredRouteFiles: ['**/.*'], // let remix-flat-routes handle routing
-  routes: async (defineRoutes) => flatRoutes('routes', defineRoutes),
+  routes: routesFn,
   serverDependenciesToBundle: ['react-idle-timer'],
 };


### PR DESCRIPTION
### Description

In preparation for upcoming routing changes (`/en/` and `/fr/` in URL, plus page aliases), we will handle routing in the application using manual configuration.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and verify that everything works?

### Additional Notes

See <https://remix.run/docs/en/main/discussion/routes#manual-route-configuration> for more info.