### PR TITLE
[gitops] Adding Interop API url configurations

### DIFF
--- a/gitops/overlays/dev/configs/frontend-config.conf
+++ b/gitops/overlays/dev/configs/frontend-config.conf
@@ -11,7 +11,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Global mock configuration
 #
-ENABLED_MOCKS=cct,lookup,power-platform,raoidc,wsaddress
+ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress
 
 #
 # Session/redis configuration
@@ -38,6 +38,11 @@ MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-dev.dev-dp.dts-stn.com/auth/callback/ra
 #
 HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
 HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
+
+#
+# Interop API configuration
+#
+INTEROP_API_BASE_URI=https://api.example.com
 
 #
 # Lookup identifiers configuration

--- a/gitops/overlays/int/configs/frontend-config.conf
+++ b/gitops/overlays/int/configs/frontend-config.conf
@@ -34,6 +34,11 @@ HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
 HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
 
 #
+# Interop API configuration
+#
+INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
+
+#
 # Lookup identifiers configuration
 #
 CANADA_COUNTRY_ID=0cf5389e-97ae-eb11-8236-000d3af4bfc3

--- a/gitops/overlays/staging/configs/frontend-config.conf
+++ b/gitops/overlays/staging/configs/frontend-config.conf
@@ -11,7 +11,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Global mock configuration
 #
-ENABLED_MOCKS=cct,lookup,power-platform,wsaddress
+ENABLED_MOCKS=cct,lookup,power-platform,status-check,wsaddress
 
 #
 # Session/redis configuration
@@ -32,6 +32,11 @@ AUTH_RASCL_LOGOUT_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/
 #
 HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
 HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
+
+#
+# Interop API configuration
+#
+INTEROP_API_BASE_URI=https://api.example.com
 
 #
 # Lookup identifiers configuration


### PR DESCRIPTION
### Description
This PR depends on the changes from https://github.com/DTS-STN/canadian-dental-care-plan/pull/727

DEV and SYS will continue to mock the `status-check` because changing the `INTEROP_API_BASE_URI` to anything other than `https://api.example.com` will break those Lookup API calls.

INT will be used to test the Interop API call.