### PR TITLE
AB#3086 -- CSRF protection

### DIFF
--- a/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -83,6 +83,8 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
 
   describe('loader()', () => {
     it('should return addressInfo', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const userService = getUserService();
       const addressService = getAddressService();
 
@@ -91,13 +93,13 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/en/personal-information/home-address/edit'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         addressInfo: {
           address: '111 Fake Home St',
           city: 'city',
@@ -127,12 +129,14 @@ describe('_gcweb-app.personal-information.home-address.edit', () => {
     });
 
     it('should throw 404 response if addressInfo is not found', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue(null);
 
       try {
         await loader({
           request: new Request('http://localhost:3000/en/personal-information/home-address/edit'),
-          context: { session: {} as Session },
+          context: { session },
           params: {},
         });
       } catch (error) {

--- a/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
@@ -1,4 +1,4 @@
-import { Session, createMemorySessionStorage } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -72,6 +72,8 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
 
   describe('loader()', () => {
     it('should return addressInfo', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const userService = getUserService();
       const addressService = getAddressService();
 
@@ -80,13 +82,13 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         addressInfo: {
           address: '111 Fake Home St',
           city: 'city',
@@ -121,12 +123,14 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
     });
 
     it('should throw 404 response if addressInfo is not found', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       vi.mocked(getAddressService().getAddressInfo).mockResolvedValue(null);
 
       try {
         await loader({
           request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-          context: { session: {} as Session },
+          context: { session },
           params: {},
         });
       } catch (error) {
@@ -156,14 +160,15 @@ describe('_gcweb-app.personal-information.mailing-address.edit', () => {
     });
 
     it('should throw 404 response if userInfo is not found', async () => {
-      const userService = getUserService();
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
+      const userService = getUserService();
       vi.mocked(userService.getUserId).mockResolvedValue('');
 
       try {
         await loader({
           request: new Request('http://localhost:3000/personal-information/mailing-address/edit'),
-          context: { session: {} as Session },
+          context: { session },
           params: {},
         });
       } catch (error) {

--- a/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { Session, createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,6 +62,7 @@ describe('_gcweb-app.personal-information.preferred-language.edit', () => {
 
   describe('loader()', () => {
     it('should return userInfo object if userInfo is found', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
       const userService = getUserService();
 
       vi.mocked(userService.getUserInfo).mockResolvedValue({ id: 'some-id', preferredLanguage: 'fr' });
@@ -81,13 +82,13 @@ describe('_gcweb-app.personal-information.preferred-language.edit', () => {
 
       const response = await loader({
         request: new Request('http://localhost:3000/personal-information/preferred/edit'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         meta: {},
         userInfo: { id: 'some-id', preferredLanguage: 'fr' },
         preferredLanguages: [

--- a/frontend/__tests__/routes/_public+/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/_public+/communication-preference.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -64,15 +64,17 @@ describe('_public.apply.id.communication-preference', () => {
 
   describe('loader()', () => {
     it('should id, state, country list and region list', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/communication-preference'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         communicationMethodEmail: {
           id: 'email',
           nameEn: 'Email',
@@ -109,17 +111,21 @@ describe('_public.apply.id.communication-preference', () => {
   });
 
   describe('action()', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
     it('should validate required preferred method', async () => {
-      afterEach(() => {
-        vi.clearAllMocks();
-      });
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
 
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('preferredLanguage', 'fr');
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -129,18 +135,18 @@ describe('_public.apply.id.communication-preference', () => {
     });
 
     it('should validate required email field', async () => {
-      afterEach(() => {
-        vi.clearAllMocks();
-      });
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
 
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('preferredMethod', 'email');
       formData.append('email', '');
       formData.append('preferredLanguage', 'fr');
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -150,11 +156,11 @@ describe('_public.apply.id.communication-preference', () => {
     });
 
     it('should validate required mismatched email addresses', async () => {
-      afterEach(() => {
-        vi.clearAllMocks();
-      });
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
 
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('preferredMethod', 'email');
       formData.append('email', 'john@gmail.com');
       formData.append('confirmEmail', 'johndoe@gmail.com');
@@ -162,7 +168,7 @@ describe('_public.apply.id.communication-preference', () => {
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/personal-information.test.tsx
+++ b/frontend/__tests__/routes/_public+/personal-information.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -56,9 +56,11 @@ describe('_public.apply.id.personal-information', () => {
 
   describe('loader()', () => {
     it('should id, state, country list and region list', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/personal-information'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/_public+/tax-filing.test.tsx
@@ -1,4 +1,4 @@
-import { Session, redirect } from '@remix-run/node';
+import { createMemorySessionStorage, redirect } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -35,15 +35,17 @@ describe('_public.apply.id.tax-filing', () => {
 
   describe('loader()', () => {
     it('should load id, and taxFiling2023', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         id: '123',
         meta: {},
         defaultState: 'yes',
@@ -53,9 +55,15 @@ describe('_public.apply.id.tax-filing', () => {
 
   describe('action()', () => {
     it('should validate missing tax filing selection', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
+      const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
+
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: new FormData() }),
-        context: { session: {} as Session },
+        request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
+        context: { session },
         params: {},
       });
 
@@ -65,12 +73,16 @@ describe('_public.apply.id.tax-filing', () => {
     });
 
     it('should redirect to date of birth page if tax filing is completed', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('taxFiling2023', 'yes');
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -79,12 +91,16 @@ describe('_public.apply.id.tax-filing', () => {
     });
 
     it('should redirect to error page if tax filing is incompleted', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('taxFiling2023', 'no');
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/_public+/type-of-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-of-application.test.tsx
@@ -1,4 +1,4 @@
-import { Session, redirect } from '@remix-run/node';
+import { createMemorySessionStorage, redirect } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -36,15 +36,17 @@ describe('_public.apply.id.type-of-application', () => {
 
   describe('loader()', () => {
     it('should load id, and typeOfApplication', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
       const data = await response.json();
 
-      expect(data).toEqual({
+      expect(data).toMatchObject({
         id: '123',
         meta: { title: 'gcweb:meta.title.template' },
         defaultState: 'delegate',
@@ -54,9 +56,15 @@ describe('_public.apply.id.type-of-application', () => {
 
   describe('action()', () => {
     it('should validate missing applcation type selection', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
+      const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
+
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: new FormData() }),
-        context: { session: {} as Session },
+        request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
+        context: { session },
         params: {},
       });
 
@@ -66,12 +74,16 @@ describe('_public.apply.id.type-of-application', () => {
     });
 
     it('should redirect to error page if delegate is selected', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('typeOfApplication', 'delegate');
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -80,12 +92,16 @@ describe('_public.apply.id.type-of-application', () => {
     });
 
     it('should redirect to tax filing page if personal is selected', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const formData = new FormData();
+      formData.append('_csrf', 'csrfToken');
       formData.append('typeOfApplication', 'personal');
 
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
@@ -16,6 +16,7 @@ import { Progress } from '~/components/progress';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,12 +44,15 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const { id, state } = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.tax-filing.page-title') }) };
 
-  return json({ id, meta, defaultState: state.taxFiling2023 });
+  return json({ id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/tax-filing');
+
   const applyRouteHelpers = getApplyRouteHelpers();
   const { id } = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -58,6 +62,14 @@ export async function action({ context: { session }, params, request }: ActionFu
   });
 
   const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
   const data = formData.get('taxFiling2023');
   const parsedDataResult = taxFilingSchema.safeParse(data);
 
@@ -76,7 +88,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { id, defaultState } = useLoaderData<typeof loader>();
+  const { csrfToken, id, defaultState } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
@@ -108,6 +120,7 @@ export default function ApplyFlowTaxFiling() {
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" aria-describedby="form-instructions" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
           <InputRadios
             id="tax-filing-2023"
             name="taxFiling2023"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-of-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-of-application.tsx
@@ -16,6 +16,7 @@ import { Progress } from '~/components/progress';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,12 +44,15 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const { id, state } = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.type-of-application.page-title') }) };
 
-  return json({ id, meta, defaultState: state.typeOfApplication });
+  return json({ id, csrfToken, meta, defaultState: state.typeOfApplication });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/type-of-application');
+
   const applyRouteHelpers = getApplyRouteHelpers();
   const { id } = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -61,6 +65,14 @@ export async function action({ context: { session }, params, request }: ActionFu
   });
 
   const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
   const data = String(formData.get('typeOfApplication') ?? '');
   const parsedDataResult = typeOfApplicationSchema.safeParse(data);
 
@@ -79,7 +91,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowTypeOfApplication() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
@@ -111,6 +123,7 @@ export default function ApplyFlowTypeOfApplication() {
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" aria-describedby="form-instructions" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
           <InputRadios
             id="type-of-application"
             name="typeOfApplication"


### PR DESCRIPTION
### Description

Add CSRF protection to all forms in the application.

- generate CSRF token in express server; add to session
- pull token from session; add to <form>
- in action(), compare submitted token with the one in session

The application will display a 500 page if the tokens do not match. We can look at modifying this behavior in a future PR.

### Related Azure Boards Work Items

- [AB#3086](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3086)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run through an /apply flow and verify nothing is broken.
