### PR TITLE
AB#2975 -- Fixed button styling for eligibility error pages

### DIFF
--- a/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/application-delegate.tsx
@@ -48,9 +48,9 @@ export default function ApplyFlowApplicationDelegate() {
         <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
       </p>
       <div className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" variant="alternative" to={`/apply/${id}/type-of-application`}>
+        <ButtonLink type="button" to={`/apply/${id}/type-of-application`}>
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.application-delegate.back-btn')}
-          <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
         <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('apply:eligibility.application-delegate.return-btn')}

--- a/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/dob-eligibility.tsx
@@ -44,9 +44,9 @@ export default function ApplyFlowFileYourTaxes() {
         <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
       </p>
       <div className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" variant="alternative" to={`/apply/${id}/date-of-birth`}>
+        <ButtonLink type="button" to={`/apply/${id}/date-of-birth`}>
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.dob-eligibility.back-btn')}
-          <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
         <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('apply:eligibility.dob-eligibility.return-btn')}

--- a/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/file-your-taxes.tsx
@@ -48,9 +48,9 @@ export default function ApplyFlowFileYourTaxes() {
       <p className="mb-6">{t('apply:eligibility.file-your-taxes.apply-after')}</p>
 
       <div className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" variant="alternative" to={`/apply/${id}/tax-filing`}>
+        <ButtonLink type="button" to={`/apply/${id}/tax-filing`}>
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.file-your-taxes.back-btn')}
-          <FontAwesomeIcon icon={faChevronLeft} className="pl-2" />
         </ButtonLink>
         <ButtonLink type="submit" variant="primary" to="/" onClick={() => sessionStorage.removeItem('flow.state')}>
           {t('apply:eligibility.file-your-taxes.return-btn')}


### PR DESCRIPTION
### Description
Fixed chevron on styling on eligibility error page back buttons.

### Related Azure Boards Work Items
AB#2975

### Screenshots (if applicable)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Visit and confirm changes on select error pages

### Additional Notes
n/a