### PR TITLE
Move session handling (init, persist) to express server

### DIFF
--- a/frontend/__tests__/routes/_protected+/letters+/index.test.tsx
+++ b/frontend/__tests__/routes/_protected+/letters+/index.test.tsx
@@ -1,7 +1,8 @@
+import { createMemorySessionStorage } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_protected+/letters+/index';
-import { getSessionService } from '~/services/session-service.server';
 
 vi.mock('~/services/audit-service.server', () => ({
   getAuditService: vi.fn().mockReturnValue({
@@ -64,18 +65,14 @@ describe('Letters Page', () => {
 
   describe('loader()', () => {
     it('should return sorted letters', async () => {
-      const request = new Request('http://localhost/letters?sort=desc');
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
 
-      const sessionService = await getSessionService();
-      const session = await sessionService.getSession(request);
-
-      vi.mocked(session.get).mockImplementation((key) => {
-        return {
-          idToken: { sub: '00000000-0000-0000-0000-000000000000' },
-        }[key];
+      const response = await loader({
+        request: new Request('http://localhost/letters?sort=desc'),
+        context: { session },
+        params: {},
       });
-
-      const response = await loader({ request, params: {}, context: {} });
 
       const data = await response.json();
 
@@ -88,18 +85,14 @@ describe('Letters Page', () => {
   });
 
   it('retrieves letter types', async () => {
-    const request = new Request('http://localhost/letters');
+    const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+    session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
 
-    const sessionService = await getSessionService();
-    const session = await sessionService.getSession(request);
-
-    vi.mocked(session.get).mockImplementation((key) => {
-      return {
-        idToken: { sub: '00000000-0000-0000-0000-000000000000' },
-      }[key];
+    const response = await loader({
+      request: new Request('http://localhost/letters'),
+      context: { session },
+      params: {},
     });
-
-    const response = await loader({ request, params: {}, context: {} });
 
     const data = await response.json();
 

--- a/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_protected+/personal-information+/home-address+/edit';
@@ -89,7 +91,7 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/en/personal-information/home-address/edit'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -130,7 +132,7 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
       try {
         await loader({
           request: new Request('http://localhost:3000/en/personal-information/home-address/edit'),
-          context: {},
+          context: { session: {} as Session },
           params: {},
         });
       } catch (error) {

--- a/frontend/__tests__/routes/_protected+/personal-information+/index.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/index.test.tsx
@@ -1,7 +1,8 @@
+import { createMemorySessionStorage } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_protected+/personal-information+/index';
-import { getSessionService } from '~/services/session-service.server';
 
 vi.mock('~/services/audit-service.server', () => ({
   getAuditService: vi.fn().mockReturnValue({
@@ -77,52 +78,40 @@ describe('_gcweb-app.personal-information._index', () => {
 
   describe('loader()', () => {
     it('should return a Response object', async () => {
-      const request = new Request('http://localhost:3000/personal-information');
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
 
-      const sessionService = await getSessionService();
-      const session = await sessionService.getSession(request);
-
-      vi.mocked(session.get).mockImplementation((key) => {
-        return {
-          idToken: { sub: '00000000-0000-0000-0000-000000000000' },
-        }[key];
+      const response = await loader({
+        request: new Request('http://localhost:3000/personal-information'),
+        context: { session },
+        params: {},
       });
-
-      const response = await loader({ request: request, context: {}, params: {} });
 
       expect(response).toBeInstanceOf(Response);
     });
 
     it('should return reponse status of 200', async () => {
-      const request = new Request('http://localhost:3000/personal-information');
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
 
-      const sessionService = await getSessionService();
-      const session = await sessionService.getSession(request);
-
-      vi.mocked(session.get).mockImplementation((key) => {
-        return {
-          idToken: { sub: '00000000-0000-0000-0000-000000000000' },
-        }[key];
+      const response = await loader({
+        request: new Request('http://localhost:3000/personal-information'),
+        context: { session },
+        params: {},
       });
-
-      const response = await loader({ request: request, context: {}, params: {} });
 
       expect(response.status).toBe(200);
     });
 
     it('should return correct mocked data', async () => {
-      const request = new Request('http://localhost:3000/personal-information');
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
 
-      const sessionService = await getSessionService();
-      const session = await sessionService.getSession(request);
-
-      vi.mocked(session.get).mockImplementation((key) => {
-        return {
-          idToken: { sub: '00000000-0000-0000-0000-000000000000' },
-        }[key];
+      const response = await loader({
+        request: new Request('http://localhost:3000/personal-information'),
+        context: { session },
+        params: {},
       });
-
-      const response = await loader({ request: request, context: {}, params: {} });
 
       const data = await response.json();
 

--- a/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
@@ -1,8 +1,9 @@
+import { Session, createMemorySessionStorage } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/$lang+/_protected+/personal-information+/mailing-address+/edit';
 import { getAddressService } from '~/services/address-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 
 vi.mock('~/services/address-service.server', () => ({
@@ -79,7 +80,7 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -125,7 +126,7 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
       try {
         await loader({
           request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-          context: {},
+          context: { session: {} as Session },
           params: {},
         });
       } catch (error) {
@@ -136,9 +137,7 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
 
   describe('action()', () => {
     it('should redirect to confirm page', async () => {
-      const sessionService = await getSessionService();
-
-      vi.mocked(sessionService.commitSession).mockResolvedValue('some-set-cookie-header');
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const formData = new FormData();
       formData.append('address', '111 Fake Home St');
@@ -149,7 +148,7 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
 
       const response = await action({
         request: new Request('http://localhost:300/en/personal-information/mailing-address/edit', { method: 'POST', body: formData }),
-        context: {},
+        context: { session },
         params: {},
       });
 
@@ -164,7 +163,7 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
       try {
         await loader({
           request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-          context: {},
+          context: { session: {} as Session },
           params: {},
         });
       } catch (error) {

--- a/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/edit.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/$lang+/_protected+/personal-information+/phone-number+/edit';
@@ -53,7 +55,7 @@ describe('_gcweb-app.personal-information.phone-number.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/en/personal-information/phone-number/edit'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -70,12 +72,15 @@ describe('_gcweb-app.personal-information.phone-number.edit', () => {
     it('should return validation errors', async () => {
       const formData = new FormData();
       formData.append('phoneNumber', '819 426-55');
-      const request = new Request('http://localhost:3000/en/personal-information/phone-number/edit', {
-        method: 'POST',
-        body: formData,
-      });
 
-      const response = await action({ request, context: {}, params: {} });
+      const response = await action({
+        request: new Request('http://localhost:3000/en/personal-information/phone-number/edit', {
+          method: 'POST',
+          body: formData,
+        }),
+        context: { session: {} as Session },
+        params: {},
+      });
       const data = await response.json();
 
       expect(response.status).toBe(200);

--- a/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_protected+/personal-information+/preferred-language+/edit';
@@ -79,7 +81,7 @@ describe('_gcweb-app.personal-information.preferred-language.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/preferred/edit'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -103,7 +105,7 @@ describe('_gcweb-app.personal-information.preferred-language.edit', () => {
       try {
         await loader({
           request: new Request('http://localhost:3000/personal-information/preferred-language/edit'),
-          context: {},
+          context: { session: {} as Session },
           params: {},
         });
       } catch (error) {

--- a/frontend/__tests__/routes/_public+/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/_public+/application-delegate.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_public+/apply+/$id+/application-delegate';
@@ -25,7 +27,7 @@ describe('_public.apply.id.application-delegate', () => {
     it('should load id', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/application-delegate'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/_public+/communication-preference.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/communication-preference';
@@ -64,7 +66,7 @@ describe('_public.apply.id.communication-preference', () => {
     it('should id, state, country list and region list', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/communication-preference'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -117,7 +119,7 @@ describe('_public.apply.id.communication-preference', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -138,7 +140,7 @@ describe('_public.apply.id.communication-preference', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -160,7 +162,7 @@ describe('_public.apply.id.communication-preference', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
+++ b/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
@@ -1,4 +1,4 @@
-import { redirect } from '@remix-run/node';
+import { Session, redirect } from '@remix-run/node';
 
 import { differenceInYears, isValid, parse } from 'date-fns';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -40,7 +40,7 @@ describe('_public.apply.id.date-of-birth', () => {
     it('should load id, and dob', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -58,7 +58,7 @@ describe('_public.apply.id.date-of-birth', () => {
     it('should validate missing day, month, and year selections', async () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: new FormData() }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -77,7 +77,7 @@ describe('_public.apply.id.date-of-birth', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -95,7 +95,7 @@ describe('_public.apply.id.date-of-birth', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
+++ b/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_public+/apply+/$id+/dob-eligibility';
@@ -25,7 +27,7 @@ describe('_public.apply.id.dob-eligibility', () => {
     it('should load id', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/dob-eligibility'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/file-your-taxes.test.tsx
+++ b/frontend/__tests__/routes/_public+/file-your-taxes.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_public+/apply+/$id+/file-your-taxes';
@@ -25,7 +27,7 @@ describe('_public.apply.id.file-your-taxes', () => {
     it('should load id', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/file-your-taxes'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/personal-information.test.tsx
+++ b/frontend/__tests__/routes/_public+/personal-information.test.tsx
@@ -1,3 +1,5 @@
+import { Session } from '@remix-run/node';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loader } from '~/routes/$lang+/_public+/apply+/$id+/personal-information';
@@ -56,7 +58,7 @@ describe('_public.apply.id.personal-information', () => {
     it('should id, state, country list and region list', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/personal-information'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/_public+/tax-filing.test.tsx
@@ -1,4 +1,4 @@
-import { redirect } from '@remix-run/node';
+import { Session, redirect } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -37,7 +37,7 @@ describe('_public.apply.id.tax-filing', () => {
     it('should load id, and taxFiling2023', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -55,7 +55,7 @@ describe('_public.apply.id.tax-filing', () => {
     it('should validate missing tax filing selection', async () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: new FormData() }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -70,7 +70,7 @@ describe('_public.apply.id.tax-filing', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -84,7 +84,7 @@ describe('_public.apply.id.tax-filing', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/type-of-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-of-application.test.tsx
@@ -1,4 +1,4 @@
-import { redirect } from '@remix-run/node';
+import { Session, redirect } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -38,7 +38,7 @@ describe('_public.apply.id.type-of-application', () => {
     it('should load id, and typeOfApplication', async () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application'),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -56,7 +56,7 @@ describe('_public.apply.id.type-of-application', () => {
     it('should validate missing applcation type selection', async () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: new FormData() }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -71,7 +71,7 @@ describe('_public.apply.id.type-of-application', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 
@@ -85,7 +85,7 @@ describe('_public.apply.id.type-of-application', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
-        context: {},
+        context: { session: {} as Session },
         params: {},
       });
 

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -10,7 +10,6 @@ import { I18nextProvider } from 'react-i18next';
 import { NonceProvider } from '~/components/nonce-context';
 import { server } from '~/mocks/node';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { generateContentSecurityPolicy } from '~/utils/csp-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getNamespaces } from '~/utils/locale-utils';
@@ -47,9 +46,12 @@ export async function handleDataRequest(response: Response, { request }: LoaderF
   log.debug('Touching session to extend its lifetime');
   instrumentationService.createCounter('http.server.requests').add(1);
 
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
-  response.headers.append('Set-Cookie', await sessionService.commitSession(session));
+  //
+  // TODO :: GjB :: Remove this?
+  //
+  // const sessionService = await getSessionService();
+  // const session = await sessionService.getSession(request);
+  // response.headers.append('Set-Cookie', await sessionService.commitSession(session));
 
   return response;
 }

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -13,10 +13,9 @@ import { Toaster } from '~/components/toaster';
 import fontLatoStyleSheet from '~/fonts/lato.css';
 import fontNotoSansStyleSheet from '~/fonts/noto-sans.css';
 import { getBuildInfoService } from '~/services/build-info-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import tailwindStyleSheet from '~/tailwind.css';
-import { getPublicEnv } from '~/utils/env.server';
 import type { FeatureName } from '~/utils/env.server';
+import { getPublicEnv } from '~/utils/env.server';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { useI18nNamespaces } from '~/utils/route-utils';
 import { getDescriptionMetaTags, getTitleMetaTags, useAlternateLanguages, useCanonicalURL } from '~/utils/seo-utils';
@@ -47,7 +46,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   ];
 };
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const buildInfoService = getBuildInfoService();
   const { toast, headers: toastHeaders } = await getToast(request);
   const requestUrl = new URL(request.url);
@@ -67,12 +66,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
   const origin = requestUrl.origin;
 
-  const userOrigin = await getUserOrigin(request);
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
+  const userOrigin = await getUserOrigin(request, session);
   session.set('userOrigin', userOrigin);
 
-  return json({ buildInfo, env, meta, origin, toast, userOrigin }, { headers: { ...toastHeaders, 'Set-Cookie': await sessionService.commitSession(session) } });
+  return json({ buildInfo, env, meta, origin, toast, userOrigin }, { headers: { ...toastHeaders } });
 }
 
 export default function App() {

--- a/frontend/app/routes/$lang+/$.tsx
+++ b/frontend/app/routes/$lang+/$.tsx
@@ -16,7 +16,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('gcweb:not-found.document-title') }) };
   return json({ meta }, { status: 404 });

--- a/frontend/app/routes/$lang+/_protected+/_route.tsx
+++ b/frontend/app/routes/$lang+/_protected+/_route.tsx
@@ -10,7 +10,7 @@ export const handle = {
   i18nNamespaces: [...layoutI18nNamespaces],
 } as const satisfies RouteHandleData;
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const env = getPublicEnv();
   return json({ env });
 }

--- a/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
+++ b/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
@@ -1,5 +1,5 @@
-import { json } from '@remix-run/node';
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
 
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -26,9 +26,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('data-unavailable:page-title') }) };

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -17,7 +17,6 @@ import { getAddressService } from '~/services/address-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getWSAddressService } from '~/services/wsaddress-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -42,14 +41,14 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const addressService = getAddressService();
   const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();
   const userService = getUserService();
 
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const userId = await userService.getUserId();
   const userInfo = await userService.getUserInfo(userId);
@@ -69,13 +68,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ addressInfo, countryList, meta, regionList });
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ context: { session }, request }: ActionFunctionArgs) {
   const instrumentationService = getInstrumentationService();
   const raoidcService = await getRaoidcService();
-  const sessionService = await getSessionService();
   const wsAddressService = await getWSAddressService();
 
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const formDataSchema = z.object({
     address: z.string().trim().min(1, { message: 'empty-field' }),
@@ -96,7 +94,6 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
-  const session = await sessionService.getSession(request);
   session.set('newHomeAddress', parsedDataResult.data);
 
   const { address, city, country, postalCode, province } = parsedDataResult.data;
@@ -108,11 +105,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   instrumentationService.countHttpStatus('home-address.edit', 302);
-  return redirectWithLocale(request, getRedirectUrl(correctedAddress.status), {
-    headers: {
-      'Set-Cookie': await sessionService.commitSession(session),
-    },
-  });
+  return redirectWithLocale(request, getRedirectUrl(correctedAddress.status));
 }
 
 function getRedirectUrl(correctedAddressStatus: string) {

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/suggested.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/suggested.tsx
@@ -11,7 +11,6 @@ import { InputRadios } from '~/components/input-radios';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -32,15 +31,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();
-  const sessionService = await getSessionService();
 
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
-  const session = await sessionService.getSession(request);
   const homeAddressInfo = session.get('newHomeAddress');
   const suggestedAddressInfo = session.get('suggestedAddress');
 
@@ -54,25 +51,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ countryList, homeAddressInfo, meta, regionList, suggestedAddressInfo });
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ context: { session }, request }: ActionFunctionArgs) {
   const instrumentationService = getInstrumentationService();
   const raoidcService = await getRaoidcService();
-  const sessionService = await getSessionService();
 
-  await raoidcService.handleSessionValidation(request);
-
-  const session = await sessionService.getSession(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const formDataRadio = Object.fromEntries(await request.formData());
   const useSuggestedAddress = formDataRadio.selectedAddress === 'suggested';
   session.set('useSuggestedAddress', useSuggestedAddress);
 
   instrumentationService.countHttpStatus('home-address.suggest', 302);
-  return redirectWithLocale(request, '/personal-information/home-address/confirm', {
-    headers: {
-      'Set-Cookie': await sessionService.commitSession(session),
-    },
-  });
+  return redirectWithLocale(request, '/personal-information/home-address/confirm');
 }
 
 export default function HomeAddressSuggested() {

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
-import { json } from '@remix-run/node';
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
@@ -13,7 +13,6 @@ import { getAddressService } from '~/services/address-service.server';
 import { getAuditService } from '~/services/audit-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -35,16 +34,14 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   if (!featureEnabled('update-personal-info')) {
     throw new Response(null, { status: 404 });
   }
 
   const raoidcService = await getRaoidcService();
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('page-view.personal-information', { userId: idToken.sub });
 

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/address-accuracy.tsx
@@ -9,7 +9,6 @@ import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -31,12 +30,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
-  await raoidcService.handleSessionValidation(request);
-
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   if (!session.has('newMailingAddress')) {
     return redirectWithLocale(request, '/');
@@ -52,9 +48,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ countryList, meta, newMailingAddress, regionList });
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ context: { session }, request }: ActionFunctionArgs) {
   const raoidcService = await getRaoidcService();
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
+
   return redirectWithLocale(request, '/personal-information/mailing-address/confirm');
 }
 

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/confirm.tsx
@@ -10,7 +10,6 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getSessionService } from '~/services/session-service.server';
 import { getUserService } from '~/services/user-service.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale, redirectWithLocale } from '~/utils/locale-utils.server';
@@ -33,14 +32,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();
-  const sessionService = await getSessionService();
   const userService = getUserService();
 
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const userId = await userService.getUserId();
   if (!userId) {
@@ -54,7 +52,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return redirectWithLocale(request, '/');
   }
 
-  const session = await sessionService.getSession(request);
   if (!session.has('newPreferredLanguage')) {
     instrumentationService.countHttpStatus('preferred-language.confirm', 302);
     return redirectWithLocale(request, '/');
@@ -69,13 +66,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ meta, preferredLanguage, userInfo });
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ context: { session }, request }: ActionFunctionArgs) {
   const instrumentationService = getInstrumentationService();
   const raoidcService = await getRaoidcService();
-  const sessionService = await getSessionService();
   const userService = getUserService();
 
-  await raoidcService.handleSessionValidation(request);
+  await raoidcService.handleSessionValidation(request, session);
 
   const userId = await userService.getUserId();
   if (!userId) {
@@ -89,7 +85,6 @@ export async function action({ request }: ActionFunctionArgs) {
     return redirectWithLocale(request, '/');
   }
 
-  const session = await sessionService.getSession(request);
   if (!session.has('newPreferredLanguage')) {
     instrumentationService.countHttpStatus('preferred-language.confirm', 302);
     return redirectWithLocale(request, '/');
@@ -100,11 +95,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const locale = getLocale(request);
 
   instrumentationService.countHttpStatus('preferred-language.confirm', 302);
-  return redirectWithSuccess(`/${locale}/personal-information`, 'personal-information:preferred-language.confirm.updated-notification', {
-    headers: {
-      'Set-Cookie': await sessionService.commitSession(session),
-    },
-  });
+  return redirectWithSuccess(`/${locale}/personal-information`, 'personal-information:preferred-language.confirm.updated-notification');
 }
 
 export default function PreferredLanguageConfirm() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
@@ -12,7 +12,7 @@ export const handle = {
   i18nNamespaces: [...layoutHandle.i18nNamespaces],
 } as const satisfies RouteHandleData;
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const locale = getLocale(request);
   return json({ locale });
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -27,9 +27,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.application-delegate.page-title') }) };
@@ -37,10 +37,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  await applyFlow.loadState({ request, params });
-  const sessionResponseInit = await applyFlow.clearState({ request, params });
+  await applyFlow.loadState({ params, request, session });
+  const sessionResponseInit = await applyFlow.clearState({ params, request, session });
   return redirectWithLocale(request, '/', sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -55,11 +55,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
   const applyFlow = getApplyFlow();
   const lookupService = getLookupService();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const preferredLanguages = await lookupService.getAllPreferredLanguages();
   const preferredCommunicationMethods = await lookupService.getAllPreferredCommunicationMethods();
@@ -74,10 +74,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ communicationMethodEmail, id, meta, preferredCommunicationMethods, preferredLanguages, defaultState: state.communicationPreferences, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const formSchema: z.ZodType<CommunicationPreferencesState> = z
@@ -141,7 +141,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format() });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { communicationPreferences: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { communicationPreferences: parsedDataResult.data } });
   return redirectWithLocale(request, state.editMode ? `/apply/${id}/review-information` : `/apply/${id}/dental-insurance`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -33,9 +33,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -34,9 +34,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.date-of-birth.page-title') }) };
@@ -44,9 +44,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, defaultState: state.dateOfBirth, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema
@@ -64,7 +64,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format() });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { dateOfBirth: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { dateOfBirth: parsedDataResult.data } });
 
   const parseDateOfBirth = parse(parsedDataResult.data, 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -35,10 +35,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
   const lookupService = getLookupService();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const options = await lookupService.getAllAccessToDentalInsuranceOptions();
 
@@ -47,9 +47,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, options, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema
@@ -66,7 +66,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format()._errors });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { dentalInsurance: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { dentalInsurance: parsedDataResult.data } });
   return redirectWithLocale(request, state.editMode ? `/apply/${id}/review-information` : `/apply/${id}/federal-provincial-territorial-benefits`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
@@ -27,9 +27,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.dob-eligibility.page-title') }) };
@@ -37,10 +37,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  await applyFlow.loadState({ request, params });
-  const sessionResponseInit = await applyFlow.clearState({ request, params });
+  await applyFlow.loadState({ params, request, session });
+  const sessionResponseInit = await applyFlow.clearState({ params, request, session });
   return redirectWithLocale(request, '/', sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
@@ -24,9 +24,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) };
@@ -34,11 +34,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  await applyFlow.loadState({ request, params });
+  await applyFlow.loadState({ params, request, session });
   //TODO: Add apply form logic
-  const sessionResponseInit = await applyFlow.clearState({ request, params });
+  const sessionResponseInit = await applyFlow.clearState({ params, request, session });
   return redirectWithLocale(request, `/apply`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -53,11 +53,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const { CANADA_COUNTRY_ID } = getEnv();
   const applyFlow = getApplyFlow();
   const lookupService = getLookupService();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const federalDentalBenefits = await lookupService.getAllFederalDentalBenefit();
@@ -72,9 +72,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ federalDentalBenefits, federalSocialPrograms, id, meta, provincialTerritorialDentalBenefits, provincialTerritorialSocialPrograms, regions, defaultState: state.dentalBenefits, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema
@@ -116,7 +116,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format() });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { dentalBenefits: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { dentalBenefits: parsedDataResult.data } });
   return redirectWithLocale(request, `/apply/${id}/review-information`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/file-your-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/file-your-taxes.tsx
@@ -27,9 +27,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.file-your-taxes.page-title') }) };
@@ -37,10 +37,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  await applyFlow.loadState({ request, params });
-  const sessionResponseInit = await applyFlow.clearState({ request, params });
+  await applyFlow.loadState({ params, request, session });
+  const sessionResponseInit = await applyFlow.clearState({ params, request, session });
   return redirectWithLocale(request, '/', sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/index.tsx
@@ -3,10 +3,10 @@ import { LoaderFunctionArgs } from '@remix-run/node';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
 import { redirectWithLocale } from '~/utils/locale-utils.server';
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state });
   return redirectWithLocale(request, `/apply/${id}/type-of-application`, sessionResponseInit);
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -43,9 +43,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // TODO: the flow for where to redirect to will need to be determined depending on the state of the form
@@ -58,9 +58,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema
@@ -95,7 +95,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format() });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { partnerInformation: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { partnerInformation: parsedDataResult.data } });
   return redirectWithLocale(request, state.editMode ? `/apply/${id}/review-information` : `/apply/${id}/personal-information`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -57,10 +57,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
   const lookupService = getLookupService();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
 
@@ -71,9 +71,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, defaultState: state.personalInformation, maritalStatus: state.applicantInformation?.maritalStatus, countryList, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, editMode: state.editMode });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
 
@@ -189,7 +189,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       }
     : parsedDataResult.data;
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { personalInformation: updatedData } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { personalInformation: updatedData } });
   return redirectWithLocale(request, state.editMode ? `/apply/${id}/review-information` : `/apply/${id}/communication-preference`, sessionResponseInit);
 }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -52,9 +52,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const maritalStatuses = await getLookupService().getAllMaritalStatuses();
   const provincialTerritorialSocialPrograms = await getLookupService().getAllProvincialTerritorialSocialPrograms();
 
@@ -151,9 +151,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, userInfo, spouseInfo, maritalStatuses, preferredLanguage, provincialTerritorialSocialPrograms, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, meta });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
 
   // prettier-ignore
   if (!state.applicantInformation ||
@@ -173,7 +173,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     submittedOn: new Date().toISOString(),
   };
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { submissionInfo } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { submissionInfo } });
 
   return redirectWithLocale(request, `/apply/${id}/confirmation`, sessionResponseInit);
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
@@ -38,9 +38,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.tax-filing.page-title') }) };
@@ -48,9 +48,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema: z.ZodType<TaxFilingState> = z.nativeEnum(TaxFilingOption, {
@@ -65,7 +65,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format()._errors });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { taxFiling2023: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { taxFiling2023: parsedDataResult.data } });
 
   if (parsedDataResult.data === TaxFilingOption.No) {
     return redirectWithLocale(request, `/apply/${id}/file-your-taxes`, sessionResponseInit);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-of-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-of-application.tsx
@@ -38,9 +38,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id, state } = await applyFlow.loadState({ request, params });
+  const { id, state } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.type-of-application.page-title') }) };
@@ -48,9 +48,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ id, meta, defaultState: state.typeOfApplication });
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyFlow = getApplyFlow();
-  const { id } = await applyFlow.loadState({ request, params });
+  const { id } = await applyFlow.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   /**
@@ -68,7 +68,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ errors: parsedDataResult.error.format()._errors });
   }
 
-  const sessionResponseInit = await applyFlow.saveState({ request, params, state: { typeOfApplication: parsedDataResult.data } });
+  const sessionResponseInit = await applyFlow.saveState({ params, request, session, state: { typeOfApplication: parsedDataResult.data } });
 
   if (parsedDataResult.data === ApplicantType.Delegate) {
     return redirectWithLocale(request, `/apply/${id}/application-delegate`, sessionResponseInit);

--- a/frontend/app/routes/$lang+/_public+/apply+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/_route.tsx
@@ -11,7 +11,7 @@ export const handle = {
   i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
 } as const satisfies RouteHandleData;
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const lang = getLocale(request);
   return { lang };
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -34,7 +34,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   const { HCAPTCHA_SITE_KEY } = getEnv();
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -43,7 +43,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return { meta, siteKey: HCAPTCHA_SITE_KEY };
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ context: { session }, request }: ActionFunctionArgs) {
   const log = getLogger('apply/index');
 
   const formData = await request.formData();
@@ -58,7 +58,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const applyFlow = getApplyFlow();
   const id = randomUUID().toString();
-  const sessionResponseInit = await applyFlow.start({ id, request });
+  const sessionResponseInit = await applyFlow.start({ id, request, session });
 
   return redirectWithLocale(request, `/apply/${id}/type-of-application`, sessionResponseInit);
 }

--- a/frontend/app/routes/$lang+/_public+/status+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/index.tsx
@@ -9,7 +9,7 @@ import { InputField } from '~/components/input-field';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const formDataSchema = z.object({
     sin: z.string().trim().min(1, { message: 'Please enter your SIN' }),
     code: z.string().trim().min(1, { message: 'Please enter your application code' }),

--- a/frontend/app/routes/$lang+/_route.tsx
+++ b/frontend/app/routes/$lang+/_route.tsx
@@ -4,7 +4,7 @@ import { Outlet, isRouteErrorResponse, useParams, useRouteError } from '@remix-r
 import { BilingualNotFoundError, NotFoundError, ServerError } from '~/components/layouts/public-layout';
 import { getLogger } from '~/utils/logging.server';
 
-export function loader({ request, params }: LoaderFunctionArgs) {
+export function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const log = getLogger('$lang+/_route');
 
   if (!['en', 'fr'].includes(String(params.lang))) {

--- a/frontend/app/routes/api+/readyz.ts
+++ b/frontend/app/routes/api+/readyz.ts
@@ -6,6 +6,6 @@ import { json } from '@remix-run/node';
  *
  * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
  */
-export function loader({ request }: LoaderFunctionArgs) {
+export function loader({ context: { session }, request }: LoaderFunctionArgs) {
   return json({ ready: true });
 }

--- a/frontend/app/routes/api+/refresh-session.ts
+++ b/frontend/app/routes/api+/refresh-session.ts
@@ -3,21 +3,11 @@
  */
 import { LoaderFunctionArgs } from '@remix-run/node';
 
-import { getSessionService } from '~/services/session-service.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('routes/api.refresh-session');
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
   log.debug('Touching session to extend its lifetime');
-
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
-
-  return new Response(null, {
-    status: 204,
-    headers: {
-      'Set-Cookie': await sessionService.commitSession(session),
-    },
-  });
+  return new Response(null, { status: 204 });
 }

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -1,3 +1,6 @@
+import { AppLoadContext, Session } from '@remix-run/node';
+import type { ActionFunctionArgs as RRActionFunctionArgs, LoaderFunctionArgs as RRLoaderFunctionArgs } from '@remix-run/router';
+
 import type apply from '../public/locales/en/apply.json';
 import type dataUnavailable from '../public/locales/en/data-unavailable.json';
 import type gcweb from '../public/locales/en/gcweb.json';
@@ -34,5 +37,21 @@ declare module 'i18next' {
       'personal-information': typeof personalInformation;
       'stub-sin-editor': typeof stubSinEditor;
     };
+  }
+}
+
+declare module '@remix-run/node' {
+  /**
+   * Augment the action function context to include the server session.
+   */
+  export interface ActionFunctionArgs extends RRActionFunctionArgs<AppLoadContext> {
+    context: AppLoadContext & { session: Session };
+  }
+
+  /**
+   * Augment the loader function context to include the server session.
+   */
+  export interface LoaderFunctionArgs extends RRLoaderFunctionArgs<AppLoadContext> {
+    context: AppLoadContext & { session: Session };
   }
 }

--- a/frontend/app/utils/user-origin-utils.server.ts
+++ b/frontend/app/utils/user-origin-utils.server.ts
@@ -1,13 +1,10 @@
-import { z } from 'zod';
+import { Session } from '@remix-run/node';
 
-import { getSessionService } from '~/services/session-service.server';
+import { z } from 'zod';
 
 export const originEnumSchema = z.enum(['msca', 'msca-d']);
 
-export async function getUserOrigin(request: Request) {
-  const sessionService = await getSessionService();
-  const session = await sessionService.getSession(request);
-
+export async function getUserOrigin(request: Request, session: Session) {
   // try to get it from search params
   const { searchParams } = new URL(request.url);
   const originParam = searchParams.get('origin');


### PR DESCRIPTION
**Centralize session management in Express server**

This PR simplifies session handling by moving initialization and persistence logic to the Express server. Previously, committing sessions required calling `sessionService.commitSession()` and manually sending the session cookie in the action/loader response via a `{ headers }` object. This change eliminates the need for those manual steps, improving code maintainability and reducing boilerplate code.

A lot of files within the application had to be modified to support this change, including many tests. I apologize for the size of this PR.

### Related Azure Boards Work Items

- [AB#3086](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3086)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and try some flows that require a session.
