### PR TITLE
AB#3097 move comms preference schema to route

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -3,6 +3,7 @@ import { Params } from '@remix-run/react';
 import { z } from 'zod';
 
 import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/applicant-information';
+import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/communication-preference';
 import { DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/date-of-birth';
 import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/dental-insurance';
 import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits';
@@ -25,22 +26,9 @@ const taxFilingSchema = z.object({
 });
 
 /**
- * Schema for communication reference.
- */
-const communicationPreferencesStateSchema = z.object({
-  preferredLanguage: z.string().min(1),
-  preferredMethod: z.string().min(1),
-  email: z.string().min(1).optional(),
-  confirmEmail: z.string().min(1).optional(),
-  emailForFuture: z.string().optional(),
-  confirmEmailForFuture: z.string().optional(),
-});
-
-/**
  * Schema for apply state.
  */
 const applyStateSchema = z.object({
-  communicationPreferences: communicationPreferencesStateSchema.optional(),
   taxFiling2023: taxFilingSchema.optional(),
 });
 
@@ -52,6 +40,7 @@ interface ApplyState extends z.infer<typeof applyStateSchema> {
   personalInformation?: PersonalInformationState;
   dentalBenefits?: DentalBenefitsState;
   applicantInformation?: ApplicantInformationState;
+  communicationPreferences?: CommunicationPreferencesState;
 }
 
 /**


### PR DESCRIPTION
### Description
Move the communication preference schema to it's respective route.

### Related Azure Boards Work Items
[AB#3097](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3097)

### Additional Notes
- because of the appended children when a radio button is selected and subsequent validation of those inputs, I had to move some of the validation into `.superRefine`.  I don't know if there's a better (more readable/maintainable) way to do the validation without using conditional logic inside of superRefine