### PR TITLE
AB#3038 -- fix flaky e2e test

### DIFF
--- a/frontend/e2e/$lang+/_protected+/letters+/_index.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/letters+/_index.spec.ts
@@ -8,10 +8,12 @@ test.describe('letters page', () => {
 
   test('it should sort letters oldest to newest', async ({ page }) => {
     await page.goto('/en/letters');
+
     const selectLocator = page.getByRole('combobox', { name: 'filter by' });
     await expect(selectLocator).toHaveValue('desc');
+
     await selectLocator.selectOption('asc');
-    await expect(page).toHaveURL(/\/letters?.*sort=asc/);
+    await page.waitForURL(/\/letters\?.*sort=asc/);
     await expect(selectLocator).toHaveValue('asc');
   });
 
@@ -19,9 +21,13 @@ test.describe('letters page', () => {
     // note: the default behaviour in the browser is to open the pdf in the tab
     // in chromium, however, this isn't the case. Instead, the pdf will fire a download event
     await page.goto('/en/letters');
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('main').getByRole('listitem').first().getByRole('link').click();
-    const download = await downloadPromise;
+
+    // prettier-ignore
+    await page.getByRole('main')
+      .getByRole('listitem').first()
+      .getByRole('link').click();
+
+    const download = await page.waitForEvent('download');
     expect(download.suggestedFilename()).toMatch(/\.pdf$/);
   });
 });


### PR DESCRIPTION
### Fix flaky `/:lang/letters` test

Since navigation to `/en/letters?sort=asc` happens client-side, a `page.waitForURL(..)` is required to consistently wait for the navigation to happen.

### Related Azure Boards Work Items

- [AB#3038](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3038)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
