### PR TITLE
3035 modify timeouts

### DIFF
--- a/frontend/app/components/session-timeout.tsx
+++ b/frontend/app/components/session-timeout.tsx
@@ -11,9 +11,11 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
-export interface SessionTimeoutProps extends Required<Pick<IIdleTimerProps, 'promptBeforeIdle' | 'timeout'>> {}
+export interface SessionTimeoutProps extends Required<Pick<IIdleTimerProps, 'promptBeforeIdle' | 'timeout'>> {
+  navigateTo: string;
+}
 
-const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
+const SessionTimeout = ({ promptBeforeIdle, timeout, navigateTo }: SessionTimeoutProps) => {
   const { t } = useTranslation(i18nNamespaces);
   const [modalOpen, setModalOpen] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState('');
@@ -21,7 +23,7 @@ const SessionTimeout = ({ promptBeforeIdle, timeout }: SessionTimeoutProps) => {
 
   const handleOnIdle = () => {
     setModalOpen(false);
-    navigate('/auth/logout');
+    navigate(navigateTo);
   };
 
   const { reset, getRemainingTime } = useIdleTimer({

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -9,7 +9,6 @@ import { getToast } from 'remix-toast';
 
 import { ClientEnv } from '~/components/client-env';
 import { NonceContext } from '~/components/nonce-context';
-import SessionTimeout from '~/components/session-timeout';
 import { Toaster } from '~/components/toaster';
 import fontLatoStyleSheet from '~/fonts/lato.css';
 import fontNotoSansStyleSheet from '~/fonts/noto-sans.css';
@@ -100,7 +99,6 @@ export default function App() {
         <Suspense>
           <Outlet />
           <Toaster toast={toast} />
-          <SessionTimeout promptBeforeIdle={env.SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={env.SESSION_TIMEOUT_SECONDS * 1000} />
         </Suspense>
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />

--- a/frontend/app/routes/$lang+/_protected+/_route.tsx
+++ b/frontend/app/routes/$lang+/_protected+/_route.tsx
@@ -1,11 +1,19 @@
-import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet, isRouteErrorResponse, json, useLoaderData, useRouteError } from '@remix-run/react';
 
 import { NotFoundError, ProtectedLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
+import SessionTimeout from '~/components/session-timeout';
+import { getPublicEnv } from '~/utils/env.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   i18nNamespaces: [...layoutI18nNamespaces],
 } as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const env = getPublicEnv();
+  return json({ env });
+}
 
 export function ErrorBoundary() {
   const error = useRouteError();
@@ -22,8 +30,10 @@ export function ErrorBoundary() {
 }
 
 export default function Layout() {
+  const { env } = useLoaderData<typeof loader>();
   return (
     <ProtectedLayout>
+      <SessionTimeout promptBeforeIdle={env.SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={env.SESSION_TIMEOUT_SECONDS * 1000} navigateTo="/auth/logout" />
       <Outlet />
     </ProtectedLayout>
   );

--- a/frontend/app/routes/$lang+/_public+/apply+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/_route.tsx
@@ -1,12 +1,20 @@
-import { Outlet, isRouteErrorResponse, useRouteError } from '@remix-run/react';
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
 
 import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import SessionTimeout from '~/components/session-timeout';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getLocale } from '~/utils/locale-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
 } as const satisfies RouteHandleData;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const lang = getLocale(request);
+  return { lang };
+}
 
 export function ErrorBoundary() {
   const error = useRouteError();
@@ -23,8 +31,10 @@ export function ErrorBoundary() {
 }
 
 export default function Layout() {
+  const { lang } = useLoaderData<typeof loader>();
   return (
     <PublicLayout>
+      <SessionTimeout navigateTo={`/${lang}/apply`} promptBeforeIdle={5 * 60 * 1000} timeout={15 * 60 * 1000} />
       <Outlet />
     </PublicLayout>
   );


### PR DESCRIPTION
### Description
The timeouts needs to be different for both the auth space and the apply space.  We can however, in my opinion, reuse the same component to handle giving an accessible message and means to extend a session to the user via the timeout component.  This may or may not be a naive implementation.  Let me know if the logic is flawed.

### Related Azure Boards Work Items
[AB#3035](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3035)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`