### PR TITLE
The lang property has been added to the language switcher component.

### DIFF
--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -20,7 +20,9 @@ export function PageHeaderBrand() {
         <section id="wb-lng">
           <h2 className="sr-only">{t('gcweb:header.language-selection')}</h2>
           <LanguageSwitcher>
-            <span className="hidden md:block">{t('gcweb:language-switcher.alt-lang')}</span>
+            <span className="hidden md:block" lang={t('gcweb:language-switcher.alt-lang-abbr')}>
+              {t('gcweb:language-switcher.alt-lang')}
+            </span>
             <abbr title={t('gcweb:language-switcher.alt-lang')} className="cursor-help uppercase md:hidden">
               {t('gcweb:language-switcher.alt-lang-abbr')}
             </abbr>

--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -20,7 +20,7 @@ export function PageHeaderBrand() {
         <section id="wb-lng">
           <h2 className="sr-only">{t('gcweb:header.language-selection')}</h2>
           <LanguageSwitcher>
-            <span className="hidden md:block" lang={t('gcweb:language-switcher.alt-lang-abbr')}>
+            <span className="hidden md:block" lang={t('gcweb:language-switcher.alt-lang-abbr-prop')}>
               {t('gcweb:language-switcher.alt-lang')}
             </span>
             <abbr title={t('gcweb:language-switcher.alt-lang')} className="cursor-help uppercase md:hidden">

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -55,7 +55,8 @@
   },
   "language-switcher": {
     "alt-lang": "Français",
-    "alt-lang-abbr": "FR"
+    "alt-lang-abbr": "FR",
+    "alt-lang-abbr-prop": "fr"
   },
   "breadcrumbs": {
     "you-are-here": "You are here:",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -55,7 +55,8 @@
   },
   "language-switcher": {
     "alt-lang": "English",
-    "alt-lang-abbr": "EN"
+    "alt-lang-abbr": "EN",
+    "alt-lang-abbr-prop": "en"
   },
   "breadcrumbs": {
     "you-are-here": "Vous êtes ici\u00a0:",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The lang property is needed for accessibility purposes.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3204](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/3204)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Listen to the letters index page with a screen reader that distinguishes between French and English content. The language toggle should be read out in the desired language.
