### PR TITLE
AB#3229 -- Fix /en/ and /fr/ to display the 404 page instead of being blank

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -57,6 +57,14 @@
     },
     "children": [
       {
+        "id": "$lang+/",
+        "file": "routes/$lang+/index.tsx",
+        "paths": {
+          "en": "/:lang/",
+          "fr": "/:lang/"
+        }
+      },
+      {
         "id": "$lang+/$",
         "file": "routes/$lang+/$.tsx",
         "paths": {

--- a/frontend/app/routes/$lang+/index.tsx
+++ b/frontend/app/routes/$lang+/index.tsx
@@ -5,5 +5,7 @@ import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/publ
 export default function LangIndex() {
   const { lang: langParam } = useParams();
 
-  return langParam && ['en', 'fr'].includes(langParam) ? <NotFoundError /> : <BilingualNotFoundError />;
+  return ['en', 'fr'].includes(langParam)
+    ? <NotFoundError />
+    : <BilingualNotFoundError />;
 }

--- a/frontend/app/routes/$lang+/index.tsx
+++ b/frontend/app/routes/$lang+/index.tsx
@@ -1,0 +1,9 @@
+import { useParams } from '@remix-run/react';
+
+import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/public-layout';
+
+export default function LangIndex() {
+  const { lang: langParam } = useParams();
+
+  return langParam && ['en', 'fr'].includes(langParam) ? <NotFoundError /> : <BilingualNotFoundError />;
+}

--- a/frontend/app/routes/$lang+/index.tsx
+++ b/frontend/app/routes/$lang+/index.tsx
@@ -5,7 +5,5 @@ import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/publ
 export default function LangIndex() {
   const { lang: langParam } = useParams();
 
-  return ['en', 'fr'].includes(langParam)
-    ? <NotFoundError />
-    : <BilingualNotFoundError />;
+  return ['en', 'fr'].includes(langParam) ? <NotFoundError /> : <BilingualNotFoundError />;
 }

--- a/frontend/app/routes/$lang+/index.tsx
+++ b/frontend/app/routes/$lang+/index.tsx
@@ -5,5 +5,5 @@ import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/publ
 export default function LangIndex() {
   const { lang: langParam } = useParams();
 
-  return ['en', 'fr'].includes(langParam) ? <NotFoundError /> : <BilingualNotFoundError />;
+  return langParam && ['en', 'fr'].includes(langParam) ? <NotFoundError /> : <BilingualNotFoundError />;
 }


### PR DESCRIPTION
### Description
Added missing 404 page for empty lang routes ( /en /en/ /fr /fr/ )

### Related Azure Boards Work Items
[AB#3229](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3229)

### Screenshots (if applicable)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Visit  /en /en/ /fr /fr/ routes to confirm 404

### Additional Notes
Modified routes.json as the solution (also possible to implement it instead in the _route.tsx loader for /lang/)