### PR TITLE
Remove unnecessary logging code from express server

### DIFF
--- a/frontend/express.server.ts
+++ b/frontend/express.server.ts
@@ -1,7 +1,7 @@
-import { createRequestHandler } from '@remix-run/express';
 import type { RequestHandler } from '@remix-run/express';
-import { broadcastDevReady, installGlobals } from '@remix-run/node';
+import { createRequestHandler } from '@remix-run/express';
 import type { ServerBuild } from '@remix-run/node';
+import { broadcastDevReady, installGlobals } from '@remix-run/node';
 
 import chokidar from 'chokidar';
 import compression from 'compression';
@@ -12,34 +12,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 import sourceMapSupport from 'source-map-support';
-import { createLogger, format, transports } from 'winston';
+
+import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('express.server');
 
 installSourceMapSupport();
 installGlobals();
 runServer();
-
-/**
- * Function copied from ./app/utils/logging.server.ts to work around typescript
- * path alias issues with ESM and ESBuild. 🤷
- */
-function getLogger(category: string) {
-  function formatCategory(category: string, size: number) {
-    const str = category.padStart(size);
-    return str.length <= size ? str : `...${str.slice(-size + 3)}`;
-  }
-
-  return createLogger({
-    level: process.env['LOG_LEVEL'] ?? 'info',
-    format: format.combine(
-      format.timestamp(),
-      format.splat(),
-      format.printf((info) => `${info.timestamp} ${info.level.toUpperCase().padStart(7)} --- [${formatCategory(category, 25)}]: ${info.message}`),
-    ),
-    transports: [new transports.Console()],
-  });
-}
 
 function installSourceMapSupport() {
   sourceMapSupport.install({


### PR DESCRIPTION
### Description

Since we can now import code from `~/` into the express server, the logging code is no longer required in `express.server.ts`.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
