### PR TITLE
[gitops] Scaling down redis in staging

### DIFF
--- a/gitops/overlays/staging/patches/stateful-sets.yaml
+++ b/gitops/overlays/staging/patches/stateful-sets.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: redis
 spec:
-  replicas: 3
+  replicas: 1
   serviceName: redis-headless
   selector:
     matchLabels:


### PR DESCRIPTION
Scaling down redis to a single instance in staging until the sentinel issue is fixed (coming in a future PR).

# Note

The staging deployment job is disabled in TeamCity. This PR will prepare the redis instances for when we re-enable that job.