### PR TITLE
3157 Add button to Clear Data (kill session) on confirmation page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -9,6 +9,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyFlow } from '~/routes-flow/apply-flow';
@@ -233,6 +234,12 @@ export default function ApplyFlowConfirm() {
       >
         {t('confirm.print-btn')}
       </button>
+
+      <div className="mt-10 flex flex-wrap items-center gap-3">
+        <ButtonLink variant="primary" onClick={() => sessionStorage.removeItem('flow.state')} to="/apply">
+          {t('apply:confirm.exit')}
+        </ButtonLink>
+      </div>
     </div>
   );
 }

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -94,7 +94,8 @@
     "dental-public": "Access to dental government insurance: {{access}}",
     "application-code": "Application code",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "exit": "Exit"
   },
   "dental-benefits": {
     "title": "Access to other federal, provincial or territorial dental benefits",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -94,7 +94,8 @@
     "dental-public": "Accès aux soins dentaires gouvernementaux\u00a0: {{access}}",
     "application-code": "Code de demande",
     "yes": "Oui",
-    "no": "Non"
+    "no": "Non",
+    "exit": "Sortie"
   },
   "dental-benefits": {
     "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",


### PR DESCRIPTION
### Description
add a button on the confirmation page of the apply flow to kill the session and navigate users away from the page. 

### Related Azure Boards Work Items
[AB#3157](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3157)
