### PR TITLE
AB#3186 -- Changed status checker link to the protected view application page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -140,7 +140,7 @@ export default function ApplyFlowConfirm() {
 
   const mscaLink = <InlineLink to={t('confirm.msca-link')} />;
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} />;
-  const cdcpLink = <InlineLink to={t('confirm.cdcp-checker-link')} />;
+  const cdcpLink = <InlineLink to={'/view-application'} />;
   const moreInfoLink = <InlineLink to={t('confirm.more-info-link')} />;
 
   return (

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -61,7 +61,6 @@
     "whats-next": "What happens next",
     "begin-process": "We will begin processing your application immediately.",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",
-    "cdcp-checker-link": "https://canadadental-uat.powerappsportals.com/en/status-etat/",
     "use-code": "You can use your application code to begin tracking the progress within 48 hours of applying.",
     "register-msca-title": "Register for a My Service Canada Account",
     "register-msca-text": "Once your application is processed, you will be able to sign into <mscaLink>My Service Canada Account (MSCA)</mscaLink> to view or update your personal information. You will also be able to view any letters sent to you from the Government of Canada regarding the Canadian Dental Care Plan.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -61,7 +61,6 @@
     "whats-next": "Prochaines étapes",
     "begin-process": "Nous commencerons à traiter votre demande immédiatement.",
     "cdcp-checker": "Vous pouvez vérifier <cdcpLink>l'état de votre demande au Régime canadien de soins dentaires en ligne</cdcpLink> ou en appelant au 1-833-537-4342.",
-    "cdcp-checker-link": "https://canadadental-uat.powerappsportals.com/fr/status-etat/",
     "use-code": "Vous pouvez utiliser votre code de demande pour suivre l'avancement de votre demande dans les 48 heures suivant sa transmission.",
     "register-msca-title": "Inscription à Mon dossier Service Canada",
     "register-msca-text": "Une fois votre demande traitée, vous pourrez vous connecter à <mscaLink>Mon dossier Service Canada (MDSC)</mscaLink>. Vous pourrez y consulter les lettres envoyées par le gouvernement du Canada au sujet du Régime canadien de soins dentaires.",


### PR DESCRIPTION
### Description
Changed the status checker link on the apply 'confirmation' page to redirect to the protected 'view application' page. (note: this page does not exist yet, returns a default 404 response)

### Related Azure Boards Work Items
AB#3186

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/65c21c88-70b5-4fd1-9a89-a48bbb5491e3)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to confirm page on the apply workflow, link should point internally to fr or en/view-application

### Additional Notes