### PR TITLE
AB#3292 -- Add autocomplete to apply input fields

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -172,6 +172,7 @@ export default function ApplyFlowApplicationInformation() {
                 className="w-full"
                 maxLength={100}
                 aria-describedby="name-instructions"
+                autoComplete="given-name"
                 errorMessage={errorMessages['first-name']}
                 defaultValue={defaultState?.firstName ?? ''}
               />
@@ -181,6 +182,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.last-name')}
                 className="w-full"
                 maxLength={100}
+                autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errorMessages['last-name']}
                 aria-describedby="name-instructions"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -213,6 +213,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             maxLength={100}
             name="emailForFuture"
             errorMessage={errorMessages['email-for-future']}
+            autoComplete="email"
             defaultValue={defaultState?.emailForFuture ?? ''}
           />
           <InputField
@@ -223,6 +224,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             maxLength={100}
             name="confirmEmailForFuture"
             errorMessage={errorMessages['confirm-email-for-future']}
+            autoComplete="email"
             defaultValue={defaultState?.confirmEmailForFuture ?? ''}
           />
         </div>
@@ -240,7 +242,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <p className="md:col-span-2" id="email-note">
             {t('apply:communication-preference.email-note')}
           </p>
-          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} defaultValue={defaultState?.email ?? ''} />
+          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} autoComplete="email" defaultValue={defaultState?.email ?? ''} />
           <InputField
             id="confirm-email"
             type="email"
@@ -249,6 +251,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             maxLength={100}
             name="confirmEmail"
             errorMessage={errorMessages['confirm-email']}
+            autoComplete="email"
             defaultValue={defaultState?.confirmEmail ?? ''}
           />
         </div>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -230,6 +230,7 @@ export default function ApplyFlowApplicationInformation() {
                 className="w-full"
                 label={t('apply:partner-information.first-name')}
                 maxLength={100}
+                autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
                 aria-describedby="name-instructions"
@@ -240,6 +241,7 @@ export default function ApplyFlowApplicationInformation() {
                 className="w-full"
                 label={t('apply:partner-information.last-name')}
                 maxLength={100}
+                autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
                 aria-describedby="name-instructions"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -360,11 +360,21 @@ export default function ApplyFlowPersonalInformation() {
         <fetcher.Form method="post" noValidate aria-describedby="form-instructions-info form-instructions">
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-6 grid gap-6 md:grid-cols-2">
-            <InputField id="phone-number" name="phoneNumber" className="w-full" defaultValue={defaultState?.phoneNumber ?? ''} errorMessage={errorMessages['phone-number']} label={t('apply:personal-information.phone-number')} maxLength={100} />
+            <InputField
+              id="phone-number"
+              name="phoneNumber"
+              className="w-full"
+              autoComplete="tel"
+              defaultValue={defaultState?.phoneNumber ?? ''}
+              errorMessage={errorMessages['phone-number']}
+              label={t('apply:personal-information.phone-number')}
+              maxLength={100}
+            />
             <InputField
               id="phone-number-alt"
               name="phoneNumberAlt"
               className="w-full"
+              autoComplete="tel"
               defaultValue={defaultState?.phoneNumberAlt ?? ''}
               errorMessage={errorMessages['phone-number-alt']}
               label={t('apply:personal-information.phone-number-alt')}
@@ -381,6 +391,7 @@ export default function ApplyFlowPersonalInformation() {
               maxLength={30}
               helpMessagePrimary={t('apply:personal-information.address-field.address-note')}
               helpMessagePrimaryClassName="text-black"
+              autoComplete="address-line1"
               defaultValue={defaultState?.mailingAddress ?? ''}
               errorMessage={errorMessages['mailing-address']}
             />
@@ -390,6 +401,7 @@ export default function ApplyFlowPersonalInformation() {
               className="w-full"
               label={t('apply:personal-information.address-field.apartment')}
               maxLength={30}
+              autoComplete="address-line2"
               defaultValue={defaultState?.mailingApartment ?? ''}
               errorMessage={errorMessages['mailing-apartment']}
             />
@@ -398,6 +410,7 @@ export default function ApplyFlowPersonalInformation() {
               name="mailingCountry"
               className="w-full sm:w-1/2"
               label={t('apply:personal-information.address-field.country')}
+              autoComplete="country"
               defaultValue={defaultState?.mailingCountry ?? ''}
               errorMessage={errorMessages['mailing-country']}
               options={[dummyOption, ...countries]}
@@ -415,13 +428,23 @@ export default function ApplyFlowPersonalInformation() {
               />
             )}
             <div className="grid gap-6 md:grid-cols-2">
-              <InputField id="mailing-city" name="mailingCity" className="w-full" label={t('apply:personal-information.address-field.city')} maxLength={100} defaultValue={defaultState?.mailingCity ?? ''} errorMessage={errorMessages['mailing-city']} />
+              <InputField
+                id="mailing-city"
+                name="mailingCity"
+                className="w-full"
+                label={t('apply:personal-information.address-field.city')}
+                maxLength={100}
+                autoComplete="address-level2"
+                defaultValue={defaultState?.mailingCity ?? ''}
+                errorMessage={errorMessages['mailing-city']}
+              />
               <InputField
                 id="mailing-postal-code"
                 name="mailingPostalCode"
                 className="w-full"
                 label={selectedMailingCountry === CANADA_COUNTRY_ID || selectedMailingCountry === USA_COUNTRY_ID ? t('apply:personal-information.address-field.postal-code') : t('apply:personal-information.address-field.postal-code-optional')}
                 maxLength={100}
+                autoComplete="postal-code"
                 defaultValue={defaultState?.mailingPostalCode}
                 errorMessage={errorMessages['mailing-postal-code']}
               />
@@ -443,6 +466,7 @@ export default function ApplyFlowPersonalInformation() {
                   helpMessagePrimary={t('apply:personal-information.address-field.address-note')}
                   helpMessagePrimaryClassName="text-black"
                   maxLength={30}
+                  autoComplete="address-line1"
                   defaultValue={defaultState?.homeAddress ?? ''}
                   errorMessage={errorMessages['home-address']}
                 />
@@ -452,6 +476,7 @@ export default function ApplyFlowPersonalInformation() {
                   className="w-full"
                   label={t('apply:personal-information.address-field.apartment')}
                   maxLength={30}
+                  autoComplete="address-line2"
                   defaultValue={defaultState?.homeApartment ?? ''}
                   errorMessage={errorMessages['home-apartment']}
                 />
@@ -460,6 +485,7 @@ export default function ApplyFlowPersonalInformation() {
                   name="homeCountry"
                   className="w-full sm:w-1/2"
                   label={t('apply:personal-information.address-field.country')}
+                  autoComplete="country"
                   defaultValue={defaultState?.homeCountry ?? ''}
                   errorMessage={errorMessages['home-country']}
                   options={[dummyOption, ...countries]}
@@ -477,13 +503,23 @@ export default function ApplyFlowPersonalInformation() {
                   />
                 )}
                 <div className="mb-6 grid gap-6 md:grid-cols-2">
-                  <InputField id="home-city" name="homeCity" className="w-full" label={t('apply:personal-information.address-field.city')} maxLength={100} defaultValue={defaultState?.homeCity ?? ''} errorMessage={errorMessages['home-city']} />
+                  <InputField
+                    id="home-city"
+                    name="homeCity"
+                    className="w-full"
+                    label={t('apply:personal-information.address-field.city')}
+                    maxLength={100}
+                    autoComplete="address-level2"
+                    defaultValue={defaultState?.homeCity ?? ''}
+                    errorMessage={errorMessages['home-city']}
+                  />
                   <InputField
                     id="home-postal-code"
                     name="homePostalCode"
                     className="w-full"
                     label={selectedHomeCountry === CANADA_COUNTRY_ID || selectedHomeCountry === USA_COUNTRY_ID ? t('apply:personal-information.address-field.postal-code') : t('apply:personal-information.address-field.postal-code-optional')}
                     maxLength={100}
+                    autoComplete="postal-code"
                     defaultValue={defaultState?.homePostalCode ?? ''}
                     errorMessage={errorMessages['home-postal-code']}
                   />


### PR DESCRIPTION
### Description
Added autocomplete attribute to specified apply input fields (email, tel, etc.)

### Related Azure Boards Work Items
[AB#3292](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3292)

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Confirm autocompletion by typing into the first/last name, phone, email, or address fields.

### Additional Notes
n/a