### PR TITLE
AB#3051:  render dynamic link user origin

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -137,6 +137,10 @@ MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc
 # (required; use the example below)
 SCCH_BASE_URI=http://www.example.com
 
+# MSCA home URL -- used as a home URL for MSCA
+# (required; use the example below)
+MSCA_HOME_URI=http://srv136.services.gc.ca
+
 # Community where the documents were generated from, and user belongs. This value is linked to the specific vault database for the given community.
 CCT_VAULT_COMMUNITY='SecurityReview'
 

--- a/frontend/__tests__/components/client-env.test.tsx
+++ b/frontend/__tests__/components/client-env.test.tsx
@@ -13,6 +13,7 @@ describe('<ClientEnv>', () => {
       ENABLED_FEATURES: ['feature1', 'feature2'],
       I18NEXT_DEBUG: true,
       SCCH_BASE_URI: 'http://www.example.com',
+      MSCA_HOME_URI: 'http://srv136.services.gc.ca',
       SESSION_TIMEOUT_SECONDS: 120,
       SESSION_TIMEOUT_PROMPT_SECONDS: 30,
     };

--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -18,6 +18,7 @@ import { SkipNavigationLinks } from '~/components/skip-navigation-links';
 import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useBreadcrumbs, useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
+import { useUserOrigin } from '~/utils/user-origin-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -49,6 +50,7 @@ function AppPageTitle() {
 function NavigationMenu() {
   const { t } = useTranslation(i18nNamespaces);
   const { SCCH_BASE_URI } = getClientEnv();
+  const userOrigin = useUserOrigin();
 
   return (
     <div className="sm:w-[260px]">
@@ -63,9 +65,11 @@ function NavigationMenu() {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-svw rounded-t-none sm:w-[260px]" sideOffset={0} align="center">
-          <DropdownMenuItem asChild className="cursor-pointer">
-            <Link to={t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI })}>{t('gcweb:header.menu-dashboard.text')}</Link>
-          </DropdownMenuItem>
+          {userOrigin && (
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link to={userOrigin.to}>{userOrigin.text}</Link>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem asChild className="cursor-pointer">
             <Link to={t('gcweb:header.menu-profile.href', { baseUri: SCCH_BASE_URI })}>{t('gcweb:header.menu-profile.text')}</Link>
           </DropdownMenuItem>

--- a/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
+++ b/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
@@ -43,7 +43,6 @@ export default function DataUnavailable() {
   const doyouqualify = <InlineLink to={t('do-you-qualify.href')} />;
   const howtoapply = <InlineLink to={t('how-to-apply.href')} />;
   const contactus = <InlineLink to={t('contact-us.href', { baseUri: SCCH_BASE_URI })} />;
-  const mydashboard = <InlineLink to={t('my-dashboard.href', { baseUri: SCCH_BASE_URI })} />;
 
   return (
     <>
@@ -57,7 +56,6 @@ export default function DataUnavailable() {
         <Trans ns={handle.i18nNamespaces} i18nKey="other-enquiry" components={{ contactus }} />
       </p>
       <p className="mb-8">{t('service-delay')}</p>
-      <Trans ns={handle.i18nNamespaces} i18nKey="my-dashboard" components={{ mydashboard }} />
     </>
   );
 }

--- a/frontend/app/routes/$lang+/_protected+/home.tsx
+++ b/frontend/app/routes/$lang+/_protected+/home.tsx
@@ -15,6 +15,7 @@ import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { getUserOrigin, userOriginCookie } from '~/utils/user-origin-utils.server';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('index', 'gcweb'),
@@ -35,8 +36,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
 
+  const userOrigin = await getUserOrigin(request);
+
   if (!userInfo) {
-    return redirectWithLocale(request, '/data-unavailable');
+    return redirectWithLocale(request, '/data-unavailable', { headers: { 'Set-Cookie': await userOriginCookie.serialize(userOrigin) } });
   }
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -54,6 +54,7 @@ const serverEnv = z.object({
   INTEROP_API_BASE_URI: z.string().url().default('https://api.example.com'),
   CCT_API_BASE_URI: z.string().url().default('https://api.example.com'),
   SCCH_BASE_URI: z.string().url().default('https://www.example.com'),
+  MSCA_HOME_URI: z.string().url().default('http://srv136.services.gc.ca'),
 
   // auth/oidc settings
   AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),
@@ -142,6 +143,7 @@ const publicEnv = serverEnv.pick({
   I18NEXT_DEBUG: true,
   LANG_QUERY_PARAM: true,
   SCCH_BASE_URI: true,
+  MSCA_HOME_URI: true,
   SESSION_TIMEOUT_SECONDS: true,
   SESSION_TIMEOUT_PROMPT_SECONDS: true,
 });

--- a/frontend/app/utils/user-origin-utils.server.ts
+++ b/frontend/app/utils/user-origin-utils.server.ts
@@ -1,0 +1,25 @@
+import { createCookie } from '@remix-run/node';
+
+import { z } from 'zod';
+
+export const userOriginCookie = createCookie('__CDCP//origin', {
+  path: '/',
+  secure: true,
+});
+
+export const originEnumSchema = z.enum(['msca', 'msca-d']);
+
+export async function getUserOrigin(request: Request) {
+  // try to get it from search params
+  const { searchParams } = new URL(request.url);
+  const originParam = searchParams.get('origin');
+  const parsedOrigin = originEnumSchema.safeParse(originParam);
+  if (parsedOrigin.success) return parsedOrigin.data;
+
+  // try to get it from session
+  const cookieHeader = request.headers.get('Cookie');
+  const cookieValue = (await userOriginCookie.parse(cookieHeader)) || {};
+
+  // default to 'msca-d' if parse throw an error
+  return originEnumSchema.catch(originEnumSchema.Enum['msca-d']).parse(cookieValue);
+}

--- a/frontend/app/utils/user-origin-utils.ts
+++ b/frontend/app/utils/user-origin-utils.ts
@@ -1,0 +1,34 @@
+import { useRouteLoaderData } from '@remix-run/react';
+import { To } from '@remix-run/router';
+
+import { useTranslation } from 'react-i18next';
+
+import { getTypedI18nNamespaces } from './locale-utils';
+import { loader as rootLoader } from '~/root';
+
+export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
+
+export function useUserOrigin(): { to: To; text: string } | undefined {
+  const data = useRouteLoaderData<typeof rootLoader>('root');
+  const { t } = useTranslation(i18nNamespaces);
+
+  if (!data) return undefined;
+
+  switch (data.userOrigin) {
+    case 'msca': {
+      return {
+        to: t('gcweb:header.menu-msca-home.href', { baseUri: data.env.MSCA_HOME_URI }),
+        text: t('gcweb:header.menu-dashboard.text'),
+      };
+    }
+    case 'msca-d': {
+      return {
+        to: t('gcweb:header.menu-dashboard.href', { baseUri: data.env.SCCH_BASE_URI }),
+        text: t('gcweb:header.menu-dashboard.text'),
+      };
+    }
+    default: {
+      throw Error(`Origin '${origin}' not supported.`);
+    }
+  }
+}

--- a/frontend/public/locales/en/data-unavailable.json
+++ b/frontend/public/locales/en/data-unavailable.json
@@ -9,8 +9,5 @@
   "how-to-apply.href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",
   "other-enquiry": "For other enquiries, please visit the <contactus>Contact us</contactus> page to find out how to reach us",
   "contact-us.href": "{{baseUri}}/en/contact-us",
-  "service-delay": "If you have recently applied, please note that there could be a delay in your application appearing within the My Service Canada Account.  For any enquiries on the status of your application please visit \"link to online status checker\".",
-  "my-dashboard": "<mydashboard>My Dashboard</mydashboard>",
-  "my-dashboard.href": "{{baseUri}}/en/my-dashboard",
-  "go-back-to-msca": "MSCA portal link"
+  "service-delay": "If you have recently applied, please note that there could be a delay in your application appearing within the My Service Canada Account.  For any enquiries on the status of your application please visit \"link to online status checker\"."
 }

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -21,6 +21,7 @@
     "menu-title": "Account",
     "menu-dashboard.text": "My Dashboard",
     "menu-dashboard.href": "{{baseUri}}/en/my-dashboard",
+    "menu-msca-home.href": "{{baseUri}}/sc/msca-mdsc/portal-portail/pro/home-accueil?Lang=eng",
     "menu-profile.text": "Profile",
     "menu-profile.href": "{{baseUri}}/en/profile",
     "menu-security-settings.text": "Security Settings",

--- a/frontend/public/locales/fr/data-unavailable.json
+++ b/frontend/public/locales/fr/data-unavailable.json
@@ -9,8 +9,5 @@
   "how-to-apply.href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html",
   "other-enquiry": "(FR) For other enquiries, please visit the <contactus>Contact us</contactus> page to find out how to reach us.",
   "contact-us.href": "{{baseUri}}/fr/contact-us",
-  "service-delay": "(FR) If you have recently applied, please note that there could be a delay in your application appearing within the My Service Canada Account.  For any enquiries on the status of your application please visit \"link to online status checker\".",
-  "my-dashboard": "<mydashboard>Mon tableau de bord</mydashboard>",
-  "my-dashboard.href": "{{baseUri}}/fr/mon-tableau-de-bord",
-  "go-back-to-msca": "(FR) MSCA portal link"
+  "service-delay": "(FR) If you have recently applied, please note that there could be a delay in your application appearing within the My Service Canada Account.  For any enquiries on the status of your application please visit \"link to online status checker\"."
 }

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -21,6 +21,7 @@
     "menu-title": "Compte",
     "menu-dashboard.text": "Mon tableau de bord",
     "menu-dashboard.href": "{{baseUri}}/fr/mon-tableau-de-bord",
+    "menu-msca-home.href": "{{baseUri}}/sc/msca-mdsc/portal-portail/pro/home-accueil?Lang=fra",
     "menu-profile.text": "Profil",
     "menu-profile.href": "{{baseUri}}/fr/profil",
     "menu-security-settings.text": "Paramètres de sécurité",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

1. "My dashboard" link in Account menu is based on where the user login from (msca home page or msca-d dashboard)
2. "My dashboard" link in Data unavailable page is based on where the user login from

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`