### PR TITLE
AB#3017 -- Removing `CCT_API_BASE_URI` references from letters service

### DIFF
--- a/frontend/__tests__/services/letters-service.server.test.ts
+++ b/frontend/__tests__/services/letters-service.server.test.ts
@@ -15,7 +15,6 @@ vi.mock('~/utils/logging.server', () => ({
 vi.mock('~/utils/env.server', () => ({
   getEnv: vi.fn().mockReturnValue({
     INTEROP_API_BASE_URI: 'https://api.example.com',
-    CCT_API_BASE_URI: 'https://api.example.com',
     CCT_VAULT_COMMUNITY: 'SecurityReview',
     ENGLISH_LETTER_LANGUAGE_CODE: 1033,
     FRENCH_LETTER_LANGUAGE_CODE: 1036,

--- a/frontend/app/services/letters-service.server.ts
+++ b/frontend/app/services/letters-service.server.ts
@@ -13,7 +13,7 @@ const log = getLogger('letters-service.server');
 export const getLettersService = moize(createLettersService, { onCacheAdd: () => log.info('Creating new letters service') });
 
 function createLettersService() {
-  const { CCT_API_BASE_URI, CCT_VAULT_COMMUNITY, GET_ALL_LETTER_TYPES_CACHE_TTL_SECONDS, INTEROP_API_BASE_URI } = getEnv();
+  const { CCT_VAULT_COMMUNITY, GET_ALL_LETTER_TYPES_CACHE_TTL_SECONDS, INTEROP_API_BASE_URI } = getEnv();
 
   /**
    * @returns returns all the letter types
@@ -77,7 +77,7 @@ function createLettersService() {
    * @returns array of letters given the userId and clientId with optional sort parameter
    */
   async function getLetters(userId: string, clientId: string, sortOrder: 'asc' | 'desc' = 'desc') {
-    const url = new URL(`${CCT_API_BASE_URI}/cctws/OnDemand/api/GetDocInfoByClientId`);
+    const url = new URL(`${INTEROP_API_BASE_URI}/cctws/OnDemand/api/GetDocInfoByClientId`);
     url.searchParams.set('userid', userId);
     url.searchParams.set('clientid', clientId);
     url.searchParams.set('community', CCT_VAULT_COMMUNITY);
@@ -123,7 +123,7 @@ function createLettersService() {
    * @returns the response containing the PDF file given the userId and referenceId
    */
   async function getPdf(userId: string, referenceId: string) {
-    const url = new URL(`${CCT_API_BASE_URI}/cctws/OnDemand/api/GetPdfByLetterId`);
+    const url = new URL(`${INTEROP_API_BASE_URI}/cctws/OnDemand/api/GetPdfByLetterId`);
     url.searchParams.set('community', CCT_VAULT_COMMUNITY);
     url.searchParams.set('id', referenceId);
     url.searchParams.set('userid', userId);

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -61,10 +61,7 @@ const serverEnv = z.object({
 
   SHOW_SIN_EDIT_STUB_PAGE : z.string().transform(toBoolean).default('false'),
 
-
-
   // TODO :: GjB :: these base URIs should not have defaults
-  CCT_API_BASE_URI: z.string().url().default('https://api.example.com'),
   SCCH_BASE_URI: z.string().url().default('https://www.example.com'),
   MSCA_BASE_URI: z.string().url().default('http://srv136.services.gc.ca'),
 


### PR DESCRIPTION
### Description
Replacing references of `CCT_API_BASE_URI` with `INTEROP_API_BASE_URI` as we are not calling CCT directly but rather through Interop.

### Related Azure Boards Work Items
[AB#3017](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3017)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/en/letters`. Viewing any letter should still work.