### PR TITLE
Add image tag to `/api/buildinfo`

### DIFF
--- a/frontend/app/routes/api+/buildinfo.ts
+++ b/frontend/app/routes/api+/buildinfo.ts
@@ -6,5 +6,8 @@ import { getBuildInfoService } from '~/services/build-info-service.server';
  * An API endpoint that returns the build info.
  */
 export function loader({ context, params, request }: LoaderFunctionArgs) {
-  return json(getBuildInfoService().getBuildInfo());
+  const buildInfo = getBuildInfoService().getBuildInfo();
+  const imageTag = `${buildInfo.buildVersion}-${buildInfo.buildRevision}-${buildInfo.buildId}`;
+
+  return json({ ...buildInfo, imageTag });
 }


### PR DESCRIPTION
### Add image tag to `/api/buildinfo`

This makes it easier to copy/paste the image tag when deploying to non-dev environments.

```
{
  "buildDate": "2000-01-01T00:00:00Z",
  "buildId": "0120",
  "buildRevision": "cf77b940",
  "buildVersion": "0.0.0",
  "imageTag": "0.0.0-cf77b940-0120"
}
```