### PR TITLE
Fix summary marker style

### DIFF
--- a/frontend/__tests__/components/collapsible.test.tsx
+++ b/frontend/__tests__/components/collapsible.test.tsx
@@ -19,7 +19,7 @@ describe('Collapsible Details', () => {
     expect(collapsibleDetailsElement.id).toBe(additionalProps.id + '-content');
 
     const collapsibleDetailsSummaryElement = getByText(additionalProps.summary);
-    expect(collapsibleDetailsSummaryElement.tagName).toBe('SPAN');
+    expect(collapsibleDetailsSummaryElement.tagName).toBe('DIV');
     expect(collapsibleDetailsSummaryElement.parentElement?.tagName).toBe('SUMMARY');
     expect(collapsibleDetailsSummaryElement.parentElement?.id).toBe(additionalProps.id + '-summary');
   });

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -7,8 +7,8 @@ export interface CollapsibleSummaryProps extends ComponentProps<'summary'> {}
 
 export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
   return (
-    <summary className={cn('cursor-pointer text-blue-900 underline', className)} {...props}>
-      <span className="ml-4">{children}</span>
+    <summary className={cn('cursor-pointer marker:text-blue-900', className)} {...props}>
+      <div className="ml-4 inline-block text-blue-900 underline">{children}</div>
     </summary>
   );
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix summary marker style for Firefox. The details summary marker was underlined and shouldn't.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3118](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3118)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Before
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/6e1f9a39-9c94-4ef9-8d75-f2e11710d453)

After
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/8f027589-b4d6-4ce0-b661-4c484268313f)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->