### PR TITLE
AB#3266 -- fix radio hitboxes

### DIFF
--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -23,9 +23,9 @@ export function InputRadio({ append, appendClassName, children, className, hasEr
   return (
     <div className={className}>
       <div className="flex items-center">
-        <input type="radio" id={inputRadioId} aria-labelledby={inputLabelId} className={cn(inputBaseClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)} data-testid="input-radio" {...restProps} />
-        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('ml-3 block leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
-          {children}
+        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
+          <input type="radio" id={inputRadioId} aria-labelledby={inputLabelId} className={cn(inputBaseClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)} data-testid="input-radio" {...restProps} />
+          <span className="ml-3">{children}</span>
         </label>
       </div>
       {append && <div className={cn('ml-7 mt-4', appendClassName)}>{append}</div>}


### PR DESCRIPTION
### Fix radio button hitboxes

The space between the radio button and its label did not react to tap/click events. This PR fixes that by moving the `<input>` inside of the label.

### Related Azure Boards Work Items

- [AB#3266](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3266)

### Screenshots

#### Before

![Screenshot from 2024-04-17 07-01-15](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/51f109e2-97d7-413d-a207-b58c9ffe2911)

#### After

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/420d33ac-b203-46a5-940b-8d2ecf1328f0)

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
