### PR TITLE
3179 first/last name instructions

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -149,6 +149,7 @@ export default function ApplyFlowApplicationInformation() {
         <fetcher.Form method="post" aria-describedby="form-instructions-sin form-instructions-info" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-8 space-y-6">
+            <em id="name-instructions">{t('applicant-information.name-instructions')}</em>
             <div className="grid gap-6 md:grid-cols-2">
               <InputField
                 id="first-name"
@@ -162,7 +163,6 @@ export default function ApplyFlowApplicationInformation() {
               />
               <InputField id="last-name" name="lastName" label={t('applicant-information.last-name')} className="w-full" required defaultValue={defaultState?.lastName ?? ''} errorMessage={errorMessages['last-name']} aria-describedby="name-instructions" />
             </div>
-            <p id="name-instructions">{t('applicant-information.name-instructions')}</p>
             <InputField
               id="social-insurance-number"
               name="socialInsuranceNumber"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -157,6 +157,7 @@ export default function ApplyFlowApplicationInformation() {
         <fetcher.Form method="post" aria-describedby="form-instructions-provide-sin form-instructions-required-information" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="space-y-6">
+            <em id="name-instructions">{t('partner-information.name-instructions')}</em>
             <div className="grid gap-6 md:grid-cols-2">
               <InputField
                 id="first-name"
@@ -179,7 +180,6 @@ export default function ApplyFlowApplicationInformation() {
                 aria-describedby="name-instructions"
               />
             </div>
-            <p id="name-instructions">{t('partner-information.name-instructions')}</p>
             <DatePickerField id="date-of-birth" name="dateOfBirth" defaultValue={defaultState?.dateOfBirth ?? ''} legend={t('apply:partner-information.date-of-birth')} required errorMessage={errorMessages['date-picker-date-of-birth-month']} />
             <InputField
               id="social-insurance-number"


### PR DESCRIPTION
### Description
Move instructions for first name and last name fields to above their respective inputs and put emphasis on the text.

### Related Azure Boards Work Items
[AB#3179](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3179)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/c027c2e6-47d0-40c3-ae1f-71e8115834df)
