### PR TITLE
AB#2977 -- Refactoring to add and use custom useHCaptcha hook and route helper

### DIFF
--- a/frontend/app/route-helpers/h-captcha-route-helpers.server.ts
+++ b/frontend/app/route-helpers/h-captcha-route-helpers.server.ts
@@ -1,0 +1,38 @@
+import { getHCaptchaService } from '~/services/hcaptcha-service.server';
+import { getEnv } from '~/utils/env.server';
+import { getClientIpAddress } from '~/utils/ip-address-utils.server';
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('h-captcha-route-helpers.server');
+
+/**
+ * Verifies an hCaptcha response token and the client's IP address from the request object and calling the hCaptchaService with these two pieces of data.
+ *
+ * @param hCaptchaResponse - The "h-captcha-response" token value
+ * @param request - The incoming HTTP request object.
+ * @returns A promise that resolves to:
+ * - 'false' if the hCaptcha verification results in a score greater than the HCAPTCHA_MAX_SCORE environment variable
+ * - 'true' otherwise
+ */
+async function verifyHCaptchaResponse(hCaptchaResponse: string, request: Request) {
+  const { HCAPTCHA_MAX_SCORE } = getEnv();
+  const clientIpAddress = getClientIpAddress(request);
+
+  try {
+    const hCaptchaService = getHCaptchaService();
+    const verifyResult = await hCaptchaService.verifyHCaptchaResponse(hCaptchaResponse, clientIpAddress);
+    if (verifyResult.score !== undefined && verifyResult.score > HCAPTCHA_MAX_SCORE) {
+      return false;
+    }
+  } catch (error) {
+    log.warn(`hCaptcha verification failed: [${error}]; Proceeding with normal application flow`);
+  }
+
+  return true;
+}
+
+export function getHCaptchaRouteHelpers() {
+  return {
+    verifyHCaptchaResponse,
+  };
+}

--- a/frontend/app/utils/hcaptcha-utils.ts
+++ b/frontend/app/utils/hcaptcha-utils.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+
+export function useHCaptcha() {
+  const captchaRef = useRef<HCaptcha>(null);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    if (captchaRef.current?.isReady()) {
+      captchaRef.current.execute();
+    } else {
+      timeoutId = setTimeout(() => {
+        captchaRef.current?.execute();
+      }, 500);
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  return { captchaRef };
+}


### PR DESCRIPTION
### Description
This PR will minimize the amount of code that needs to be placed into routes that require hCaptcha.
- `hCaptchaRouteHelpers.verifyHCaptchaResponse(..)` will be used in the `action(..)` of routes that require hCaptcha
- `useHCaptcha` hook will be used in the component of routes that require hCaptcha

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and ensure and verify that hCaptcha service calls are still being logged like it was before this refactoring.