### PR TITLE
AB#2977 -- Adding unable to process request page for when the hCaptcha score exceeds max score threshold

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -51,6 +51,9 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 ENABLED_FEATURES=view-letters,update-personal-info
 
 
+# hCaptcha maximum allowed score denoting malicious activity
+# (optional; default: 0.79)
+HCAPTCHA_MAX_SCORE=0.79
 # hCaptcha secret key -- used for server-side verifification
 # (required; use the example below)
 HCAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -229,6 +229,14 @@
               "en": "/:lang/status",
               "fr": "/:lang/statut"
             }
+          },
+          {
+            "id": "$lang+/_public+/unable-to-process-request",
+            "file": "routes/$lang+/_public+/unable-to-process-request.tsx",
+            "paths": {
+              "en": "/:lang/unable-to-process-request",
+              "fr": "/:lang/impossible-de-traiter-la-demande"
+            }
           }
         ]
       },

--- a/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
+++ b/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
@@ -1,0 +1,35 @@
+import { LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
+
+import pageIds from '../page-ids.json';
+import { PublicLayout } from '~/components/layouts/public-layout';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('gcweb'),
+  pageIdentifier: pageIds.public.unableToProcessRequest,
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: 'Unable to process CDCP requests' }) };
+
+  return json({ meta });
+}
+
+export default function UnableToProcessRequest() {
+  return (
+    <PublicLayout>
+      <div className="mb-8 space-y-4">
+        <p>You may not proceed with the application.</p>
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -37,6 +37,7 @@
       "confirmation": "CDCP-APPL-0017"
     },
     "status": "CDCP-STAT-0001",
+    "unableToProcessRequest": "CDCP-UNAB-0001",
     "notFound": "CDCP-ERR-0404"
   }
 }

--- a/frontend/app/services/hcaptcha-service.server.ts
+++ b/frontend/app/services/hcaptcha-service.server.ts
@@ -50,20 +50,21 @@ function createHCaptchaService() {
 
     const verifyResultSchema = z.object({
       success: z.boolean(),
-      challenge_ts: z.string().datetime().optional(),
-      hostname: z.string().optional(),
-      'error-codes': z.array(z.string()).optional(),
       score: z.number().optional(),
     });
 
-    const verifyResult = verifyResultSchema.parse(await response.json());
+    const json = await response.json();
+    const verifyResult = verifyResultSchema.parse(json);
+
     if (verifyResult.success) {
       instrumentationService.countHttpStatus('http.client.hcaptcha.posts.success', 200);
-      log.info(`hCaptcha verification successful: [${JSON.stringify(verifyResult)}]`);
+      log.info(`hCaptcha verification successful: [${JSON.stringify(json)}]`);
     } else {
       instrumentationService.countHttpStatus('http.client.hcaptcha.posts.failed', 200);
-      log.warn(`hCaptcha verification failed: [${JSON.stringify(verifyResult)}]`);
+      log.warn(`hCaptcha verification failed: [${JSON.stringify(json)}]`);
     }
+
+    return verifyResult;
   }
 
   return { verifyHCaptchaResponse };

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -91,6 +91,7 @@ const serverEnv = z.object({
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
   // hCaptcha settings
+  HCAPTCHA_MAX_SCORE: z.coerce.number().default(0.79),
   HCAPTCHA_SECRET_KEY: z.string().trim().min(1),
   HCAPTCHA_SITE_KEY: z.string().trim().min(1),
   HCAPTCHA_VERIFY_URL: z.string().url().default('https://api.hcaptcha.com/siteverify'),


### PR DESCRIPTION
### Description
- Introduced new environment variable for maximum score and defaulting it to 0.79
- If hCaptcha verification results in a score greater than the above maximum score, redirect to new "Unable to Process Request" page
- New page placed in root `_public+` directory because both the CDCP Intake Application and Status Checker should use it
- Content has not yet been added to new page - the route name is long because the original non-finalized title is actually "Unable to Process CDCP Request"
- Refactoring hCaptcha service to log the verification result and only parsing/returning the fields we care about (`success` and `score`).

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
In your `.env`, add/update the following `HCAPTCHA_SITE_KEY=30000000-ffff-ffff-ffff-000000000003`.
Run the application locally and go to `/en/apply` and try to continue with the application. You should see the new skeleton page. You may need to try a few times locally as the hCaptcha component struggles locally with Strict Mode enabled.

### Additional Notes
Content for new page will be added in a future PR.