### PR TITLE
AB#3032 -- add metrics to letter download

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
         "remix-toast": "^1.2.0",
         "source-map-support": "^0.5.21",
         "tailwind-merge": "^2.2.2",
+        "tiny-invariant": "^1.3.3",
         "undici": "^6.9.0",
         "validator": "^13.11.0",
         "web-streams-node": "^0.4.0",
@@ -14884,6 +14885,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/tinybench": {
       "version": "2.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "remix-toast": "^1.2.0",
     "source-map-support": "^0.5.21",
     "tailwind-merge": "^2.2.2",
+    "tiny-invariant": "^1.3.3",
     "undici": "^6.9.0",
     "validator": "^13.11.0",
     "web-streams-node": "^0.4.0",


### PR DESCRIPTION
### Description

Add metrics to letter download route. Introduces a new instrumentation helper function that will be used in future PRs related to metrics.

### Related Azure Boards Work Items

- [AB#3032](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3032)

### Screenshots (if applicable)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/b73c5501-1b6a-4db8-9edc-aa9cf529d743)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
