### PR TITLE
[gitops] Create a mounted volume for audit logs

### DIFF
--- a/gitops/base/frontend/deployments.yaml
+++ b/gitops/base/frontend/deployments.yaml
@@ -36,3 +36,9 @@ spec:
               memory: 1024Mi
           securityContext:
             allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: audit-logs
+              mountPath: /home/node/logs
+      volumes:
+        - name: audit-logs
+          emptyDir: {}


### PR DESCRIPTION
In order for fluentd to read the audit logs, they need to be stored on a mounted volume.