### PR TITLE
Add bilingual 404 page

### DIFF
--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -1,5 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
+import { Link } from '@remix-run/react';
+
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Breadcrumbs } from '~/components/breadcrumbs';
@@ -67,19 +69,93 @@ function PageBreadcrumbs() {
   );
 }
 
+export interface BilingualNotFoundErrorProps {
+  error?: unknown;
+}
+
+/**
+ * A 404 page that renders both languages, for when the user's language cannot be detected
+ */
+export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
+  const { i18n } = useTranslation(['gcweb']);
+  const en = i18n.getFixedT('en');
+  const fr = i18n.getFixedT('fr');
+
+  const homeLink = <Link to="/" className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" />;
+
+  return (
+    <>
+      <header className="border-b-[3px] border-slate-700 print:hidden">
+        <div id="wb-bnr">
+          <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
+            <div property="publisher" typeof="GovernmentOrganization">
+              <Link to="https://canada.ca/" property="url">
+                <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} property="logo" width="300" height="28" decoding="async" />
+              </Link>
+              <meta property="name" content={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} />
+              <meta property="areaServed" typeof="Country" content="Canada" />
+              <link property="logo" href="/assets/wmms-blk.svg" />
+            </div>
+          </div>
+        </div>
+      </header>
+      <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+        <div className="grid grid-cols-1 gap-6 py-2.5 sm:grid-cols-2 sm:py-3.5">
+          <div id="english" lang="en">
+            <PageTitle className="my-8">
+              <span>{en('gcweb:not-found.page-title')}</span>
+              <small className="block text-2xl font-normal text-neutral-500">{en('gcweb:not-found.page-subtitle')}</small>
+            </PageTitle>
+            <p className="mb-8 text-lg text-gray-500">{en('gcweb:not-found.page-message')}</p>
+            <ul className="list-disc space-y-2 pl-10">
+              <li>
+                <Trans t={en} ns={['gcweb']} i18nKey="gcweb:not-found.page-link" components={{ home: homeLink }} />
+              </li>
+            </ul>
+          </div>
+          <div id="french" lang="fr">
+            <PageTitle className="my-8">
+              <span>{fr('gcweb:not-found.page-title')}</span>
+              <small className="block text-2xl font-normal text-neutral-500">{fr('gcweb:not-found.page-subtitle')}</small>
+            </PageTitle>
+            <p className="mb-8 text-lg text-gray-500">{fr('gcweb:not-found.page-message')}</p>
+            <ul className="list-disc space-y-2 pl-10">
+              <li>
+                <Trans t={fr} ns={['gcweb']} i18nKey="gcweb:not-found.page-link" components={{ home: homeLink }} />
+              </li>
+            </ul>
+          </div>
+        </div>
+      </main>
+      <footer id="wb-info" className="bg-stone-50 print:hidden">
+        <div className="container flex items-center justify-end gap-6 py-2.5 sm:py-3.5">
+          <div>
+            <h2 className="sr-only">
+              <span lang="en">{en('gcweb:footer.about-site')}</span> / <span lang="fr">{fr('gcweb:footer.about-site')}</span>
+            </h2>
+            <div>
+              <img src="/assets/wmms-blk.svg" alt={`${en('gcweb:footer.gc-symbol')} / ${fr('gcweb:footer.gc-symbol')}`} width={300} height={71} className="h-10 w-auto" />
+            </div>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}
+
 export interface NotFoundErrorProps {
   error?: unknown;
 }
 
 export function NotFoundError({ error }: NotFoundErrorProps) {
   const { t } = useTranslation(i18nNamespaces);
-  const home = <InlineLink to="/" />;
+  const home = <InlineLink to="/apply" />;
 
   return (
     <>
       <PageHeader />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        <PageTitle>
+        <PageTitle className="my-8">
           <span>{t('gcweb:not-found.page-title')}</span>
           <small className="block text-2xl font-normal text-neutral-500">{t('gcweb:not-found.page-subtitle')}</small>
         </PageTitle>

--- a/frontend/app/routes/$lang+/$.tsx
+++ b/frontend/app/routes/$lang+/$.tsx
@@ -1,0 +1,27 @@
+import { LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+
+import pageIds from './page-ids.json';
+import { NotFoundError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: [...layoutI18nNamespaces],
+  pageIdentifier: pageIds.public.notFound,
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('gcweb:not-found.document-title') }) };
+  return json({ meta }, { status: 404 });
+}
+
+export default function NotFound() {
+  return <NotFoundError />; // delegate rendering to the layout's 404 component
+}

--- a/frontend/app/routes/$lang+/_route.tsx
+++ b/frontend/app/routes/$lang+/_route.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunctionArgs, json } from '@remix-run/node';
-import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
+import { Outlet, isRouteErrorResponse, useParams, useRouteError } from '@remix-run/react';
 
-import { NotFoundError, ServerError } from '~/components/layouts/public-layout';
+import { BilingualNotFoundError, NotFoundError, ServerError } from '~/components/layouts/public-layout';
 import { getLogger } from '~/utils/logging.server';
 
 export function loader({ request, params }: LoaderFunctionArgs) {
@@ -25,14 +25,25 @@ export default function Route() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
+  const { lang: langParam } = useParams();
 
   if (isRouteErrorResponse(error)) {
     switch (error.status) {
       case 404: {
-        return <NotFoundError error={error} />;
+        // prettier-ignore
+        return isValidLang(langParam)
+          ? <NotFoundError error={error} />
+          : <BilingualNotFoundError error={error}/>;
       }
     }
   }
 
-  return <ServerError error={error} />;
+  //prettier-ignore
+  return isValidLang(langParam)
+    ? <ServerError error={error} />
+    : <ServerError error={error} />; // TODO :: GjB :: create bilingual 500 page
+}
+
+function isValidLang(lang?: string) {
+  return lang && ['en', 'fr'].includes(lang);
 }

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -24,6 +24,7 @@
       "reviewInformation": "CDCP-APPL-0018",
       "exitApplication": "CDCP-APPL-0019",
       "confirmation": "CDCP-APPL-0020"
-    }
+    },
+    "notFound": "CDCP-ERR-0404"
   }
 }


### PR DESCRIPTION
### Description

App needs a 404 page that shows both languages when the user language is not detectable.

### Related Azure Boards Work Items

- [AB#3055](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3055)

### Screenshots

#### iPhone 12 Pro landscape

![localhost_3000_asdf(iPhone 12 Pro)](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/de45469e-f4b2-4492-9339-125d2c7f88dd)

#### iPhone 12 Pro portrait

![localhost_3000_asdf(iPhone 12 Pro) (1)](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/c75837f0-a3ef-4e4b-af58-45376e750424)


### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Navigate to <http://localhost:3000/galneryus> to trigger a 404.

### Additional Notes

- Error page was only added to the **public** pages.
- [AB#3055](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3055) also needs a bilingual 500 page. I will add that in a future PR.
