### PR TITLE
Fix Font Awesome CSP issue

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -4,6 +4,8 @@ import type { LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run
 import { json } from '@remix-run/node';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData, useLocation, useRouteLoaderData } from '@remix-run/react';
 
+import { config as fontAwesomeConfig } from '@fortawesome/fontawesome-svg-core';
+import fontawesomeStyleSheet from '@fortawesome/fontawesome-svg-core/styles.css';
 import { useTranslation } from 'react-i18next';
 import reactPhoneNumberInputStyleSheet from 'react-phone-number-input/style.css';
 
@@ -22,10 +24,14 @@ import { useI18nNamespaces } from '~/utils/route-utils';
 import { getDescriptionMetaTags, getTitleMetaTags, useAlternateLanguages, useCanonicalURL } from '~/utils/seo-utils';
 import { getUserOrigin } from '~/utils/user-origin-utils.server';
 
+// see: https://docs.fontawesome.com/web/dig-deeper/security#content-security-policy
+fontAwesomeConfig.autoAddCss = false;
+
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: fontLatoStyleSheet },
   { rel: 'stylesheet', href: fontNotoSansStyleSheet },
   { rel: 'stylesheet', href: reactPhoneNumberInputStyleSheet },
+  { rel: 'stylesheet', href: fontawesomeStyleSheet },
   { rel: 'stylesheet', href: tailwindStyleSheet },
 ];
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Since, by default, the SVG with JavaScript library attempts to add CSS to the <head> of the DOM it will violate a strict CSP. Follow the steps below to workaround this:

1. Disable automatic CSS insertion.
2. Reference the external CSS file explicitly.

https://docs.fontawesome.com/web/dig-deeper/security#content-security-policy

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Issue logged in Browser

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/72e75bf6-83d4-4c15-9a43-69c5b74e02cd)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->