### PR TITLE
Move instrumentation to express server

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -17,14 +17,11 @@ import { getLocale, initI18n } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { randomHexString } from '~/utils/string-utils';
 
-// instrumentation should be started as early as possible to ensure proper initialization
-const instrumentationService = getInstrumentationService();
-instrumentationService.startInstrumentation();
-
 const abortDelay = 5_000;
 const log = getLogger('entry.server');
 
 const { ENABLED_MOCKS } = getEnv();
+const instrumentationService = getInstrumentationService();
 
 if (ENABLED_MOCKS.length > 0) {
   server.listen({ onUnhandledRequest: 'bypass' });


### PR DESCRIPTION
### Description

This PR fixes the "@opentelemetry/api: Attempted duplicate registration of API" error that occurs during application reloading.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
