### PR TITLE
Fix Collapsible id bug and remove default spacing

### DIFF
--- a/frontend/__tests__/components/collapsible.test.tsx
+++ b/frontend/__tests__/components/collapsible.test.tsx
@@ -2,14 +2,14 @@ import { render } from '@testing-library/react';
 
 import { describe, expect, it } from 'vitest';
 
-import { CollapsibleDetails } from '~/components/collapsible';
+import { Collapsible } from '~/components/collapsible';
 
 describe('Collapsible Details', () => {
   it('renders children and applies additional props', () => {
     const additionalProps = { id: 'joke', summary: 'How do we make the Internet more eco-friendly?' };
     const children = 'Integrate botany.';
 
-    const { getByText } = render(<CollapsibleDetails {...additionalProps}>{children}</CollapsibleDetails>);
+    const { getByText } = render(<Collapsible {...additionalProps}>{children}</Collapsible>);
 
     const collapsibleDetailsElement = getByText(children);
 

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -1,10 +1,7 @@
+import { useId } from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 
 import { cn } from '~/utils/tw-utils';
-
-export interface CollapsibleDetailsProps extends ComponentProps<'details'> {
-  summary: ReactNode;
-}
 
 export interface CollapsibleSummaryProps extends ComponentProps<'summary'> {}
 
@@ -16,13 +13,19 @@ export function CollapsibleSummary({ children, className, ...props }: Collapsibl
   );
 }
 
-export function CollapsibleDetails({ children, id, className, summary, ...props }: CollapsibleDetailsProps) {
-  const summaryId = `${id}-summary`;
-  const contentId = `${id}-content`;
+export interface CollapsibleProps extends ComponentProps<'details'> {
+  contentClassName?: string;
+  summary: ReactNode;
+}
+
+export function Collapsible({ children, contentClassName, id, summary, ...props }: CollapsibleProps) {
+  const uniqueId = useId();
+  const summaryId = `${id ?? uniqueId}-summary`;
+  const contentId = `${id ?? uniqueId}-content`;
   return (
-    <details className="mb-4 mt-4" {...props}>
+    <details id={id ?? uniqueId} {...props}>
       <CollapsibleSummary id={summaryId}>{summary}</CollapsibleSummary>
-      <div id={contentId} className={cn('mt-2 border-l-[6px] border-gray-400 px-6 py-4', className)}>
+      <div id={contentId} className={cn('mt-2 border-l-[6px] border-gray-400 px-6 py-4', contentClassName)}>
         {children}
       </div>
     </details>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -10,7 +10,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import { Button, ButtonLink } from '~/components/buttons';
-import { CollapsibleDetails } from '~/components/collapsible';
+import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
@@ -90,27 +90,25 @@ export default function AccessToDentalInsuranceQuestion() {
   const errorSummaryItems = createErrorSummaryItems(errorMessages);
 
   const helpMessage = (
-    <>
-      <ul className="mb-4 list-disc">
-        <li>{t('dental-insurance.list.employment')}</li>
-        <li>{t('dental-insurance.list.pension')}</li>
-        <li>{t('dental-insurance.list.purchased')}</li>
-        <li>{t('dental-insurance.list.professional')}</li>
-        <li className="list-none">
-          <CollapsibleDetails id={t('dental-insurance.detail.additional-info.title')} summary={t('dental-insurance.detail.additional-info.title')}>
-            <div>
-              <p className="mt-4">{t('dental-insurance.detail.additional-info.not-eligible')}</p>
-              <p className="mt-4">{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
-              <p className="mt-4">{t('dental-insurance.detail.additional-info.eligible')}</p>
-              <ul className="mb-4 list-disc pl-6">
-                <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
-                <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
-              </ul>
-            </div>
-          </CollapsibleDetails>
-        </li>
-      </ul>
-    </>
+    <ul className="mb-4 list-disc space-y-1 pl-7">
+      <li>{t('dental-insurance.list.employment')}</li>
+      <li>{t('dental-insurance.list.pension')}</li>
+      <li>{t('dental-insurance.list.purchased')}</li>
+      <li>{t('dental-insurance.list.professional')}</li>
+      <li className="list-none">
+        <Collapsible summary={t('dental-insurance.detail.additional-info.title')} className="mt-2">
+          <div className="space-y-4">
+            <p>{t('dental-insurance.detail.additional-info.not-eligible')}</p>
+            <p>{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
+            <p>{t('dental-insurance.detail.additional-info.eligible')}</p>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
+              <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
+            </ul>
+          </div>
+        </Collapsible>
+      </li>
+    </ul>
   );
 
   return (
@@ -129,7 +127,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 defaultChecked: state.dentalInsurance?.dentalInsurance === option.id,
               }))}
               helpMessagePrimary={helpMessage}
-              helpMessagePrimaryClassName="pl-8 text-black"
+              helpMessagePrimaryClassName="text-black"
               required={errorSummaryItems.length > 0}
               errorMessage={errorMessages.dentalInsurance}
             />

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { ButtonLink } from '~/components/buttons';
-import { CollapsibleDetails } from '~/components/collapsible';
+import { Collapsible } from '~/components/collapsible';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -59,9 +59,9 @@ export default function TermsAndConditions() {
 
   return (
     <div className="max-w-prose">
-      <div className="space-y-4">
+      <div className="space-y-6">
         <p>{t('apply:terms-and-conditions.intro-text')}</p>
-        <CollapsibleDetails id="collapsable-description-first-part" summary={t('apply:terms-and-conditions.terms-and-conditions-of-use.summary')}>
+        <Collapsible summary={t('apply:terms-and-conditions.terms-and-conditions-of-use.summary')}>
           <div className="space-y-4">
             <h2 className="font-bold">{t('apply:terms-and-conditions.terms-and-conditions-of-use.heading')}</h2>
             <p>
@@ -99,9 +99,9 @@ export default function TermsAndConditions() {
             <h2 className="font-bold">{t('apply:terms-and-conditions.terms-and-conditions-of-use.changes-to-these-terms-of-use.heading')}</h2>
             <p>{t('apply:terms-and-conditions.terms-and-conditions-of-use.changes-to-these-terms-of-use.esdc-terms-amendment-policy')}</p>
           </div>
-        </CollapsibleDetails>
+        </Collapsible>
 
-        <CollapsibleDetails id="collapsable-description-second-part" summary={t('apply:terms-and-conditions.privacy-notice-statement.summary')}>
+        <Collapsible summary={t('apply:terms-and-conditions.privacy-notice-statement.summary')}>
           <div className="space-y-4">
             <h2 className="font-bold"> {t('apply:terms-and-conditions.privacy-notice-statement.personal-information.heading')}</h2>
             <p>{t('apply:terms-and-conditions.privacy-notice-statement.personal-information.service-canada-application-administration')}</p>
@@ -130,7 +130,7 @@ export default function TermsAndConditions() {
             <h2 className="font-bold">{t('apply:terms-and-conditions.privacy-notice-statement.what-happens-if-you-dont-give-us-your-information-heading')} </h2>
             <p>{t('apply:terms-and-conditions.privacy-notice-statement.what-happens-if-you-dont-give-us-your-information-text')}</p>
           </div>
-        </CollapsibleDetails>
+        </Collapsible>
       </div>
       <h2 className="my-8 font-lato text-2xl font-bold">{t('apply:terms-and-conditions.apply-now.heading')}</h2>
       <p>{t('apply:terms-and-conditions.apply-now.application-start-consent')}</p>

--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -11,7 +11,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import { Button } from '~/components/buttons';
-import { CollapsibleDetails } from '~/components/collapsible';
+import { Collapsible } from '~/components/collapsible';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getHCaptchaService } from '~/services/hcaptcha-service.server';
@@ -106,7 +106,7 @@ export default function ApplyIndex() {
         <ul className="list-disc space-y-1 pl-7">
           <li>
             <p>{t('apply:index.to-qualify.conditions.insurance-access.heading')}</p>
-            <CollapsibleDetails summary={t('apply:index.to-qualify.conditions.insurance-access.details.summary')}>
+            <Collapsible summary={t('apply:index.to-qualify.conditions.insurance-access.details.summary')} className="my-4">
               <div className="space-y-4">
                 <p>{t('apply:index.to-qualify.conditions.insurance-access.details.access-to-dental-insurance-definition')}</p>
                 <ul className="list-disc space-y-1 pl-7">
@@ -117,11 +117,11 @@ export default function ApplyIndex() {
                 </ul>
                 <p>{t('apply:index.to-qualify.conditions.insurance-access.details.opt-out-consideration')}</p>
               </div>
-            </CollapsibleDetails>
+            </Collapsible>
           </li>
           <li>
             <p>{t('apply:index.to-qualify.conditions.income.heading')}</p>
-            <CollapsibleDetails summary={t('apply:index.to-qualify.conditions.income.details.summary')}>
+            <Collapsible summary={t('apply:index.to-qualify.conditions.income.details.summary')} className="my-4">
               <div className="space-y-4">
                 <p>{t('apply:index.to-qualify.conditions.income.details.family-net-income-definition')}</p>
                 <p>
@@ -135,7 +135,7 @@ export default function ApplyIndex() {
                   <Trans ns={handle.i18nNamespaces} i18nKey="apply:index.to-qualify.conditions.income.details.adjusted-family-net-income" />
                 </p>
               </div>
-            </CollapsibleDetails>
+            </Collapsible>
           </li>
           <li>{t('apply:index.to-qualify.conditions.resident-status')}</li>
           <li>
@@ -155,11 +155,11 @@ export default function ApplyIndex() {
         </ul>
       </div>
       <h2 className="my-8 font-lato text-2xl font-bold">{t('apply:index.apply-behalf.heading')}</h2>
-      <div className="space-y-4">
+      <div className="space-y-6">
         <p>
           <Trans ns={handle.i18nNamespaces} i18nKey="apply:index.apply-behalf.delegate-assisted-cdcp-application" components={{ contactCDCPLink, serviceCanadaOfficeLink }} />
         </p>
-        <CollapsibleDetails summary={t('apply:index.apply-behalf.trusted-person.summary')}>
+        <Collapsible summary={t('apply:index.apply-behalf.trusted-person.summary')}>
           <div className="space-y-4">
             <p>
               <Trans ns={handle.i18nNamespaces} i18nKey="apply:index.apply-behalf.trusted-person.details.application-assistance" components={{ serviceCanadaOfficeLink }} />
@@ -172,8 +172,8 @@ export default function ApplyIndex() {
               <li>{t('apply:index.apply-behalf.trusted-person.details.types-of-assistants.interpreter')}</li>
             </ul>
           </div>
-        </CollapsibleDetails>
-        <CollapsibleDetails summary={t('apply:index.apply-behalf.delegate.summary')}>
+        </Collapsible>
+        <Collapsible summary={t('apply:index.apply-behalf.delegate.summary')}>
           <div className="space-y-4">
             <p>{t('apply:index.apply-behalf.delegate.delegate-definition')}</p>
             <p>{t('apply:index.apply-behalf.delegate.delegates-on-document')}</p>
@@ -238,7 +238,7 @@ export default function ApplyIndex() {
             </ul>
             <p>{t('apply:index.apply-behalf.delegate.submit-delegate-proof.in-person.document-processing-note')}</p>
           </div>
-        </CollapsibleDetails>
+        </Collapsible>
       </div>
       <Form method="post" onSubmit={handleSubmit} noValidate className="mt-8">
         <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request addresses the bug related to the `id` attribute that I've introduced by making it optional (refer to the screenshot). Essentially, the problem arises when the `id` is omitted, resulting in `undefined-summary` and `undefined-content` being assigned as IDs, which poses accessibility issues.

Additionally, this pull request eliminates the default spacing for the details. It is now up to the consumer to apply spacing within the usage context.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/2b9d39e1-93c0-426a-91a4-4e0db7426662)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->