### PR TITLE
DatePicker input labels' `for` attribute now associated with correct input `id`

### DIFF
--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -194,7 +194,7 @@ function DatePickerMonth({ ariaDescribedBy, ariaErrorMessage, className, default
 
   return (
     <div id={wrapperId} data-testid="date-picker-month">
-      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={selectId} className="mb-2">
         {label}
       </InputLabel>
       <select
@@ -250,7 +250,7 @@ function DatePickerYear({ ariaDescribedBy, ariaErrorMessage, className, defaultV
 
   return (
     <div id={wrapperId} data-testid="date-picker-year">
-      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={inputId} className="mb-2">
         {label}
       </InputLabel>
       <input
@@ -298,7 +298,7 @@ function DatePickerDay({ ariaDescribedBy, ariaErrorMessage, className, defaultVa
 
   return (
     <div id={wrapperId} data-testid="date-picker-day">
-      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={inputId} className="mb-2">
         {label}
       </InputLabel>
       <input


### PR DESCRIPTION
### Description
As per title.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and start an application until you reach the `/date-of-birth` page. Click on the "Month", "Day", and "Year" labels. The corresponding input element should be focused.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->