### PR TITLE
AB#3024 -- Refactoring where sample JSON files are used and adding 'abbr' field for regions

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -1,10 +1,8 @@
 import { fakerEN_CA as faker } from '@faker-js/faker';
 import { factory, oneOf, primaryKey } from '@mswjs/data';
 
-import countriesJson from './power-platform-data/countries.json';
 import federalProgramsJson from './power-platform-data/federal-programs.json';
 import provincialProgramsJson from './power-platform-data/provincial-programs.json';
-import regionsJson from './power-platform-data/regions.json';
 
 // (Optional) Seed `faker` to ensure reproducible
 // random values of model properties.
@@ -28,9 +26,9 @@ const db = factory({
     addressApartmentUnitNumber: faker.location.buildingNumber,
     addressStreet: faker.location.street,
     addressCity: faker.location.city,
-    addressProvince: () => faker.location.state({ abbreviated: true }),
+    addressProvince: String,
     addressPostalZipCode: faker.location.zipCode,
-    addressCountry: () => 'CAN',
+    addressCountry: String,
   },
   preferredLanguage: {
     id: primaryKey(String),
@@ -213,10 +211,14 @@ db.applicationTypes.create({
 // seed avaliable addresses (before user)
 db.address.create({
   id: 'home-address-id',
+  addressProvince: 'daf4d05b-37b3-eb11-8236-0022486d8d5f', // "Ontario", @see /power-platform-data/regions.json
+  addressCountry: '0cf5389e-97ae-eb11-8236-000d3af4bfc3', // "Canada", @see /power-platform-data/countries.json
 });
 
 db.address.create({
   id: 'mailing-address-id',
+  addressProvince: '5abc28c9-38b3-eb11-8236-0022486d8d5f', // "Newfoundland and Labrador", @see /power-platform-data/regions.json
+  addressCountry: '0cf5389e-97ae-eb11-8236-000d3af4bfc3', // "Canada", @see /power-platform-data/countries.json
 });
 
 // seed users
@@ -286,26 +288,6 @@ db.maritalStatus.create({
   nameEn: 'Separated',
   nameFr: '(FR) Separated',
 });
-
-// seed country list
-countriesJson.value.forEach((country) =>
-  db.country.create({
-    countryId: country.esdc_countryid,
-    countryCode: country.esdc_countrycodealpha3,
-    nameEn: country.esdc_nameenglish,
-    nameFr: country.esdc_namefrench,
-  }),
-);
-
-// seed region list
-regionsJson.value.forEach((region) =>
-  db.region.create({
-    countryId: db.country.findFirst({ where: { countryId: { equals: region._esdc_countryid_value } } })?.countryCode,
-    provinceTerritoryStateId: region.esdc_provinceterritorystateid,
-    nameEn: region.esdc_nameenglish,
-    nameFr: region.esdc_namefrench,
-  }),
-);
 
 // seed federal social program list
 federalProgramsJson.value.forEach((program) =>

--- a/frontend/app/mocks/lookup-api.server.ts
+++ b/frontend/app/mocks/lookup-api.server.ts
@@ -1,6 +1,8 @@
 import { HttpResponse, http } from 'msw';
 import { z } from 'zod';
 
+import countriesJson from './power-platform-data/countries.json';
+import regionsJson from './power-platform-data/regions.json';
 import { db } from '~/mocks/db';
 import { demographicDB } from '~/mocks/demographics-db';
 import { getLogger } from '~/utils/logging.server';
@@ -185,8 +187,7 @@ export function getLookupApiMockHandlers() {
     //
     http.get('https://api.example.com/lookups/countries', ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
-      const countryList = db.country.getAll();
-      return HttpResponse.json(countryList);
+      return HttpResponse.json(countriesJson);
     }),
 
     //
@@ -194,8 +195,7 @@ export function getLookupApiMockHandlers() {
     //
     http.get('https://api.example.com/lookups/regions', ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
-      const provinceList = db.region.getAll();
-      return HttpResponse.json(provinceList);
+      return HttpResponse.json(regionsJson);
     }),
 
     //

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/address-accuracy.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/address-accuracy.tsx
@@ -75,7 +75,7 @@ export default function PersonalInformationHomeAddressAccuracy() {
                 <Address
                   address={newHomeAddress.address}
                   city={newHomeAddress.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === newHomeAddress.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === newHomeAddress.province)?.abbr}
                   postalZipCode={newHomeAddress.postalCode}
                   country={countryList.find((country) => country.countryId === newHomeAddress.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
                 />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/confirm.tsx
@@ -93,7 +93,7 @@ export default function PersonalInformationHomeAddressConfirm() {
   const { address, city, province, postalCode, country } = newAddress;
 
   const region = regionList.find((region) => region.provinceTerritoryStateId === province);
-  const provinceState = region?.provinceTerritoryStateId;
+  const provinceState = region?.abbr;
   const countryName = getCountryName(country);
 
   return (
@@ -108,7 +108,7 @@ export default function PersonalInformationHomeAddressConfirm() {
                 <Address
                   address={homeAddressInfo.address}
                   city={homeAddressInfo.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.abbr}
                   postalZipCode={homeAddressInfo.postalCode}
                   country={getCountryName(homeAddressInfo.country)}
                 />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -13,7 +13,6 @@ import { InputField } from '~/components/input-field';
 import type { InputOptionProps } from '~/components/input-option';
 import { InputSelect } from '~/components/input-select';
 import { getAddressService } from '~/services/address-service.server';
-import type { RegionInfo } from '~/services/lookup-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
@@ -127,7 +126,7 @@ export default function PersonalInformationHomeAddressEdit() {
   const actionData = useActionData<typeof action>();
   const { addressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const [selectedCountry, setSelectedCountry] = useState('');
-  const [countryRegions, setCountryRegions] = useState<RegionInfo[]>([]);
+  const [countryRegions, setCountryRegions] = useState<typeof regionList>([]);
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const errorSummaryId = 'error-summary';
 

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/suggested.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/suggested.tsx
@@ -84,7 +84,7 @@ export default function HomeAddressSuggested() {
                 <Address
                   address={homeAddressInfo.address}
                   city={homeAddressInfo.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.abbr}
                   postalZipCode={homeAddressInfo.postalCode}
                   country={countryList.find((country) => country.countryId === homeAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
                 />
@@ -100,7 +100,7 @@ export default function HomeAddressSuggested() {
                 <Address
                   address={suggestedAddressInfo.address}
                   city={suggestedAddressInfo.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === suggestedAddressInfo.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === suggestedAddressInfo.province)?.abbr}
                   postalZipCode={suggestedAddressInfo.postalCode}
                   country={countryList.find((country) => country.countryId === suggestedAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
                 />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -80,7 +80,7 @@ export default function PersonalInformationIndex() {
             <Address
               address={homeAddressInfo.address}
               city={homeAddressInfo.city}
-              provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.provinceTerritoryStateId}
+              provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.abbr}
               postalZipCode={homeAddressInfo.postalCode}
               country={countryList.find((country) => country.countryId === homeAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
             />
@@ -98,7 +98,7 @@ export default function PersonalInformationIndex() {
             <Address
               address={mailingAddressInfo.address}
               city={mailingAddressInfo.city}
-              provinceState={regionList.find((region) => region.provinceTerritoryStateId === mailingAddressInfo.province)?.provinceTerritoryStateId}
+              provinceState={regionList.find((region) => region.provinceTerritoryStateId === mailingAddressInfo.province)?.abbr}
               postalZipCode={mailingAddressInfo.postalCode}
               country={countryList.find((country) => country.countryId === mailingAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
             />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
@@ -75,7 +75,7 @@ export default function PersonalInformationMailingAddressAccuracy() {
                 <Address
                   address={newMailingAddress.address}
                   city={newMailingAddress.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === newMailingAddress.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === newMailingAddress.province)?.abbr}
                   postalZipCode={newMailingAddress.postalCode}
                   country={countryList.find((country) => country.countryId === newMailingAddress.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
                 />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/confirm.tsx
@@ -87,7 +87,7 @@ export default function PersonalInformationMailingAddressConfirm() {
                 <Address
                   address={mailingAddressInfo.address}
                   city={mailingAddressInfo.city}
-                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === mailingAddressInfo.province)?.provinceTerritoryStateId}
+                  provinceState={regionList.find((region) => region.provinceTerritoryStateId === mailingAddressInfo.province)?.abbr}
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={countryList.find((country) => country.countryId === mailingAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
                 />
@@ -100,7 +100,7 @@ export default function PersonalInformationMailingAddressConfirm() {
               <Address
                 address={newMailingAddress.address}
                 city={newMailingAddress.city}
-                provinceState={regionList.find((region) => region.provinceTerritoryStateId === newMailingAddress.province)?.provinceTerritoryStateId}
+                provinceState={regionList.find((region) => region.provinceTerritoryStateId === newMailingAddress.province)?.abbr}
                 postalZipCode={newMailingAddress.postalCode}
                 country={countryList.find((country) => country.countryId === newMailingAddress.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
               />

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -15,7 +15,6 @@ import { InputField } from '~/components/input-field';
 import type { InputOptionProps } from '~/components/input-option';
 import { InputSelect } from '~/components/input-select';
 import { getAddressService } from '~/services/address-service.server';
-import type { RegionInfo } from '~/services/lookup-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
@@ -129,7 +128,7 @@ export default function PersonalInformationMailingAddressEdit() {
   const actionData = useActionData<typeof action>();
   const { addressInfo, homeAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const [selectedCountry, setSelectedCountry] = useState('');
-  const [countryRegions, setCountryRegions] = useState<RegionInfo[]>([]);
+  const [countryRegions, setCountryRegions] = useState<typeof regionList>([]);
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const errorSummaryId = 'error-summary';
   const [copyAddressChecked, setCopyAddressChecked] = useState(false);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -16,7 +16,7 @@ import { InputField } from '~/components/input-field';
 import { InputOptionProps } from '~/components/input-option';
 import { InputSelect } from '~/components/input-select';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
-import { RegionInfo, getLookupService } from '~/services/lookup-service.server';
+import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { redirectWithLocale } from '~/utils/locale-utils.server';
@@ -188,10 +188,10 @@ export default function ApplyFlowPersonalInformation() {
   const { id, state, countryList, maritalStatus, regionList, COUNTRY_CODE_CANADA, COUNTRY_CODE_USA } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(state?.mailingCountry);
-  const [mailingCountryRegions, setMailingCountryRegions] = useState<RegionInfo[]>([]);
+  const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(state?.copyMailingAddress === 'on');
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(state?.homeCountry);
-  const [homeCountryRegions, setHomeCountryRegions] = useState<RegionInfo[]>([]);
+  const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const actionData = useActionData<typeof action>();
   const errorSummaryId = 'error-summary';


### PR DESCRIPTION
### Description
- API mock (as opposed to DB mock) are now returning the sample JSON for countries and regions (the rest of the JSON files will be moved over in a future PR)
- Adding and using new `abbr` field for regions (previously the `id` was displaying)
- Refactoring `lookup-service` so schemas are close to where they are used. Removing unnecessary schemas (`RegionInfo` and `PreferredLanguageInfo`).

### Related Azure Boards Work Items
[AB#3024](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3024)

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/3252f670-26fe-4528-9086-f0cb14a479c4)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/6e69b87e-f039-4235-9ee0-bcbe4bd7e463)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/home` then click "Personal Information'. The correct province abbreviation and country should show.