### PR TITLE
AB#3038 -- flaky e2e tests

### DIFF
--- a/frontend/e2e/$lang+/_protected+/letters+/_index.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/letters+/_index.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { sleep } from 'moderndash';
 
 test.describe('letters page', () => {
   test('should navigate to letters page', async ({ page }) => {
@@ -8,10 +9,12 @@ test.describe('letters page', () => {
 
   test('it should sort letters oldest to newest', async ({ page }) => {
     await page.goto('/en/letters');
+    await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
+
     const selectLocator = page.getByRole('combobox', { name: 'filter by' });
     await expect(selectLocator).toHaveValue('desc');
     await selectLocator.selectOption('asc');
-    await expect(page).toHaveURL(/\/letters?.*sort=asc/);
+    await expect(page).toHaveURL(/\/letters\?.*sort=asc/);
     await expect(selectLocator).toHaveValue('asc');
   });
 

--- a/frontend/e2e/$lang+/_protected+/personal-information+/home-address+/edit.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/personal-information+/home-address+/edit.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { sleep } from 'moderndash';
 
 test.describe('personal information home address edit page', () => {
   test('should navigate to home address edit page', async ({ page }) => {
@@ -12,6 +13,7 @@ test.describe('personal information home address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/home-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('submit invalid form data', async () => {
@@ -37,6 +39,7 @@ test.describe('personal information home address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/home-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('enter and submit form data', async () => {
@@ -49,6 +52,7 @@ test.describe('personal information home address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/home-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/home-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('click cancel', async () => {

--- a/frontend/e2e/$lang+/_protected+/personal-information+/mailing-address+/edit.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/personal-information+/mailing-address+/edit.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { sleep } from 'moderndash';
 
 test.describe('personal information mailing address edit page', () => {
   test('should navigate to mailing address edit page', async ({ page }) => {
@@ -19,6 +20,7 @@ test.describe('personal information mailing address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/mailing-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('submit invalid form data', async () => {
@@ -38,6 +40,7 @@ test.describe('personal information mailing address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/mailing-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('enter and submit form data', async () => {
@@ -54,6 +57,7 @@ test.describe('personal information mailing address edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/mailing-address/edit');
       await expect(page).toHaveURL(/.*personal-information\/mailing-address\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('click cancel', async () => {

--- a/frontend/e2e/$lang+/_protected+/personal-information+/phone-number+/confirm.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/personal-information+/phone-number+/confirm.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { sleep } from 'moderndash';
 
 test.describe('phone number change confirmation page', () => {
   test('should navigate to phone number change confirmation page', async ({ page }) => {
     await page.goto('/en/personal-information/phone-number/edit');
     await expect(page).toHaveURL('/en/personal-information/phone-number/edit');
+    await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
 
     await page.getByRole('textbox', { name: 'phone number' }).fill('(506) 555-5555');
     await page.getByRole('button', { name: 'change' }).click();

--- a/frontend/e2e/$lang+/_protected+/personal-information+/phone-number+/edit.spec.ts
+++ b/frontend/e2e/$lang+/_protected+/personal-information+/phone-number+/edit.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { sleep } from 'moderndash';
 
 test.describe('personal information phone number edit page', () => {
   test('should navigate to phone number edit page', async ({ page }) => {
@@ -12,6 +13,7 @@ test.describe('personal information phone number edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/phone-number/edit');
       await expect(page).toHaveURL(/.*personal-information\/phone-number\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('submit invalid form data', async () => {
@@ -36,6 +38,7 @@ test.describe('personal information phone number edit page', () => {
     await test.step('navigate', async () => {
       await page.goto('/en/personal-information/phone-number/edit');
       await expect(page).toHaveURL(/.*personal-information\/phone-number\/edit/);
+      await sleep(250); // wait 250ms for page to hydrate and onChange handlers to be bound
     });
 
     await test.step('enter and submit form data', async () => {


### PR DESCRIPTION
### Fix flaky e2e tests (attempt #312)

This PR adds some `sleep()` calls to the various e2e tests that rely on client-side hydration.

I've tested these changes in a special TeamCity build pipeline and they appear to work.

### Related Azure Boards Work Items

- [AB#3038](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3038)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
