### PR TITLE
if letter.name is invalid, do not display the letter.

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
@@ -97,13 +97,14 @@ export default function LettersIndex() {
       <ul className="divide-y border-y">
         {letters.map((letter) => {
           const letterType = letterTypes.find(({ id }) => id === letter.name);
-          const translatedLetterName = letterType ? getNameByLanguage(i18n.language, letterType) : letter.name;
-          const letterName = translatedLetterName ?? letter.name;
+          if (!letterType) {
+            return;
+          }
 
           return (
             <li key={letter.id} className="py-4 sm:py-6">
               <InlineLink reloadDocument to={`/letters/${letter.id}/download`} className="external-link font-lato font-semibold" target="_blank">
-                {letterName}
+                {getNameByLanguage(i18n.language, letterType)}
               </InlineLink>
               <p className="mt-1 text-sm text-gray-500">{t('letters:index.date', { date: letter.issuedOn })}</p>
             </li>


### PR DESCRIPTION
### Description
If letter.name is invalid, do not display the letter.

This check can also be done in the `/app/services` `getLetters()`

### Related Azure Boards Work Items
[AB#3144](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3144)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to /en/letters
Nothing should change since there are currently no letters in our mocks that have an invalid name.

### Additional Notes
Once we get the new JSON file, some tweaks might be needed. However, the structure of the new JSON file is said to not alter the current one. 