### PR TITLE
Push AA pageLoad event with with a transformed url

### DIFF
--- a/frontend/__tests__/utils/url-utils.test.ts
+++ b/frontend/__tests__/utils/url-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeUUIDSegmentsFromURL } from '~/utils/url-utils';
+
+describe('removeUUIDSegmentsFromURL', () => {
+  it('should remove UUID segments from the URL', () => {
+    const url = 'https://example.com/some/pathname/segment/with/uuid/8309ab03-b7a8-4a1c-bcf4-fcaecfdfbdbd/and/another/uuid/03f021b5-90ec-4854-9c02-c338888f3395';
+    const expectedURL = 'https://example.com/some/pathname/segment/with/uuid/and/another/uuid';
+    expect(removeUUIDSegmentsFromURL(url)).toEqual(expectedURL);
+  });
+
+  it('should handle URLs with only UUID segments', () => {
+    const url = 'https://example.com/4d490c11-9ca4-41e1-85db-5182783742bc/ae1f0aa1-bed5-4fa6-81c0-a994bc4267e2';
+    const expectedURL = 'https://example.com/';
+    expect(removeUUIDSegmentsFromURL(url)).toEqual(expectedURL);
+  });
+
+  it('should handle URLs without UUID segments', () => {
+    const url = 'https://example.com/some/pathname/without/uuid';
+    expect(removeUUIDSegmentsFromURL(url)).toEqual(url);
+  });
+});

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -86,7 +86,7 @@ export default function App() {
 
   useEffect(() => {
     if (env.ADOBE_ANALYTICS_SRC && env.ADOBE_ANALYTICS_JQUERY_SRC) {
-      adobeAnalytics.pageview(location.pathname);
+      adobeAnalytics.pageview(document.location.toString());
     }
   }, [env.ADOBE_ANALYTICS_JQUERY_SRC, env.ADOBE_ANALYTICS_SRC, location.pathname]);
 

--- a/frontend/app/utils/adobe-analytics.client.ts
+++ b/frontend/app/utils/adobe-analytics.client.ts
@@ -1,3 +1,5 @@
+import { removeUUIDSegmentsFromURL } from './url-utils';
+
 type AdobeDataLayer = { push?: (object: Record<string, string>) => void };
 
 declare global {
@@ -9,17 +11,27 @@ declare global {
 // help to prevent double firing of adobe analytics pageLoad event
 let appPreviousLocationPathname = '';
 
-export const pageview = (pathname: string) => {
+export const pageview = (locationUrl: string) => {
   if (!window.adobeDataLayer) {
     console.warn('window.adobeDataLayer is not defined. This could mean your adobe analytics script has not loaded on the page yet.');
     return;
   }
 
-  // only push event if pathname is different
-  if (pathname === appPreviousLocationPathname) {
+  // only push event if location pathname is different
+  const locationUrlObj = new URL(locationUrl);
+  if (locationUrlObj.pathname === appPreviousLocationPathname) {
     return;
   }
 
-  window.adobeDataLayer.push?.({ event: 'pageLoad' });
-  appPreviousLocationPathname = pathname;
+  // Adobe Analytics needs us to clean up URLs before sending event data. This ensures their reports focus
+  // on the core content, not things like tracking codes, because they don't want those to mess up their
+  // website visitor categories.
+  const transformedUrl = removeUUIDSegmentsFromURL(locationUrl.toString());
+  const urlObj = new URL(transformedUrl);
+  window.adobeDataLayer.push?.({
+    event: 'pageLoad',
+    url: `${urlObj.origin}${urlObj.pathname}`,
+  });
+
+  appPreviousLocationPathname = locationUrlObj.pathname;
 };

--- a/frontend/app/utils/url-utils.ts
+++ b/frontend/app/utils/url-utils.ts
@@ -1,0 +1,12 @@
+import { validate } from 'uuid';
+
+export function removeUUIDSegmentsFromURL(url: string) {
+  const urlObj = new URL(url);
+  const pathname = urlObj.pathname;
+  const segments = pathname.split('/').filter((segment) => segment !== '');
+
+  const filteredSegments = segments.filter((segment) => !validate(segment));
+  urlObj.pathname = '/' + filteredSegments.join('/');
+
+  return urlObj.toString();
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

TLDR; Adobe Analytics asked us to remove the dynamic URL segments when pushing `pageLoad` event to them. In our case, the only dynamic segement are for the application flow and they are auto-generated UUIDs.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#2830](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/2830)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->