### PR TITLE
AB#3138 Remove partner information from state if Marital Status is not common in law and married

### DIFF
--- a/frontend/app/routes-flow/apply-flow.ts
+++ b/frontend/app/routes-flow/apply-flow.ts
@@ -75,6 +75,7 @@ interface SaveStateArgs {
   params: Params;
   request: Request;
   state: ApplyState;
+  remove?: keyof ApplyState;
 }
 
 /**
@@ -82,9 +83,13 @@ interface SaveStateArgs {
  * @param args - The arguments.
  * @returns The Set-Cookie header to be used in the HTTP response.
  */
-async function saveState({ params, request, state }: SaveStateArgs) {
+async function saveState({ params, request, state, remove = undefined }: SaveStateArgs) {
   const { id, state: currentState } = await loadState({ params, request });
   const newState = { ...currentState, ...state };
+
+  if (remove && remove in newState) {
+    delete newState[remove];
+  }
 
   const sessionService = await getSessionService();
   const session = await sessionService.getSession(request);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -82,7 +82,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format() });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { applicantInformation: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { applicantInformation: parsedDataResult.data }, remove: !['MARRIED', 'COMMONLAW'].includes(parsedDataResult.data.maritalStatus) ? 'partnerInformation' : undefined });
 
   if (['MARRIED', 'COMMONLAW'].includes(parsedDataResult.data.maritalStatus)) {
     return redirectWithLocale(request, `/apply/${id}/partner-information`, sessionResponseInit);


### PR DESCRIPTION
### Description
Remove `partnerInformation` from state if and only if `applicantInformation` declares that their marital status is not married or common law. 

Before anybody asks, why not put the logic to remove parts of the state in the route action?  I did actually attempt that, but for whatever reason, the old state was being persisted even after a few attempts at saving the state with `partnerInformation` cleared.  Not sure if that's by design, so I went with a different approach here.

### Related Azure Boards Work Items
[AB#3138](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3138)
