### PR TITLE
AB#3024 -- Refactoring where sample JSON files are used for federal and provincial social programs

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -1,9 +1,6 @@
 import { fakerEN_CA as faker } from '@faker-js/faker';
 import { factory, oneOf, primaryKey } from '@mswjs/data';
 
-import federalProgramsJson from './power-platform-data/federal-programs.json';
-import provincialProgramsJson from './power-platform-data/provincial-programs.json';
-
 // (Optional) Seed `faker` to ensure reproducible
 // random values of model properties.
 faker.seed(123);
@@ -288,24 +285,5 @@ db.maritalStatus.create({
   nameEn: 'Separated',
   nameFr: '(FR) Separated',
 });
-
-// seed federal social program list
-federalProgramsJson.value.forEach((program) =>
-  db.federalSocialProgram.create({
-    code: program.esdc_code,
-    nameEn: program.esdc_nameenglish,
-    nameFr: program.esdc_namefrench,
-  }),
-);
-
-// seed provincial and territorial program list
-provincialProgramsJson.value.forEach((program) =>
-  db.provincialTerritorialSocialProgram.create({
-    code: program.esdc_code,
-    provinceTerritoryStateId: program._esdc_provinceterritorystateid_value,
-    nameEn: program.esdc_nameenglish,
-    nameFr: program.esdc_namefrench,
-  }),
-);
 
 export { db };

--- a/frontend/app/mocks/lookup-api.server.ts
+++ b/frontend/app/mocks/lookup-api.server.ts
@@ -2,6 +2,8 @@ import { HttpResponse, http } from 'msw';
 import { z } from 'zod';
 
 import countriesJson from './power-platform-data/countries.json';
+import federalProgramsJson from './power-platform-data/federal-programs.json';
+import provincialProgramsJson from './power-platform-data/provincial-programs.json';
 import regionsJson from './power-platform-data/regions.json';
 import { db } from '~/mocks/db';
 import { demographicDB } from '~/mocks/demographics-db';
@@ -151,8 +153,7 @@ export function getLookupApiMockHandlers() {
     //
     http.get('https://api.example.com/lookups/federal-social-programs', ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
-      const federalSocialProgram = db.federalSocialProgram.getAll();
-      return HttpResponse.json(federalSocialProgram);
+      return HttpResponse.json(federalProgramsJson);
     }),
 
     //
@@ -160,8 +161,7 @@ export function getLookupApiMockHandlers() {
     //
     http.get('https://api.example.com/lookups/provincial-territorial-social-programs', ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
-      const provincialTerritorialSocialProgram = db.provincialTerritorialSocialProgram.getAll();
-      return HttpResponse.json(provincialTerritorialSocialProgram);
+      return HttpResponse.json(provincialProgramsJson);
     }),
 
     //


### PR DESCRIPTION
### Description
- API mock (as opposed to DB mock) now return the sample JSON for federal and provincial/territorial social programs
- Refactoring `lookup-service` so schemas are close to where they are used

### Related Azure Boards Work Items
[AB#3024](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3024)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and start an `/apply` flow. Navigate to `/federal-provincial-territorial-benefits`. The page should render correctly with the sample JSON files from `frontend/app/mocks/power-platform-data`.