### PR TITLE
AB#3004 -- Creating mock for Dental Application API

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -134,7 +134,7 @@ REDIS_PASSWORD=password
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress
+ENABLED_MOCKS=cct,dental-application,lookup,power-platform,raoidc,status-check,wsaddress
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/mocks/dental-application-api.server.ts
+++ b/frontend/app/mocks/dental-application-api.server.ts
@@ -1,0 +1,128 @@
+import { HttpResponse, http } from 'msw';
+// import { setTimeout } from 'timers/promises'; // uncomment to simulate the length of the full API call
+import { z } from 'zod';
+
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('dental-application-api.server');
+
+/**
+ * Server-side MSW mocks for the Dental Application API
+ */
+export function getDentalApplicationApiMockHandlers() {
+  log.info('Initializing Dental Application mock handlers');
+
+  return [
+    http.post('https://api.example.com/SubmitDentalApplication', async ({ request }) => {
+      log.debug('Handling request for [%s]', request.url);
+
+      const dentalApplicationSchema = z.object({
+        esdc_captcha: z
+          .object({
+            sitekey: z.string(),
+            response: z.string(),
+          })
+          .optional(),
+        esdc_applicationinfo: z.object({
+          Application: z.object({
+            'esdc_ApplicationYearid@odata.bind': z.string().optional(),
+            esdc_recordsource: z.string().optional(),
+          }),
+          Applicant: z.object({
+            Record: z.object({
+              esdc_socialinsurancenumber: z.string(),
+              esdc_firstname: z.string(),
+              esdc_lastname: z.string(),
+              esdc_maritalstatus: z.number(),
+              esdc_dateofbirth: z.string().datetime(),
+
+              esdc_preferredmethodofcommunication: z.number(),
+              esdc_preferredlanguage: z.number(),
+
+              emailaddress: z.string().optional(),
+              esdc_phonenumber: z.string().optional(),
+              esdc_phonenumber2: z.string().optional(),
+
+              esdc_homeaddressapartmentunitnumber: z.string().optional(),
+              esdc_homeaddressstreet: z.string(),
+              esdc_homeaddresscity: z.string(),
+              'esdc_HomeAddressProvinceTerritoryStateid@odata.bind': z.string().optional(),
+              'esdc_HomeAddressCountryid@odata.bind': z.string(),
+              esdc_homeaddresspostalzipcode: z.string().optional(),
+
+              esdc_mailingaddresssameashomeaddress: z.number(),
+
+              esdc_mailingaddressapartmentunitnumber: z.string().optional(),
+              esdc_mailingaddressstreet: z.string(),
+              esdc_mailingaddresscity: z.string(),
+              'esdc_MailingAddressProvinceTerritoryStateid@odata.bind': z.string().optional(),
+              'esdc_MailingAddressCountryid@odata.bind': z.string(),
+              esdc_mailingaddresspostalzipcode: z.string().optional(),
+
+              esdc_hasdentalinsurancecoverageemployerprivate: z.number(),
+              esdc_hasdentalinsurancecoverageprovincialfederal: z.number(),
+            }),
+            esdc_governmentinsuranceplans: z
+              .array(
+                z.object({
+                  id: z.string(),
+                }),
+              )
+              .optional(),
+          }),
+          Spouse: z
+            .object({
+              Record: z.object({
+                esdc_socialinsurancenumber: z.string(),
+                esdc_firstname: z.string(),
+                esdc_lastname: z.string(),
+                esdc_dateofbirth: z.string(),
+              }),
+            })
+            .optional(),
+          Dependants: z
+            .array(
+              z.object({
+                Record: z.object({
+                  esdc_socialinsurancenumber: z.string(),
+                  esdc_firstname: z.string(),
+                  esdc_lastname: z.string(),
+                  esdc_dateofbirth: z.string(),
+                }),
+              }),
+            )
+            .optional(),
+          Demographics: z
+            .object({
+              esdc_wherewereyouborn: z.number().optional(),
+              esdc_areyoufirstnations: z.number().optional(),
+              esdc_ethnicity: z.number().optional(),
+              esdc_ethnicityother: z.string().optional(),
+              esdc_identifiesaspersonwithdisability: z.number().optional(),
+              esdc_gender: z.number().optional(),
+              esdc_sexatbirth: z.number().optional(),
+              esdc_mouthpainoccurancepast12months: z.number().optional(),
+              esdc_lasttimevisiteddentist: z.number().optional(),
+              esdc_avoidedvisitingdentistlast12months: z.number().optional(),
+            })
+            .optional(),
+        }),
+      });
+
+      // await setTimeout(5000); // uncomment to simulate the potential (5s) length of the full API call
+
+      const dentalApplicationRequest = dentalApplicationSchema.safeParse(await request.json());
+      if (!dentalApplicationRequest.success) {
+        return new HttpResponse(null, { status: 400 });
+      }
+
+      return HttpResponse.json({
+        esdc_processed: true,
+        esdc_confirmationnumber: '123-123-123',
+        esdc_errors: [],
+        esdc_createdrecords: [],
+        esdc_updatedrecords: [],
+      });
+    }),
+  ];
+}

--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 
+import { getDentalApplicationApiMockHandlers } from './dental-application-api.server';
 import { getCCTApiMockHandlers } from '~/mocks/cct-api.server';
 import { getLookupApiMockHandlers } from '~/mocks/lookup-api.server';
 import { getPowerPlatformApiMockHandlers } from '~/mocks/power-platform-api.server';
@@ -10,6 +11,7 @@ import { mockEnabled } from '~/utils/env.server';
 
 export const server = setupServer(
   ...(mockEnabled('cct') ? getCCTApiMockHandlers() : []),
+  ...(mockEnabled('dental-application') ? getDentalApplicationApiMockHandlers() : []),
   ...(mockEnabled('lookup') ? getLookupApiMockHandlers() : []),
   ...(mockEnabled('power-platform') ? getPowerPlatformApiMockHandlers() : []),
   ...(mockEnabled('raoidc') ? getRaoidcMockHandlers() : []),

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -16,7 +16,7 @@ function tryOrElseFalse(fn: () => unknown) {
   catch { return false; }
 }
 
-const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
+const validMockNames = ['cct', 'dental-application', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 const validFeatureNames = ['doc-upload', 'email-alerts', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       AUTH_RAOIDC_CLIENT_ID: 'CDCP',
       AUTH_RASCL_LOGOUT_URL: 'http://localhost:3000/',
       CANADA_COUNTRY_ID: '0cf5389e-97ae-eb11-8236-000d3af4bfc3',
-      ENABLED_MOCKS: 'cct,lookup,power-platform,raoidc,status-check,wsaddress',
+      ENABLED_MOCKS: 'cct,dental-application,lookup,power-platform,raoidc,status-check,wsaddress',
       HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000',
       HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',
       HCAPTCHA_VERIFY_URL: 'https://api.hcaptcha.com/siteverify',


### PR DESCRIPTION
### Description
Used the current `/SubmitDentalApplication` schema developed by Power Platform to create a mock for submitting a dental application.

### Related Azure Boards Work Items
[AB#3004](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/3004)
