### PR TITLE
AB#3017 -- Adding configs for CCT subscription key and url

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -67,6 +67,16 @@ INTEROP_API_BASE_URI=https://api.example.com
 # Interop API subscription key
 # (required; use the example below)
 INTEROP_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
+# Interop's CCT API base url
+# (required; use the example below)
+INTEROP_CCT_API_BASE_URI=https://api.example.com
+# Interop's CCT API subscription key
+# (required; use the example below)
+INTEROP_CCT_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
+# Interop's CCT API community header value; linked to the specific vault database for the given community
+# (optional; default: CDCP)
+INTEROP_CCT_API_COMMUNITY=CDCP
+
 
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)
@@ -157,9 +167,6 @@ SCCH_BASE_URI=https://secure-client-hub-dev.bdm.dshp-phdn.net
 # MSCA base URL -- used as a base URL for MSCA
 # (optional; default https://srv136.services.gc.ca)
 MSCA_BASE_URI=https://srv136.services.gc.ca
-
-# Community where the documents were generated from, and user belongs. This value is linked to the specific vault database for the given community.
-CCT_VAULT_COMMUNITY=SecurityReview
 
 # Cache durations for data retrieval
 # (optional; default: 24 * 60 * 60)

--- a/frontend/__tests__/services/letters-service.server.test.ts
+++ b/frontend/__tests__/services/letters-service.server.test.ts
@@ -15,7 +15,9 @@ vi.mock('~/utils/logging.server', () => ({
 vi.mock('~/utils/env.server', () => ({
   getEnv: vi.fn().mockReturnValue({
     INTEROP_API_BASE_URI: 'https://api.example.com',
-    CCT_VAULT_COMMUNITY: 'SecurityReview',
+    INTEROP_CCT_API_BASE_URI: 'https://api.example.com',
+    INTEROP_CCT_API_SUBSCRIPTION_KEY: '00000000000000000000000000000000',
+    INTEROP_CCT_API_COMMUNITY: 'CDCP',
     ENGLISH_LETTER_LANGUAGE_CODE: 1033,
     FRENCH_LETTER_LANGUAGE_CODE: 1036,
   }),

--- a/frontend/app/mocks/cct-api.server.ts
+++ b/frontend/app/mocks/cct-api.server.ts
@@ -19,11 +19,16 @@ export function getCCTApiMockHandlers() {
       log.debug('Handling request for [%s]', request.url);
 
       const url = new URL(request.url);
-      const community = url.searchParams.get('cct-community');
+      const community = request.headers.get('cct-community');
       const id = url.searchParams.get('id');
 
       if (community === null || id === null) {
-        return new HttpResponse(null, { status: 404 });
+        return new HttpResponse(null, { status: 400 });
+      }
+
+      const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');
+      if (!subscriptionKey) {
+        return new HttpResponse(null, { status: 401 });
       }
 
       return HttpResponse.json(getPdfByLetterIdJson);
@@ -35,10 +40,15 @@ export function getCCTApiMockHandlers() {
     http.get('https://api.example.com/dental-care/client-letters/cct/v1/GetDocInfoByClientId', ({ request }) => {
       const url = new URL(request.url);
       const clientId = url.searchParams.get('clientid');
-      const community = url.searchParams.get('cct-community');
+      const community = request.headers.get('cct-community');
 
       if (clientId === null || community === null) {
-        throw new HttpResponse(null, { status: 404 });
+        throw new HttpResponse(null, { status: 400 });
+      }
+
+      const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');
+      if (!subscriptionKey) {
+        return new HttpResponse(null, { status: 401 });
       }
 
       return HttpResponse.json([

--- a/frontend/app/services/letters-service.server.ts
+++ b/frontend/app/services/letters-service.server.ts
@@ -13,7 +13,14 @@ const log = getLogger('letters-service.server');
 export const getLettersService = moize(createLettersService, { onCacheAdd: () => log.info('Creating new letters service') });
 
 function createLettersService() {
-  const { CCT_VAULT_COMMUNITY, GET_ALL_LETTER_TYPES_CACHE_TTL_SECONDS, INTEROP_API_BASE_URI } = getEnv();
+  // prettier-ignore
+  const { 
+    GET_ALL_LETTER_TYPES_CACHE_TTL_SECONDS, 
+    INTEROP_API_BASE_URI, 
+    INTEROP_CCT_API_BASE_URI, 
+    INTEROP_CCT_API_SUBSCRIPTION_KEY, 
+    INTEROP_CCT_API_COMMUNITY 
+  } = getEnv();
 
   /**
    * @returns returns all the letter types
@@ -77,11 +84,16 @@ function createLettersService() {
    * @returns array of letters given the clientId with optional sort parameter
    */
   async function getLetters(clientId: string, sortOrder: 'asc' | 'desc' = 'desc') {
-    const url = new URL(`${INTEROP_API_BASE_URI}/dental-care/client-letters/cct/v1/GetDocInfoByClientId`);
+    const url = new URL(`${INTEROP_CCT_API_BASE_URI}/dental-care/client-letters/cct/v1/GetDocInfoByClientId`);
     url.searchParams.set('clientid', clientId);
-    url.searchParams.set('cct-community', CCT_VAULT_COMMUNITY);
 
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Ocp-Apim-Subscription-Key': INTEROP_CCT_API_SUBSCRIPTION_KEY,
+        'cct-community': INTEROP_CCT_API_COMMUNITY,
+      },
+    });
 
     if (!response.ok) {
       log.error('%j', {
@@ -120,11 +132,16 @@ function createLettersService() {
    * @returns a promise that resolves to a base64 encoded string representing the PDF document
    */
   async function getPdf(letterId: string) {
-    const url = new URL(`${INTEROP_API_BASE_URI}/dental-care/client-letters/cct/v1/GetPdfByLetterId`);
-    url.searchParams.set('cct-community', CCT_VAULT_COMMUNITY);
+    const url = new URL(`${INTEROP_CCT_API_BASE_URI}/dental-care/client-letters/cct/v1/GetPdfByLetterId`);
     url.searchParams.set('id', letterId);
 
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Ocp-Apim-Subscription-Key': INTEROP_CCT_API_SUBSCRIPTION_KEY,
+        'cct-community': INTEROP_CCT_API_COMMUNITY,
+      },
+    });
 
     if (!response.ok) {
       log.error('%j', {

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -60,6 +60,9 @@ const serverEnv = z.object({
   // interop api settings
   INTEROP_API_BASE_URI: z.string().url(),
   INTEROP_API_SUBSCRIPTION_KEY: z.string().trim().min(1),
+  INTEROP_CCT_API_BASE_URI: z.string().url(),
+  INTEROP_CCT_API_SUBSCRIPTION_KEY: z.string().trim().min(1),
+  INTEROP_CCT_API_COMMUNITY: z.string().default('CDCP'),
 
   SHOW_SIN_EDIT_STUB_PAGE : z.string().transform(toBoolean).default('false'),
 
@@ -103,9 +106,6 @@ const serverEnv = z.object({
   // mocks settings
   ENABLED_MOCKS: z.string().transform(emptyToUndefined).transform(csvToArray).refine(areValidMockNames).default(''),
   MOCK_AUTH_ALLOWED_REDIRECTS: z.string().transform(emptyToUndefined).transform(csvToArray).default('http://localhost:3000/auth/callback/raoidc'),
-
-  // CCT get PDF settings
-  CCT_VAULT_COMMUNITY: z.string().default('community_default'),
 
   // cache duration settings
   LOOKUP_SVC_ALL_ACCESS_TO_DENTAL_INSURANCE_OPTIONS_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),

--- a/frontend/other/docker-compose.yml
+++ b/frontend/other/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
       - INTEROP_API_BASE_URI=https://api.example.com
       - INTEROP_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
+      - INTEROP_CCT_API_BASE_URI=https://api.example.com
+      - INTEROP_CCT_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
       - MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc
       - MSCA_BASE_URI=http://srv136.services.gc.ca
       - SCCH_BASE_URI=http://www.example.com

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
       HCAPTCHA_VERIFY_URL: 'https://api.hcaptcha.com/siteverify',
       INTEROP_API_BASE_URI: 'https://api.example.com',
       INTEROP_API_SUBSCRIPTION_KEY: '00000000000000000000000000000000',
+      INTEROP_CCT_API_BASE_URI: 'https://api.example.com',
+      INTEROP_CCT_API_SUBSCRIPTION_KEY: '00000000000000000000000000000000',
       MOCK_AUTH_ALLOWED_REDIRECTS: 'http://localhost:3000/auth/callback/raoidc',
       USA_COUNTRY_ID: 'fcf7389e-97ae-eb11-8236-000d3af4bfc3',
       PORT: port,


### PR DESCRIPTION
### Description
As per title. These additions are needed to make a successful call to Interop's CCT API.

Also modified existing community variable (and its name), as it should be passed through the header and not query param.

### Related Azure Boards Work Items
[AB#3017](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3017)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
**Testing with Mock:**
Replace your current .env file with what's in .env.example and run the application. Navigate to `/en/letters`. You should see the list of letters and letter content from the mocks.

**Testing with actual Interop API endpoint:**
You must be on-premise (via ESDC VPN) to do this (or connect through proxy to reach Interop). Add/change the `INTEROP_CCT_API_BASE_URI` and `INTEROP_CCT_API_SUBSCRIPTION_KEY` environment variables. Since the application currently does not pass the correct `clientId`, modify `/app/routes/$lang+/_protected+/letters+/$id.download.tsx` and replace the existing line that initializes `pdfBytes` with:

```typescript
const allLetters = await lettersService.getLetters('81400774242');
console.log(JSON.stringify(allLetters));
const pdfBytes = await lettersService.getPdf('038d9d0f-fb35-4d98-8f31-a4b2171e521a');
```

Then navigate to `/en/letters/1/download`. 
`allLetters` should print and the letter for the corresponding UUID above will be rendered.

### Additional Notes
Gitops project will be updated in a future PR.