### PR TITLE
Fix partnerInformation page id

### DIFF
--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -32,7 +32,7 @@
       "dateOfBirth": "CDCP-APPL-0007",
       "dataOfBirthEligibility": "CDCP-APPL-0008",
       "applicantInformation": "CDCP-APPL-0009",
-      "partnerInformation": "CDCP-APPL-00010",
+      "partnerInformation": "CDCP-APPL-0010",
       "personalInformation": "CDCP-APPL-0011",
       "communicationPreference": "CDCP-APPL-0012",
       "dentalInsurance": "CDCP-APPL-0013",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix partnerInformation page id from `CDCP-APPL-00010` to `CDCP-APPL-0010` (remove an extra zero).

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3243](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3243)