### PR TITLE
Remove unnecessary `await` from `getLocale()` calls

### DIFF
--- a/frontend/__tests__/routes/_protected+/personal-information+/home-address+/confirm.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/home-address+/confirm.test.tsx
@@ -75,7 +75,7 @@ vi.mock('~/services/user-service.server', () => ({
 
 vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
-  getLocale: vi.fn().mockResolvedValue('en'),
+  getLocale: vi.fn().mockReturnValue('en'),
 }));
 
 describe('_gcweb-app.personal-information.home-address.confirm', () => {

--- a/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/confirm.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/confirm.test.tsx
@@ -43,7 +43,7 @@ vi.mock('~/services/user-service.server', () => ({
 
 vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
-  getLocale: vi.fn().mockResolvedValue('en'),
+  getLocale: vi.fn().mockReturnValue('en'),
   redirectWithLocale: vi.fn().mockResolvedValue(new Response('/', { status: 302 })),
 }));
 

--- a/frontend/__tests__/utils/locale-utils.server.test.ts
+++ b/frontend/__tests__/utils/locale-utils.server.test.ts
@@ -20,12 +20,12 @@ describe('locale-utils.server', () => {
 
   describe('getLocale()', () => {
     it('should return the locale from the URL if it exists', async () => {
-      expect(await getLocale(new Request('http://localhost:3000/en/home'))).toEqual('en');
-      expect(await getLocale(new Request('http://localhost:3000/fr/home'))).toEqual('fr');
+      expect(getLocale(new Request('http://localhost:3000/en/home'))).toEqual('en');
+      expect(getLocale(new Request('http://localhost:3000/fr/home'))).toEqual('fr');
     });
 
     it('should return the default locale if there is no locale in the URL', async () => {
-      expect(await getLocale(new Request('http://localhost:3000/'))).toEqual('en');
+      expect(getLocale(new Request('http://localhost:3000/'))).toEqual('en');
     });
   });
 

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -73,7 +73,7 @@ export default async function handleRequest(request: Request, responseStatusCode
   log.debug(`Handling [${request.method}] request to [${request.url}] with handler function [${handlerFnName}]`);
   instrumentationService.createCounter('http.server.requests').add(1);
 
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
   const routes = Object.values(remixContext.routeModules);
   const i18n = await initI18n(locale, getNamespaces(routes));
   const nonce = randomHexString(32);

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -52,7 +52,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const buildInfoService = getBuildInfoService();
   const { toast, headers: toastHeaders } = await getToast(request);
   const requestUrl = new URL(request.url);
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
   const t = await getFixedT(request, ['gcweb']);
 
   const buildInfo = buildInfoService.getBuildInfo();

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/confirm.tsx
@@ -83,7 +83,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('update-data.home-address', { userId: idToken.sub });
 
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   instrumentationService.countHttpStatus('home-address.confirm', 302);
   // TODO remove new home address from session and handle case when it is missing

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/confirm.tsx
@@ -72,7 +72,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('update-data.mailing-address', { userId: idToken.sub });
 
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   // TODO remove new mailing address from session and handle case when it is missing
   return redirectWithSuccess(`/${locale}/personal-information`, 'personal-information:mailing-address.confirm.updated-notification');

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/phone-number+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/phone-number+/confirm.tsx
@@ -100,7 +100,7 @@ export async function action({ request }: ActionFunctionArgs) {
   getAuditService().audit('update-data.phone-number', { userId: idToken.sub });
 
   session.unset('newPhoneNumber');
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   instrumentationService.countHttpStatus('phone-number.confirm', 302);
   return redirectWithSuccess(`/${locale}/personal-information`, 'personal-information:phone-number.confirm.updated-notification', {

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/confirm.tsx
@@ -96,7 +96,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   await userService.updateUserInfo(userId, { preferredLanguage: session.get('newPreferredLanguage') });
   session.unset('newPreferredLanguage');
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   instrumentationService.countHttpStatus('preferred-language.confirm', 302);
   return redirectWithSuccess(`/${locale}/personal-information`, 'personal-information:preferred-language.confirm.updated-notification', {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
@@ -13,7 +13,7 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
   return json({ locale });
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -37,7 +37,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
   const { id, state } = await applyFlow.loadState({ request, params });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   // prettier-ignore
   if (!state.applicantInformation ||

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -54,7 +54,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   // Getting province by Id
   const allRegions = await getLookupService().getAllRegions();
@@ -141,7 +141,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   // TODO if the state is cleared here, the confirmation page can't access the state to display information
   // const sessionResponseInit = await applyFlow.clearState({ request, params });
 
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   const sessionResponseInit = await applyFlow.saveState({
     request,

--- a/frontend/app/routes/auth+/$.tsx
+++ b/frontend/app/routes/auth+/$.tsx
@@ -88,7 +88,7 @@ async function handleLogoutRequest({ request }: LoaderFunctionArgs) {
   }
 
   const idToken: IdToken = session.get('idToken');
-  const locale = await getLocale(request);
+  const locale = getLocale(request);
 
   const raoidcService = await getRaoidcService();
   const signoutUrl = raoidcService.generateSignoutRequest(idToken.sid, locale);

--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -16,7 +16,7 @@ const log = getLogger('locale-utils.server');
  * @see https://www.i18next.com/overview/api#getfixedt
  */
 export async function getFixedT<N extends Namespace>(localeOrRequest: 'en' | 'fr' | Request, namespaces: N) {
-  const locale = typeof localeOrRequest === 'string' ? localeOrRequest : await getLocale(localeOrRequest);
+  const locale = typeof localeOrRequest === 'string' ? localeOrRequest : getLocale(localeOrRequest);
   const i18n = await initI18n(locale, namespaces);
   return i18n.getFixedT(locale, namespaces);
 }


### PR DESCRIPTION
### Description

Since the locale cookie has been removed, `getLocale()` no longer returns a promise. This PR removes all of the dangling awaits that used to be required, but now aren't.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
