### PR TITLE
[gitops] AB#3066 -- audit logging (dev env)

### DIFF
--- a/gitops/overlays/dev/configs/fluentd-archiver/fluentd.conf
+++ b/gitops/overlays/dev/configs/fluentd-archiver/fluentd.conf
@@ -1,0 +1,15 @@
+<source>
+  @type forward
+  tag audit-events
+</source>
+
+<match audit-events>
+  @type file
+
+  append true
+  path /logs/audit-%Y-%m-%d
+
+  <buffer>
+    flush_mode immediate
+  </buffer>
+</match>

--- a/gitops/overlays/dev/configs/frontend/fluentd.conf
+++ b/gitops/overlays/dev/configs/frontend/fluentd.conf
@@ -1,0 +1,23 @@
+<source>
+  @type tail
+
+  tag audit-events
+  path /logs/*.log
+  pos_file /logs/tail.pos
+
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<match audit-events>
+  @type forward
+
+  <server>
+    host fluentd-archiver-dev
+  </server>
+
+  <buffer>
+    flush_interval 30s
+  </buffer>
+</match>

--- a/gitops/overlays/dev/deployments.yaml
+++ b/gitops/overlays/dev/deployments.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fluentd-archiver
+  labels:
+    app.kubernetes.io/name: fluentd-archiver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluentd-archiver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluentd-archiver
+    spec:
+      containers:
+        - name: fluentd-archiver
+          image: docker.io/fluentd
+          args: [--config, /etc/fluentd.conf]
+          ports:
+            - name: fluentd
+              containerPort: 24224
+          volumeMounts:
+            - name: audit-logs
+              mountPath: /logs
+            - name: fluentd-conf
+              mountPath: /etc/fluentd.conf
+              subPath: fluentd.conf
+      securityContext:
+        fsGroup: 101 # `fluent` gid
+      volumes:
+        - name: audit-logs
+          persistentVolumeClaim:
+            claimName: audit-logs
+        - name: fluentd-conf
+          configMap:
+            name: fluentd-archiver

--- a/gitops/overlays/dev/kustomization.yaml
+++ b/gitops/overlays/dev/kustomization.yaml
@@ -16,7 +16,10 @@ labels:
 resources:
   - ../../base/frontend/
   - ../../base/redis/
+  - ./deployments.yaml
   - ./ingresses.yaml
+  - ./pvcs.yaml
+  - ./services.yaml
 patches:
   - path: ./patches/deployments.yaml
   - path: ./patches/services.yaml
@@ -26,6 +29,10 @@ configMapGenerator:
     behavior: merge
     envs:
       - ./configs/frontend/config.conf
+  - name: frontend-fluentd
+    behavior: create
+    files:
+      - ./configs/frontend/fluentd.conf
   - name: redis
     behavior: merge
     files:
@@ -35,6 +42,10 @@ configMapGenerator:
     behavior: create
     files:
       - ./configs/oauth-proxy/config.conf
+  - name: fluentd-archiver
+    behavior: create
+    files:
+      - ./configs/fluentd-archiver/fluentd.conf
 secretGenerator:
   - name: frontend
     behavior: replace

--- a/gitops/overlays/dev/patches/deployments.yaml
+++ b/gitops/overlays/dev/patches/deployments.yaml
@@ -54,7 +54,19 @@ spec:
             - name: oauth-proxy-conf
               mountPath: /etc/oauth-proxy.conf
               subPath: config.conf
+        - name: fluentd
+          image: docker.io/fluentd
+          args: [--config, /etc/fluentd.conf]
+          volumeMounts:
+            - name: audit-logs
+              mountPath: /logs
+            - name: fluentd-conf
+              mountPath: /etc/fluentd.conf
+              subPath: fluentd.conf
       volumes:
+        - name: fluentd-conf
+          configMap:
+            name: frontend-fluentd
         - name: oauth-proxy-conf
           configMap:
             name: oauth-proxy

--- a/gitops/overlays/dev/pvcs.yaml
+++ b/gitops/overlays/dev/pvcs.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audit-logs
+  labels:
+    app.kubernetes.io/name: audit-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/gitops/overlays/dev/services.yaml
+++ b/gitops/overlays/dev/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd-archiver
+  labels:
+    app.kubernetes.io/name: fluentd-archiver
+spec:
+  ports:
+    - name: fluentd
+      port: 24224
+      targetPort: fluentd
+  selector:
+    app.kubernetes.io/name: fluentd-archiver


### PR DESCRIPTION
### Add audit log aggregation to `dev` environment

This PR adds event log aggregation (via [fluentd](https://www.fluentd.org/)) to the `dev` environment.

#### How it works

- pods log audit events to `/home/node/logs`
- pods have a fluentd container running inside, watching `/home/node/logs/*`
- fluentd in the pods forwards all audit events to the `fluentd-archiver` pod
- `fluentd-archiver` writes the audit events to a persistent volume (under the `/logs/` directory)

### Related Azure Boards Work Items

- [AB#3066](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3066)

### Things to do

- tweak the buffering so that fluentd isn't sending or writing the log events in realtime