### PR TITLE
AB#3016 added endpoint to add the personal information in the session if its available.

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/address-accuracy.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/address-accuracy.tsx
@@ -9,11 +9,13 @@ import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
+import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import type { UserinfoToken } from '~/utils/raoidc-utils.server';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
@@ -36,9 +38,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();
   const sessionService = await getSessionService();
-
+  const personalInformationService = await getPersonalInformationService();
   await raoidcService.handleSessionValidation(request);
   const session = await sessionService.getSession(request);
+
+  const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  await personalInformationService.getPersonalInformationIntoSession(session, request, userInfoToken.sin);
 
   if (!session.has('newHomeAddress')) {
     instrumentationService.countHttpStatus('home-address.validate.no-session', 302);

--- a/frontend/app/services/personal-information-service.server.ts
+++ b/frontend/app/services/personal-information-service.server.ts
@@ -1,7 +1,11 @@
+import { Session } from '@remix-run/server-runtime/dist/sessions';
+
 import moize from 'moize';
+import { HttpResponse } from 'msw';
 import { z } from 'zod';
 
 import { getEnv } from '~/utils/env.server';
+import { redirectWithLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('personal-information-service.server');
@@ -185,6 +189,22 @@ function createPersonalInformationService() {
       },
     };
   }
+  async function getPersonalInformationIntoSession(session: Session, request: Request, sin?: string) {
+    if (session.has('personalInformation')) {
+      log.debug(`User has personal information object;`);
+      return session.get('personalInformation');
+    }
+    if (!sin) {
+      throw new HttpResponse('SIN must be present', { status: 401 });
+    }
 
-  return { getPersonalInformation };
+    const personalInformation = await getPersonalInformation(sin);
+    if (!personalInformation) {
+      log.debug(`No personal information found for SIN`);
+      throw redirectWithLocale(request, '/data-unavailable');
+    }
+    session.set('personalInformation', personalInformation);
+    return personalInformation;
+  }
+  return { getPersonalInformation, getPersonalInformationIntoSession };
 }


### PR DESCRIPTION

### Description
added endpoint to add the personal information in the session if its available.If there is no information for the provided SIN, the user is redirected to the /data-unavailable page

Only one page has been modified to use this code in order to keep the PR small

### Related Azure Boards Work Items
AB#3016



### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

