### PR TITLE
[gitops] Removing ENABLED_MOCKS configuration as we shouldn't be using mocks for INT/Staging/PERF

### DIFF
--- a/gitops/overlays/int/configs/frontend/config.conf
+++ b/gitops/overlays/int/configs/frontend/config.conf
@@ -9,11 +9,6 @@ OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
 
 #
-# Global mock configuration
-#
-ENABLED_MOCKS=lookup,power-platform,wsaddress
-
-#
 # Session/redis configuration
 #
 SESSION_STORAGE_TYPE=redis

--- a/gitops/overlays/perf/configs/frontend/config.conf
+++ b/gitops/overlays/perf/configs/frontend/config.conf
@@ -15,11 +15,6 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 ENABLED_FEATURES=view-letters
 
 #
-# Global mock configuration
-#
-ENABLED_MOCKS=lookup,power-platform,status-check,wsaddress
-
-#
 # Session/redis configuration
 #
 SESSION_STORAGE_TYPE=redis

--- a/gitops/overlays/staging/configs/frontend/config.conf
+++ b/gitops/overlays/staging/configs/frontend/config.conf
@@ -15,11 +15,6 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 ENABLED_FEATURES=view-letters
 
 #
-# Global mock configuration
-#
-ENABLED_MOCKS=lookup,power-platform,status-check,wsaddress
-
-#
 # Session/redis configuration
 #
 SESSION_STORAGE_TYPE=redis


### PR DESCRIPTION
### Description
The mocks would not have been hit anyway because `INTEROP_API_BASE_URI` is set to an actual Interop endpoint and not `https://api.example.com` for these environments.