### PR TITLE
AB#2977 -- Adding feature flag for hCaptcha

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -47,8 +47,8 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 
 # Application feature flags -- see ./app/utils/env.server.ts for valid values
-# (optional; default: doc-upload,email-alerts,update-personal-info,view-applications,view-letters,view-messages)
-ENABLED_FEATURES=view-letters,update-personal-info
+# (optional; default: doc-upload,email-alerts,hcaptcha,update-personal-info,view-applications,view-letters,view-messages)
+ENABLED_FEATURES=hcaptcha,view-letters,update-personal-info
 
 
 # hCaptcha maximum allowed score denoting malicious activity

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -22,7 +22,7 @@ function tryOrElseFalse(fn: () => unknown) {
 const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
-const validFeatureNames = ['doc-upload', 'email-alerts', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;
+const validFeatureNames = ['doc-upload', 'email-alerts', 'hcaptcha', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;
 export type FeatureName = (typeof validFeatureNames)[number];
 
 // refiners


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
[AB#2977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2977)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Add/remove `hcaptcha` as an `ENABLED_FEATURES` environment variable and run the application locally.
- When enabled (`hcaptcha` is an `ENABLED_FEATURE`), you will see the (invisible) hCaptcha component render and a call made to `hcaptcha-service.server` will be logged.
- When disabled (`hcaptcha` is not an `ENABLED_FEATURE`), you will not see the (invisible) hCaptcha component nor will a call made to `hcaptcha-service.server` be logged.