### PR TITLE
Fixing application title in header of protected space to be My Service Canada Account

### DIFF
--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -93,6 +93,7 @@ function NavigationMenu() {
 
 function PageHeader() {
   const { t } = useTranslation(i18nNamespaces);
+  const userOrigin = useUserOrigin();
 
   return (
     <header>
@@ -102,8 +103,8 @@ function PageHeader() {
         <div className="sm:container">
           <div className="flex flex-col items-stretch justify-between sm:flex-row sm:items-center">
             <h2 className="p-4 font-lato text-xl font-semibold sm:p-0 sm:py-3 sm:text-2xl">
-              <AppLink to="/" className="hover:underline">
-                {t('gcweb:header.application-title')}
+              <AppLink to={userOrigin ? userOrigin.to : '/home'} className="hover:underline">
+                {t('gcweb:header.application-title-msca')}
               </AppLink>
             </h2>
             <NavigationMenu />

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -15,6 +15,7 @@
   },
   "header": {
     "application-title": "Canadian Dental Care Plan",
+    "application-title-msca": "My Service Canada Account",
     "language-selection": "Language selection",
     "govt-of-canada.text": "Government of Canada",
     "govt-of-canada.href": "https://www.canada.ca/en.html",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -15,6 +15,7 @@
   },
   "header": {
     "application-title": "Régime canadien de soins dentaires",
+    "application-title-msca": "Mon dossier Service Canada",
     "language-selection": "Sélection de la langue",
     "govt-of-canada.text": "Gouvernement du Canada",
     "govt-of-canada.href": "https://www.canada.ca/fr.html",


### PR DESCRIPTION
### Description
As per title to match Figma

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/1d81994f-bbad-43e4-9af1-bfe0ad4ded68)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/595436b4-c3a7-4414-bb11-66d5348554a7)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and look up and to the left
