### PR TITLE
3061 bug with province selector

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -34,7 +34,7 @@ const dentalBenefitsStateSchema = z.object({
   federalSocialProgram: z.string().trim().min(1).optional(),
   provincialTerritorialBenefit: z.string({ required_error: 'provincial-benefit' }).trim().min(1),
   provincialTerritorialSocialProgram: z.string().trim().min(1).optional(),
-  province: z.string().min(1, { message: 'empty-province' }),
+  province: z.string().trim().optional(),
 });
 
 /**

--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -34,7 +34,7 @@ const dentalBenefitsStateSchema = z.object({
   federalSocialProgram: z.string().trim().min(1).optional(),
   provincialTerritorialBenefit: z.string({ required_error: 'provincial-benefit' }).trim().min(1),
   provincialTerritorialSocialProgram: z.string().trim().min(1).optional(),
-  province: z.string().min(1),
+  province: z.string().min(1, { message: 'empty-province' }),
 });
 
 /**

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -99,8 +99,8 @@ export default function AccessToDentalInsuranceQuestion() {
   const { federalSocialPrograms, provincialTerritorialSocialPrograms, provincialTerritorialDentalBenefits, federalDentalBenefits, regions, state, id } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const [federalBenefitChecked, setFederalBenefitChecked] = useState(state?.federalBenefit);
-  const [provincialTerritorialBenefitChecked, setProvincialTerritorialBenefitChecked] = useState(state?.provincialTerritorialBenefit);
+  const [checkedFederalOption, setCheckedFederalOption] = useState(state?.federalBenefit);
+  const [checkedProvincialOption, setCheckedProvincialOption] = useState(state?.provincialTerritorialBenefit);
   const [provincialProgramOption, setProvincialProgramOption] = useState(state?.provincialTerritorialSocialProgram);
   const errorSummaryId = 'error-summary';
   const navigation = useNavigation();
@@ -114,13 +114,10 @@ export default function AccessToDentalInsuranceQuestion() {
   const [selectedRegion, setSelectedRegion] = useState(state?.province);
 
   useEffect(() => {
-    if (provincialTerritorialBenefitChecked !== 'yes') {
-      setSelectedRegion('');
-    }
     if (actionData?.formData && hasErrors(actionData.formData)) {
       scrollAndFocusToErrorSummary(errorSummaryId);
     }
-  }, [actionData, provincialTerritorialBenefitChecked]);
+  }, [actionData]);
 
   function getErrorMessage(errorI18nKey?: string): string | undefined {
     if (!errorI18nKey) return undefined;
@@ -163,8 +160,8 @@ export default function AccessToDentalInsuranceQuestion() {
                   children: <Trans ns={handle.i18nNamespaces}>{`dental-benefits.federal-benefits.option-${option.code}`}</Trans>,
                   value: option.code,
                   defaultChecked: state?.federalBenefit === option.code,
-                  onChange: (e) => setFederalBenefitChecked(e.target.value),
-                  append: option.code === 'yes' && federalBenefitChecked === 'yes' && (
+                  onChange: (e) => setCheckedFederalOption(e.target.value),
+                  append: option.code === 'yes' && checkedFederalOption === 'yes' && (
                     <InputRadios
                       id="federal-social-programs"
                       name="federalSocialProgram"
@@ -197,8 +194,8 @@ export default function AccessToDentalInsuranceQuestion() {
                   children: <Trans ns={handle.i18nNamespaces}>{`dental-benefits.provincial-territorial-benefits.option-${option.code}`}</Trans>,
                   value: option.code,
                   defaultChecked: state?.provincialTerritorialBenefit === option.code,
-                  onChange: (e) => setProvincialTerritorialBenefitChecked(e.target.value),
-                  append: option.code === 'yes' && provincialTerritorialBenefitChecked === 'yes' && regions.length > 0 && (
+                  onChange: (e) => setCheckedProvincialOption(e.target.value),
+                  append: option.code === 'yes' && checkedProvincialOption === 'yes' && regions.length > 0 && (
                     <Fragment key={option.code}>
                       <InputSelect
                         id="province"
@@ -215,7 +212,7 @@ export default function AccessToDentalInsuranceQuestion() {
                             children: i18n.language === 'en' ? region.nameEn : region.nameFr,
                           })),
                         ]}
-                        defaultValue={state?.province}
+                        defaultValue={selectedRegion}
                         errorMessage={errorMessages.province}
                         required={errorSummaryItems.length > 0}
                       />
@@ -230,7 +227,7 @@ export default function AccessToDentalInsuranceQuestion() {
                           .map((option) => ({
                             children: <span className="font-bold">{getNameByLanguage(i18n.language, option)}</span>,
                             value: getNameByLanguage(i18n.language, option),
-                            defaultChecked: provincialProgramOption === getNameByLanguage(i18n.language, option),
+                            checked: provincialProgramOption === getNameByLanguage(i18n.language, option),
                             onChange: (e) => setProvincialProgramOption(e.target.value),
                           }))}
                       />

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -123,6 +123,7 @@
   "dental-benefits": {
     "title": "Access to other federal, provincial or territorial dental benefits",
     "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
+    "select-one": "Select one",
     "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no duplication or gaps in coverage.",
     "federal-benefits": {
       "title": "Federal benefits",
@@ -151,7 +152,8 @@
       "federal-benefit": "Federal benefit must be selected",
       "federal-program": "Federal program must be selected",
       "provincial-benefit": "Provincial benefit must be selected",
-      "provincial-program": "Provincial program must be selected"
+      "provincial-program": "Provincial program must be selected",
+      "empty-province": "Province must be selected"
     }
   },
   "dental-insurance": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -124,6 +124,7 @@
     "title": "(Fr) Access to other federal, provincial or territorial dental benefits",
     "access-to-dental": "(Fr) Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
     "eligibility-criteria": "(Fr) If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no duplication or gaps in coverage.",
+    "select-one": "(Fr) Select one",
     "federal-benefits": {
       "title": "(Fr) Federal benefits",
       "legend": "(Fr) Do you have dental benefits through a social program offered by a federal program?",
@@ -151,7 +152,8 @@
       "federal-benefit": "(Fr) Federal benefit must be selected",
       "federal-program": "(Fr) Federal program must be selected",
       "provincial-benefit": "(Fr) Provincial benefit must be selected",
-      "provincial-program": "(Fr) Provincial program must be selected"
+      "provincial-program": "(Fr) Provincial program must be selected",
+      "empty-province": "(Fr) Province must be selected"
     }
   },
   "dental-insurance": {


### PR DESCRIPTION
### Description
Open this pr to address the bugs found on the province selector on `federal-provincial-territorial-benefits` page.

1. The dropdown shouldn't have a pre-selected value. Validation error should display when the user didn't select anything.
2. The radio stays selected when choosing a different province. This is because the defaulChecked attribute does not control the component's state after initial render, if the state changes later, the checked state does not automatically update to reflect the new state. Use `checked` instead of `defaultChecked` should fix the issue.
3. Fixed the issue when toggle the radio off and on again (Provincial and Territotial question), radio options displayed with the wrong province

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`