### PR TITLE
Fixing broken e2e tests

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
@@ -69,7 +69,7 @@ export async function action({ context: { session }, request }: ActionFunctionAr
   await raoidcService.handleSessionValidation(request, session);
 
   const formDataSchema = z.object({
-    preferredLanguage: z.enum(['en', 'fr']),
+    preferredLanguage: z.string().trim().min(1),
   });
 
   const formData = Object.fromEntries(await request.formData());

--- a/frontend/app/services/user-service.server.ts
+++ b/frontend/app/services/user-service.server.ts
@@ -6,8 +6,6 @@ import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('user-service.server');
-const LANGUAGES = ['fr', 'en'] as const;
-const LanguageEnum = z.enum(LANGUAGES);
 
 const userInfoSchema = z.object({
   id: z.string().uuid().optional(),
@@ -16,7 +14,7 @@ const userInfoSchema = z.object({
   phoneNumber: z.string().optional(),
   homeAddress: z.string().optional(),
   mailingAddress: z.string().optional(),
-  preferredLanguage: LanguageEnum.optional(),
+  preferredLanguage: z.string().optional(),
 });
 
 export type UserInfo = z.infer<typeof userInfoSchema>;


### PR DESCRIPTION
### Description
Broken e2e tests were a result of a change introduced in https://github.com/DTS-STN/canadian-dental-care-plan/pull/874
`/personal-information/preferred-language` was still expecting an enum of `'en'` and `'fr'` rather than the language codes.

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/12ecce98-b284-450c-a3e6-07ee09105ff0)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`