### PR TITLE
AB#3029 -- Added feature flag for demographics, fixed routes

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -37,7 +37,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env.server.ts for valid values
 # (optional; default: doc-upload,email-alerts,update-personal-info,view-applications,view-letters,view-messages)
-ENABLED_FEATURES=doc-upload,email-alerts,update-personal-info,view-applications,view-letters,view-messages
+ENABLED_FEATURES=demographic-questions,doc-upload,email-alerts,update-personal-info,view-applications,view-letters,view-messages
 
 
 # hCaptcha secret key -- used for server-side verifification

--- a/frontend/app/routes/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/applicant-information.tsx
@@ -67,11 +67,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (['MARRIED', 'COMMONLAW'].includes(parsedDataResult.data.maritalStatus)) {
     return redirect(`/apply/${id}/partner-information`, sessionResponseInit);
   }
-  return redirect(`/apply/${id}/contact-information`, sessionResponseInit);
+  return redirect(`/apply/${id}/personal-information`, sessionResponseInit);
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { state, maritalStatuses } = useLoaderData<typeof loader>();
+  const { id, state, maritalStatuses } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
@@ -151,7 +151,7 @@ export default function ApplyFlowApplicationInformation() {
           errorMessage={errorMessages.maritalStatus}
         />
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to="/apply">
+          <ButtonLink id="back-button" to={`/apply/${id}/date-of-birth`}>
             <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
             {t('applicant-information.back-btn')}
           </ButtonLink>

--- a/frontend/app/routes/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -14,7 +14,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
-import { getEnv } from '~/utils/env.server';
+import { featureEnabled, getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -68,7 +68,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     state: { dentalBenefit: parsedDataResult.data },
   });
 
-  return redirect(`/apply/${id}/confirm`, sessionResponseInit);
+  return featureEnabled('demographic-questions') ? redirect(`/apply/${id}/demographics`, sessionResponseInit) : redirect(`/apply/${id}/confirm`, sessionResponseInit);
 }
 
 export default function AccessToDentalInsuranceQuestion() {

--- a/frontend/app/routes/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/partner-information.tsx
@@ -68,11 +68,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     state: { partnerInformation: parsedDataResult.data },
   });
 
-  return redirect(`/apply/${id}/contact-information`, sessionResponseInit);
+  return redirect(`/apply/${id}/personal-information`, sessionResponseInit);
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { state } = useLoaderData<typeof loader>();
+  const { id, state } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
@@ -173,7 +173,7 @@ export default function ApplyFlowApplicationInformation() {
         </InputCheckbox>
 
         <div className="mt-5 flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to="/apply">
+          <ButtonLink id="back-button" to={`/apply/${id}/applicant-information`}>
             <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
             {t('applicant-information.back-btn')}
           </ButtonLink>

--- a/frontend/app/routes/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/personal-information.tsx
@@ -44,7 +44,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
 
-  return json({ id, state: state.personalInformation, countryList, regionList, COUNTRY_CODE_CANADA, COUNTRY_CODE_USA });
+  return json({ id, state: state.personalInformation, maritalStatus: state.applicantInformation?.maritalStatus, countryList, regionList, COUNTRY_CODE_CANADA, COUNTRY_CODE_USA });
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -184,7 +184,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export default function ApplyFlowPersonalInformation() {
-  const { id, state, countryList, regionList, COUNTRY_CODE_CANADA, COUNTRY_CODE_USA } = useLoaderData<typeof loader>();
+  const { id, state, countryList, maritalStatus, regionList, COUNTRY_CODE_CANADA, COUNTRY_CODE_USA } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(state?.mailingCountry);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<RegionInfo[]>([]);
@@ -420,7 +420,7 @@ export default function ApplyFlowPersonalInformation() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to={`/apply/${id}/partner-information`}>
+          <ButtonLink id="back-button" to={['MARRIED', 'COMMONLAW'].includes(maritalStatus ?? '') ? `/apply/${id}/partner-information` : `/apply/${id}/applicant-information`}>
             <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
             {t('apply:personal-information.back')}
           </ButtonLink>

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -19,7 +19,7 @@ function tryOrElseFalse(fn: () => unknown) {
 const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
-const validFeatureNames = ['doc-upload', 'email-alerts', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;
+const validFeatureNames = ['demographic-questions', 'doc-upload', 'email-alerts', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;
 export type FeatureName = (typeof validFeatureNames)[number];
 
 // refiners


### PR DESCRIPTION
### Description
Added in feature flag for the demographics apply page (skips to submit if disabled)

Fixed "apply" routing to reach demographics page via navigation buttons

### Related Azure Boards Work Items
[AB#3029](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3029)

### Screenshots (if applicable)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Use apply workflow to navigate to the demographics page with the flag turned on/off

### Additional Notes
N/A