### PR TITLE
AB#3086 -- Adding missing CSRF protection to various form pages in apply flow

### DIFF
--- a/frontend/__tests__/routes/_public+/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/_public+/application-delegate.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,9 +24,12 @@ describe('_public.apply.id.application-delegate', () => {
 
   describe('loader()', () => {
     it('should load id', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/application-delegate'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -34,6 +37,7 @@ describe('_public.apply.id.application-delegate', () => {
 
       expect(data).toEqual({
         id: '123',
+        csrfToken: 'csrfToken',
         meta: {},
       });
     });

--- a/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
+++ b/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,9 +24,12 @@ describe('_public.apply.id.dob-eligibility', () => {
 
   describe('loader()', () => {
     it('should load id', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/dob-eligibility'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -34,6 +37,7 @@ describe('_public.apply.id.dob-eligibility', () => {
 
       expect(data).toEqual({
         id: '123',
+        csrfToken: 'csrfToken',
         meta: {},
       });
     });

--- a/frontend/__tests__/routes/_public+/file-taxes.test.tsx
+++ b/frontend/__tests__/routes/_public+/file-taxes.test.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@remix-run/node';
+import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,9 +24,12 @@ describe('_public.apply.id.file-your-taxes', () => {
 
   describe('loader()', () => {
     it('should load id', async () => {
+      const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
+      session.set('csrfToken', 'csrfToken');
+
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/file-your-taxes'),
-        context: { session: {} as Session },
+        context: { session },
         params: {},
       });
 
@@ -34,6 +37,7 @@ describe('_public.apply.id.file-your-taxes', () => {
 
       expect(data).toEqual({
         id: '123',
+        csrfToken: 'csrfToken',
         meta: {},
       });
     });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { useFetcher, useParams } from '@remix-run/react';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,6 +13,7 @@ import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -31,21 +32,36 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const applyRouteHelpers = getApplyRouteHelpers();
   const { id } = await applyRouteHelpers.loadState({ params, request, session });
 
+  const csrfToken = String(session.get('csrfToken'));
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.application-delegate.page-title') }) };
 
-  return json({ id, meta });
+  return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/application-delegate');
   const applyRouteHelpers = getApplyRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
   await applyRouteHelpers.clearState({ params, request, session });
+
   return redirect(t('apply:eligibility.application-delegate.return-btn-link'));
 }
 
 export default function ApplyFlowApplicationDelegate() {
   const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -71,6 +87,7 @@ export default function ApplyFlowApplicationDelegate() {
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.application-delegate.back-btn')}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/exit-application.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { useFetcher, useParams } from '@remix-run/react';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -10,6 +10,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,21 +29,35 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const applyRouteHelpers = getApplyRouteHelpers();
   const { id } = await applyRouteHelpers.loadState({ params, request, session });
 
+  const csrfToken = String(session.get('csrfToken'));
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) };
 
-  return json({ id, meta });
+  return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/exit-application');
   const applyRouteHelpers = getApplyRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
   await applyRouteHelpers.clearState({ params, request, session });
   return redirect(t('exit-application.exit-link'));
 }
 
 export default function ApplyFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -54,6 +69,7 @@ export default function ApplyFlowTaxFiling() {
         <p>{t('apply:exit-application.click-back')}</p>
       </div>
       <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:exit-application.back-btn')}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
-import { useFetcher, useParams } from '@remix-run/react';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,6 +13,7 @@ import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -31,21 +32,35 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const applyRouteHelpers = getApplyRouteHelpers();
   const { id } = await applyRouteHelpers.loadState({ params, request, session });
 
+  const csrfToken = String(session.get('csrfToken'));
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.file-your-taxes.page-title') }) };
 
-  return json({ id, meta });
+  return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/file-taxes');
   const applyRouteHelpers = getApplyRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
   await applyRouteHelpers.clearState({ params, request, session });
   return redirect(t('apply:eligibility.file-your-taxes.return-btn-link'));
 }
 
 export default function ApplyFlowFileYourTaxes() {
   const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -70,6 +85,7 @@ export default function ApplyFlowFileYourTaxes() {
         <p>{t('apply:eligibility.file-your-taxes.apply-after')}</p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/tax-filing" params={params} disabled={isSubmitting}>
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:eligibility.file-your-taxes.back-btn')}


### PR DESCRIPTION
### Description
The impacted pages in this PR introduced a `<Form>` element after CSRF protection was applied to every (other) page with a form in https://github.com/DTS-STN/canadian-dental-care-plan/pull/841.

### Related Azure Boards Work Items
[AB#3086](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3086)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and go through the `/apply` flow. Verify that the six pages impacted in this PR are not broken.