### PR TITLE
Add status check api env

### DIFF
--- a/gitops/overlays/int/configs/frontend/config.conf
+++ b/gitops/overlays/int/configs/frontend/config.conf
@@ -38,6 +38,7 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 # Interop API configuration
 #
 INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/int/stream1
+INTEROP_STATUS_CHECK_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
 
 #
 # SIN edit stub page configuration


### PR DESCRIPTION
### Description
Right now, the status checker api is not available in Interop's INT. This pr should make the status checker api point to UAT. I've already added the environment variable in TeamCity.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`