### PR TITLE
3210 remove SIN placeholder for client/partner information

### DIFF
--- a/frontend/__tests__/utils/sin-utils.test.ts
+++ b/frontend/__tests__/utils/sin-utils.test.ts
@@ -26,10 +26,14 @@ describe('isValidSin', () => {
 
 describe('formatSin', () => {
   it('should format a SIN using the default separator', () => {
-    expect(formatSin('123456789')).toEqual('123 456 789');
+    expect(formatSin('800000002')).toEqual('800 000 002');
   });
 
   it('should format a SIN using the a supplied separator', () => {
-    expect(formatSin('123456789', '-')).toEqual('123-456-789');
+    expect(formatSin('800000002', '-')).toEqual('800-000-002');
+  });
+
+  it('should throw an error for invalid SIN', () => {
+    expect(() => formatSin('123456789')).toThrowError();
   });
 });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -66,7 +66,12 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   // state validation schema
   const applicantInformationSchema: z.ZodType<ApplicantInformationState> = z.object({
-    socialInsuranceNumber: z.string().trim().min(1, t('apply:applicant-information.error-message.sin-required')).refine(isValidSin, t('apply:applicant-information.error-message.sin-valid')),
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('apply:applicant-information.error-message.sin-required'))
+      .refine(isValidSin, t('apply:applicant-information.error-message.sin-valid'))
+      .transform((sin) => formatSin(sin, '')),
     firstName: z.string().trim().min(1, t('apply:applicant-information.error-message.first-name-required')),
     lastName: z.string().trim().min(1, t('apply:applicant-information.error-message.last-name-required')),
     maritalStatus: z
@@ -164,19 +169,7 @@ export default function ApplyFlowApplicationInformation() {
               />
               <InputField id="last-name" name="lastName" label={t('applicant-information.last-name')} className="w-full" required defaultValue={defaultState?.lastName ?? ''} errorMessage={errorMessages['last-name']} aria-describedby="name-instructions" />
             </div>
-            <InputField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              label={t('applicant-information.sin')}
-              required
-              inputMode="numeric"
-              pattern="\d{9}"
-              placeholder={formatSin('000000000', '-')}
-              minLength={9}
-              maxLength={9}
-              defaultValue={defaultState?.socialInsuranceNumber ?? ''}
-              errorMessage={errorMessages['social-insurance-number']}
-            />
+            <InputField id="social-insurance-number" name="socialInsuranceNumber" label={t('applicant-information.sin')} required defaultValue={defaultState?.socialInsuranceNumber ?? ''} errorMessage={errorMessages['social-insurance-number']} />
             <InputRadios
               id="marital-status"
               name="maritalStatus"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -85,7 +85,8 @@ export async function action({ context: { session }, params, request }: ActionFu
       .trim()
       .min(1, t('apply:partner-information.error-message.sin-required'))
       .refine(isValidSin, t('apply:partner-information.error-message.sin-valid'))
-      .refine((sin) => sin !== state.applicantInformation?.socialInsuranceNumber, t('apply:partner-information.error-message.sin-unique')),
+      .refine((sin) => sin !== state.applicantInformation?.socialInsuranceNumber, t('apply:partner-information.error-message.sin-unique'))
+      .transform((sin) => formatSin(sin, '')),
   });
 
   const formData = await request.formData();
@@ -184,19 +185,7 @@ export default function ApplyFlowApplicationInformation() {
               />
             </div>
             <DatePickerField id="date-of-birth" name="dateOfBirth" defaultValue={defaultState?.dateOfBirth ?? ''} legend={t('apply:partner-information.date-of-birth')} required errorMessage={errorMessages['date-picker-date-of-birth-month']} />
-            <InputField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              label={t('apply:partner-information.sin')}
-              required
-              inputMode="numeric"
-              pattern="\d{9}"
-              placeholder={formatSin('000000000', '-')}
-              minLength={9}
-              maxLength={9}
-              defaultValue={defaultState?.socialInsuranceNumber ?? ''}
-              errorMessage={errorMessages['social-insurance-number']}
-            />
+            <InputField id="social-insurance-number" name="socialInsuranceNumber" label={t('apply:partner-information.sin')} required defaultValue={defaultState?.socialInsuranceNumber ?? ''} errorMessage={errorMessages['social-insurance-number']} />
             <InputCheckbox id="confirm" name="confirm" value="yes" required errorMessage={errorMessages['input-checkbox-confirm']} defaultChecked={defaultState?.confirm === true}>
               {t('partner-information.confirm-checkbox')}
             </InputCheckbox>

--- a/frontend/app/utils/sin-utils.ts
+++ b/frontend/app/utils/sin-utils.ts
@@ -1,3 +1,5 @@
+const sinRegex = /^\d{3}[ -]?\d{3}[ -]?\d{3}$/;
+
 /**
  *
  * @param sin - the Social Insurance Number (SIN)
@@ -15,8 +17,8 @@
  *
  */
 export function isValidSin(sin: string): boolean {
-  if (!/^\d{9}$/.test(sin)) return false;
-  const multDigitString = [...sin].map((digit, index) => Number(digit) * (index % 2 === 0 ? 1 : 2)).join('');
+  if (!sinRegex.test(sin)) return false;
+  const multDigitString = [...sin.replace(/\D/g, '')].map((digit, index) => Number(digit) * (index % 2 === 0 ? 1 : 2)).join('');
   const digitSum = [...multDigitString].reduce((acc, cur) => acc + Number(cur), 0);
   return digitSum % 10 === 0;
 }
@@ -27,5 +29,6 @@ export function isValidSin(sin: string): boolean {
  * @returns a formatted SIN using a supplied separator
  */
 export function formatSin(sin: string, separator = ' '): string {
-  return (sin.match(/.../g) ?? []).join(separator);
+  if (!isValidSin(sin)) throw new Error('Invalid SIN format');
+  return (sin.replace(/\D/g, '').match(/.../g) ?? []).join(separator);
 }


### PR DESCRIPTION
### Description
Change the SIN inputs so that they can accept spaces or hyphens as input.

### Related Azure Boards Work Items
[AB#3210](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3210) 

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`