### PR TITLE
Status checker field validation

### DIFF
--- a/frontend/public/locales/en/status.json
+++ b/frontend/public/locales/en/status.json
@@ -56,7 +56,8 @@
     "submit": "Check status",
     "error-message": {
       "sin-required": "The Social Insurance Number (SIN) is required.",
-      "sin-valid": "The Social Insurance Number (SIN) must be valid."
+      "sin-valid": "The Social Insurance Number (SIN) must be valid.",
+      "application-code-required": "The application code or client number is required"
     }
   }
 }

--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -56,7 +56,8 @@
     "submit": "Vérifier l'état de votre demande",
     "error-message": {
       "sin-required": "Le numéro d'assurance sociale (NAS) est requis.",
-      "sin-valid": "Le numéro d'assurance sociale (NAS) doit être valide."
+      "sin-valid": "Le numéro d'assurance sociale (NAS) doit être valide.",
+      "application-code-required": "(FR) The application code or client number is required"
     }
   }
 }


### PR DESCRIPTION
### Description
Added validation for social insurance number and application code
social insurance number has the same validation with the one in `apply/applicant-information`
application code only has an empty field validation for now, waiting for confirmation on what other validation is needed.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`