### PR TITLE
[gitops] Enabling the SIN stub page for DEV and INT

### DIFF
--- a/gitops/overlays/dev/configs/frontend-config.conf
+++ b/gitops/overlays/dev/configs/frontend-config.conf
@@ -50,3 +50,8 @@ INTEROP_CCT_API_BASE_URI=https://api.example.com
 #
 CANADA_COUNTRY_ID=0cf5389e-97ae-eb11-8236-000d3af4bfc3
 USA_COUNTRY_ID=fcf7389e-97ae-eb11-8236-000d3af4bfc3
+
+#
+# SIN edit stub page configuration
+#
+SHOW_SIN_EDIT_STUB_PAGE=true

--- a/gitops/overlays/int/configs/frontend-config.conf
+++ b/gitops/overlays/int/configs/frontend-config.conf
@@ -44,3 +44,8 @@ INTEROP_CCT_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/int/strea
 #
 CANADA_COUNTRY_ID=0cf5389e-97ae-eb11-8236-000d3af4bfc3
 USA_COUNTRY_ID=fcf7389e-97ae-eb11-8236-000d3af4bfc3
+
+#
+# SIN edit stub page configuration
+#
+SHOW_SIN_EDIT_STUB_PAGE=true


### PR DESCRIPTION
### Description
As per title - we don't want to go through ECAS/RAOIDC (and create GCKey accounts) to test integration with Interop.