### PR TITLE
Fix province or territory required error message

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     .superRefine((val, ctx) => {
       if (val.hasProvincialTerritorialBenefits) {
         if (!val.province || validator.isEmpty(val.province)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.program-required'), path: ['province'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.provincial-territorial-required'), path: ['province'] });
         } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.program-required'), path: ['provincialTerritorialSocialProgram'] });
         }

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -126,7 +126,8 @@
     "error-message": {
       "federal-benefit-required": "Select whether you have federal dental benefits",
       "program-required": "Select a program",
-      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits"
+      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
+      "provincial-territorial-required": "Select a province or territory"
     }
   },
   "dental-insurance": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -126,7 +126,8 @@
     "error-message": {
       "federal-benefit-required": "Sélectionnez si vous avez la prestation dentaire fédérale",
       "program-required": "Sélectionnez un programme",
-      "provincial-benefit-required": "Sélectionnez si vous avez la prestation dentaire provinciale ou territoriale"
+      "provincial-benefit-required": "Sélectionnez si vous avez la prestation dentaire provinciale ou territoriale",
+      "provincial-territorial-required": "Sélectionnez une province ou territoire"
     }
   },
   "dental-insurance": {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix wrong error message if province omitted by the user. `Select a program` is wrong and I change it to `Select a province or territory`.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Before
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/f67b59ef-f856-4b88-80ce-7548a5d3d779)

After
![Screenshot 2024-04-11 093905](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/76357bb7-71df-4f0d-bf25-a8e9e63d5619)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->