### PR TITLE
add post-zip-code-utils unit tests

### DIFF
--- a/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
+++ b/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+
+vi.mock('~/utils/env.server', () => ({
+  getEnv: vi.fn().mockReturnValue({
+    CANADA_COUNTRY_ID: 'CA',
+    USA_COUNTRY_ID: 'US',
+  }),
+}));
+
+describe('~/utils/postal-zip-code-utils.server.ts', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isValidPostalCode()', () => {
+    // Canadian Postal Codes
+    it('should return true for Canadian postal code without space', () => {
+      expect(isValidPostalCode('CA', 'H0H0H0')).toEqual(true);
+    });
+
+    it('should return true Canadian postal code with space', () => {
+      expect(isValidPostalCode('CA', 'H0H 0H0')).toEqual(true);
+    });
+
+    it('should return false for Canadian postal code with too many spaces', () => {
+      expect(isValidPostalCode('CA', 'H0H  0H0')).toEqual(false);
+    });
+
+    it('should return false for Canadian postal code of invalid format', () => {
+      expect(isValidPostalCode('CA', 'H0H0')).toEqual(false);
+    });
+
+    // American Zip Code
+    it('should return true for American zip code without space', () => {
+      expect(isValidPostalCode('US', '12345')).toEqual(true);
+    });
+
+    it('should return false for American zip code of invalid format', () => {
+      expect(isValidPostalCode('US', '123')).toEqual(false);
+    });
+
+    it('should return true for country codes that are not Canadian or American codes', () => {
+      expect(isValidPostalCode('XYZ', 'ABC 123')).toEqual(true);
+    });
+  });
+
+  describe('formatPostalCode()', () => {
+    it('should format Canadian postal code without space in middle', () => {
+      expect(formatPostalCode('CA', 'H0H0H0')).toEqual('H0H 0H0');
+    });
+
+    it('should format Canadian postal code with space in middle', () => {
+      expect(formatPostalCode('CA', 'H0H 0H0')).toEqual('H0H 0H0');
+    });
+
+    it('should return the input if country code is not a Canadian code', () => {
+      expect(formatPostalCode('US', '12345')).toEqual('12345');
+    });
+
+    it('should throw an error if the country code is Canadian and the format is invalid', () => {
+      expect(() => formatPostalCode('CA', 'H0H  0H0')).toThrowError();
+    });
+
+    it('should throw an error if the country code is American and the format is invalid', () => {
+      expect(() => formatPostalCode('US', '123')).toThrowError();
+    });
+  });
+});


### PR DESCRIPTION
### Description
Add unit tests for the postal/zip code utils.  

### Related Azure Boards Work Items
[AB#3223](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3223)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
