### PR TITLE
AB#3074 refine personal information

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -65,13 +65,13 @@ const typeOfApplicationSchema = z.object({
  * Schema for intake state.
  */
 const partnerInformationSchema = z.object({
-  socialInsuranceNumber: z.string().refine(isValidSin, { message: 'valid-sin' }),
+  socialInsuranceNumber: z.string().optional(),
   firstName: z.string().optional(),
-  lastName: z.string().min(1, { message: 'last-name' }),
-  month: z.coerce.number({ required_error: 'month' }).int().min(0, { message: 'month' }).max(11, { message: 'month' }),
-  day: z.coerce.number({ required_error: 'day' }).int().min(1, { message: 'day' }).max(31, { message: 'day' }),
-  year: z.coerce.number({ required_error: 'year' }).int().min(1, { message: 'year' }).max(new Date().getFullYear(), { message: 'year' }),
-  confirm: z.string({ required_error: 'confirm' }),
+  lastName: z.string().optional(),
+  month: z.coerce.number().optional(),
+  day: z.coerce.number().optional(),
+  year: z.coerce.number().optional(),
+  confirm: z.string().optional(),
 });
 
 /**

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -129,7 +129,7 @@ export default function ApplyFlowApplicationInformation() {
       <fetcher.Form method="post" aria-describedby="form-instructions-sin form-instructions-info" noValidate>
         <div className="mb-8 space-y-6">
           <div className="grid gap-6 md:grid-cols-2">
-            <InputField id="firstName" name="firstName" label={t('applicant-information.first-name')} className="w-full" aria-labelledby="name-instructions" defaultValue={defaultValues.firstName} />
+            <InputField id="firstName" name="firstName" label={t('applicant-information.first-name')} className="w-full" required aria-labelledby="name-instructions" defaultValue={defaultValues.firstName} />
             <InputField id="lastName" name="lastName" label={t('applicant-information.last-name')} className="w-full" required defaultValue={defaultValues.lastName} errorMessage={errorMessages.lastName} aria-labelledby="name-instructions" />
           </div>
           <p id="name-instructions">{t('applicant-information.name-instructions')}</p>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -145,8 +145,8 @@ export default function ApplyFlowCommunicationPreferencePage() {
   const isSubmitting = fetcher.state !== 'idle';
   const [emailMethodChecked, setEmailMethodChecked] = useState(state?.preferredMethod === communicationMethodEmail.id);
   const [nonEmailMethodChecked, setNonEmailMethodChecked] = useState(state && state.preferredMethod !== communicationMethodEmail.id);
-  const errorSummaryId = 'error-summary';
 
+  const errorSummaryId = 'error-summary';
   const emailMethodHandler = () => {
     setEmailMethodChecked(true);
     setNonEmailMethodChecked(false);

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -403,6 +403,7 @@
     "continue-btn": "Continue",
     "error-message": {
       "valid-sin": "Must be a valid SIN",
+      "unique-sins": "SINs must be unique",
       "last-name": "Last name must be provided",
       "month": "Month must be valid",
       "day": "Day must be valid for the given month and year",
@@ -412,12 +413,11 @@
   },
   "personal-information": {
     "page-title": "Personal information",
-    "form-instructions": "Adding a telephone number helps Service Canada reach you if there is an issue with your application and may help reduce delays in processing your application. Otherwise, we will contact you by mail using the mailing address you provide.",
+    "form-instructions": "Adding a phone number helps Service Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
     "telephone-number": "Telephone number (optional)",
-    "telephone-number-alt": "Telephone number (alternate) (optional)",
+    "telephone-number-alt": "Alternate phone number (optional)",
     "mailing-address": {
-      "header": "Mailing address",
-      "note": "We may send you letters by mail related to your CDCP application."
+      "header": "Mailing address"
     },
     "home-address": {
       "header": "Home address",
@@ -425,7 +425,7 @@
     },
     "address-field": {
       "address": "Address",
-      "address-note": "Include street number and name.",
+      "address-note": "Include street number and name",
       "apartment": "Apartment, suite, etc. (optional)",
       "country": "Country",
       "province": "Province, territory, state, or region",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -403,6 +403,7 @@
     "continue-btn": "Continuer",
     "error-message": {
       "valid-sin": "(FR) Must be a valid SIN",
+      "unique-sins": "(FR) SINs must be unique",
       "last-name": "(FR) Last name must be provided",
       "month": "(FR) Month must be valid",
       "day": "(FR) Day must be valid for the given month and year",
@@ -412,12 +413,11 @@
   },
   "personal-information": {
     "page-title": "Renseignements personnels",
-    "form-instructions": "L'ajout d'un numéro de téléphone aide Service Canada à vous joindre en cas de problème avec votre demande et peut contribuer à réduire les délais de traitement de votre demande. Sinon, nous communiquerons avec vous par la poste en utilisant l'adresse postale que vous fournissez.",
+    "form-instructions": "L'ajout d'un numéro de téléphone permet à Service Canada de vous joindre en cas de problème avec votre demande. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
     "telephone-number": "Numéro de téléphone (facultatif)",
-    "telephone-number-alt": "Le numéro de téléphone secondaire (facultatif)",
+    "telephone-number-alt": "Autre numéro de téléphone (facultatif)",
     "mailing-address": {
-      "header": "Adresse postale",
-      "note": "Nous pouvons vous envoyer des lettres par la poste au sujet de votre demande au RCSD."
+      "header": "Adresse postale"
     },
     "home-address": {
       "header": "Adresse du domicile",
@@ -425,7 +425,7 @@
     },
     "address-field": {
       "address": "Adresse",
-      "address-note": "Indiquez le numéro et le nom de la rue.",
+      "address-note": "Indiquez le numéro et le nom de la rue",
       "apartment": "Appartement, bureau, etc. (facultatif)",
       "country": "Pays",
       "province": "Province, territoire, État ou région",


### PR DESCRIPTION
### Description
- made changes to `/personal-information` and `/partner-information` to conform with figma and last week's refinement (check ADO ticket for more information)
- moved partner information schema into its route so it can validate partner SIN vs. applicant SIN (ensure no duplicates)
- postal codes are stripped of all whitespace on form submission

### Related Azure Boards Work Items
[AB#3074](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3074)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`