### PR TITLE
AB#2977 -- Removing 'Cross-Origin-Embedder-Policy' header as it was preventing an hCaptcha client file from being retrieved

### DIFF
--- a/frontend/express.server.ts
+++ b/frontend/express.server.ts
@@ -74,7 +74,6 @@ async function runServer() {
 
   // @see: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html
   const securityRequestHandler = (req: Request, res: Response, next: NextFunction) => {
-    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
     res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
     res.setHeader('Permissions-Policy', 'camera=(), display-capture=(), fullscreen=(), geolocation=(), interest-cohort=(), microphone=(), publickey-credentials-get=(), screen-wake-lock=()');


### PR DESCRIPTION
### Description
As per title

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/3f646893-78e2-42f2-a416-a73520ef042f)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/177d0c8f-68f4-4a81-82dc-4abc7fc57410)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and verify that the file in the screenshot is loaded in `/en/apply`.