### PR TITLE
render no if no federal/provincial benefits selected

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -222,7 +222,7 @@ export default function ApplyFlowConfirm() {
       </UnorderedList>
       <UnorderedList term={t('confirm.dental-insurance')}>
         <li>{t('confirm.dental-private', { access: dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no') })}</li>
-        <li>{t('confirm.dental-public', { access: dentalInsurance.selectedBenefits })}</li>
+        <li>{t('confirm.dental-public', { access: dentalInsurance.selectedBenefits ? dentalInsurance.selectedBenefits : t('confirm.no') })}</li>
       </UnorderedList>
 
       <button


### PR DESCRIPTION
### Description
if not benefits are selected, what was previously displayed was an empty string.  This has been changed to display "no" or"non".

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/3f43fd6c-3112-4bbe-a315-cc57ae53c365)