### PR TITLE
Allow passing language in to `getFixedT()`

### DIFF
--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -15,8 +15,8 @@ const log = getLogger('locale-utils.server');
  * Returns a t function that defaults to the language resolved through the request.
  * @see https://www.i18next.com/overview/api#getfixedt
  */
-export async function getFixedT<N extends Namespace>(request: Request, namespaces: N) {
-  const locale = await getLocale(request);
+export async function getFixedT<N extends Namespace>(localeOrRequest: 'en' | 'fr' | Request, namespaces: N) {
+  const locale = typeof localeOrRequest === 'string' ? localeOrRequest : await getLocale(localeOrRequest);
   const i18n = await initI18n(locale, namespaces);
   return i18n.getFixedT(locale, namespaces);
 }


### PR DESCRIPTION
### Description

Prep PR for upcoming change. This PR adds the ability to pass a specific language/locale to the server-side `getFixedT()` function.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
