### PR TITLE
mailing-address/edit and home-address/edit trim validation fix

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -77,20 +77,11 @@ export async function action({ request }: ActionFunctionArgs) {
   await raoidcService.handleSessionValidation(request);
 
   const formDataSchema = z.object({
-    address: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
-    city: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
+    address: z.string().trim().min(1, { message: 'empty-field' }),
+    city: z.string().trim().min(1, { message: 'empty-field' }),
     province: z.string().trim().optional(),
     postalCode: z.string().trim().optional(),
-    country: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
+    country: z.string().trim().min(1, { message: 'empty-field' }),
   });
 
   const formData = Object.fromEntries(await request.formData());

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -72,20 +72,11 @@ export async function action({ request }: ActionFunctionArgs) {
     copyHomeAddress: z.string().transform((value) => value === 'on'),
   });
   const addressFormSchema = z.object({
-    address: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
-    city: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
+    address: z.string().trim().min(1, { message: 'empty-field' }),
+    city: z.string().trim().min(1, { message: 'empty-field' }),
     province: z.string().trim().optional(),
     postalCode: z.string().trim().optional(),
-    country: z
-      .string()
-      .min(1, { message: 'empty-field' })
-      .transform((val) => val.trim()),
+    country: z.string().trim().min(1, { message: 'empty-field' }),
   });
   const formDataSchema = z.union([copyHomeAddressSchema, addressFormSchema]);
 


### PR DESCRIPTION
### Description
Quick fix to not allow whitespace strings in the mailing-address/edit and home-address/edit routes.

### Related Azure Boards Work Items
[AB#3106](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3106)
[AB#3107](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3107)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to persoanl-information/mailing-address/edit and personal-information/home-adress/edit

Test the validation on the address, city and country  (Try only whitespaces)
