### PR TITLE
Remove toast from public application

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -8,7 +8,6 @@ import { faSpinner, faX } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { parse } from 'date-fns';
 import { useTranslation } from 'react-i18next';
-import { redirectWithSuccess } from 'remix-toast';
 
 import pageIds from '../../../page-ids.json';
 import { Address } from '~/components/address';
@@ -19,7 +18,7 @@ import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { getLookupService } from '~/services/lookup-service.server';
 import { toLocaleDateString } from '~/utils/date-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale, redirectWithLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -141,15 +140,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
   // TODO if the state is cleared here, the confirmation page can't access the state to display information
   // const sessionResponseInit = await applyFlow.clearState({ request, params });
 
-  const locale = getLocale(request);
-
   const sessionResponseInit = await applyFlow.saveState({
     request,
     params,
     state,
   });
 
-  return redirectWithSuccess(`/${locale}/apply/${id}/confirmation`, 'Form Submitted!', sessionResponseInit);
+  return redirectWithLocale(request, `/apply/${id}/confirmation`, sessionResponseInit);
 }
 
 export default function ReviewInformation() {


### PR DESCRIPTION
### Description

Since we have a confirmation page in the public flow, there is no reason to fire a toast message anymore.

### Related Azure Boards Work Items

- [AB#3083](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3083)

### Screenshots

The area where the toast would be:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/49b49b54-649f-45c0-9883-d4164ed5a8d6)

### Checklist

- [x] I have tested the changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Submit the online application and verify the toast message no longer fires.
