### PR TITLE
3230 application-delegate and file-taxes page broken

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
@@ -8,11 +8,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
 import pageIds from '../../../page-ids.json';
-import { ButtonLink } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,9 +39,9 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
-  await applyRouteHelpers.loadState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirectWithLocale(request, '/');
+  return redirect(t('apply:eligibility.application-delegate.return-btn-link'));
 }
 
 export default function ApplyFlowApplicationDelegate() {
@@ -75,10 +75,10 @@ export default function ApplyFlowApplicationDelegate() {
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.application-delegate.back-btn')}
         </ButtonLink>
-        <ButtonLink type="submit" variant="primary" onClick={() => sessionStorage.removeItem('flow.state')} to={t('apply:eligibility.application-delegate.return-btn-link')}>
+        <Button type="submit" variant="primary">
           {t('apply:eligibility.application-delegate.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
-        </ButtonLink>
+        </Button>
       </fetcher.Form>
     </>
   );

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
@@ -8,11 +8,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
 import pageIds from '../../../page-ids.json';
-import { ButtonLink } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,9 +39,9 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
-  await applyRouteHelpers.loadState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirectWithLocale(request, '/');
+  return redirect(t('apply:eligibility.file-your-taxes.return-btn-link'));
 }
 
 export default function ApplyFlowFileYourTaxes() {
@@ -74,10 +74,10 @@ export default function ApplyFlowFileYourTaxes() {
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.file-your-taxes.back-btn')}
         </ButtonLink>
-        <ButtonLink type="submit" variant="primary" onClick={() => sessionStorage.removeItem('flow.state')} to={t('apply:eligibility.file-your-taxes.return-btn-link')}>
+        <Button type="submit" variant="primary">
           {t('apply:eligibility.file-your-taxes.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
-        </ButtonLink>
+        </Button>
       </fetcher.Form>
     </>
   );


### PR DESCRIPTION
### Description
The state should be cleared when an applicant clicks the "return to main page" button on these two pages. 

### Related Azure Boards Work Items
[AB#3230](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3230)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`