### PR TITLE
AB#2977 -- Refactor hCaptchaResponse validation, allow execution on failure; add instrumentation

### DIFF
--- a/frontend/app/services/hcaptcha-service.server.ts
+++ b/frontend/app/services/hcaptcha-service.server.ts
@@ -1,5 +1,8 @@
 import moize from 'moize';
+import { z } from 'zod';
 
+import { getAuditService } from '~/services/audit-service.server';
+import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
@@ -19,6 +22,10 @@ function createHCaptchaService() {
    * @see https://docs.hcaptcha.com/#verify-the-user-response-server-side
    */
   async function verifyHCaptchaResponse(hCaptchaResponse: string) {
+    const instrumentationService = getInstrumentationService();
+
+    getAuditService().audit('hcaptcha.verify', { userId: 'anonymous' });
+
     const url = new URL(HCAPTCHA_VERIFY_URL);
     url.searchParams.set('response', hCaptchaResponse);
     url.searchParams.set('secret', HCAPTCHA_SECRET_KEY);
@@ -26,6 +33,7 @@ function createHCaptchaService() {
     const response = await fetch(url, { method: 'POST' });
 
     if (!response.ok) {
+      instrumentationService.countHttpStatus('http.client.hcaptcha.posts', response.status);
       log.error('%j', {
         message: 'Failed to verify hCaptcha',
         status: response.status,
@@ -37,7 +45,22 @@ function createHCaptchaService() {
       throw new Error(`Failed to verify hCaptcha: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    return response.json();
+    const verifyResultSchema = z.object({
+      success: z.boolean(),
+      challenge_ts: z.string().datetime(),
+      hostname: z.string(),
+      'error-codes': z.array(z.string()).optional(),
+      score: z.number().optional(),
+    });
+
+    const verifyResult = verifyResultSchema.parse(await response.json());
+    if (verifyResult.success) {
+      instrumentationService.countHttpStatus('http.client.hcaptcha.posts.success', 200);
+      log.info(`hCaptcha verification successful: [${JSON.stringify(verifyResult)}]`);
+    } else {
+      instrumentationService.countHttpStatus('http.client.hcaptcha.posts.failed', 200);
+      log.warn(`hCaptcha verification failed: [${JSON.stringify(verifyResult)}]`);
+    }
   }
 
   return { verifyHCaptchaResponse };


### PR DESCRIPTION
### Description
We don't want the application to block the user from applying as a result of hCaptcha. Therefore, this PR
* removes validation of `h-captcha-response` 
* logs the outcome of hCaptcha's `/siteverify` API call and logs a warning if this API call fails 

Also added metrics and auditing to `hcaptcha-service`

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2977)

### Screenshots (if applicable)
**Application can't reach hCaptcha API:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/35cc3e94-edef-4a76-894c-96e56ba498c9)

**hCaptcha API returns `success: true`:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/bd734b04-c54e-47e5-8998-f0573c9294b5)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Change the `HCAPTCHA_VERIFY_URL` in your `.env` to something like `https://api.example.com/siteverify`. Run the application and continue with the apply flow. The application should log a warning that the hCaptcha API call failed but you should still be able to proceed with applying.

### Additional notes
We don't currently block potential bots, only log it.