### PR TITLE
Refactor apply type-of-application error handling

### DIFF
--- a/frontend/__tests__/routes/_public+/type-of-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-of-application.test.tsx
@@ -47,7 +47,7 @@ describe('_public.apply.id.type-of-application', () => {
       expect(data).toEqual({
         id: '123',
         meta: { title: 'gcweb:meta.title.template' },
-        state: 'delegate',
+        defaultState: 'delegate',
       });
     });
   });
@@ -62,7 +62,7 @@ describe('_public.apply.id.type-of-application', () => {
 
       const data = await response.json();
       expect(response.status).toBe(200);
-      expect(data.errors._errors).toContain('apply:eligibility.type-of-application.error-message.type-of-application-required');
+      expect(data.errors).toContain('apply:eligibility.type-of-application.error-message.type-of-application-required');
     });
 
     it('should redirect to error page if delegate is selected', async () => {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title. I stopped returning the action FormData on validation error since this functionnality would only be useful if the user disable Javascript (like @gregory-j-baker #weirdo). We've decided that Javascript is required to run our application then no need to clutter it.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Go to `/apply/$id/type-of-application` page and trigger the validation error. Test it by navigating with your keyboard to ensure the proper navigation behavior like on errors the ErrorSummary should be displayed and become focused. If it's already there and you trigger another error then it should become focus again.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->