### PR TITLE
AB#3026 -- Using sample letter-types.json to mock API response

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -186,3 +186,10 @@ OTHER_GENDER_TYPE_ID='gender-other'
 ## id for 'United States of America'
 # (required; use the example below)
 USA_COUNTRY_ID='fcf7389e-97ae-eb11-8236-000d3af4bfc3'
+
+# lanuage code for English letter type
+# (optional; default: 1033)
+ENGLISH_LETTER_LANGUAGE_CODE=1033
+# lanuage code for French letter type
+# (optional; default: 1036)
+FRENCH_LETTER_LANGUAGE_CODE=1036

--- a/frontend/__tests__/routes/_protected+/letters+/index.test.tsx
+++ b/frontend/__tests__/routes/_protected+/letters+/index.test.tsx
@@ -23,8 +23,8 @@ vi.mock('~/services/interop-service.server', () => ({
       { id: '3', referenceId: '003', issuedOn: undefined, name: 'DEN' },
     ]),
     getAllLetterTypes: vi.fn().mockResolvedValue([
-      { code: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
-      { code: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
+      { id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
+      { id: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
     ]),
   }),
 }));
@@ -103,7 +103,7 @@ describe('Letters Page', () => {
 
     const data = await response.json();
 
-    expect(data.letterTypes.includes({ code: 'DEN', nameEn: 'DENIED', nameFr: '(FR) DENIED' }));
-    expect(data.letterTypes.includes({ code: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' }));
+    expect(data.letterTypes.includes({ id: 'DEN', nameEn: 'DENIED', nameFr: '(FR) DENIED' }));
+    expect(data.letterTypes.includes({ id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' }));
   });
 });

--- a/frontend/__tests__/services/interop-service.server.test.ts
+++ b/frontend/__tests__/services/interop-service.server.test.ts
@@ -1,73 +1,105 @@
-import { HttpResponse, http } from 'msw';
-import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getLetterEntities } from '~/mocks/cct-api.server';
-import { getAllLetterTypes } from '~/mocks/power-platform-api.server';
 import { getInteropService } from '~/services/interop-service.server';
-import type { ParsedLetterInfo } from '~/services/interop-service.server';
+
+global.fetch = vi.fn();
 
 vi.mock('~/utils/logging.server', () => ({
   getLogger: vi.fn().mockReturnValue({
     info: vi.fn(),
+    error: vi.fn(),
   }),
 }));
 
-vi.mock('~/utils/env.server.ts', () => ({
+vi.mock('~/utils/env.server', () => ({
   getEnv: vi.fn().mockReturnValue({
     INTEROP_API_BASE_URI: 'https://api.example.com',
     CCT_API_BASE_URI: 'https://api.example.com',
     CCT_VAULT_COMMUNITY: 'SecurityReview',
+    ENGLISH_LETTER_LANGUAGE_CODE: 1033,
+    FRENCH_LETTER_LANGUAGE_CODE: 1036,
   }),
 }));
 
-const handlers = [
-  http.get('https://api.example.com/cctws/OnDemand/api/GetDocInfoByClientId', ({ request }) => {
-    const url = new URL(request.url);
-    const userId = url.searchParams.get('userid') as string;
-    const letterEntities = getLetterEntities(userId);
-    return HttpResponse.json(letterEntities.map((letter) => ({ LetterRecordId: letter.id, LetterDate: letter.issuedOn, LetterId: letter.referenceId, LetterName: letter.letterType?.code })));
-  }),
-  http.get('https://api.example.com/letter-types', () => {
-    const letterEntities = getAllLetterTypes();
-    return HttpResponse.json(letterEntities);
-  }),
-];
-
-const server = setupServer(...handlers);
-
-const interopService = getInteropService();
-
-describe('interop-service.server.ts', () => {
-  beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
-  afterAll(() => {
-    server.close();
-  });
+describe('interop-service.server tests', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
   });
 
-  it('it should return letters associated with a valid user', async () => {
-    const letters = await interopService.getLetterInfoByClientId('00000000-0000-0000-0000-000000000000', 'clientId');
-    expect(letters.length).toBeGreaterThan(0);
+  describe('getLetterInfoByClientId()', () => {
+    it('should return all letters found for a user', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        HttpResponse.json([
+          {
+            LetterRecordId: 'some-record-id',
+            LetterDate: 'some-date',
+            LetterId: 'some-id',
+            LetterName: 'some-name',
+          },
+        ]),
+      );
+
+      const interopService = getInteropService();
+      const letters = await interopService.getLetterInfoByClientId('userId', 'clientId');
+      expect(letters).toEqual([
+        {
+          id: 'some-record-id',
+          issuedOn: 'some-date',
+          name: 'some-name',
+          referenceId: 'some-id',
+        },
+      ]);
+    });
+
+    it('should throw error if response is not ok', async () => {
+      vi.mocked(fetch).mockResolvedValue(new HttpResponse(null, { status: 500 }));
+
+      const interopService = getInteropService();
+      await expect(() => interopService.getLetterInfoByClientId('userId', 'clientId')).rejects.toThrowError();
+    });
   });
 
-  it('it should return letters that match the corresponding type', async () => {
-    const letters = await interopService.getLetterInfoByClientId('00000000-0000-0000-0000-000000000000', 'clientId');
-    expectTypeOf(letters).toMatchTypeOf<ParsedLetterInfo>();
-  });
+  describe('getAllLetterTypes()', () => {
+    it('should return all the letter types', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        HttpResponse.json({
+          value: [
+            {
+              OptionSet: {
+                Options: [
+                  {
+                    Value: 775170000,
+                    Label: {
+                      LocalizedLabels: [
+                        {
+                          Label: 'Invitation to Apply Letter',
+                          LanguageCode: 1033,
+                        },
+                        {
+                          Label: "Lettre d'invitation",
+                          LanguageCode: 1036,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
 
-  it('it should not return letters associated with an invalid user', async () => {
-    const letters = await interopService.getLetterInfoByClientId('00000000-0000-0000-0000-000000000001', 'clientId');
-    expect(letters.length).toBe(0);
-  });
-
-  it('it should throw and error when given an invalid user', () => {
-    expect(async () => await interopService.getLetterInfoByClientId('invalidUserId', 'clientId')).rejects.toThrowError();
-  });
-
-  it('it should return all the letter types', async () => {
-    const letterTypes = await interopService.getAllLetterTypes();
-    expect(letterTypes.length).toBeGreaterThan(0);
+      const interopService = getInteropService();
+      const letterTypes = await interopService.getAllLetterTypes();
+      expect(letterTypes).toEqual([
+        {
+          id: '775170000',
+          nameEn: 'Invitation to Apply Letter',
+          nameFr: "Lettre d'invitation",
+        },
+      ]);
+    });
   });
 });

--- a/frontend/app/mocks/cct-api.server.ts
+++ b/frontend/app/mocks/cct-api.server.ts
@@ -85,7 +85,7 @@ export function getCCTApiMockHandlers() {
           LetterRecordId: letter.id,
           LetterDate: letter.issuedOn,
           LetterId: letter.referenceId,
-          LetterName: letter.letterType?.code,
+          LetterName: letter.letterType,
         })),
       );
     }),

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -1,5 +1,7 @@
 import { fakerEN_CA as faker } from '@faker-js/faker';
-import { factory, oneOf, primaryKey } from '@mswjs/data';
+import { factory, primaryKey } from '@mswjs/data';
+
+import letterTypesJson from './power-platform-data/letter-types.json';
 
 // (Optional) Seed `faker` to ensure reproducible
 // random values of model properties.
@@ -82,16 +84,10 @@ const db = factory({
     nameEn: String,
     nameFr: String,
   },
-  letterType: {
-    id: primaryKey(faker.string.uuid),
-    code: String,
-    nameEn: String,
-    nameFr: String,
-  },
   letter: {
     id: primaryKey(faker.string.uuid),
     issuedOn: () => faker.date.past({ years: 1 }).toISOString().split('T')[0],
-    letterType: oneOf('letterType'),
+    letterType: String,
     referenceId: String,
     userId: String,
   },
@@ -226,21 +222,6 @@ const defaultUser = db.user.create({
   preferredLanguage: frenchLanguage.id,
 });
 
-// seed letter type list
-const seededLetterTypes = [
-  db.letterType.create({
-    code: 'ACC',
-    nameEn: 'Accepted',
-    nameFr: '(FR) Accepted',
-  }),
-
-  db.letterType.create({
-    code: 'DEN',
-    nameEn: 'Denied',
-    nameFr: '(FR) Denied',
-  }),
-];
-
 // seed available letters
 const numberOfLetters = faker.number.int({ min: 10, max: 20 }); // Adjust min and max as needed
 for (let i = 0; i < numberOfLetters; i++) {
@@ -249,7 +230,7 @@ for (let i = 0; i < numberOfLetters; i++) {
 
   db.letter.create({
     userId: defaultUser.id,
-    letterType: faker.helpers.arrayElement(seededLetterTypes),
+    letterType: faker.helpers.arrayElement(letterTypesJson.value[0].OptionSet.Options).Value.toString(),
     referenceId: seededPDF.referenceId,
   });
 }

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -3,21 +3,11 @@ import type { Operation } from 'fast-json-patch';
 import { HttpResponse, http } from 'msw';
 import { z } from 'zod';
 
+import letterTypesJson from './power-platform-data/letter-types.json';
 import { db } from '~/mocks/db';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('power-platform-api.server');
-
-const letterTypeCodeSchema = z.object({
-  code: z.string(),
-  nameFr: z.string(),
-  nameEn: z.string(),
-  id: z.string().optional(),
-});
-
-const listOfLetterTypeCodeSchema = z.array(letterTypeCodeSchema);
-
-export type LetterTypeCodeList = z.infer<typeof listOfLetterTypeCodeSchema>;
 
 /**
  * Server-side MSW mocks for the Power Platform API.
@@ -87,30 +77,12 @@ export function getPowerPlatformApiMockHandlers() {
     }),
 
     /**
-     * Handler for GET requests to retrieve letters details.
+     * Handler for GET requests to retrieve letters types.
      */
     http.get('https://api.example.com/letter-types', () => {
-      return HttpResponse.json(
-        getAllLetterTypes().map((letterType) => {
-          return {
-            nameEn: letterType.nameEn,
-            nameFr: letterType.nameFr,
-            code: letterType.code,
-            id: letterType.id,
-          };
-        }),
-      );
+      return HttpResponse.json(letterTypesJson);
     }),
   ];
-}
-
-/**
- * Retrieves list of letter types.
- *
- * @returns All the letter types found.
- */
-export function getAllLetterTypes() {
-  return db.letterType.getAll();
 }
 
 /**

--- a/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
@@ -55,7 +55,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const sortOrder = orderEnumSchema.catch('desc').parse(sortParam);
   const userId = await userService.getUserId();
   const letters = await interopService.getLetterInfoByClientId(userId, 'clientId', sortOrder); // TODO where and what is clientId?
-  const letterTypes = (await interopService.getAllLetterTypes()).filter(({ code }) => letters.some(({ name }) => name === code));
+  const letterTypes = (await interopService.getAllLetterTypes()).filter(({ id }) => letters.some(({ name }) => name === id));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('letters:index.page-title') }) };
@@ -98,8 +98,10 @@ export default function LettersIndex() {
       </div>
       <ul className="divide-y border-y">
         {letters.map((letter) => {
-          const letterType = letterTypes.find(({ code }) => code === letter.name);
-          const letterName = letterType ? getNameByLanguage(i18n.language, letterType) : letter.name;
+          const letterType = letterTypes.find(({ id }) => id === letter.name);
+          const translatedLetterName = letterType ? getNameByLanguage(i18n.language, letterType) : letter.name;
+          const letterName = translatedLetterName ?? letter.name;
+
           return (
             <li key={letter.id} className="py-4 sm:py-6">
               <InlineLink reloadDocument to={`/letters/${letter.referenceId}/download`} className="font-lato font-semibold">

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -49,6 +49,10 @@ const serverEnv = z.object({
   OTHER_EQUITY_TYPE_ID: z.string().trim().min(1).default('equity-other'),
   OTHER_GENDER_TYPE_ID: z.string().trim().min(1).default('gender-other'),
   USA_COUNTRY_ID: z.string().trim().min(1),
+
+  // language codes for letter types
+  ENGLISH_LETTER_LANGUAGE_CODE: z.coerce.number().default(1033),
+  FRENCH_LETTER_LANGUAGE_CODE: z.coerce.number().default(1036),
   
   // TODO :: GjB :: these base URIs should not have defaults
   INTEROP_API_BASE_URI: z.string().url().default('https://api.example.com'),


### PR DESCRIPTION
### Description
- Updating `interop-service.server` to map the sample JSON to our own domain entity
- Removing letter types from Mock DB in favour of using Mock (Power Platform) API to return `letter-types.json` (introduced in https://github.com/DTS-STN/canadian-dental-care-plan/pull/691)
- Removed the use of `handlers` in unit test and mocking the response instead
- Removing unnecessary schemas and types

### Related Azure Boards Work Items
[AB#3026](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3026)

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/9e566097-10bb-4a0b-83f4-bcfa71c53648)

**After:**
English:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/71579906-1532-4df3-b8b9-7cc59f1e9dbf)

French:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/dafc9928-a6a7-4576-a3f4-34d4101a00af)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/en/letters` or `/fr/letters`. Verify that the name of the letter matches the letter types from `/power-platform-data/letter-types.json`