### PR TITLE
Personal Information Service now called on personal information page

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -82,7 +82,7 @@ db.personalInformation.create({
   emailAddressId: 'rhapsody@domain.ca',
   primaryTelephoneNumber: '222-555-5555',
   alternateTelephoneNumber: '416-555-6666',
-  preferredMethodCommunicationCode: '775170002',
+  preferredMethodCommunicationCode: '1033',
   sinIdentification: '800011819',
 });
 

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -49,9 +49,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const regionList = await getLookupService().getAllRegions();
   const preferredLanguage = personalInformation.preferredLanguageId ? await getLookupService().getPreferredLanguage(personalInformation.preferredLanguageId) : undefined;
 
-  if (!personalInformation.clientNumber) {
-    throw new Response(null, { status: 404 });
-  }
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('personal-information:index.page-title') }) };
 

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -9,16 +9,15 @@ import { useTranslation } from 'react-i18next';
 import pageIds from '../../page-ids.json';
 import { Address } from '~/components/address';
 import { InlineLink } from '~/components/inline-link';
-import { getAddressService } from '~/services/address-service.server';
+import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-information-route-helpers.server';
 import { getAuditService } from '~/services/audit-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getUserService } from '~/services/user-service.server';
 import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { IdToken } from '~/utils/raoidc-utils.server';
+import { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -34,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('update-personal-info');
 
   const raoidcService = await getRaoidcService();
@@ -43,28 +42,24 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('page-view.personal-information', { userId: idToken.sub });
 
-  const userService = getUserService();
-  const userId = await userService.getUserId();
-  const userInfo = await userService.getUserInfo(userId);
+  const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
+  const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
+  const preferredLanguage = personalInformation.preferredLanguageId ? await getLookupService().getPreferredLanguage(personalInformation.preferredLanguageId) : undefined;
 
-  if (!userInfo) {
+  if (!personalInformation.clientNumber) {
     throw new Response(null, { status: 404 });
   }
-
-  const preferredLanguage = userInfo.preferredLanguage && (await getLookupService().getPreferredLanguage(userInfo.preferredLanguage));
-  const homeAddressInfo = userInfo.homeAddress && (await getAddressService().getAddressInfo(userId, userInfo.homeAddress));
-  const mailingAddressInfo = userInfo.mailingAddress && (await getAddressService().getAddressInfo(userId, userInfo.mailingAddress));
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('personal-information:index.page-title') }) };
 
-  return json({ countryList, homeAddressInfo, mailingAddressInfo, meta, preferredLanguage, regionList, user: userInfo });
+  return json({ preferredLanguage, countryList, personalInformation, meta, regionList });
 }
 
 export default function PersonalInformationIndex() {
-  const { user, preferredLanguage, homeAddressInfo, mailingAddressInfo, countryList, regionList } = useLoaderData<typeof loader>();
+  const { personalInformation, preferredLanguage, countryList, regionList } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const params = useParams();
 
@@ -72,7 +67,7 @@ export default function PersonalInformationIndex() {
     <>
       <p className="mb-8 text-lg text-gray-500">{t('personal-information:index.on-file')}</p>
       <dl className="mt-6 divide-y border-y">
-        <DescriptionListItem term={t('personal-information:index.full-name')}>{`${user.firstName} ${user.lastName}`}</DescriptionListItem>
+        <DescriptionListItem term={t('personal-information:index.full-name')}>{`${personalInformation.firstName} ${personalInformation.lastName}`}</DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.preferred-language')}>
           <p>{preferredLanguage ? getNameByLanguage(i18n.language, preferredLanguage) : t('personal-information:index.no-preferred-language-on-file')}</p>
           <p>
@@ -82,13 +77,13 @@ export default function PersonalInformationIndex() {
           </p>
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.home-address')}>
-          {homeAddressInfo ? (
+          {personalInformation.homeAddress ? (
             <Address
-              address={homeAddressInfo.address}
-              city={homeAddressInfo.city}
-              provinceState={regionList.find((region) => region.provinceTerritoryStateId === homeAddressInfo.province)?.abbr}
-              postalZipCode={homeAddressInfo.postalCode}
-              country={countryList.find((country) => country.countryId === homeAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
+              address={personalInformation.homeAddress.streetName ?? ''}
+              city={personalInformation.homeAddress.cityName ?? ''}
+              provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.homeAddress!.provinceTerritoryStateId)?.abbr}
+              postalZipCode={personalInformation.homeAddress.postalCode}
+              country={countryList.find((country) => country.countryId === personalInformation.homeAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
@@ -100,13 +95,13 @@ export default function PersonalInformationIndex() {
           </p>
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.mailing-address')}>
-          {mailingAddressInfo ? (
+          {personalInformation.mailingAddress ? (
             <Address
-              address={mailingAddressInfo.address}
-              city={mailingAddressInfo.city}
-              provinceState={regionList.find((region) => region.provinceTerritoryStateId === mailingAddressInfo.province)?.abbr}
-              postalZipCode={mailingAddressInfo.postalCode}
-              country={countryList.find((country) => country.countryId === mailingAddressInfo.country)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
+              address={personalInformation.mailingAddress.streetName ?? ''}
+              city={personalInformation.mailingAddress.cityName ?? ''}
+              provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.mailingAddress!.provinceTerritoryStateId)?.abbr}
+              postalZipCode={personalInformation.mailingAddress.postalCode}
+              country={countryList.find((country) => country.countryId === personalInformation.mailingAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
@@ -118,7 +113,7 @@ export default function PersonalInformationIndex() {
           </p>
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.phone-number')}>
-          <p>{user.phoneNumber}</p>
+          <p>{personalInformation.primaryTelephoneNumber}</p>
           <p>
             <InlineLink id="change-phone-number-button" routeId="$lang+/_protected+/personal-information+/phone-number+/edit" params={params}>
               {t('personal-information:index.change-phone-number')}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->
The main /personal-information page now uses the `PersonalInformationService` and the `UserService` has been removed

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->
[AB#3216](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/3216)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Bring up the personal information main page.