### PR TITLE
AB#3163 -- Support for bilingual routing

### DIFF
--- a/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/confirm.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/confirm.test.tsx
@@ -79,7 +79,7 @@ describe('_gcweb-app.personal-information.phone-number.confirm', () => {
           method: 'POST',
         }),
         context: { session },
-        params: {},
+        params: { lang: 'en' },
       });
 
       expect(response.status).toBe(302);

--- a/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
+++ b/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
@@ -91,7 +91,7 @@ describe('_public.apply.id.date-of-birth', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
@@ -114,7 +114,7 @@ describe('_public.apply.id.date-of-birth', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);

--- a/frontend/__tests__/routes/_public+/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/_public+/tax-filing.test.tsx
@@ -83,7 +83,7 @@ describe('_public.apply.id.tax-filing', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
@@ -101,11 +101,11 @@ describe('_public.apply.id.tax-filing', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/file-your-taxes');
+      expect(response.headers.get('location')).toBe('/en/apply/123/file-taxes');
     });
   });
 });

--- a/frontend/__tests__/routes/_public+/type-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-application.test.tsx
@@ -84,7 +84,7 @@ describe('_public.apply.id.type-of-application', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
@@ -102,7 +102,7 @@ describe('_public.apply.id.type-of-application', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
         context: { session },
-        params: {},
+        params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);

--- a/frontend/app/components/app-link.tsx
+++ b/frontend/app/components/app-link.tsx
@@ -1,34 +1,47 @@
 import { ComponentProps } from 'react';
 
-import { Link, useHref, useParams } from '@remix-run/react';
+import { Link, Params, useHref } from '@remix-run/react';
+
+import type { To } from 'react-router';
+import invariant from 'tiny-invariant';
+
+import { getPathById } from '~/utils/route-utils';
 
 /**
  * Props for the AppLink component.
  */
-export interface AppLinkProps extends ComponentProps<typeof Link> {
+export interface AppLinkProps extends Omit<ComponentProps<typeof Link>, 'to'> {
+  params?: Params;
+  routeId?: string;
   targetLang?: 'en' | 'fr';
+  to?: To;
+}
+
+function getTo(params?: Params, routeId?: string, targetLang?: 'en' | 'fr', to?: To) {
+  if (to) {
+    return to;
+  }
+
+  invariant(routeId, 'either routeId or to must be provided');
+  const lang = targetLang ?? params?.lang;
+  return getPathById(routeId, { ...params, lang });
 }
 
 /**
  * A component that renders a localized link.
  */
-export function AppLink({ targetLang, ...props }: AppLinkProps) {
-  const href = useHref(props.to);
-  const { lang: langParam } = useParams();
+export function AppLink({ params, routeId, targetLang, to, ...props }: AppLinkProps) {
+  const href = useHref(getTo(params, routeId, targetLang, to), { relative: 'route' });
 
-  const isExternalHref = typeof props.to === 'string' && props.to.startsWith('http');
+  const isExternalHref = typeof to === 'string' && to.startsWith('http');
 
   if (isExternalHref) {
     // external links must be respected as they are 🫡
-    return <Link {...props} />;
+    return <Link {...props} to={to} />;
   }
 
-  // passed-in language takes precedence over language in URL
-  const lang = targetLang ?? langParam;
-  const localizedTo = `/${lang}${href}`;
-
   return (
-    <Link {...props} to={localizedTo}>
+    <Link {...props} to={href}>
       {props.children}
     </Link>
   );

--- a/frontend/app/components/breadcrumbs.tsx
+++ b/frontend/app/components/breadcrumbs.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+import { useParams } from '@remix-run/react';
+
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
@@ -9,11 +11,12 @@ import { InlineLink } from './inline-link';
 
 export interface BreadcrumbsProps {
   className?: string;
-  items: Array<{ content: string; to?: To }>;
+  items: Array<{ content: string; routeId?: string; to?: To }>;
 }
 
 export function Breadcrumbs({ className, items }: BreadcrumbsProps) {
   const { t } = useTranslation(['gcweb']);
+
   return (
     <nav id="wb-bc" className={className} property="breadcrumb" aria-labelledby="breadcrumbs">
       <h2 id="breadcrumbs" className="sr-only">
@@ -21,11 +24,13 @@ export function Breadcrumbs({ className, items }: BreadcrumbsProps) {
       </h2>
       <div className="container">
         <ol className="flex flex-wrap items-center gap-x-3 gap-y-1" typeof="BreadcrumbList">
-          {items.map(({ content, to }, idx) => {
+          {items.map(({ content, routeId, to }, idx) => {
             return (
               <li key={content} property="itemListElement" typeof="ListItem" className="flex items-center">
                 {idx !== 0 && <FontAwesomeIcon icon={faChevronRight} className="mr-2 size-3 text-slate-700" />}
-                <Breadcrumb to={to}>{content}</Breadcrumb>
+                <Breadcrumb routeId={routeId} to={to}>
+                  {content}
+                </Breadcrumb>
               </li>
             );
           })}
@@ -35,9 +40,11 @@ export function Breadcrumbs({ className, items }: BreadcrumbsProps) {
   );
 }
 
-function Breadcrumb({ children, to }: { children: ReactNode; to?: To }) {
+function Breadcrumb({ children, routeId, to }: { children: ReactNode; routeId?: string; to?: To }) {
+  const params = useParams();
+
   // prettier-ignore
-  return to === undefined
+  return routeId === undefined && to === undefined
     ? <span property="name">{children}</span>
-    : <InlineLink to={to} property="item" typeof="WebPage"><span property="name">{children}</span></InlineLink>;
+    : <InlineLink routeId={routeId} params={params} to={to} property="item" typeof="WebPage"><span property="name">{children}</span></InlineLink>;
 }

--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -1,8 +1,8 @@
-import { useHref, useLocation, useParams } from '@remix-run/react';
+import { useMatches, useParams } from '@remix-run/react';
 
 import type { InlineLinkProps } from '~/components/inline-link';
 import { InlineLink } from '~/components/inline-link';
-import { getAltLanguage, removeLanguageFromPath } from '~/utils/locale-utils';
+import { getAltLanguage } from '~/utils/locale-utils';
 
 export type LanguageSwitcherProps = Omit<InlineLinkProps, 'to' | 'reloadDocument'>;
 
@@ -11,15 +11,15 @@ export type LanguageSwitcherProps = Omit<InlineLinkProps, 'to' | 'reloadDocument
  * (ie: 'en' → 'fr'; 'fr' → 'en')
  */
 export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) {
-  const location = useLocation();
+  const matches = useMatches();
   const params = useParams();
 
   const altLang = getAltLanguage(params.lang);
-  const pathname = removeLanguageFromPath(location.pathname);
-  const href = useHref({ ...location, pathname });
+  const currentRoute = matches[matches.length - 1];
+  const routeId = currentRoute.id.replace(/-(en|fr)$/, '');
 
   return (
-    <InlineLink data-testid="language-switcher" reloadDocument to={href} targetLang={altLang} {...props}>
+    <InlineLink data-testid="language-switcher" reloadDocument routeId={routeId} params={params} targetLang={altLang} {...props}>
       {children}
     </InlineLink>
   );

--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -133,6 +133,7 @@ function PageBreadcrumbs() {
         { content: t('gcweb:breadcrumbs.home'), to: userOrigin?.to },
         ...breadcrumbs.map((item) => ({
           content: t(item.labelI18nKey),
+          routeId: item.routeId,
           to: item.to,
         })),
       ]}

--- a/frontend/app/route-helpers/personal-information-route-helpers.server.ts
+++ b/frontend/app/route-helpers/personal-information-route-helpers.server.ts
@@ -1,9 +1,10 @@
-import { Session } from '@remix-run/node';
+import { Session, redirect } from '@remix-run/node';
+import { Params } from '@remix-run/react';
 
 import { PersonalInfo, getPersonalInformationService } from '~/services/personal-information-service.server';
-import { redirectWithLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { UserinfoToken } from '~/utils/raoidc-utils.server';
+import { getPathById } from '~/utils/route-utils';
 
 const log = getLogger('personal-information-route-helpers.server');
 
@@ -18,7 +19,7 @@ const log = getLogger('personal-information-route-helpers.server');
  * @throws A redirect to the '/data-unavailable' route if the personal information is not found in the session or service
  * @returns The user's personal information
  */
-async function getPersonalInformation(userInfoToken: UserinfoToken, request: Request, session: Session) {
+async function getPersonalInformation(userInfoToken: UserinfoToken, params: Params, request: Request, session: Session) {
   if (!userInfoToken.sin) {
     log.warn('No SIN found in userInfoToken for userId [%s]', userInfoToken.sub);
     throw new Response(null, { status: 401 });
@@ -38,7 +39,7 @@ async function getPersonalInformation(userInfoToken: UserinfoToken, request: Req
   }
 
   log.debug('No personal information found in session or from service for userId [%s]; Redirecting to "/data-unavailable"', userInfoToken.sub);
-  throw redirectWithLocale(request, '/data-unavailable');
+  throw redirect(getPathById('$lang+/_protected+/data-unavailable', params));
 }
 
 export function getPersonalInformationRouteHelpers() {

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -1,9 +1,15 @@
 [
   {
+    "id": "index",
     "file": "routes/index.tsx",
+    "paths": {
+      "en": "/",
+      "fr": "/"
+    },
     "index": true
   },
   {
+    "id": "[.]well-known.jwks[.]json",
     "file": "routes/[.]well-known.jwks[.]json.tsx",
     "paths": {
       "en": "/.well-known/jwks.json",
@@ -11,6 +17,7 @@
     }
   },
   {
+    "id": "api+/readyz",
     "file": "routes/api+/readyz.ts",
     "paths": {
       "en": "/api/readyz",
@@ -18,6 +25,7 @@
     }
   },
   {
+    "id": "api+/refresh-session",
     "file": "routes/api+/refresh-session.ts",
     "paths": {
       "en": "/api/refresh-session",
@@ -25,6 +33,7 @@
     }
   },
   {
+    "id": "auth+/$",
     "file": "routes/auth+/$.tsx",
     "paths": {
       "en": "/auth/*",
@@ -32,6 +41,7 @@
     }
   },
   {
+    "id": "$lang+/_route",
     "file": "routes/$lang+/_route.tsx",
     "paths": {
       "en": "/:lang",
@@ -39,6 +49,7 @@
     },
     "children": [
       {
+        "id": "$lang+/$",
         "file": "routes/$lang+/$.tsx",
         "paths": {
           "en": "/:lang/*",
@@ -46,20 +57,24 @@
         }
       },
       {
+        "id": "$lang+/_public+/_route",
         "file": "routes/$lang+/_public+/_route.tsx",
         "children": [
           {
+            "id": "$lang+/_public+/apply+/_route",
             "file": "routes/$lang+/_public+/apply+/_route.tsx",
-            "paths": {
-              "en": "/:lang/apply",
-              "fr": "/:lang/appliquer"
-            },
             "children": [
               {
+                "id": "$lang+/_public+/apply+/index",
                 "file": "routes/$lang+/_public+/apply+/index.tsx",
+                "paths": {
+                  "en": "/:lang/apply",
+                  "fr": "/:lang/appliquer"
+                },
                 "index": true
               },
               {
+                "id": "$lang+/_public+/apply+/$id+/_route",
                 "file": "routes/$lang+/_public+/apply+/$id+/_route.tsx",
                 "paths": {
                   "en": "/:lang/apply/:id",
@@ -67,6 +82,7 @@
                 },
                 "children": [
                   {
+                    "id": "$lang+/_public+/apply+/$id+/applicant-information",
                     "file": "routes/$lang+/_public+/apply+/$id+/applicant-information.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/applicant-information",
@@ -74,6 +90,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/application-delegate",
                     "file": "routes/$lang+/_public+/apply+/$id+/application-delegate.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/application-delegate",
@@ -81,6 +98,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/communication-preference",
                     "file": "routes/$lang+/_public+/apply+/$id+/communication-preference.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/communication-preference",
@@ -88,6 +106,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/confirmation",
                     "file": "routes/$lang+/_public+/apply+/$id+/confirmation.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/confirmation",
@@ -95,6 +114,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/date-of-birth",
                     "file": "routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/date-of-birth",
@@ -102,6 +122,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/dental-insurance",
                     "file": "routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/dental-insurance",
@@ -109,6 +130,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/dob-eligibility",
                     "file": "routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/dob-eligibility",
@@ -116,6 +138,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/exit-application",
                     "file": "routes/$lang+/_public+/apply+/$id+/exit-application.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/exit-application",
@@ -123,6 +146,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits",
                     "file": "routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/federal-provincial-territorial-benefits",
@@ -130,6 +154,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/file-taxes",
                     "file": "routes/$lang+/_public+/apply+/$id+/file-taxes.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/file-taxes",
@@ -137,6 +162,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/partner-information",
                     "file": "routes/$lang+/_public+/apply+/$id+/partner-information.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/partner-information",
@@ -144,6 +170,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/personal-information",
                     "file": "routes/$lang+/_public+/apply+/$id+/personal-information.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/personal-information",
@@ -151,6 +178,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/review-information",
                     "file": "routes/$lang+/_public+/apply+/$id+/review-information.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/review-information",
@@ -158,6 +186,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/tax-filing",
                     "file": "routes/$lang+/_public+/apply+/$id+/tax-filing.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/tax-filing",
@@ -165,6 +194,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/terms-and-conditions",
                     "file": "routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/terms-and-conditions",
@@ -172,6 +202,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_public+/apply+/$id+/type-application",
                     "file": "routes/$lang+/_public+/apply+/$id+/type-application.tsx",
                     "paths": {
                       "en": "/:lang/apply/:id/type-application",
@@ -183,6 +214,7 @@
             ]
           },
           {
+            "id": "$lang+/_public+/status+/index",
             "file": "routes/$lang+/_public+/status+/index.tsx",
             "index": true,
             "paths": {
@@ -193,9 +225,11 @@
         ]
       },
       {
+        "id": "$lang+/_protected+/_route",
         "file": "routes/$lang+/_protected+/_route.tsx",
         "children": [
           {
+            "id": "$lang+/_protected+/data-unavailable",
             "file": "routes/$lang+/_protected+/data-unavailable.tsx",
             "paths": {
               "en": "/:lang/data-unavailable",
@@ -203,6 +237,7 @@
             }
           },
           {
+            "id": "$lang+/_protected+/home",
             "file": "routes/$lang+/_protected+/home.tsx",
             "paths": {
               "en": "/:lang/home",
@@ -210,17 +245,20 @@
             }
           },
           {
+            "id": "$lang+/_protected+/letters+/_route",
             "file": "routes/$lang+/_protected+/letters+/_route.tsx",
-            "paths": {
-              "en": "/:lang/letters",
-              "fr": "/:lang/lettres"
-            },
             "children": [
               {
+                "id": "$lang+/_protected+/letters+/index",
                 "file": "routes/$lang+/_protected+/letters+/index.tsx",
+                "paths": {
+                  "en": "/:lang/letters",
+                  "fr": "/:lang/lettres"
+                },
                 "index": true
               },
               {
+                "id": "$lang+/_protected+/letters+/$id.download",
                 "file": "routes/$lang+/_protected+/letters+/$id.download.tsx",
                 "paths": {
                   "en": "/:lang/letters/:id/download",
@@ -230,17 +268,20 @@
             ]
           },
           {
+            "id": "$lang+/_protected+/personal-information+/_route",
             "file": "routes/$lang+/_protected+/personal-information+/_route.tsx",
-            "paths": {
-              "en": "/:lang/personal-information",
-              "fr": "/:lang/informations-personnelles"
-            },
             "children": [
               {
+                "id": "$lang+/_protected+/personal-information+/index",
                 "file": "routes/$lang+/_protected+/personal-information+/index.tsx",
+                "paths": {
+                  "en": "/:lang/personal-information",
+                  "fr": "/:lang/informations-personnelles"
+                },
                 "index": true
               },
               {
+                "id": "$lang+/_protected+/personal-information+/home-address+/_route",
                 "file": "routes/$lang+/_protected+/personal-information+/home-address+/_route.tsx",
                 "paths": {
                   "en": "/:lang/personal-information/home-address",
@@ -248,6 +289,7 @@
                 },
                 "children": [
                   {
+                    "id": "$lang+/_protected+/personal-information+/home-address+/address-accuracy",
                     "file": "routes/$lang+/_protected+/personal-information+/home-address+/address-accuracy.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/home-address/address-accuracy",
@@ -255,6 +297,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/home-address+/edit",
                     "file": "routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/home-address/edit",
@@ -262,6 +305,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/home-address+/suggested",
                     "file": "routes/$lang+/_protected+/personal-information+/home-address+/suggested.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/home-address/suggested",
@@ -271,6 +315,7 @@
                 ]
               },
               {
+                "id": "$lang+/_protected+/personal-information+/mailing-address+/_route",
                 "file": "routes/$lang+/_protected+/personal-information+/mailing-address+/_route.tsx",
                 "paths": {
                   "en": "/:lang/personal-information/mailing-address",
@@ -278,6 +323,7 @@
                 },
                 "children": [
                   {
+                    "id": "$lang+/_protected+/personal-information+/mailing-address+/address-accuracy",
                     "file": "routes/$lang+/_protected+/personal-information+/mailing-address+/address-accuracy.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/mailing-address/address-accuracy",
@@ -285,6 +331,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/mailing-address+/confirm",
                     "file": "routes/$lang+/_protected+/personal-information+/mailing-address+/confirm.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/mailing-address/confirm",
@@ -292,6 +339,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/mailing-address+/edit",
                     "file": "routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/mailing-address/edit",
@@ -301,6 +349,7 @@
                 ]
               },
               {
+                "id": "$lang+/_protected+/personal-information+/phone-number+/_route",
                 "file": "routes/$lang+/_protected+/personal-information+/phone-number+/_route.tsx",
                 "paths": {
                   "en": "/:lang/personal-information/phone-number",
@@ -308,6 +357,7 @@
                 },
                 "children": [
                   {
+                    "id": "$lang+/_protected+/personal-information+/phone-number+/confirm",
                     "file": "routes/$lang+/_protected+/personal-information+/phone-number+/confirm.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/phone-number/confirm",
@@ -315,6 +365,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/phone-number+/edit",
                     "file": "routes/$lang+/_protected+/personal-information+/phone-number+/edit.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/phone-number/edit",
@@ -324,6 +375,7 @@
                 ]
               },
               {
+                "id": "$lang+/_protected+/personal-information+/preferred-language+/_route",
                 "file": "routes/$lang+/_protected+/personal-information+/preferred-language+/_route.tsx",
                 "paths": {
                   "en": "/:lang/personal-information/preferred-language",
@@ -331,6 +383,7 @@
                 },
                 "children": [
                   {
+                    "id": "$lang+/_protected+/personal-information+/preferred-language+/confirm",
                     "file": "routes/$lang+/_protected+/personal-information+/preferred-language+/confirm.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/preferred-language/confirm",
@@ -338,6 +391,7 @@
                     }
                   },
                   {
+                    "id": "$lang+/_protected+/personal-information+/preferred-language+/edit",
                     "file": "routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx",
                     "paths": {
                       "en": "/:lang/personal-information/preferred-language/edit",
@@ -349,6 +403,7 @@
             ]
           },
           {
+            "id": "$lang+/_protected+/stub-sin-editor",
             "file": "routes/$lang+/_protected+/stub-sin-editor.tsx",
             "paths": {
               "en": "/:lang/stub-sin-editor",

--- a/frontend/app/routes/$lang+/_protected+/home.tsx
+++ b/frontend/app/routes/$lang+/_protected+/home.tsx
@@ -1,13 +1,13 @@
-import type { ComponentProps, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { Link } from '@remix-run/react';
+import { useParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
 import pageIds from '../page-ids.json';
-import { AppLink } from '~/components/app-link';
+import { AppLink, AppLinkProps } from '~/components/app-link';
 import { useFeature } from '~/root';
 import { getAuditService } from '~/services/audit-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -48,37 +48,38 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 
 export default function Index() {
   const { t } = useTranslation(handle.i18nNamespaces);
+  const params = useParams();
 
   return (
     <>
       <div className="grid gap-4">
         {useFeature('update-personal-info') && (
-          <CardLink title={t('index:personal-info')} to="/personal-information">
+          <CardLink title={t('index:personal-info')} routeId="$lang+/_protected+/personal-information+/index" params={params}>
             {t('index:personal-info-desc')}
           </CardLink>
         )}
         {useFeature('view-letters') && (
-          <CardLink title={t('index:view-letters')} to="/letters">
+          <CardLink title={t('index:view-letters')} routeId="$lang+/_protected+/letters+/index" params={params}>
             {t('index:view-letters-desc')}
           </CardLink>
         )}
         {useFeature('view-applications') && (
-          <CardLink title={t('index:view-my-application')} to="/view-application" inProgress>
+          <CardLink title={t('index:view-my-application')} routeId="$lang+/_protected+/home" params={params}>
             {t('index:view-my-application-desc')}
           </CardLink>
         )}
         {useFeature('doc-upload') && (
-          <CardLink title={t('index:upload')} to="/upload-document" inProgress>
+          <CardLink title={t('index:upload')} routeId="$lang+/_protected+/home" params={params}>
             {t('index:upload-desc')}
           </CardLink>
         )}
         {useFeature('view-messages') && (
-          <CardLink title={t('index:view-cdcp')} to="/messages" inProgress>
+          <CardLink title={t('index:view-cdcp')} routeId="$lang+/_protected+/home" params={params}>
             {t('index:view-cdcp-desc')}
           </CardLink>
         )}
         {useFeature('email-alerts') && (
-          <CardLink title={t('index:subscribe')} to="/alert-me" inProgress>
+          <CardLink title={t('index:subscribe')} routeId="$lang+/_protected+/home" params={params}>
             {t('index:subscribe-desc')}
           </CardLink>
         )}
@@ -87,9 +88,15 @@ export default function Index() {
   );
 }
 
-function CardLink({ children, inProgress, title, to }: { children: ReactNode; inProgress?: boolean; title: ReactNode; to: ComponentProps<typeof Link>['to'] }) {
+interface CardLinkProps extends Omit<AppLinkProps, 'className' | 'title'> {
+  children: ReactNode;
+  inProgress?: boolean;
+  title: ReactNode;
+}
+
+function CardLink({ children, inProgress, title, ...props }: CardLinkProps) {
   return (
-    <AppLink className="flex flex-col gap-4 rounded-xl border border-slate-300 bg-slate-50 p-6 hover:shadow-md " to={to}>
+    <AppLink className="flex flex-col gap-4 rounded-xl border border-slate-300 bg-slate-50 p-6 hover:shadow-md" {...props}>
       <h2 className="font-lato text-2xl font-semibold leading-8">{title}</h2>
       <p>{children}</p>
       {inProgress && (

--- a/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from 'react';
 
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { useLoaderData, useSearchParams } from '@remix-run/react';
+import { useLoaderData, useParams, useSearchParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 
 const orderEnumSchema = z.enum(['asc', 'desc']);
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
   const auditService = getAuditService();
@@ -55,7 +55,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
-  const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, request, session);
+  const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
   const letters = personalInformation.clientNumber ? await lettersService.getLetters(personalInformation.clientNumber, sortOrder) : [];
   session.set('letters', letters);
 
@@ -75,6 +75,7 @@ export default function LettersIndex() {
   const [, setSearchParams] = useSearchParams();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const { letters, letterTypes, sortOrder } = useLoaderData<typeof loader>();
+  const params = useParams();
   const userOrigin = useUserOrigin();
 
   function handleOnSortOrderChange(e: ChangeEvent<HTMLSelectElement>) {
@@ -113,7 +114,7 @@ export default function LettersIndex() {
 
           return (
             <li key={letter.id} className="py-4 sm:py-6">
-              <InlineLink reloadDocument to={`/letters/${letter.id}/download`} className="external-link font-lato font-semibold" target="_blank">
+              <InlineLink reloadDocument routeId="$lang+/_protected+/letters+/$id.download" params={{ ...params, id: letter.id }} className="external-link font-lato font-semibold" target="_blank">
                 {getNameByLanguage(i18n.language, letterType)}
                 <NewTabIndicator />
               </InlineLink>

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { useLoaderData, useParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -66,6 +66,8 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 export default function PersonalInformationIndex() {
   const { user, preferredLanguage, homeAddressInfo, mailingAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const params = useParams();
+
   return (
     <>
       <p className="mb-8 text-lg text-gray-500">{t('personal-information:index.on-file')}</p>
@@ -74,7 +76,7 @@ export default function PersonalInformationIndex() {
         <DescriptionListItem term={t('personal-information:index.preferred-language')}>
           <p>{preferredLanguage ? getNameByLanguage(i18n.language, preferredLanguage) : t('personal-information:index.no-preferred-language-on-file')}</p>
           <p>
-            <InlineLink id="change-preferred-language-button" to="/personal-information/preferred-language/edit">
+            <InlineLink id="change-preferred-language-button" routeId="$lang+/_protected+/personal-information+/preferred-language+/edit" params={params}>
               {t('personal-information:index.change-preferred-language')}
             </InlineLink>
           </p>
@@ -92,7 +94,7 @@ export default function PersonalInformationIndex() {
             <p>{t('personal-information:index.no-address-on-file')}</p>
           )}
           <p>
-            <InlineLink id="change-home-address-button" to="/personal-information/home-address/edit">
+            <InlineLink id="change-home-address-button" routeId="$lang+/_protected+/personal-information+/home-address+/edit" params={params}>
               {t('personal-information:index.change-home-address')}
             </InlineLink>
           </p>
@@ -110,7 +112,7 @@ export default function PersonalInformationIndex() {
             <p>{t('personal-information:index.no-address-on-file')}</p>
           )}
           <p>
-            <InlineLink id="change-mailing-address-button" to="/personal-information/mailing-address/edit">
+            <InlineLink id="change-mailing-address-button" routeId="$lang+/_protected+/personal-information+/mailing-address+/edit" params={params}>
               {t('personal-information:index.change-mailing-address')}
             </InlineLink>
           </p>
@@ -118,7 +120,7 @@ export default function PersonalInformationIndex() {
         <DescriptionListItem term={t('personal-information:index.phone-number')}>
           <p>{user.phoneNumber}</p>
           <p>
-            <InlineLink id="change-phone-number-button" to="/personal-information/phone-number/edit">
+            <InlineLink id="change-phone-number-button" routeId="$lang+/_protected+/personal-information+/phone-number+/edit" params={params}>
               {t('personal-information:index.change-phone-number')}
             </InlineLink>
           </p>

--- a/frontend/app/routes/$lang+/_protected+/stub-sin-editor.tsx
+++ b/frontend/app/routes/$lang+/_protected+/stub-sin-editor.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
 
 import md5 from 'md5';
@@ -12,10 +12,10 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputField } from '~/components/input-field';
 import { getEnv } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { UserinfoToken } from '~/utils/raoidc-utils.server';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { isValidSin } from '~/utils/sin-utils';
 
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
   return { meta };
 }
 
-export async function action({ context: { session }, request }: ActionFunctionArgs) {
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const sinToStubSchema = z.object({
     socialInsuranceNumberToStub: z.string().refine(isValidSin, { message: 'valid-sin' }),
   });
@@ -92,7 +92,7 @@ export async function action({ context: { session }, request }: ActionFunctionAr
   }
   session.set('idToken', idToken);
 
-  return redirectWithLocale(request, `/home`);
+  return redirect(getPathById('$lang+/_protected+/home', params));
 }
 
 export default function StubSinEditorPage() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/_route.tsx
@@ -1,35 +1,33 @@
 import { useEffect } from 'react';
 
-import { LoaderFunctionArgs, json } from '@remix-run/node';
-import { Outlet, useLoaderData, useNavigate } from '@remix-run/react';
+import { Outlet, useNavigate, useParams } from '@remix-run/react';
 
 import { handle as layoutHandle } from '~/routes/$lang+/_public+/apply+/_route';
-import { getLocale } from '~/utils/locale-utils.server';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 
 export const handle = {
   // ensure that the parent layout's i18n namespaces are loaded
   i18nNamespaces: [...layoutHandle.i18nNamespaces],
 } as const satisfies RouteHandleData;
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
-  const locale = getLocale(request);
-  return json({ locale });
-}
-
 /**
  * The parent route of all /apply/{id}/* routes, used to
  * redirect to /apply if the flow has not yet been initialized.
  */
 export default function Route() {
-  const { locale } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
+  const params = useParams();
+
+  const path = getPathById('$lang+/_public+/apply+/index', params);
 
   useEffect(() => {
     // redirect to start if the flow has not yet been initialized
     const flowState = sessionStorage.getItem('flow.state');
-    if (flowState !== 'active') navigate(`/${locale}/apply`, { replace: true });
-  }, [locale, navigate]);
+
+    if (flowState !== 'active') {
+      navigate(path, { replace: true });
+    }
+  }, [navigate, path]);
 
   return <Outlet />;
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -18,10 +18,10 @@ import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server
 import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
 import { cn } from '~/utils/tw-utils';
@@ -104,19 +104,20 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, remove, request, session, state: { applicantInformation: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirectWithLocale(request, `/apply/${state.id}/review-information`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
   }
 
   if ([MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW].includes(Number(parsedDataResult.data.maritalStatus))) {
-    return redirectWithLocale(request, `/apply/${state.id}/partner-information`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/partner-information', params));
   }
 
-  return redirectWithLocale(request, `/apply/${state.id}/personal-information`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/personal-information', params));
 }
 
 export default function ApplyFlowApplicationInformation() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, id, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
@@ -199,7 +200,7 @@ export default function ApplyFlowApplicationInformation() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting}>
                 {t('apply:applicant-information.save-btn')}
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
                 {t('apply:applicant-information.cancel-btn')}
               </ButtonLink>
             </div>
@@ -209,7 +210,7 @@ export default function ApplyFlowApplicationInformation() {
                 {t('apply:applicant-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/date-of-birth`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting}>
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:applicant-information.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { useFetcher, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -46,7 +46,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowApplicationDelegate() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -71,7 +71,7 @@ export default function ApplyFlowApplicationDelegate() {
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" to={`/apply/${id}/type-application`} disabled={isSubmitting}>
+        <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.application-delegate.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -1,8 +1,8 @@
 import { ChangeEventHandler, useEffect, useMemo, useState } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,9 +20,10 @@ import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server
 import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
@@ -146,15 +147,16 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { communicationPreferences: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirectWithLocale(request, `/apply/${state.id}/review-information`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
   }
 
-  return redirectWithLocale(request, `/apply/${state.id}/dental-insurance`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/dental-insurance', params));
 }
 
 export default function ApplyFlowCommunicationPreferencePage() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, id, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState?.preferredMethod ?? '');
@@ -294,7 +296,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting}>
                 {t('apply:communication-preference.save-btn')}
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
                 {t('apply:communication-preference.cancel-btn')}
               </ButtonLink>
             </div>
@@ -304,7 +306,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 {t('apply:communication-preference.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/personal-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params} disabled={isSubmitting}>
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:communication-preference.back')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { parse } from 'date-fns';
@@ -16,9 +16,9 @@ import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server
 import { getLookupService } from '~/services/lookup-service.server';
 import { toLocaleDateString } from '~/utils/date-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, getLocale, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
@@ -145,7 +145,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const applyRouteHelpers = getApplyRouteHelpers();
   await applyRouteHelpers.loadState({ params, request, session });
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirectWithLocale(request, '/apply');
+  return redirect(getPathById('$lang+/_public+/apply+/index', params));
 }
 
 export default function ApplyFlowConfirm() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,10 +16,10 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { Progress } from '~/components/progress';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -83,19 +83,20 @@ export async function action({ context: { session }, params, request }: ActionFu
   const age = differenceInYears(new Date(), parseDateOfBirth);
 
   if (age < 65) {
-    return redirectWithLocale(request, `/apply/${state.id}/dob-eligibility`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/dob-eligibility', params));
   }
 
   if (state.editMode) {
-    return redirectWithLocale(request, `/apply/${state.id}/review-information`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
   }
 
-  return redirectWithLocale(request, `/apply/${state.id}/applicant-information`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
 }
 
 export default function ApplyFlowDateOfBirth() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, id, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
@@ -136,7 +137,7 @@ export default function ApplyFlowDateOfBirth() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting}>
                 {t('apply:eligibility.date-of-birth.save-btn')}
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
                 {t('apply:eligibility.date-of-birth.cancel-btn')}
               </ButtonLink>
             </div>
@@ -146,7 +147,7 @@ export default function ApplyFlowDateOfBirth() {
                 {t('apply:eligibility.date-of-birth.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/tax-filing`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/tax-filing" params={params} disabled={isSubmitting}>
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:eligibility.date-of-birth.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -17,9 +17,10 @@ import { InputRadios } from '~/components/input-radios';
 import { Progress } from '~/components/progress';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -75,15 +76,16 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { dentalInsurance: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirectWithLocale(request, `/apply/${state.id}/review-information`);
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
   }
 
-  return redirectWithLocale(request, `/apply/${state.id}/federal-provincial-territorial-benefits`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits', params));
 }
 
 export default function AccessToDentalInsuranceQuestion() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, id, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
@@ -165,7 +167,7 @@ export default function AccessToDentalInsuranceQuestion() {
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Button variant="primary">{t('dental-insurance.button.save-btn')}</Button>
-              <ButtonLink to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
                 {t('dental-insurance.button.cancel-btn')}
               </ButtonLink>
             </div>
@@ -175,7 +177,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 {t('dental-insurance.button.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink to={`/apply/${id}/communication-preference`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/communication-preference" params={params} disabled={isSubmitting}>
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('dental-insurance.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -12,9 +12,9 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
@@ -41,12 +41,12 @@ export async function action({ context: { session }, params, request }: ActionFu
   const applyRouteHelpers = getApplyRouteHelpers();
   await applyRouteHelpers.loadState({ params, request, session });
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirectWithLocale(request, '/');
+  return redirect(getPathById('index', params));
 }
 
 export default function ApplyFlowFileYourTaxes() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -67,7 +67,7 @@ export default function ApplyFlowFileYourTaxes() {
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" to={`/apply/${id}/date-of-birth`} disabled={isSubmitting}>
+        <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.dob-eligibility.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
@@ -1,5 +1,5 @@
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,9 +9,9 @@ import pageIds from '../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
@@ -37,14 +37,15 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
   await applyRouteHelpers.loadState({ params, request, session });
+
   //TODO: Add apply form logic
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirectWithLocale(request, `/apply`);
+  return redirect(getPathById('$lang+/_public+/apply+/index', params));
 }
 
 export default function ApplyFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -55,7 +56,7 @@ export default function ApplyFlowTaxFiling() {
         <p>{t('apply:exit-application.click-back')}</p>
       </div>
       <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <ButtonLink id="back-button" to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:exit-application.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,9 +20,10 @@ import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server
 import { getLookupService } from '~/services/lookup-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -90,7 +91,6 @@ export async function action({ context: { session }, params, request }: ActionFu
   const log = getLogger('apply/federal-provincial-territorial');
 
   const applyRouteHelpers = getApplyRouteHelpers();
-  const { id } = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // NOTE: state validation schemas are independent otherwise user have to anwser
@@ -179,12 +179,13 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
-  return redirectWithLocale(request, `/apply/${id}/review-information`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
 }
 
 export default function AccessToDentalInsuranceQuestion() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, id, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);
@@ -372,7 +373,7 @@ export default function AccessToDentalInsuranceQuestion() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting}>
                 {t('apply:dental-benefits.button.save-btn')}
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/review-information`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
                 {t('apply:dental-benefits.button.cancel-btn')}
               </ButtonLink>
             </div>
@@ -382,7 +383,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 {t('apply:dental-benefits.button.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" to={`/apply/${id}/dental-insurance`} disabled={isSubmitting}>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/dental-insurance" params={params} disabled={isSubmitting}>
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { useFetcher, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -46,7 +46,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowFileYourTaxes() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -70,7 +70,7 @@ export default function ApplyFlowFileYourTaxes() {
         <p>{t('apply:eligibility.file-your-taxes.apply-after')}</p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <ButtonLink type="button" to={`/apply/${id}/tax-filing`} disabled={isSubmitting}>
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/tax-filing" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.file-your-taxes.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/index.tsx
@@ -1,12 +1,12 @@
-import { LoaderFunctionArgs } from '@remix-run/node';
+import { LoaderFunctionArgs, redirect } from '@remix-run/node';
 
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
-import { redirectWithLocale } from '~/utils/locale-utils.server';
+import { getPathById } from '~/utils/route-utils';
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
   const state = await applyRouteHelpers.loadState({ params, request, session });
 
   await applyRouteHelpers.saveState({ params, request, session, state });
-  return redirectWithLocale(request, `/apply/${state.id}/type-application`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/type-application', params));
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -1,6 +1,6 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faSpinner, faX } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -19,9 +19,9 @@ import { getBenefitApplicationService } from '~/services/benefit-application-ser
 import { getLookupService } from '~/services/lookup-service.server';
 import { toLocaleDateString } from '~/utils/date-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, getLocale, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
@@ -187,12 +187,13 @@ export async function action({ context: { session }, params, request }: ActionFu
   };
 
   await applyRouteHelpers.saveState({ params, request, session, state: { submissionInfo } });
-  return redirectWithLocale(request, `/apply/${state.id}/confirmation`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/confirmation', params));
 }
 
 export default function ReviewInformation() {
+  const params = useParams();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { id, userInfo, spouseInfo, maritalStatuses, preferredLanguage, federalSocialPrograms, provincialTerritorialSocialPrograms, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, maritalStatuses, preferredLanguage, federalSocialPrograms, provincialTerritorialSocialPrograms, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -222,7 +223,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.full-name-title')}>
                 {`${userInfo.firstName} ${userInfo.lastName}`}
                 <p className="mt-4">
-                  <InlineLink id="change-full-name" to={`/apply/${id}/applicant-information`}>
+                  <InlineLink id="change-full-name" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
                     {t('apply:review-information.full-name-change')}
                   </InlineLink>
                 </p>
@@ -230,7 +231,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.dob-title')}>
                 {userInfo.birthday}
                 <p className="mt-4">
-                  <InlineLink id="change-date-of-birth" to={{ pathname: `/apply/${id}/date-of-birth` }}>
+                  <InlineLink id="change-date-of-birth" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params}>
                     {t('apply:review-information.dob-change')}
                   </InlineLink>
                 </p>
@@ -238,7 +239,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.sin-title')}>
                 {formatSin(userInfo.sin)}
                 <p className="mt-4">
-                  <InlineLink id="change-sin" to={`/apply/${id}/applicant-information`}>
+                  <InlineLink id="change-sin" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
                     {t('apply:review-information.sin-change')}
                   </InlineLink>
                 </p>
@@ -246,7 +247,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.marital-title')}>
                 {maritalStatus}
                 <p className="mt-4">
-                  <InlineLink id="change-martial-status" to={`/apply/${id}/applicant-information`}>
+                  <InlineLink id="change-martial-status" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
                     {t('apply:review-information.marital-change')}
                   </InlineLink>
                 </p>
@@ -260,7 +261,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.full-name-title')}>
                   {`${spouseInfo.firstName} ${spouseInfo.lastName}`}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-full-name" to={`/apply/${id}/partner-information`}>
+                    <InlineLink id="change-spouse-full-name" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
                       {t('apply:review-information.full-name-change')}
                     </InlineLink>
                   </p>
@@ -268,7 +269,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.dob-title')}>
                   {spouseInfo.birthday}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" to={`/apply/${id}/partner-information`}>
+                    <InlineLink id="change-spouse-date-of-birth" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
                       {t('apply:review-information.dob-change')}
                     </InlineLink>
                   </p>
@@ -276,7 +277,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.sin-title')}>
                   {formatSin(spouseInfo.sin)}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-sin" to={`/apply/${id}/partner-information`}>
+                    <InlineLink id="change-spouse-sin" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
                       {t('apply:review-information.sin-change')}
                     </InlineLink>
                   </p>
@@ -291,7 +292,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.phone-title')}>
                 {userInfo.phoneNumber}
                 <p className="mt-4">
-                  <InlineLink id="change-phone-number" to={`/apply/${id}/personal-information`}>
+                  <InlineLink id="change-phone-number" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
                     {t('apply:review-information.phone-change')}
                   </InlineLink>
                 </p>
@@ -299,7 +300,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.alt-phone-title')}>
                 {userInfo.altPhoneNumber}
                 <p className="mt-4">
-                  <InlineLink id="change-alternate-phone-number" to={`/apply/${id}/personal-information`}>
+                  <InlineLink id="change-alternate-phone-number" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
                     {t('apply:review-information.alt-phone-change')}
                   </InlineLink>
                 </p>
@@ -314,7 +315,7 @@ export default function ReviewInformation() {
                   altFormat={true}
                 />
                 <p className="mt-4">
-                  <InlineLink id="change-mailing-address" to={`/apply/${id}/personal-information`}>
+                  <InlineLink id="change-mailing-address" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
                     {t('apply:review-information.mailing-change')}
                   </InlineLink>
                 </p>
@@ -329,7 +330,7 @@ export default function ReviewInformation() {
                   altFormat={true}
                 />
                 <p className="mt-4">
-                  <InlineLink id="change-home-address" to={`/apply/${id}/personal-information`}>
+                  <InlineLink id="change-home-address" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
                     {t('apply:review-information.home-change')}
                   </InlineLink>
                 </p>
@@ -350,7 +351,7 @@ export default function ReviewInformation() {
                   </div>
                 )}
                 <p className="mt-4">
-                  <InlineLink id="change-communication-preference" to={`/apply/${id}/communication-preference`}>
+                  <InlineLink id="change-communication-preference" routeId="$lang+/_public+/apply+/$id+/communication-preference" params={params}>
                     {t('apply:review-information.comm-pref-change')}
                   </InlineLink>
                 </p>
@@ -359,7 +360,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.lang-pref-title')}>
                   {getNameByLanguage(i18n.language, preferredLanguage)}
                   <p className="mt-4">
-                    <InlineLink id="change-language-preference" to={`/apply/${id}/communication-preference`}>
+                    <InlineLink id="change-language-preference" routeId="$lang+/_public+/apply+/$id+/communication-preference" params={params}>
                       {t('apply:review-information.lang-pref-change')}
                     </InlineLink>
                   </p>
@@ -373,7 +374,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.dental-insurance-title')}>
                 {dentalInsurance ? t('apply:review-information.yes') : t('apply:review-information.no')}
                 <p className="mt-4">
-                  <InlineLink id="change-access-dental" to={`/apply/${id}/dental-insurance`}>
+                  <InlineLink id="change-access-dental" routeId="$lang+/_public+/apply+/$id+/dental-insurance" params={params}>
                     {t('apply:review-information.dental-insurance-change')}
                   </InlineLink>
                 </p>
@@ -394,7 +395,7 @@ export default function ReviewInformation() {
                   <>{t('apply:review-information.no')}</>
                 )}
                 <p className="mt-4">
-                  <InlineLink id="change-dental-benefits" to={`/apply/${id}/federal-provincial-territorial-benefits`}>
+                  <InlineLink id="change-dental-benefits" routeId="$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits" params={params}>
                     {t('apply:review-information.dental-benefit-change')}
                   </InlineLink>
                 </p>
@@ -411,7 +412,7 @@ export default function ReviewInformation() {
             {t('apply:review-information.submit-button')}
             {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
           </Button>
-          <ButtonLink to={`/apply/${id}/exit-application`} variant="alternative" disabled={isSubmitting}>
+          <ButtonLink routeId="$lang+/_public+/apply+/$id+/exit-application" params={params} variant="alternative" disabled={isSubmitting}>
             {t('apply:review-information.exit-button')}
             <FontAwesomeIcon icon={faX} className="ms-3 block size-4" />
           </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef } from 'react';
 
-import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
@@ -17,10 +17,10 @@ import { getHCaptchaService } from '~/services/hcaptcha-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getClientIpAddress } from '~/utils/ip-address-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT, redirectWithLocale } from '~/utils/locale-utils.server';
+import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -49,7 +49,6 @@ export async function loader({ context: { session }, request, params }: LoaderFu
 export async function action({ context: { session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('apply/index');
   const applyRouteHelpers = getApplyRouteHelpers();
-  const { id } = await applyRouteHelpers.loadState({ params, request, session });
 
   const formData = await request.formData();
   const expectedCsrfToken = String(session.get('csrfToken'));
@@ -71,8 +70,7 @@ export async function action({ context: { session }, request, params }: ActionFu
   }
 
   await applyRouteHelpers.saveState({ params, request, session, state: {} });
-
-  return redirectWithLocale(request, `/apply/${id}/type-application`);
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/type-application', params));
 }
 
 export default function ApplyIndex() {

--- a/frontend/app/routes/$lang+/_public+/apply+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
-import { useLoaderData, useNavigate } from '@remix-run/react';
+import { useLoaderData, useNavigate, useParams } from '@remix-run/react';
 
 import { randomUUID } from 'crypto';
 
@@ -10,7 +10,7 @@ import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData } from '~/utils/route-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
@@ -37,13 +37,16 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 }
 
 export default function ApplyIndex() {
-  const { id, locale } = useLoaderData<typeof loader>();
+  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
   const navigate = useNavigate();
+
+  const path = getPathById('$lang+/_public+/apply+/$id+/terms-and-conditions', { ...params, id });
 
   useEffect(() => {
     sessionStorage.setItem('flow.state', 'active');
-    navigate(`/${locale}/apply/${id}/terms-and-conditions`, { replace: true });
-  }, [id, locale, navigate]);
+    navigate(path, { replace: true });
+  }, [navigate, path]);
 
   return (
     <div className="max-w-prose animate-pulse">

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -55,13 +55,13 @@ export default function RootIndex() {
           <div className="mb-2 mt-9 grid grid-cols-2 gap-8 md:mx-4 lg:mx-8">
             <section lang="en">
               <h2 className="sr-only">Government of Canada</h2>
-              <ButtonLink variant="primary" to="/apply" id="english-button" lang="en" targetLang="en" size="lg" className="w-full" reloadDocument>
+              <ButtonLink variant="primary" routeId="$lang+/_public+/apply+/index" id="english-button" lang="en" targetLang="en" size="lg" className="w-full" reloadDocument>
                 English
               </ButtonLink>
             </section>
             <section lang="fr">
               <h2 className="sr-only">Gouvernement du Canada</h2>
-              <ButtonLink variant="primary" to="/apply" id="french-button" lang="fr" targetLang="fr" size="lg" className="w-full" reloadDocument>
+              <ButtonLink variant="primary" routeId="$lang+/_public+/apply+/index" id="french-button" lang="fr" targetLang="fr" size="lg" className="w-full" reloadDocument>
                 Français
               </ButtonLink>
             </section>

--- a/frontend/remix.config.js
+++ b/frontend/remix.config.js
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs';
  * @typedef {{
  *   children?: JsonRoute;
  *   file: string;
+ *   id: string;
  *   index?: boolean;
  *   paths?: {
  *     en: string;
@@ -44,7 +45,7 @@ function defineRoute(language, routeFn, jsonRoute) {
   const defineRouteChildren = jsonRoute.children ? () => jsonRoute.children.forEach((child) => defineRoute(language, routeFn, child)) : () => {};
 
   /** @type {DefineRouteOptions} */
-  const options = { ...jsonRoute, id: `${jsonRoute.file}-${language}` };
+  const options = { ...jsonRoute, id: `${jsonRoute.id}-${language}` };
 
   routeFn(path, file, options, defineRouteChildren);
 }


### PR DESCRIPTION
### This PR adds support for bilingual routes in the application

To support bilingual routes in the application, the following changes were made:

- Manual routing in `remix.config.js` via an `app/routes.json` file
- `<AppLink>` modified to support passing in a `routeId` attribute (instead of using `to` to specify the target URL
- A new `getPathById(..)` function added to `route-utils.ts`, used to look up the path for a given route id
- All `redirectWithLocale(..)` calls have been replaced with calls to `getPathById(..)`
- Breadcrumbs modified to allow passing in a `routeId` attribute
- Tests fixed

There is probably more stuff that I'm not thinking about.

### Related Azure Boards Work Items

- [AB#3163](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3163)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and click around.. toggle the language and verify that the links are no bilingual.

### Additional Notes

Apologies for the size of this PR. I couldn't break it into smaller changesets.
