### PR TITLE
AB#3309 -- Initial commit of backend project

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,15 @@
       "request": "launch",
       "type": "node-terminal",
       "cwd": "${workspaceFolder}/frontend/"
+    },
+    {
+      "type": "java",
+      "name": "Launch Canadian Dental Care Plan API",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "mainClass": "ca.gov.dtsstn.cdcp.api.Application",
+      "projectName": "cdcp-api",
+      "args": "--spring.profiles.active=local"
     }
   ]
 }

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,37 @@
+target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Temporary Files
+**/tmp/
+
+### Application-Specific Local Configuration ###
+**/application-local.properties
+**/application-local.yml
+**/application-local.yaml

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.4</version>
+	</parent>
+
+
+	<groupId>ca.gov.dts-stn</groupId>
+	<artifactId>cdcp-api</artifactId>
+	<version>${revision}</version>
+	<name>cdcp-api</name>
+	<description>Canadian Dental Care Plan API</description>
+
+
+	<properties>
+		<java.version>21</java.version>
+		<revision>0.0.0-00000000-0000</revision>
+	</properties>
+
+
+	<dependencies>
+		<!-- Spring dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- optional/provided dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/Application.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/Application.java
@@ -1,0 +1,13 @@
+package ca.gov.dtsstn.cdcp.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/controller/SampleController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/controller/SampleController.java
@@ -1,0 +1,14 @@
+package ca.gov.dtsstn.cdcp.api.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SampleController {
+
+	@GetMapping("/samples")
+	public String getSamples() {
+		return "Hello world!";
+	}
+
+}

--- a/backend/src/main/resources/application-local.yml.sample
+++ b/backend/src/main/resources/application-local.yml.sample
@@ -1,0 +1,7 @@
+# Sample configuration file for application-local.yml.
+# Copy this file as application-local.yml and customize the values for your local environment.
+# application-local.yml is excluded from version control (gitignored).
+
+logging:
+  level:
+    "[ca.gov.dtsstn.cdcp.api]": trace

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: cdcp-api

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/controller/SampleControllerTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/controller/SampleControllerTest.java
@@ -1,0 +1,16 @@
+package ca.gov.dtsstn.cdcp.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SampleControllerTest {
+
+	@Test
+	void testGetSamples_shouldReturnHelloWorld() {
+		final SampleController controller = new SampleController();
+		final String response = controller.getSamples();
+		assertEquals("Hello world!", response);
+	}
+
+}


### PR DESCRIPTION
### Description
Project generated with https://start.spring.io/ with Spring Boot Starters for Actuator, Web, DevTools, Test.
Removed default maven wrapper package and added sample `@RestController` and unit test.

### Related Azure Boards Work Items
[AB#3309](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3309)

### Screenshots (if applicable)
`/samples`:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/c6f4d4ef-f689-4139-b361-65097eab90d4)

`/actuator`:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/5322299c-c932-49b5-b18b-3e1a0c6ecd57)

### Test Instructions
Download Java 21+ and Maven 3+.
Within the `backend` project, run `mvn spring-boot:run`.
In your browser, open `localhost:8080/samples` - "Hello world!" should display.