### PR TITLE
AB#3182 -- Review page - Removed the right side "Access to dental insurance" label

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -373,7 +373,7 @@ export default function ReviewInformation() {
             <h2 className="mt-8 text-2xl font-semibold">{t('apply:review-information.dental-title')}</h2>
             <dl className="mt-6 divide-y border-y">
               <DescriptionListItem term={t('apply:review-information.dental-insurance-title')}>
-                {dentalInsurance === 'yes' ? t('apply:review-information.dental-insurance-has-access') : t('apply:review-information.dental-insurance-has-no-access')}
+                {dentalInsurance === 'yes' ? t('apply:review-information.yes') : t('apply:review-information.no')}
                 <p className="mt-4">
                   <InlineLink id="change-access-dental" to={`/apply/${id}/dental-insurance`}>
                     {t('apply:review-information.dental-insurance-change')}

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -358,8 +358,6 @@
     "lang-pref-change": "Change language preference",
     "dental-title": "Access to dental insurance",
     "dental-insurance-title": "Access to dental insurance",
-    "dental-insurance-has-access": "Access to dental insurance or coverage: Yes",
-    "dental-insurance-has-no-access": "Access to dental insurance or coverage: No",
     "dental-insurance-change": "Change answer to dental insurance",
     "dental-benefit-title": "Access to governmental dental benefit",
     "dental-benefit-change": "Change answer to public dental benefits",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -358,8 +358,6 @@
     "lang-pref-change": "Modifier la langue de préférence",
     "dental-title": "Accès à l'assurance dentaire",
     "dental-insurance-title": "Accès à une autre assurance dentaire",
-    "dental-insurance-has-access": "Accès à une assurance dentaire\u00a0: Oui",
-    "dental-insurance-has-no-access": "Accès à une assurance dentaire\u00a0: Non",
     "dental-insurance-change": "Modifier les réponses à «\u00a0accès à une autre assurance dentaire\u00a0»",
     "dental-benefit-title": "Accès aux soins dentaires gouvernementaux",
     "dental-benefit-change": "Modifier la réponse à «\u00a0soins dentaires gouvernementaux\u00a0»",


### PR DESCRIPTION
### Description
For the insurance review section: removed the right side "Access to dental insurance: x" label (now using only yes/no labels)

### Related Azure Boards Work Items
[AB#3182](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3182)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/c3972a46-7c2f-4026-b3d3-3f89da1bc804)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to the review page to confirm changes.

### Additional Notes
N/A