### PR TITLE
AB#3066 -- custom audit events

### DIFF
--- a/frontend/__tests__/utils/raoidc-utils.server.test.ts
+++ b/frontend/__tests__/utils/raoidc-utils.server.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/utils/logging.server', () => ({
   getLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),
-    silly: vi.fn(),
+    trace: vi.fn(),
   }),
 }));
 

--- a/frontend/app/services/audit-service.server.ts
+++ b/frontend/app/services/audit-service.server.ts
@@ -18,7 +18,7 @@ function createAuditService() {
     audit: function (eventId: string, auditDetails?: AuditDetails) {
       const { userId, ...otherDetails } = auditDetails ?? {};
       const details = Object.keys(otherDetails).length === 0 ? undefined : otherDetails;
-      log.info('%j', { eventId, userId, details, timestamp: new Date().toISOString() });
+      log.audit('%j', { eventId, userId, details, timestamp: new Date().toISOString() });
     },
   };
 }

--- a/frontend/app/utils/raoidc-utils.server.ts
+++ b/frontend/app/utils/raoidc-utils.server.ts
@@ -167,7 +167,7 @@ export async function fetchServerMetadata(authServerUrl: string, fetchFn?: Fetch
 
   const serverMetadata = (await discoveryResponse.json()) as ServerMetadata;
   validateServerMetadata(serverMetadata);
-  log.silly('Server metadata response: [%j]', serverMetadata);
+  log.trace('Server metadata response: [%j]', serverMetadata);
 
   const jwksUrl = serverMetadata.jwks_uri;
   log.info('Fetching OIDC server public keys from [%s]', jwksUrl);
@@ -183,7 +183,7 @@ export async function fetchServerMetadata(authServerUrl: string, fetchFn?: Fetch
 
   const jwkSet = (await jwksResponse.json()) as JWKSet;
   validateJwkSet(jwkSet);
-  log.silly('Server JWKS response: [%j]', jwkSet);
+  log.trace('Server JWKS response: [%j]', jwkSet);
 
   return { jwkSet, serverMetadata };
 }


### PR DESCRIPTION
### Description

Reconfigure the application logger to have custom log levels, including `AUDIT` and `TRACE`.

This is an incremental PR in support of [AB#3066](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3066). Eventually the audit logging will be logged to an `audit.log` file, which will be persisted to fulfil some SA&A requirements.

### Related Azure Boards Work Items

- [AB#3066](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3066)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
