### PR TITLE
Defaulting SCCH/MSCA-D's base url to their production base url

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -140,12 +140,12 @@ ENABLED_MOCKS=cct,dental-application,lookup,power-platform,raoidc,status-check,w
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc
 
 # SCCH base URL -- used as a base URL for all SCCH calls
-# (required; use the example below)
-SCCH_BASE_URI=http://www.example.com
+# (optional; default https://service.canada.ca)
+SCCH_BASE_URI=https://secure-client-hub-dev.bdm.dshp-phdn.net
 
 # MSCA base URL -- used as a base URL for MSCA
-# (required; use the example below)
-MSCA_BASE_URI=http://srv136.services.gc.ca
+# (optional; default https://srv136.services.gc.ca)
+MSCA_BASE_URI=https://srv136.services.gc.ca
 
 # Community where the documents were generated from, and user belongs. This value is linked to the specific vault database for the given community.
 CCT_VAULT_COMMUNITY='SecurityReview'

--- a/frontend/__tests__/components/client-env.test.tsx
+++ b/frontend/__tests__/components/client-env.test.tsx
@@ -12,8 +12,8 @@ describe('<ClientEnv>', () => {
     const env: PublicEnv = {
       ENABLED_FEATURES: ['feature1', 'feature2'],
       I18NEXT_DEBUG: true,
-      SCCH_BASE_URI: 'http://www.example.com',
-      MSCA_BASE_URI: 'http://srv136.services.gc.ca',
+      SCCH_BASE_URI: 'https://service.canada.ca',
+      MSCA_BASE_URI: 'https://srv136.services.gc.ca',
       SESSION_TIMEOUT_SECONDS: 120,
       SESSION_TIMEOUT_PROMPT_SECONDS: 30,
     };

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -54,16 +54,15 @@ const serverEnv = z.object({
   ENGLISH_LETTER_LANGUAGE_CODE: z.coerce.number().default(1033),
   FRENCH_LETTER_LANGUAGE_CODE: z.coerce.number().default(1036),
 
-
   // interop api settings
   INTEROP_API_BASE_URI: z.string().url(),
   INTEROP_API_SUBSCRIPTION_KEY: z.string().trim().min(1),
 
   SHOW_SIN_EDIT_STUB_PAGE : z.string().transform(toBoolean).default('false'),
 
-  // TODO :: GjB :: these base URIs should not have defaults
-  SCCH_BASE_URI: z.string().url().default('https://www.example.com'),
-  MSCA_BASE_URI: z.string().url().default('http://srv136.services.gc.ca'),
+  // base URIs for My Service Canada Account variations
+  SCCH_BASE_URI: z.string().url().default('https://service.canada.ca'),
+  MSCA_BASE_URI: z.string().url().default('https://srv136.services.gc.ca'),
 
   // auth/oidc settings
   AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),


### PR DESCRIPTION
### Description
Also updated `.env.example` to use MSCA-D/SCCH's dev instance, which can currently be accessed publicly.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Update your `.env` file with the contents of `.env.example`.
Run the application locally and navigate to `/en/home`. Click on "My Account" > "My dashboard". You should be redirected to MSCA-D's dev instance dashboard.
