### PR TITLE
[gitops] Switching INT to point to Interop's UAT instance

### DIFF
--- a/gitops/overlays/int/configs/frontend/config.conf
+++ b/gitops/overlays/int/configs/frontend/config.conf
@@ -35,7 +35,7 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 #
 # Interop API configuration
 #
-INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/int/stream1
+INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
 
 #
 # SIN edit stub page configuration


### PR DESCRIPTION
### Description
As per title.

The status check API endpoint is not currently available in INT.