### PR TITLE
Update application status check service to use different set of configuration

### DIFF
--- a/frontend/app/services/application-status-service.server.ts
+++ b/frontend/app/services/application-status-service.server.ts
@@ -14,7 +14,7 @@ const log = getLogger('application-status-service.server');
 export const getApplicationStatusService = moize(createApplicationStatusService, { onCacheAdd: () => log.info('Creating new application status service') });
 
 function createApplicationStatusService() {
-  const { INTEROP_API_BASE_URI, INTEROP_API_SUBSCRIPTION_KEY } = getEnv();
+  const { INTEROP_POWERPLATFORM_API_BASE_URI, INTEROP_POWERPLATFORM_API_SUBSCRIPTION_KEY } = getEnv();
 
   /**
    * @returns the status id of a dental application given the sin and application code
@@ -24,7 +24,7 @@ function createApplicationStatusService() {
 
     getAuditService().audit('application-status.post', { userId: 'anonymous' });
 
-    const url = new URL(`${INTEROP_API_BASE_URI}/dental-care/status-check/v1/status`);
+    const url = new URL(`${INTEROP_POWERPLATFORM_API_BASE_URI}/dental-care/status-check/v1/status`);
     const statusRequest = {
       BenefitApplication: {
         Applicant: {
@@ -45,7 +45,7 @@ function createApplicationStatusService() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Ocp-Apim-Subscription-Key': INTEROP_API_SUBSCRIPTION_KEY,
+        'Ocp-Apim-Subscription-Key': INTEROP_POWERPLATFORM_API_SUBSCRIPTION_KEY,
       },
       body: JSON.stringify(statusRequest),
     });


### PR DESCRIPTION
### Description
As per title. 

The original `INTEROP_API_BASE_URI` will be used to make requests to mocks.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/en/status` and verify that the status still displays.