### PR TITLE
Fixing view letters logic where filtering of letters by letter type happens too late (and other small fixes)

### DIFF
--- a/frontend/public/locales/en/index.json
+++ b/frontend/public/locales/en/index.json
@@ -1,5 +1,5 @@
 {
-  "page-title": "Canadian Detal Care Plan (CDCP)",
+  "page-title": "Canadian Dental Care Plan (CDCP)",
   "personal-info": "Personal information",
   "apply": "Apply",
   "personal-info-desc": "In this section, you can see and update your personal information.",


### PR DESCRIPTION
### Description
Previously, we were filtering letters by letter types in the component. However, there is a check for no letters before this happens meaning an empty page can render. This PR moves the filtering of letters by letter types in the loader.

PR also includes minor changes:
- adding alert around "There are no letters on file." message
- including "Back" button when no letters are found
- fixing typo with `/home`

### Screenshots (if applicable)
**Before:**
Filtering letter types in component:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/b85fa0d7-fc41-42b2-b648-6cd2e410a0dc)

There are no letters on file (original):
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/17acfee7-ddb1-4a79-99fc-2f8fc8a5fdb0)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/5dfc6ed5-fbf5-44e8-978e-fb3ed15a803d)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Change the `cct-api-server` mock to have letters with `LetterName` that don't correspond to a letter type (like `00000`). Run the application and navigate to `/en/letters`. A message indicating that there are no letters on file should appear.

### Additional notes
There weren't that many changes in the `LettersIndex` component as Github shows. Actual changes:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/09eaf115-e61c-4169-b802-2f37d3984848)

