### PR TITLE
AB#3290 -- Removed required attribute from InputLabel

### DIFF
--- a/frontend/__tests__/components/input-field.test.tsx
+++ b/frontend/__tests__/components/input-field.test.tsx
@@ -42,6 +42,19 @@ describe('InputField', () => {
     expect(actual).not.toBeRequired();
   });
 
+  it('should render with required', async () => {
+    render(<InputField id="test-id" name="test" label="label test" defaultValue="default value" required />);
+
+    const actual = screen.getByTestId('input-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test (input-label.required)');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('default value');
+    expect(actual).toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
   it('should render with error message', async () => {
     render(<InputField id="test-id" name="test" label="label test" defaultValue="default value" errorMessage="error message" />);
 

--- a/frontend/__tests__/components/input-field.test.tsx
+++ b/frontend/__tests__/components/input-field.test.tsx
@@ -42,19 +42,6 @@ describe('InputField', () => {
     expect(actual).not.toBeRequired();
   });
 
-  it('should render with required', async () => {
-    render(<InputField id="test-id" name="test" label="label test" defaultValue="default value" required />);
-
-    const actual = screen.getByTestId('input-field');
-
-    expect(actual).toBeInTheDocument();
-    expect(actual).toHaveAccessibleName('label test (input-label.required)');
-    expect(actual).toHaveAttribute('id', 'test-id');
-    expect(actual).toHaveValue('default value');
-    expect(actual).toBeRequired();
-    expect(actual).not.toHaveAccessibleDescription();
-  });
-
   it('should render with error message', async () => {
     render(<InputField id="test-id" name="test" label="label test" defaultValue="default value" errorMessage="error message" />);
 

--- a/frontend/__tests__/components/input-field.test.tsx
+++ b/frontend/__tests__/components/input-field.test.tsx
@@ -48,7 +48,6 @@ describe('InputField', () => {
     const actual = screen.getByTestId('input-field');
 
     expect(actual).toBeInTheDocument();
-    expect(actual).toHaveAccessibleName('label test (input-label.required)');
     expect(actual).toHaveAttribute('id', 'test-id');
     expect(actual).toHaveValue('default value');
     expect(actual).toBeRequired();

--- a/frontend/__tests__/components/input-label.test.tsx
+++ b/frontend/__tests__/components/input-label.test.tsx
@@ -1,4 +1,4 @@
-import { getByTestId, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -22,23 +22,5 @@ describe('InputLabel', () => {
     expect(actualLabel).toBeInTheDocument();
     expect(actualLabel).toHaveAttribute('id', 'id');
     expect(actualLabel).toHaveTextContent('input test');
-
-    expect(() => getByTestId(actualLabel, 'input-label-required')).toThrow();
-  });
-
-  it('should render with required', () => {
-    render(
-      <InputLabel id="id" required>
-        input test
-      </InputLabel>,
-    );
-
-    const actualLabel = screen.getByTestId('input-label');
-    expect(actualLabel).toBeInTheDocument();
-    expect(actualLabel).toHaveAttribute('id', 'id');
-    expect(actualLabel).toHaveTextContent('input test');
-
-    const actualRequired = getByTestId(actualLabel, 'input-label-required');
-    expect(actualRequired).toHaveTextContent('(input-label.required)');
   });
 });

--- a/frontend/__tests__/components/input-phone-field.test.tsx
+++ b/frontend/__tests__/components/input-phone-field.test.tsx
@@ -48,7 +48,6 @@ describe('InputPhoneField', () => {
     const actual = screen.getByTestId('input-phone-field');
 
     expect(actual).toBeInTheDocument();
-    expect(actual).toHaveAccessibleName('label test (input-label.required)');
     expect(actual).toHaveAttribute('id', 'test-id');
     expect(actual).toHaveValue('+1 514 666 7777');
     expect(actual).toBeRequired();

--- a/frontend/__tests__/components/input-select.test.tsx
+++ b/frontend/__tests__/components/input-select.test.tsx
@@ -78,7 +78,6 @@ describe('InputSelect', () => {
     const actual = screen.getByTestId('input-some-id-test');
 
     expect(actual).toBeInTheDocument();
-    expect(actual).toHaveAccessibleName('label test (input-label.required)');
     expect(actual).toHaveAttribute('id', 'some-id');
     expect(actual).toHaveValue('first');
     expect(actual).toBeRequired();

--- a/frontend/__tests__/components/input-textarea.test.tsx
+++ b/frontend/__tests__/components/input-textarea.test.tsx
@@ -48,7 +48,6 @@ describe('InputTextarea', () => {
     const actual = screen.getByTestId('input-textarea');
 
     expect(actual).toBeInTheDocument();
-    expect(actual).toHaveAccessibleName('label test (input-label.required)');
     expect(actual).toHaveAttribute('id', 'test-id');
     expect(actual).toHaveValue('default value');
     expect(actual).toBeRequired();

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -137,7 +137,7 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
   return (
     <div id={inputWrapperId} data-testid="date-picker-field">
       <fieldset>
-        <InputLegend id={inputLegendId} required={required} className="mb-2">
+        <InputLegend id={inputLegendId} className="mb-2">
           {legend}
         </InputLegend>
         {errorMessages && (

--- a/frontend/app/components/input-checkboxes.tsx
+++ b/frontend/app/components/input-checkboxes.tsx
@@ -35,7 +35,7 @@ export function InputCheckboxes({ errorMessage, helpMessagePrimary, helpMessageP
 
   return (
     <fieldset id={inputWrapperId} data-testid={inputWrapperId}>
-      <InputLegend id={inputLegendId} required={required} className="mb-2">
+      <InputLegend id={inputLegendId} className="mb-2">
         {legend}
       </InputLegend>
       {errorMessage && (

--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -41,7 +41,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>((props, ref) =>
 
   return (
     <div id={inputWrapperId} data-testid={inputWrapperId}>
-      <InputLabel id={inputLabelId} htmlFor={id} required={required} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
         {label}
       </InputLabel>
       {errorMessage && (

--- a/frontend/app/components/input-label.tsx
+++ b/frontend/app/components/input-label.tsx
@@ -1,33 +1,18 @@
 import type { ComponentProps, ReactNode } from 'react';
 
-import { useTranslation } from 'react-i18next';
-
 import { cn } from '~/utils/tw-utils';
 
 export interface InputLabelProps extends ComponentProps<'label'> {
   children: ReactNode;
   id: string;
-  required?: boolean;
 }
 
 export function InputLabel(props: InputLabelProps) {
-  const { t } = useTranslation('gcweb');
-  const { children, className, required, ...restProps } = props;
+  const { children, className, ...restProps } = props;
 
   return (
     <label className={cn('inline-block font-semibold', className)} data-testid="input-label" {...restProps}>
       <span>{children}</span>
-      {required && (
-        <>
-          &nbsp;
-          <i aria-hidden="true" className="font-bold text-red-600">
-            *
-          </i>
-          <strong className="sr-only" data-testid="input-label-required">
-            ({t('input-label.required')})
-          </strong>
-        </>
-      )}
     </label>
   );
 }

--- a/frontend/app/components/input-legend.tsx
+++ b/frontend/app/components/input-legend.tsx
@@ -1,32 +1,17 @@
 import type { ComponentProps, ReactNode } from 'react';
 
-import { useTranslation } from 'react-i18next';
-
 import { cn } from '~/utils/tw-utils';
 
 export interface InputLegendProps extends ComponentProps<'legend'> {
   children: ReactNode;
-  required?: boolean;
 }
 
 export function InputLegend(props: InputLegendProps) {
-  const { t } = useTranslation('gcweb');
-  const { children, className, required, ...restProps } = props;
+  const { children, className, ...restProps } = props;
 
   return (
     <legend className={cn('block font-semibold', className)} data-testid="input-legend" {...restProps}>
       <span>{children}</span>
-      {required && (
-        <>
-          &nbsp;
-          <i aria-hidden="true" className="font-bold text-red-600">
-            *
-          </i>
-          <strong className="sr-only" data-testid="input-label-required">
-            ({t('input-label.required')})
-          </strong>
-        </>
-      )}
     </legend>
   );
 }

--- a/frontend/app/components/input-phone-field.tsx
+++ b/frontend/app/components/input-phone-field.tsx
@@ -54,7 +54,7 @@ export function InputPhoneField(props: InputPhoneFieldProps) {
 
   return (
     <div id={inputWrapperId} data-testid={inputWrapperId}>
-      <InputLabel id={inputLabelId} htmlFor={id} required={required} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
         {label}
       </InputLabel>
       {errorMessage && (

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -35,7 +35,7 @@ const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClass
 
   return (
     <fieldset id={inputWrapperId} data-testid={inputWrapperId}>
-      <InputLegend id={inputLegendId} required={required} className="mb-2">
+      <InputLegend id={inputLegendId} className="mb-2">
         {legend}
       </InputLegend>
       {errorMessage && (

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -37,7 +37,7 @@ const InputSelect = forwardRef<HTMLSelectElement, InputSelectProps>((props, ref)
 
   return (
     <div id={inputWrapperId} data-testid={inputWrapperId}>
-      <InputLabel id={inputLabelId} htmlFor={id} required={required} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
         {label}
       </InputLabel>
       {errorMessage && (

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -33,7 +33,7 @@ const InputTextarea = forwardRef<HTMLTextAreaElement, InputTextareaProps>((props
 
   return (
     <div id={inputWrapperId} data-testid={inputWrapperId} className="form-group">
-      <InputLabel id={inputLabelId} htmlFor={id} required={required} className="mb-2">
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
         {label}
       </InputLabel>
       {errorMessage && (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -185,6 +185,7 @@ export default function ApplyFlowApplicationInformation() {
                 aria-describedby="name-instructions"
                 errorMessage={errorMessages['first-name']}
                 defaultValue={defaultState?.firstName ?? ''}
+                required
               />
               <InputField
                 id="last-name"
@@ -195,6 +196,7 @@ export default function ApplyFlowApplicationInformation() {
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errorMessages['last-name']}
                 aria-describedby="name-instructions"
+                required
               />
               <em id="name-instructions" className="col-span-full">
                 {t('applicant-information.name-instructions')}
@@ -207,6 +209,7 @@ export default function ApplyFlowApplicationInformation() {
               placeholder="000-000-000"
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errorMessages['social-insurance-number']}
+              required
             />
             <InputRadios
               id="marital-status"
@@ -214,6 +217,7 @@ export default function ApplyFlowApplicationInformation() {
               legend={t('applicant-information.marital-status')}
               options={maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState?.maritalStatus, children: getNameByLanguage(i18n.language, status), value: status.id }))}
               errorMessage={errorMessages['input-radio-marital-status-option-0']}
+              required
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -240,7 +240,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <p className="md:col-span-2" id="email-note">
             {t('apply:communication-preference.email-note')}
           </p>
-          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} defaultValue={defaultState?.email ?? ''} />
+          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} defaultValue={defaultState?.email ?? ''} required />
           <InputField
             id="confirm-email"
             type="email"
@@ -250,6 +250,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             name="confirmEmail"
             errorMessage={errorMessages['confirm-email']}
             defaultValue={defaultState?.confirmEmail ?? ''}
+            required
           />
         </div>
       ),
@@ -284,10 +285,11 @@ export default function ApplyFlowCommunicationPreferencePage() {
                   value: language.id,
                 }))}
                 errorMessage={errorMessages['input-radio-preferred-language-option-0']}
+                required
               />
             )}
             {preferredCommunicationMethods.length > 0 && (
-              <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages['input-radio-preferred-methods-option-0']} />
+              <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages['input-radio-preferred-methods-option-0']} required />
             )}
           </div>
           {editMode ? (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -206,6 +206,7 @@ export default function ApplyFlowDateOfBirth() {
               month: fetcher.data?.errors.dateOfBirthMonth?._errors[0],
               day: fetcher.data?.errors.dateOfBirthDay?._errors[0],
             }}
+            required
           />
 
           {editMode ? (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -162,6 +162,7 @@ export default function AccessToDentalInsuranceQuestion() {
               helpMessagePrimary={helpMessage}
               helpMessagePrimaryClassName="text-black"
               errorMessage={errorMessages['input-radio-dental-insurance-option-0']}
+              required
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -295,11 +295,13 @@ export default function AccessToDentalInsuranceQuestion() {
                         value: option.id,
                       }))}
                       errorMessage={errorMessages['input-radio-federal-social-programs-option-0']}
+                      required
                     />
                   ),
                 },
               ]}
               errorMessage={errorMessages['input-radio-has-federal-benefits-option-0']}
+              required
             />
           </section>
           <section>
@@ -340,6 +342,7 @@ export default function AccessToDentalInsuranceQuestion() {
                         ]}
                         defaultValue={provinceValue}
                         errorMessage={errorMessages['province']}
+                        required
                       />
                       {provinceValue && (
                         <InputRadios
@@ -355,6 +358,7 @@ export default function AccessToDentalInsuranceQuestion() {
                               checked: provincialTerritorialSocialProgramValue === option.id,
                               onChange: handleOnProvincialTerritorialSocialProgramChanged,
                             }))}
+                          required
                         />
                       )}
                     </div>
@@ -362,6 +366,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 },
               ]}
               errorMessage={errorMessages['input-radio-has-provincial-territorial-benefits-option-0']}
+              required
             />
           </section>
           {editMode ? (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -231,6 +231,7 @@ export default function ApplyFlowApplicationInformation() {
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
                 aria-describedby="name-instructions"
+                required
               />
               <InputField
                 id="last-name"
@@ -241,6 +242,7 @@ export default function ApplyFlowApplicationInformation() {
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
                 aria-describedby="name-instructions"
+                required
               />
               <em id="name-instructions" className="col-span-full">
                 {t('partner-information.name-instructions')}
@@ -261,6 +263,7 @@ export default function ApplyFlowApplicationInformation() {
                 month: fetcher.data?.errors.dateOfBirthMonth?._errors[0],
                 day: fetcher.data?.errors.dateOfBirthDay?._errors[0],
               }}
+              required
             />
             <InputField
               id="social-insurance-number"
@@ -269,8 +272,9 @@ export default function ApplyFlowApplicationInformation() {
               placeholder="000-000-000"
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={fetcher.data?.errors.socialInsuranceNumber?._errors[0]}
+              required
             />
-            <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={fetcher.data?.errors.confirm?._errors[0]} defaultChecked={defaultState?.confirm === true}>
+            <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={fetcher.data?.errors.confirm?._errors[0]} defaultChecked={defaultState?.confirm === true} required>
               {t('partner-information.confirm-checkbox')}
             </InputCheckbox>
           </div>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -381,6 +381,7 @@ export default function ApplyFlowPersonalInformation() {
               helpMessagePrimaryClassName="text-black"
               defaultValue={defaultState?.mailingAddress ?? ''}
               errorMessage={errorMessages['mailing-address']}
+              required
             />
             <InputField
               id="mailing-apartment"
@@ -390,6 +391,7 @@ export default function ApplyFlowPersonalInformation() {
               maxLength={30}
               defaultValue={defaultState?.mailingApartment ?? ''}
               errorMessage={errorMessages['mailing-apartment']}
+              required
             />
             <InputSelect
               id="mailing-country"
@@ -400,6 +402,7 @@ export default function ApplyFlowPersonalInformation() {
               errorMessage={errorMessages['mailing-country']}
               options={[dummyOption, ...countries]}
               onChange={mailingCountryChangeHandler}
+              required
             />
             {mailingRegions.length > 0 && (
               <InputSelect
@@ -410,10 +413,20 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.mailingProvince ?? ''}
                 errorMessage={errorMessages['mailing-province']}
                 options={[dummyOption, ...mailingRegions]}
+                required
               />
             )}
             <div className="grid gap-6 md:grid-cols-2">
-              <InputField id="mailing-city" name="mailingCity" className="w-full" label={t('apply:personal-information.address-field.city')} maxLength={100} defaultValue={defaultState?.mailingCity ?? ''} errorMessage={errorMessages['mailing-city']} />
+              <InputField
+                id="mailing-city"
+                name="mailingCity"
+                className="w-full"
+                label={t('apply:personal-information.address-field.city')}
+                maxLength={100}
+                defaultValue={defaultState?.mailingCity ?? ''}
+                errorMessage={errorMessages['mailing-city']}
+                required
+              />
               <InputField
                 id="mailing-postal-code"
                 name="mailingPostalCode"
@@ -422,6 +435,7 @@ export default function ApplyFlowPersonalInformation() {
                 maxLength={100}
                 defaultValue={defaultState?.mailingPostalCode}
                 errorMessage={errorMessages['mailing-postal-code']}
+                required={selectedMailingCountry === CANADA_COUNTRY_ID || selectedMailingCountry === USA_COUNTRY_ID}
               />
             </div>
           </div>
@@ -443,6 +457,7 @@ export default function ApplyFlowPersonalInformation() {
                   maxLength={30}
                   defaultValue={defaultState?.homeAddress ?? ''}
                   errorMessage={errorMessages['home-address']}
+                  required
                 />
                 <InputField
                   id="home-apartment"
@@ -452,6 +467,7 @@ export default function ApplyFlowPersonalInformation() {
                   maxLength={30}
                   defaultValue={defaultState?.homeApartment ?? ''}
                   errorMessage={errorMessages['home-apartment']}
+                  required
                 />
                 <InputSelect
                   id="home-country"
@@ -462,6 +478,7 @@ export default function ApplyFlowPersonalInformation() {
                   errorMessage={errorMessages['home-country']}
                   options={[dummyOption, ...countries]}
                   onChange={homeCountryChangeHandler}
+                  required
                 />
                 {homeRegions.length > 0 && (
                   <InputSelect
@@ -472,10 +489,11 @@ export default function ApplyFlowPersonalInformation() {
                     defaultValue={defaultState?.homeProvince ?? ''}
                     errorMessage={errorMessages['home-province']}
                     options={[dummyOption, ...homeRegions]}
+                    required
                   />
                 )}
                 <div className="mb-6 grid gap-6 md:grid-cols-2">
-                  <InputField id="home-city" name="homeCity" className="w-full" label={t('apply:personal-information.address-field.city')} maxLength={100} defaultValue={defaultState?.homeCity ?? ''} errorMessage={errorMessages['home-city']} />
+                  <InputField id="home-city" name="homeCity" className="w-full" label={t('apply:personal-information.address-field.city')} maxLength={100} defaultValue={defaultState?.homeCity ?? ''} errorMessage={errorMessages['home-city']} required />
                   <InputField
                     id="home-postal-code"
                     name="homePostalCode"
@@ -484,6 +502,7 @@ export default function ApplyFlowPersonalInformation() {
                     maxLength={100}
                     defaultValue={defaultState?.homePostalCode ?? ''}
                     errorMessage={errorMessages['home-postal-code']}
+                    required={selectedMailingCountry === CANADA_COUNTRY_ID || selectedMailingCountry === USA_COUNTRY_ID}
                   />
                 </div>
               </>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
@@ -131,6 +131,7 @@ export default function ApplyFlowTaxFiling() {
               { value: TaxFilingOption.No, children: t('apply:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === TaxFilingOption.No },
             ]}
             errorMessage={errorMessages['input-radio-tax-filing-2023-option-0']}
+            required
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button variant="primary" id="continue-button" disabled={isSubmitting}>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -141,6 +141,7 @@ export default function ApplyFlowTypeOfApplication() {
                 defaultChecked: defaultState === ApplicantType.Delegate,
               },
             ]}
+            required
             errorMessage={errorMessages['input-radio-type-of-application-option-0']}
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">


### PR DESCRIPTION
### Description
Removed the 'required' attribute from `InputLabel` in `InputField`, `InputRadio`, and `DatePickerField` components. Re-added 'required' on page inputs to enable the a11y 'aria-required' attribute.

### Related Azure Boards Work Items
[AB#3290](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3290)

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Confirm asterisks are not present on apply flow.

### Additional Notes
n/a