### PR TITLE
Feature flag for editing personal informations 

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -48,7 +48,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env.server.ts for valid values
 # (optional; default: doc-upload,email-alerts,hcaptcha,update-personal-info,view-applications,view-letters,view-messages)
-ENABLED_FEATURES=hcaptcha,view-letters,update-personal-info
+ENABLED_FEATURES=hcaptcha,view-letters,view-personal-info,edit-personal-info
 
 
 # hCaptcha maximum allowed score denoting malicious activity

--- a/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/home-address+/edit.test.tsx
@@ -67,6 +67,7 @@ vi.mock('~/utils/env.server', () => ({
     CANADA_COUNTRY_ID: 'CAN',
     USA_COUNTRY_ID: 'USA',
   }),
+  featureEnabled: vi.fn().mockResolvedValue(true),
 }));
 
 describe('_gcweb-app.personal-information.home-address.edit', () => {

--- a/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/mailing-address+/edit.test.tsx
@@ -62,6 +62,7 @@ vi.mock('~/utils/env.server', () => ({
     CANADA_COUNTRY_ID: 'CAN',
     USA_COUNTRY_ID: 'USA',
   }),
+  featureEnabled: vi.fn().mockResolvedValue(true),
 }));
 
 describe('_gcweb-app.personal-information.mailing-address.edit', () => {

--- a/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/phone-number+/edit.test.tsx
@@ -41,7 +41,9 @@ vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
   redirectWithLocale: vi.fn().mockResolvedValue('/personal-information/phone-number/confirm'),
 }));
-
+vi.mock('~/utils/env.server', () => ({
+  featureEnabled: vi.fn().mockResolvedValue(true),
+}));
 describe('_gcweb-app.personal-information.phone-number.edit', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
+++ b/frontend/__tests__/routes/_protected+/personal-information+/preferred-language+/edit.test.tsx
@@ -55,6 +55,10 @@ vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+vi.mock('~/utils/env.server', () => ({
+  featureEnabled: vi.fn().mockResolvedValue(true),
+}));
+
 describe('_gcweb-app.personal-information.preferred-language.edit', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/frontend/app/routes/$lang+/_protected+/home.tsx
+++ b/frontend/app/routes/$lang+/_protected+/home.tsx
@@ -53,7 +53,7 @@ export default function Index() {
   return (
     <>
       <div className="grid gap-4">
-        {useFeature('update-personal-info') && (
+        {useFeature('view-personal-info') && (
           <CardLink title={t('index:personal-info')} routeId="$lang+/_protected+/personal-information+/index" params={params}>
             {t('index:personal-info-desc')}
           </CardLink>

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -23,6 +23,7 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getEnv } from '~/utils/env.server';
+import { featureEnabled } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -50,6 +51,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  featureEnabled('edit-personal-info');
   const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -22,8 +22,7 @@ import { getInstrumentationService } from '~/services/instrumentation-service.se
 import { getLookupService } from '~/services/lookup-service.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getEnv } from '~/utils/env.server';
-import { featureEnabled } from '~/utils/env.server';
+import { featureEnabled, getEnv } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import pageIds from '../../page-ids.json';
 import { Address } from '~/components/address';
 import { InlineLink } from '~/components/inline-link';
+import { useFeature } from '~/root';
 import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-information-route-helpers.server';
 import { getAuditService } from '~/services/audit-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
@@ -34,7 +35,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  featureEnabled('update-personal-info');
+  featureEnabled('view-personal-info');
 
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request, session);
@@ -67,11 +68,13 @@ export default function PersonalInformationIndex() {
         <DescriptionListItem term={t('personal-information:index.full-name')}>{`${personalInformation.firstName} ${personalInformation.lastName}`}</DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.preferred-language')}>
           <p>{preferredLanguage ? getNameByLanguage(i18n.language, preferredLanguage) : t('personal-information:index.no-preferred-language-on-file')}</p>
-          <p>
-            <InlineLink id="change-preferred-language-button" routeId="$lang+/_protected+/personal-information+/preferred-language+/edit" params={params}>
-              {t('personal-information:index.change-preferred-language')}
-            </InlineLink>
-          </p>
+          {useFeature('edit-personal-info') && (
+            <p>
+              <InlineLink id="change-preferred-language-button" routeId="$lang+/_protected+/personal-information+/preferred-language+/edit" params={params}>
+                {t('personal-information:index.change-preferred-language')}
+              </InlineLink>
+            </p>
+          )}
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.home-address')}>
           {personalInformation.homeAddress ? (
@@ -85,11 +88,13 @@ export default function PersonalInformationIndex() {
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
           )}
-          <p>
-            <InlineLink id="change-home-address-button" routeId="$lang+/_protected+/personal-information+/home-address+/edit" params={params}>
-              {t('personal-information:index.change-home-address')}
-            </InlineLink>
-          </p>
+          {useFeature('edit-personal-info') && (
+            <p>
+              <InlineLink id="change-home-address-button" routeId="$lang+/_protected+/personal-information+/home-address+/edit" params={params}>
+                {t('personal-information:index.change-home-address')}
+              </InlineLink>
+            </p>
+          )}
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.mailing-address')}>
           {personalInformation.mailingAddress ? (
@@ -103,19 +108,23 @@ export default function PersonalInformationIndex() {
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
           )}
-          <p>
-            <InlineLink id="change-mailing-address-button" routeId="$lang+/_protected+/personal-information+/mailing-address+/edit" params={params}>
-              {t('personal-information:index.change-mailing-address')}
-            </InlineLink>
-          </p>
+          {useFeature('edit-personal-info') && (
+            <p>
+              <InlineLink id="change-mailing-address-button" routeId="$lang+/_protected+/personal-information+/mailing-address+/edit" params={params}>
+                {t('personal-information:index.change-mailing-address')}
+              </InlineLink>
+            </p>
+          )}
         </DescriptionListItem>
         <DescriptionListItem term={t('personal-information:index.phone-number')}>
           <p>{personalInformation.primaryTelephoneNumber}</p>
-          <p>
-            <InlineLink id="change-phone-number-button" routeId="$lang+/_protected+/personal-information+/phone-number+/edit" params={params}>
-              {t('personal-information:index.change-phone-number')}
-            </InlineLink>
-          </p>
+          {useFeature('edit-personal-info') && (
+            <p>
+              <InlineLink id="change-phone-number-button" routeId="$lang+/_protected+/personal-information+/phone-number+/edit" params={params}>
+                {t('personal-information:index.change-phone-number')}
+              </InlineLink>
+            </p>
+          )}
         </DescriptionListItem>
       </dl>
     </>

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -22,8 +22,7 @@ import { getInstrumentationService } from '~/services/instrumentation-service.se
 import { getLookupService } from '~/services/lookup-service.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { getEnv } from '~/utils/env.server';
-import { featureEnabled } from '~/utils/env.server';
+import { featureEnabled, getEnv } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -23,6 +23,7 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getEnv } from '~/utils/env.server';
+import { featureEnabled } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -50,6 +51,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  featureEnabled('edit-personal-info');
   const instrumentationService = getInstrumentationService();
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request, session);

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/phone-number+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/phone-number+/edit.tsx
@@ -15,6 +15,7 @@ import { InputField } from '~/components/input-field';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getUserService } from '~/services/user-service.server';
+import { featureEnabled } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -39,6 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+  featureEnabled('edit-personal-info');
   const instrumentationService = getInstrumentationService();
   const raoidcService = await getRaoidcService();
   const userService = getUserService();

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
@@ -12,6 +12,7 @@ import { getInstrumentationService } from '~/services/instrumentation-service.se
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getUserService } from '~/services/user-service.server';
+import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -36,6 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+  featureEnabled('edit-personal-info');
   const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
   const raoidcService = await getRaoidcService();

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -22,7 +22,7 @@ function tryOrElseFalse(fn: () => unknown) {
 const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
-const validFeatureNames = ['doc-upload', 'email-alerts', 'hcaptcha', 'update-personal-info', 'view-applications', 'view-letters', 'view-messages'] as const;
+const validFeatureNames = ['doc-upload', 'email-alerts', 'hcaptcha', 'view-personal-info', 'view-applications', 'view-letters', 'view-messages', 'edit-personal-info'] as const;
 export type FeatureName = (typeof validFeatureNames)[number];
 
 // refiners


### PR DESCRIPTION
### Description
Added a feature flag to hide the links to edit someone's personal information. Also, if someone was to manually navigate to those page by editing the links, they would be returned to a 404 error page.

### Related Azure Boards Work Items
[AB#3268](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3268)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

