### PR TITLE
preserve firstName state in apply flow

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -42,6 +42,7 @@ const dentalBenefitsStateSchema = z.object({
  */
 const applicantInformationSchema = z.object({
   socialInsuranceNumber: z.string().refine(isValidSin, { message: 'valid-sin' }),
+  firstName: z.string(),
   lastName: z.string().min(1, { message: 'last-name' }),
   maritalStatus: z.string({ required_error: 'marital-status' }),
 });
@@ -65,6 +66,7 @@ const typeOfApplicationSchema = z.object({
  */
 const partnerInformationSchema = z.object({
   socialInsuranceNumber: z.string().refine(isValidSin, { message: 'valid-sin' }),
+  firstName: z.string(),
   lastName: z.string().min(1, { message: 'last-name' }),
   month: z.coerce.number({ required_error: 'month' }).int().min(0, { message: 'month' }).max(11, { message: 'month' }),
   day: z.coerce.number({ required_error: 'day' }).int().min(1, { message: 'day' }).max(31, { message: 'day' }),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -97,6 +97,7 @@ export default function ApplyFlowApplicationInformation() {
 
   const defaultValues = {
     socialInsuranceNumber: actionData?.formData.socialInsuranceNumber ?? state?.socialInsuranceNumber ?? '',
+    firstName: actionData?.formData.firstName ?? state?.firstName ?? '',
     lastName: actionData?.formData.lastName ?? state?.lastName ?? '',
     maritalStatus: actionData?.formData.maritalStatus ?? state?.maritalStatus ?? '',
   };
@@ -126,7 +127,7 @@ export default function ApplyFlowApplicationInformation() {
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
       <Form method="post" aria-describedby="form-instructions-sin form-instructions-info" noValidate className="max-w-prose space-y-6">
         <div className="grid gap-6 md:grid-cols-2">
-          <InputField id="firstName" name="firstName" label={t('applicant-information.first-name')} className="w-full" aria-labelledby="name-instructions" />
+          <InputField id="firstName" name="firstName" label={t('applicant-information.first-name')} className="w-full" aria-labelledby="name-instructions" defaultValue={defaultValues.firstName} />
           <InputField id="lastName" name="lastName" label={t('applicant-information.last-name')} className="w-full" required defaultValue={defaultValues.lastName} errorMessage={errorMessages.lastName} aria-labelledby="name-instructions" />
         </div>
         <p id="name-instructions">{t('applicant-information.name-instructions')}</p>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -98,6 +98,7 @@ export default function ApplyFlowApplicationInformation() {
 
   const defaultValues = {
     socialInsuranceNumber: actionData?.formData.socialInsuranceNumber ?? state?.socialInsuranceNumber ?? '',
+    firstName: actionData?.formData.firstName ?? state?.firstName ?? '',
     lastName: actionData?.formData.lastName ?? state?.lastName ?? '',
     month: actionData?.formData.month ?? state?.month ?? '',
     day: actionData?.formData.day ?? state?.day ?? '',
@@ -134,7 +135,7 @@ export default function ApplyFlowApplicationInformation() {
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
       <Form method="post" aria-describedby="form-instructions-provide-sin form-instructions-required-information" noValidate className="max-w-prose space-y-6">
         <div className="grid gap-6 md:grid-cols-2">
-          <InputField id="firstName" name="firstName" className="w-full" label={t('applicant-information.first-name')} aria-labelledby="name-instructions" />
+          <InputField id="firstName" name="firstName" className="w-full" label={t('applicant-information.first-name')} aria-labelledby="name-instructions" defaultValue={defaultValues.firstName} />
           <InputField id="lastName" name="lastName" className="w-full" label={t('applicant-information.last-name')} required defaultValue={defaultValues.lastName} errorMessage={errorMessages.lastName} aria-labelledby="name-instructions" />
         </div>
         <p id="name-instructions">{t('partner-information.name-instructions')}</p>


### PR DESCRIPTION
The `firstName` field state wasn't being preserved on subsequent navigations.   Note: these field(s) are NOT mandatory, hence the zod schema is just `z.string()`