### PR TITLE
AB#2977 -- Including `remoteip` field in `/siteverify` request to obtain the score

### DIFF
--- a/frontend/__tests__/utils/ip-address-utils.server.test.ts
+++ b/frontend/__tests__/utils/ip-address-utils.server.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getEnv } from '~/utils/env.server';
+import { getClientIpAddress } from '~/utils/ip-address-utils.server';
+
+vi.mock('~/utils/env.server', () => ({
+  getEnv: vi.fn(),
+}));
+
+describe('ip-address.server', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getClientIpAddress()', () => {
+    it('should return first IP from "X-Forwarded-For" header', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ NODE_ENV: 'production' });
+      const request = new Request('https://example.com', {
+        headers: { 'X-Forwarded-For': '1.2.3.4, 5.6.7.8' },
+      });
+      expect(getClientIpAddress(request)).toEqual('1.2.3.4');
+    });
+
+    it('should return null if missing "X-Forwarded-For" header', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ NODE_ENV: 'production' });
+      const request = new Request('https://example.com');
+      expect(getClientIpAddress(request)).toBeNull();
+    });
+
+    it('should trim whitespace from first IP address', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ NODE_ENV: 'production' });
+      const request = new Request('https://example.com', {
+        headers: { 'X-Forwarded-For': '    1.2.3.4    , 5.6.7.8' },
+      });
+      expect(getClientIpAddress(request)).toEqual('1.2.3.4');
+    });
+
+    it('should return "172.0.0.1" when NODE_ENV=development', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ NODE_ENV: 'development' });
+      const request = new Request('https://example.com', {});
+      expect(getClientIpAddress(request)).toEqual('127.0.0.1');
+    });
+  });
+});

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -15,6 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getHCaptchaService } from '~/services/hcaptcha-service.server';
 import { getEnv } from '~/utils/env.server';
+import { getClientIpAddress } from '~/utils/ip-address-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -60,10 +61,11 @@ export async function action({ context: { session }, request, params }: ActionFu
   }
 
   const hCaptchaResponse = String(formData.get('h-captcha-response') ?? '');
+  const clientIpAddress = getClientIpAddress(request);
 
   try {
     const hCaptchaService = getHCaptchaService();
-    await hCaptchaService.verifyHCaptchaResponse(hCaptchaResponse);
+    await hCaptchaService.verifyHCaptchaResponse(hCaptchaResponse, clientIpAddress);
   } catch (error) {
     log.warn(`hCaptcha verification failed: [${error}]; Proceeding with normal application flow`);
   }

--- a/frontend/app/services/hcaptcha-service.server.ts
+++ b/frontend/app/services/hcaptcha-service.server.ts
@@ -21,7 +21,7 @@ function createHCaptchaService() {
    *
    * @see https://docs.hcaptcha.com/#verify-the-user-response-server-side
    */
-  async function verifyHCaptchaResponse(hCaptchaResponse: string) {
+  async function verifyHCaptchaResponse(hCaptchaResponse: string, ipAddress: string | null) {
     const instrumentationService = getInstrumentationService();
 
     getAuditService().audit('hcaptcha.verify', { userId: 'anonymous' });
@@ -29,6 +29,9 @@ function createHCaptchaService() {
     const url = new URL(HCAPTCHA_VERIFY_URL);
     url.searchParams.set('response', hCaptchaResponse);
     url.searchParams.set('secret', HCAPTCHA_SECRET_KEY);
+    if (ipAddress) {
+      url.searchParams.set('remoteip', ipAddress);
+    }
 
     const response = await fetch(url, { method: 'POST' });
 

--- a/frontend/app/utils/ip-address-utils.server.ts
+++ b/frontend/app/utils/ip-address-utils.server.ts
@@ -1,0 +1,22 @@
+import { getEnv } from './env.server';
+
+/**
+ * Attempts to retrieve the client's IP address from the "X-Forwarded-For" header of the HTTP request.
+ *
+ * If the "X-Forwarded-For" header exists, the first element of the comma-separated header is extracted.
+ * This is because the header may contain a chain of IP addresses, representing intermediate proxies.
+ *
+ * In a development environment, this function will return "127.0.0.1" (localhost IP).
+ *
+ * @param request the incoming HTTP request object.
+ * @returns the trimmed IP address or null if the "X-Forwarded-For" header is missing.
+ */
+export function getClientIpAddress(request: Request): string | null {
+  const { NODE_ENV } = getEnv();
+  if (NODE_ENV === 'development') {
+    return '127.0.0.1';
+  }
+
+  const xForwardedForHeader = request.headers.get('X-Forwarded-For');
+  return xForwardedForHeader?.split(',')[0].trim() ?? null;
+}


### PR DESCRIPTION
### Description
The `remoteip` field needs to be supplied to the `/siteverify` request for an Enterprise sitekey.

A utility function (and tests) has been created to grab the client's IP from the `X-Forwarded-For` header.
> By default NGINX uses the content of the header X-Forwarded-For as the source of truth to get information about the client IP address. 

See https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/ :shrug: 

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Set the `HCAPTCHA_SITE_KEY` environment variable to `30000000-ffff-ffff-ffff-000000000003`, which represents an Enterprise test site key where a bot is detected. 
Run the application locally and go through the `/terms-and-conditions` page. You should see a `score` of `1` logged.