### PR TITLE
Fix margins on error pages

### DIFF
--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -144,7 +144,7 @@ export function NotFoundError({ error }: NotFoundErrorProps) {
     <>
       <PageHeader />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        <PageTitle>
+        <PageTitle className="my-8">
           <span>{t('gcweb:not-found.page-title')}</span>
           <small className="block text-2xl font-normal text-neutral-500">{t('gcweb:not-found.page-subtitle')}</small>
         </PageTitle>
@@ -172,7 +172,7 @@ export function ServerError({ error }: ServerErrorProps) {
     <>
       <PageHeader />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        <PageTitle>
+        <PageTitle className="my-8">
           <span>{t('gcweb:server-error.page-title')}</span>
           <small className="block text-2xl font-normal text-neutral-500">{t('gcweb:server-error.page-subtitle')}</small>
         </PageTitle>


### PR DESCRIPTION
### Description

Fix margins on `<PageTitle>` for error pages.

### Screenshots

Before:
![Screenshot from 2024-03-21 10-14-09](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/a927342c-95f1-4160-90c8-c60c1267e5e0)

After:
![Screenshot from 2024-03-21 10-14-54](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/45b0412c-49d2-4451-b8ca-1edaaf548f62)
