### PR TITLE
AB#2998 -- add two new fields into communication preference page

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -75,10 +75,12 @@ const partnerInformationSchema = z.object({
  * Schema for communication reference.
  */
 const communicationPreferencesStateSchema = z.object({
+  preferredLanguage: z.string().min(1),
   preferredMethod: z.string().min(1),
   email: z.string().min(1).optional(),
   confirmEmail: z.string().min(1).optional(),
-  preferredLanguage: z.string().min(1),
+  emailForFuture: z.string().optional(),
+  confirmEmailForFuture: z.string().optional(),
 });
 
 /**

--- a/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
@@ -243,7 +243,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
 
         {preferredCommunicationMethods.length > 0 && (
           <div id="preferredMethod">
-            <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages.preferredMethod} required></InputRadios>
+            <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages.preferredMethod} required />
           </div>
         )}
         <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/_public+/apply+/$id+/communication-preference.tsx
@@ -58,33 +58,49 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
   const { id } = await applyFlow.loadState({ request, params });
 
-  const emailsMatch = (val: { preferredMethod: string; email?: string; confirmEmail?: string }) => {
-    if (!val.email || !val.confirmEmail) {
+  const emailsMatch = (email: string | undefined, confirmEmail: string | undefined) => {
+    if (!email || !confirmEmail) {
       // if either email is omitted, skip the matching
       // check and render 'please enter a value'
       return true;
     }
-    if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-      // emails have to match only when the preferred method is email id
-      return val.email.trim() === val.confirmEmail.trim();
-    }
-    return true;
+
+    return email.trim() === confirmEmail.trim();
   };
 
   const formSchema = z
     .object({
+      preferredLanguage: z.string({ required_error: 'empty-language' }),
       preferredMethod: z.string({ required_error: 'empty-method' }),
       email: z.string().min(1, { message: 'empty-email' }).email({ message: 'invalid-email' }).optional(),
       confirmEmail: z.string().min(1, { message: 'empty-confirm-email' }).optional(),
-      preferredLanguage: z.string({ required_error: 'empty-language' }),
+      emailForFuture: z.preprocess((arg) => (arg === '' ? undefined : arg), z.string().email({ message: 'invalid-email' }).optional()),
+      confirmEmailForFuture: z.string().optional(),
     })
     .superRefine((val, ctx) => {
-      if (!emailsMatch(val)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'not-the-same',
-          path: ['confirmEmail'],
-        });
+      if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
+        if (!emailsMatch(val.email, val.confirmEmail)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'not-the-same',
+            path: ['confirmEmail'],
+          });
+        }
+      } else {
+        if (val.emailForFuture && !val.confirmEmailForFuture) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'empty-confirm-email',
+            path: ['confirmEmailForFuture'],
+          });
+        }
+        if (!emailsMatch(val.emailForFuture, val.confirmEmailForFuture)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'not-the-same',
+            path: ['confirmEmailForFuture'],
+          });
+        }
       }
     });
 
@@ -111,16 +127,19 @@ export default function ApplyFlowCommunicationPreferencePage() {
   const { id, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, state } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [emailMethodChecked, setEmailMethodChecked] = useState(state?.preferredMethod === communicationMethodEmail.id);
+  const [nonEmailMethodChecked, setNonEmailMethodChecked] = useState(state && state.preferredMethod !== communicationMethodEmail.id);
 
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';
 
   const emailMethodHandler = () => {
     setEmailMethodChecked(true);
+    setNonEmailMethodChecked(false);
   };
 
   const nonEmailMethodHandler = () => {
     setEmailMethodChecked(false);
+    setNonEmailMethodChecked(true);
   };
 
   /**
@@ -141,10 +160,12 @@ export default function ApplyFlowCommunicationPreferencePage() {
   }
 
   const errorMessages = {
+    preferredLanguage: getErrorMessage(actionData?.errors.preferredLanguage?._errors[0]),
     preferredMethod: getErrorMessage(actionData?.errors.preferredMethod?._errors[0]),
     email: getErrorMessage(actionData?.errors.email?._errors[0]),
     confirmEmail: getErrorMessage(actionData?.errors.confirmEmail?._errors[0]),
-    preferredLanguage: getErrorMessage(actionData?.errors.preferredLanguage?._errors[0]),
+    emailForFuture: getErrorMessage(actionData?.errors.emailForFuture?._errors[0]),
+    confirmEmailForFuture: getErrorMessage(actionData?.errors.confirmEmailForFuture?._errors[0]),
     sameEmail: getErrorMessage(actionData?.errors._errors[0]),
   };
 
@@ -162,6 +183,23 @@ export default function ApplyFlowCommunicationPreferencePage() {
       children: i18n.language === 'fr' ? method.nameFr : method.nameEn,
       value: method.id,
       defaultChecked: state && state.preferredMethod !== communicationMethodEmail.id,
+      append: nonEmailMethodChecked && (
+        <div className="mb-4 grid max-w-prose gap-6 md:grid-cols-2 ">
+          <p className="col-span-2" id="future-email-note">
+            {t('apply:communication-preference.future-email-note')}
+          </p>
+          <InputField id="emailForFuture" type="email" className="w-full" label={t('apply:communication-preference.future-email')} name="emailForFuture" errorMessage={errorMessages.emailForFuture} defaultValue={state?.emailForFuture} />
+          <InputField
+            id="confirmEmailForFuture"
+            type="email"
+            className="w-full"
+            label={t('apply:communication-preference.future-confirm-email')}
+            name="confirmEmailForFuture"
+            errorMessage={errorMessages.confirmEmailForFuture ?? errorMessages.sameEmail}
+            defaultValue={state?.confirmEmailForFuture}
+          />
+        </div>
+      ),
       onClick: nonEmailMethodHandler,
     }));
 
@@ -186,11 +224,6 @@ export default function ApplyFlowCommunicationPreferencePage() {
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
       <p className="mb-6">{t('apply:communication-preference.note')}</p>
       <Form method="post" noValidate className="space-y-6">
-        {preferredCommunicationMethods.length > 0 && (
-          <div id="preferredMethod">
-            <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages.preferredMethod} required></InputRadios>
-          </div>
-        )}
         {preferredLanguages.length > 0 && (
           <div id="preferredLanguage">
             <InputRadios
@@ -205,6 +238,12 @@ export default function ApplyFlowCommunicationPreferencePage() {
               errorMessage={errorMessages.preferredLanguage}
               required
             />
+          </div>
+        )}
+
+        {preferredCommunicationMethods.length > 0 && (
+          <div id="preferredMethod">
+            <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages.preferredMethod} required></InputRadios>
           </div>
         )}
         <div className="flex flex-wrap items-center gap-3">

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -23,6 +23,9 @@
     "preferred-language": "What is your preferred official language of communication?",
     "email": "Email address",
     "confirm-email": "Confirm email address",
+    "future-email-note": "Add your email to receive future communication from Service Canada and Health Canada for the purpose of the Canadian Dental Care Plan.",
+    "future-email": "Email address(optional)",
+    "future-confirm-email": "Confirm email address(optional)",
     "back": "Back",
     "continue": "Continue",
     "error-message": {

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -24,8 +24,8 @@
     "email": "Email address",
     "confirm-email": "Confirm email address",
     "future-email-note": "Add your email to receive future communication from Service Canada and Health Canada for the purpose of the Canadian Dental Care Plan.",
-    "future-email": "Email address(optional)",
-    "future-confirm-email": "Confirm email address(optional)",
+    "future-email": "Email address (optional)",
+    "future-confirm-email": "Confirm email address (optional)",
     "back": "Back",
     "continue": "Continue",
     "error-message": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -23,6 +23,9 @@
     "preferred-language": "Quelle langue officielle de communication préférez-vous?",
     "email": "Adresse courriel",
     "confirm-email": "Confirmer l'adresse courriel",
+    "future-email-note": "(FR) Add your email to receive future communication from Service Canada and Health Canada for the purpose of the Canadian Dental Care Plan.",
+    "future-email": "Adresse courriel (facultatif)",
+    "future-confirm-email": "Confirmer l'adresse courriel (facultatif)",    
     "back": "Retour",
     "continue": "Continuer",
     "error-message": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -25,7 +25,7 @@
     "confirm-email": "Confirmer l'adresse courriel",
     "future-email-note": "(FR) Add your email to receive future communication from Service Canada and Health Canada for the purpose of the Canadian Dental Care Plan.",
     "future-email": "Adresse courriel (facultatif)",
-    "future-confirm-email": "Confirmer l'adresse courriel (facultatif)",    
+    "future-confirm-email": "Confirmer l'adresse courriel (facultatif)",
     "back": "Retour",
     "continue": "Continuer",
     "error-message": {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

1. add two optional fields for Post mail method
2. validate these two fields if not empty

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/132592996/fba13782-72ed-4746-bceb-5a814b6f538b)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [] I have checked that all e2e tests pass by running `npm run test:e2e`