### PR TITLE
AB#3066 -- custom audit transport

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,9 +2,20 @@
 # Copy this file to `.env` and edit as required.
 
 
-# application log level; valid values are: error, warn, info, http, verbose, debug, silly
+# application log level; valid values are: audit, error, warn, info, debug, and trace
 # (optional; default: info)
 LOG_LEVEL=debug
+
+
+# enable/disable the persistent audit log
+# (optional; default: true)
+AUDIT_LOG_ENABLED=true
+# directory in which to store audit logs
+# (optional; default: logs)
+AUDIT_LOG_DIRNAME=logs
+# name of the audit log file; will be appended with '_{date}_{hostname}.log'
+# (optional; default: audit)
+AUDIT_LOG_FILENAME=audit
 
 
 # i18next debug flag

--- a/frontend/app/utils/logging.server.ts
+++ b/frontend/app/utils/logging.server.ts
@@ -1,16 +1,18 @@
+import os from 'node:os';
 import { LeveledLogMethod, Logger, createLogger, format, transports } from 'winston';
+import 'winston-daily-rotate-file';
 import { z } from 'zod';
 
 // see https://github.com/winstonjs/winston?tab=readme-ov-file#using-custom-logging-levels
-const logLevels = { audit: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 };
+const logLevels = { audit: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 } as const;
 
-const isValidLogLevel = (val: string) => Object.keys(logLevels).includes(val);
-
-const logLevel = z
-  .string()
-  .refine(isValidLogLevel, { message: 'Invalid log level', path: ['process.env.LOG_LEVEL'] })
-  .default('info')
-  .parse(process.env.LOG_LEVEL);
+// prettier-ignore
+const env = {
+  logLevel: z.string().refine(((val: string) => Object.keys(logLevels).includes(val)), { message: 'Invalid log level' }).default('info').parse(process.env.LOG_LEVEL),
+  auditLogEnabled: z.string().transform((val: string) => val === 'true').default('true').parse(process.env.AUDIT_LOG_ENABLED),
+  auditLogDirname: z.string().trim().min(1, { message: 'Invalid audit log directory name' }).default('logs').parse(process.env.AUDIT_LOG_DIRNAME),
+  auditLogFilename: z.string().trim().min(1, { message: 'Invalid audit log file name' }).default('audit').parse(process.env.AUDIT_LOG_FILENAME),
+} as const;
 
 /**
  * Formats a log category string to be a fixed length. When the category string
@@ -26,11 +28,8 @@ function formatCategory(category: string, size: number) {
  * Returns a logger for the specified logging category.
  */
 export const getLogger = (category: string) => {
-  // required so typescript knows about log.audit(..), log.trace(..), etc
-  type CustomLogger = Logger & { [level in keyof typeof logLevels]: LeveledLogMethod };
-
-  return createLogger({
-    level: logLevel,
+  const logger = createLogger({
+    level: env.logLevel,
     levels: logLevels,
     format: format.combine(
       format.timestamp(),
@@ -38,5 +37,27 @@ export const getLogger = (category: string) => {
       format.printf((info) => `${info.timestamp} ${info.level.toUpperCase().padStart(7)} --- [${formatCategory(category, 25)}]: ${info.stack ?? info.message}`),
     ),
     transports: [new transports.Console()],
-  }) as CustomLogger;
+  });
+
+  //
+  // Audit logs are persisted to disk to ensure that we
+  // can retain a history record of important system events
+  //
+  if (env.auditLogEnabled) {
+    logger.add(
+      new transports.DailyRotateFile({
+        level: 'audit',
+        dirname: env.auditLogDirname,
+        filename: env.auditLogFilename,
+        format: format.printf((info) => info.message),
+        extension: `_${os.hostname()}.log`,
+        utc: true,
+      }),
+    );
+  }
+
+  // required so typescript knows about log.audit(..), log.trace(..), etc
+  type LeveledLogMethods = { [level in keyof typeof logLevels]: LeveledLogMethod };
+
+  return logger as Logger & LeveledLogMethods;
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,6 +65,7 @@
         "validator": "^13.11.0",
         "web-streams-node": "^0.4.0",
         "winston": "^3.12.0",
+        "winston-daily-rotate-file": "^5.0.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -7832,6 +7833,14 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -11245,6 +11254,14 @@
         "micro-memoize": "^4.1.2"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -11791,7 +11808,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16626,6 +16642,23 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,6 +82,7 @@
     "validator": "^13.11.0",
     "web-streams-node": "^0.4.0",
     "winston": "^3.12.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Add the ability to log audit events to an `audit.log` file. Audit log filename have the format: `{filename}_{date}_{hostname}.log` and will be rotated daily.

### Related Azure Boards Work Items

- [AB#3066](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3066)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and hit a route that fires audit events (ie: update email). Check that a log file exists in `./logs/`

### Additional Notes

The e2e tests are broken. This was not caused by this PR.