### PR TITLE
Preload i18n resources

### DIFF
--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -125,6 +125,7 @@ export async function initI18n<N extends Namespace>(locale: string | undefined, 
       },
       lng: locale,
       ns: namespaces,
+      preload: ['en', 'fr'],
     });
 
   log.debug('i18next initialization complete');

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -65,6 +65,7 @@ export async function initI18n(namespaces: Array<string>) {
         escapeValue: false,
       },
       ns: namespaces,
+      preload: ['en', 'fr'],
     });
 
   return i18n;


### PR DESCRIPTION
⚠️ Incremental PR ⚠️

### Description

To build bilingual error pages, both language translations must be loaded and available to i18next. This PR preloads both english and french translations so that `getFixedT(language)` can be used to fetch strings from either resource file.

This is not ideal, since it loads 2x the translations up-front. I will continue to play around with the configuration to see if I can avoid doing this, but right now this seems like the only way to do what I need.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
