### PR TITLE
Creating sceean reader new tab component.

### DIFF
--- a/frontend/app/components/new-tab-indicator.tsx
+++ b/frontend/app/components/new-tab-indicator.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '~/utils/tw-utils';
+
+export function NewTabIndicator({ className, ...props }: Omit<ComponentProps<'span'>, 'children'>) {
+  const { t } = useTranslation('gcweb');
+  return (
+    <span className={cn('sr-only', className)} {...props}>
+      {/*Following whitespace is important to ensure the content's text is seperated for the screen-reader text*/}&#32;({t('screen-reader.new-tab')})
+    </span>
+  );
+}

--- a/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
@@ -11,6 +11,7 @@ import pageIds from '../../page-ids.json';
 import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { InputSelect } from '~/components/input-select';
+import { NewTabIndicator } from '~/components/new-tab-indicator';
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLettersService } from '~/services/letters-service.server';
@@ -108,6 +109,7 @@ export default function LettersIndex() {
             <li key={letter.id} className="py-4 sm:py-6">
               <InlineLink reloadDocument to={`/letters/${letter.id}/download`} className="external-link font-lato font-semibold" target="_blank">
                 {getNameByLanguage(i18n.language, letterType)}
+                <NewTabIndicator />
               </InlineLink>
               <p className="mt-1 text-sm text-gray-500">{t('letters:index.date', { date: letter.issuedOn })}</p>
             </li>

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -123,5 +123,8 @@
       "label": "Year",
       "placeholder": "YYYY"
     }
+  },
+  "screen-reader": {
+    "new-tab": "opens in a new tab"
   }
 }

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -123,5 +123,8 @@
       "label": "Année",
       "placeholder": "AAAA"
     }
+  },
+  "screen-reader": {
+    "new-tab": "s'ouvre dans un nouvel onglet"
   }
 }


### PR DESCRIPTION
### Description
Reusable span sr-only component.

### Related Azure Boards Work Items
[AB#3164](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3164)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/letters` and inspect each link in the list. <span sr-only> should be right after the text.