### PR TITLE
AB#2977 -- Trigger a challenge request only when the hCaptcha API loads

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -70,11 +70,15 @@ export default function ApplyIndex() {
   const isSubmitting = fetcher.state !== 'idle';
   const captchaRef = useRef<HCaptcha>(null);
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  function handleHCaptchaLoad() {
+    captchaRef.current?.execute();
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (captchaRef.current) {
       const formData = new FormData(event.currentTarget);
-      const { response } = await captchaRef.current.execute({ async: true });
+      const response = captchaRef.current.getResponse();
       formData.set('h-captcha-response', response);
       fetcher.submit(formData, { method: 'POST' });
 
@@ -169,7 +173,7 @@ export default function ApplyIndex() {
       </div>
       <p className="my-8">{t('apply:index.apply.application-start-consent')}</p>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
-        <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />
+        <HCaptcha size="invisible" onLoad={handleHCaptchaLoad} sitekey={siteKey} ref={captchaRef} />
         <Button variant="primary" id="continue-button" disabled={isSubmitting}>
           {t('apply:index.apply.start-button')}
           <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />

--- a/frontend/app/services/hcaptcha-service.server.ts
+++ b/frontend/app/services/hcaptcha-service.server.ts
@@ -47,8 +47,8 @@ function createHCaptchaService() {
 
     const verifyResultSchema = z.object({
       success: z.boolean(),
-      challenge_ts: z.string().datetime(),
-      hostname: z.string(),
+      challenge_ts: z.string().datetime().optional(),
+      hostname: z.string().optional(),
       'error-codes': z.array(z.string()).optional(),
       score: z.number().optional(),
     });


### PR DESCRIPTION
### Description
This PR is a workaround where users cannot proceed with the application form if the hCaptcha client fails to load. In the current case, the hCaptcha API client isn't setting the correct CORS headers. 

Previously, the challenge request was being invoked when the form is submitted. The CORS issue above prevented the form submission from proceeding. I have moved the challenge request to a new `onLoad` handler function so that it is executed when the API client loads. If the API client does not load successfully, the challenge response value will be empty, the empty response is logged, but the application form will proceed as normal.

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application and navigate to `/en/apply`. You should be able to start an application form.

### Additional notes
See [hCaptcha documentation on Local Development](https://docs.hcaptcha.com/#local-development) to get around the CORS issue when developing locally. 