### PR TITLE
Revert STAGING fontend version and enabel AA on INT

### DIFF
--- a/gitops/overlays/int/configs/frontend-config.conf
+++ b/gitops/overlays/int/configs/frontend-config.conf
@@ -49,3 +49,8 @@ USA_COUNTRY_ID=fcf7389e-97ae-eb11-8236-000d3af4bfc3
 # SIN edit stub page configuration
 #
 SHOW_SIN_EDIT_STUB_PAGE=true
+
+#
+# Adobe Analytics Script URL
+#
+ADOBE_ANALYTICS_SRC=https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-e9c7a51f-0031c
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-2ba3b27a-002f0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title. The reason is that the tester are using STAGING for a while now and they started to detect bugs because Interop submission is not working at the moment.