### PR TITLE
Fix regression text change.

### DIFF
--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -252,8 +252,8 @@
   },
   "partner-information": {
     "page-title": "Spouse or Common-law partner information",
-    "provide-sin": "Please provide your legal name as indicated on your Social Insurance Number (SIN) card or letter.",
-    "required-information": "We'll use the information you provide to verify your identity. Any information that does not match the information on your SIN application may cause a delay in the processing of your application.",
+    "provide-sin": "Provide information on your current spouse or common-law partner as indicated on their Social Insurance Number (SIN) card or letter.",
+    "required-information": "This information is required to calculate the adjusted family net income. Your spouse or common-law partner must submit their own application for the Canadian Dental Care Plan.",
     "sin": "Social Insurance Number (SIN)",
     "date-of-birth": "Date of birth",
     "last-name": "Last name",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix regression text change for the `/apply/:id/partner-information` route.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3242](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3242)