### PR TITLE
AB#2977 -- Adding preliminary content for Unable to Process CDCP Request page (when hCaptcha score is too high)

### DIFF
--- a/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
+++ b/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
@@ -1,6 +1,9 @@
 import { LoaderFunctionArgs, MetaFunction, json } from '@remix-run/node';
 
+import { Trans, useTranslation } from 'react-i18next';
+
 import pageIds from '../page-ids.json';
+import { InlineLink } from '~/components/inline-link';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -9,8 +12,9 @@ import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('unable-to-process-request', 'gcweb'),
   pageIdentifier: pageIds.public.unableToProcessRequest,
+  pageTitleI18nKey: 'unable-to-process-request:page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -19,16 +23,42 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: 'Unable to process CDCP requests' }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('unable-to-process-request:page-title') }) };
 
   return json({ meta });
 }
 
 export default function UnableToProcessRequest() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+
+  const noWrap = <span className="whitespace-nowrap" />;
+  const eServiceCanadaLink = <InlineLink to={t('unable-to-process-request:e-service-canada-link')} />;
+  const cdcpLink = <InlineLink to={t('unable-to-process-request:cdcp-link')} />;
+
   return (
     <PublicLayout>
-      <div className="mb-8 space-y-4">
-        <p>You may not proceed with the application.</p>
+      <div className="max-w-prose">
+        <div className="space-y-4">
+          <p>{t('unable-to-process-request:unable-to-process')}</p>
+          <p>{t('unable-to-process-request:try-again')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('unable-to-process-request:disable-vpn')}</li>
+            <li>{t('unable-to-process-request:another-device')}</li>
+          </ul>
+          <p>{t('unable-to-process-request:difficulties')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey="unable-to-process-request:call-centre" components={{ noWrap }} />
+            </li>
+            <li>{t('unable-to-process-request:visit-centre')}</li>
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey="unable-to-process-request:submit-request" components={{ eServiceCanadaLink }} />
+            </li>
+          </ul>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="unable-to-process-request:return-cdcp" components={{ cdcpLink }} />
+          </p>
+        </div>
       </div>
     </PublicLayout>
   );

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -9,6 +9,7 @@ import type letters from '../public/locales/en/letters.json';
 import type personalInformation from '../public/locales/en/personal-information.json';
 import type status from '../public/locales/en/status.json';
 import type stubSinEditor from '../public/locales/en/stub-sin-editor.json';
+import type unableToProcessRequest from '../public/locales/en/unable-to-process-request.json';
 import type { PublicEnv } from '~/utils/env.server';
 
 /**
@@ -36,8 +37,9 @@ declare module 'i18next' {
       index: typeof index;
       letters: typeof letters;
       'personal-information': typeof personalInformation;
-      'stub-sin-editor': typeof stubSinEditor;
       status: typeof status;
+      'stub-sin-editor': typeof stubSinEditor;
+      'unable-to-process-request': typeof unableToProcessRequest;
     };
   }
 }

--- a/frontend/public/locales/en/unable-to-process-request.json
+++ b/frontend/public/locales/en/unable-to-process-request.json
@@ -1,0 +1,14 @@
+{
+  "page-title": "Unable to process CDCP request",
+  "unable-to-process": "We are unable to process your Canadian Dental Care Plan (CDCP) request at this moment. This could be due to an incorrect input, a timeout, or a technical problem.",
+  "try-again": "To try again, you can:",
+  "disable-vpn": "disable your virtual private network (VPN), or browser or proxy server, if you use one; or",
+  "another-device": "try making the request on another device.",
+  "difficulties": "If you're still experiencing difficulties:",
+  "call-centre": "call the CDCP Specialized Call Center for assistance at <noWrap>1-833-537-4342</noWrap>;",
+  "visit-centre": "visit the nearest Service Canada Centre and bring 2 pieces of identification (one with photo); or",
+  "submit-request": "submit an <eServiceCanadaLink>eServiceCanada request</eServiceCanadaLink> by selecting \"Canadian Dental Care Plan\" and \"Help with the Canadian Dental Care Plan application or attestation\", and we'll call you back within 2 business days.",
+  "e-service-canada-link": "https://eservices.canada.ca/en/service/",
+  "return-cdcp": "Return to the <cdcpLink>Canadian Dental Care Plan</cdcpLink> home page.",
+  "cdcp-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+}

--- a/frontend/public/locales/fr/unable-to-process-request.json
+++ b/frontend/public/locales/fr/unable-to-process-request.json
@@ -1,0 +1,14 @@
+{
+  "page-title": "[FR] Unable to process CDCP request",
+  "unable-to-process": "[FR] We are unable to process your Canadian Dental Care Plan (CDCP) request at this moment. This could be due to an incorrect input, a timeout, or a technical problem.",
+  "try-again": "[FR] To try again, you can:",
+  "disable-vpn": "[FR] disable your virtual private network (VPN), or browser or proxy server, if you use one; or",
+  "another-device": "[FR] try making the request on another device.",
+  "difficulties": "[FR] If you're still experiencing difficulties:",
+  "call-centre": "[FR] call the CDCP Specialized Call Center for assistance at <noWrap>1-833-537-4342</noWrap>;",
+  "visit-centre": "[FR] visit the nearest Service Canada Centre and bring 2 pieces of identification (one with photo); or",
+  "submit-request": "[FR] submit an <eServiceCanadaLink>eServiceCanada request</eServiceCanadaLink> by selecting \"Canadian Dental Care Plan\" and \"Help with the Canadian Dental Care Plan application or attestation\", and we'll call you back within 2 business days.",
+  "e-service-canada-link": "https://eservices.canada.ca/fr/service/",
+  "return-cdcp": "[FR] Return to the <cdcpLink>Canadian Dental Care Plan</cdcpLink> home page.",
+  "cdcp-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+}


### PR DESCRIPTION
### Description
As per title

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/03c6745c-24d8-472c-bcdf-71d8036d022b)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- In your `.env`, add/update the following `HCAPTCHA_SITE_KEY=30000000-ffff-ffff-ffff-000000000003`, which upon hCaptcha verification, will return a `score` of `1`, which exceeds the max score of `0.79`.
- Run the application locally and go to `/en/apply` and try to continue with the application. You should see the "Unable to process CDCP request" page. You may need to try a few times locally as the hCaptcha component struggles locally with Strict Mode enabled.

### Additional Notes
Content has not yet been finalized.