### PR TITLE
3061 Province dropdown bug

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -34,6 +34,7 @@ const dentalBenefitsStateSchema = z.object({
   federalSocialProgram: z.string().trim().min(1).optional(),
   provincialTerritorialBenefit: z.string({ required_error: 'provincial-benefit' }).trim().min(1),
   provincialTerritorialSocialProgram: z.string().trim().min(1).optional(),
+  province: z.string().min(1),
 });
 
 /**

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -102,7 +102,7 @@ export default function AccessToDentalInsuranceQuestion() {
     return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
   });
 
-  const [selectedRegion, setSelectedRegion] = useState(state?.provincialTerritorialSocialProgram ?? sortedRegions[0].provinceTerritoryStateId);
+  const [selectedRegion, setSelectedRegion] = useState(state?.province ?? sortedRegions[0].provinceTerritoryStateId);
 
   useEffect(() => {
     if (actionData?.formData && hasErrors(actionData.formData)) {
@@ -192,7 +192,7 @@ export default function AccessToDentalInsuranceQuestion() {
                           value: region.provinceTerritoryStateId,
                           children: i18n.language === 'en' ? region.nameEn : region.nameFr,
                         }))}
-                        defaultValue={state?.provincialTerritorialBenefit}
+                        defaultValue={state?.province}
                         required
                       />
                       <InputRadios


### PR DESCRIPTION
### Description
The province dropdown value is not stored in state, when the user navigates to the previous or the next page, the state will lose. The province value now stored in state when the form submits. 

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`