### PR TITLE
AB#2977 -- Proceed with submission if hCaptcha component fails to render

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -71,7 +71,7 @@ export default function ApplyIndex() {
   const captchaRef = useRef<HCaptcha>(null);
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: ReturnType<typeof setTimeout>;
 
     if (captchaRef.current?.isReady()) {
       captchaRef.current.execute();
@@ -99,6 +99,9 @@ export default function ApplyIndex() {
       } finally {
         captchaRef.current.resetCaptcha();
       }
+
+      fetcher.submit(formData, { method: 'POST' });
+      sessionStorage.setItem('flow.state', 'active');
     }
   }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -88,15 +88,19 @@ export default function ApplyIndex() {
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (captchaRef.current) {
-      const formData = new FormData(event.currentTarget);
-      const response = captchaRef.current.getResponse();
-      formData.set('h-captcha-response', response);
-      fetcher.submit(formData, { method: 'POST' });
 
-      captchaRef.current.resetCaptcha();
+    const formData = new FormData(event.currentTarget);
+    try {
+      if (captchaRef.current) {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+        captchaRef.current.resetCaptcha();
+      }
+    } catch (error) {
+      /* intentionally ignore and proceed with submission */
     }
 
+    fetcher.submit(formData, { method: 'POST' });
     sessionStorage.setItem('flow.state', 'active');
   }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -88,20 +88,18 @@ export default function ApplyIndex() {
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-
     const formData = new FormData(event.currentTarget);
-    try {
-      if (captchaRef.current) {
+
+    if (captchaRef.current) {
+      try {
         const response = captchaRef.current.getResponse();
         formData.set('h-captcha-response', response);
+      } catch (error) {
+        /* intentionally ignore and proceed with submission */
+      } finally {
         captchaRef.current.resetCaptcha();
       }
-    } catch (error) {
-      /* intentionally ignore and proceed with submission */
     }
-
-    fetcher.submit(formData, { method: 'POST' });
-    sessionStorage.setItem('flow.state', 'active');
   }
 
   const canadaTermsConditions = <InlineLink to={t('apply:index.links.canada-ca-terms-and-conditions')} />;


### PR DESCRIPTION
### Description
As per title.

The user can now proceed with the application if the hCaptcha component fails to render.

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Disconnect from internet and run the application locally. Navigate to `/en/apply`. Hit the "Agree and continue" button. You should go to the next page.
