### PR TITLE
3205 postal code needs to be formatted with a space

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -25,10 +25,10 @@ import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
-import { isValidPostalCode } from '~/utils/validation-utils.server';
 
 export type PersonalInformationState = {
   copyMailingAddress: boolean;
@@ -105,7 +105,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         .string()
         .trim()
         .optional()
-        .transform((val) => val?.toUpperCase()),
+        .transform((val) => (val ? formatPostalCode(val) : val)),
       copyMailingAddress: z.boolean(),
       homeAddress: z.string().trim().optional(),
       homeApartment: z.string().trim().optional(),
@@ -116,7 +116,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         .string()
         .trim()
         .optional()
-        .transform((val) => val?.toUpperCase()),
+        .transform((val) => (val ? formatPostalCode(val) : val)),
     })
     .superRefine((val, ctx) => {
       if (val.mailingCountry === CANADA_COUNTRY_ID || val.mailingCountry === USA_COUNTRY_ID) {

--- a/frontend/app/utils/postal-zip-code-utils.server.ts
+++ b/frontend/app/utils/postal-zip-code-utils.server.ts
@@ -14,3 +14,13 @@ export const isValidPostalCode = (countryCode: string, postalCode: string) => {
       return true;
   }
 };
+
+export function formatPostalCode(postalCode: string) {
+  if (!postalCodeRegex.test(postalCode) || zipCodeRegex.test(postalCode)) throw new Error('Invalid postal or zip code');
+  // Canadian postal code
+  if (postalCodeRegex.test(postalCode)) {
+    postalCode = postalCode.replace(/\s/g, '');
+    return `${postalCode.slice(0, 3)} ${postalCode.slice(3)}`.toUpperCase();
+  }
+  return postalCode;
+}


### PR DESCRIPTION
### Description
Format Canadian postal codes in `/personal-information` of Apply Online such that they always have a space separator between the two chunks of alphanumeric characters.

### Related Azure Boards Work Items
[AB#3205](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3205)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`