### PR TITLE
Fixed identified en/fr translation bugs for apply flow

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -74,7 +74,6 @@ export default function ApplyIndex() {
         <p>{t('apply:terms-and-conditions.intro-text')}</p>
         <Collapsible summary={t('apply:terms-and-conditions.terms-and-conditions-of-use.summary')}>
           <div className="space-y-4">
-            <h2 className="font-bold">{t('apply:terms-and-conditions.terms-and-conditions-of-use.heading')}</h2>
             <p>
               <Trans ns={handle.i18nNamespaces} i18nKey="apply:terms-and-conditions.terms-and-conditions-of-use.online-application-legal-terms" components={{ canadaTermsConditions }} />
             </p>
@@ -90,7 +89,9 @@ export default function ApplyIndex() {
               <li>{t('apply:terms-and-conditions.terms-and-conditions-of-use.online-application.self-agreement')}</li>
               <li>{t('apply:terms-and-conditions.terms-and-conditions-of-use.online-application.on-behalf-of-someone-else')}</li>
               <li>{t('apply:terms-and-conditions.terms-and-conditions-of-use.online-application.at-your-own-risk')}</li>
-              <li>{t('apply:terms-and-conditions.terms-and-conditions-of-use.online-application.msdc')}</li>
+              <li>
+                <Trans ns={handle.i18nNamespaces} i18nKey="apply:terms-and-conditions.terms-and-conditions-of-use.online-application.msdc" components={{ microsoftDataPrivacyPolicy }} />
+              </li>
               <li>
                 <Trans ns={handle.i18nNamespaces} i18nKey="apply:terms-and-conditions.terms-and-conditions-of-use.online-application.antibot" components={{ hcaptchaTermsOfService }} />
               </li>

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -387,8 +387,7 @@
     "intro-text": "Thank you for using the Canadian Dental Care Plan (CDCP) Online Application (\"the Online Application\"). We have developed terms and conditions for using this service (\"Terms\"). Please read them carefully.",
     "terms-and-conditions-of-use": {
       "summary": "Terms and Conditions of Use",
-      "heading": "Terms and Conditions of Use for the Canadian Dental Care Plan Online Application",
-      "online-application-legal-terms": "<strong>PLEASE READ CAREFULLY.</strong> These Terms for the Canadian Dental Care Plan (CDCP) Online Application contain information about your legal rights and obligations and regulate your use of the Online Application. These Terms should be read in conjunction with the <canadaTermsConditions>Canada.ca</canadaTermsConditions> website Terms and Conditions. In case they are differing, the present Terms take precedence over Canada.ca Terms and Conditions.",
+      "online-application-legal-terms": "PLEASE READ CAREFULLY. These Terms for the Canadian Dental Care Plan (CDCP) Online Application contain information about your legal rights and obligations and regulate your use of the Online Application. These Terms should be read in conjunction with the <canadaTermsConditions>Canada.ca</canadaTermsConditions> website Terms and Conditions. In case they are differing, the present Terms take precedence over Canada.ca Terms and Conditions.",
       "online-application-access-terms": "Your access to and use of the Online Application, including any and all content, is subject to (1) your acceptance of, and (2) your compliance with these Terms.",
       "online-application-usage-terms": "Every time you use the Online Application, these Terms will apply. By using the Online Application, you agree to abide by the following Terms. It is your responsibility to understand and retain these Terms.",
       "online-application-outage": "There will be times when the system might be down for maintenance.",
@@ -400,7 +399,7 @@
         "self-agreement": "Using the Online Application means that you have read and agree to these Terms and the Privacy Notice Statement. If, at any time, you withdraw your agreement to any of the Terms you must stop use of the Online Application.",
         "on-behalf-of-someone-else": "If you are using the Application on behalf of a child, by using the Online Application, you certify that you have all the necessary authority to agree to the Terms on behalf of that individual, and that you agree to the Terms on behalf of the individual you are representing.",
         "at-your-own-risk": "If you are using a shared computer or shared internet connection, you are using this service at your own risk, and you will need to keep any personal information safe. If you are using a public computer make sure to close the browser or log out when you are done.",
-        "msdc": "ESDC uses services from Microsoft Corporation to run the Online Application. The Microsoft data centres used by ESDC are in Canada in accordance with Microsoft Corporation's Terms of Service Agreement.",
+        "msdc": "ESDC uses services from Microsoft Corporation to run the Online Application. The Microsoft data centres used by ESDC are in Canada in accordance with <microsoftDataPrivacyPolicy>Microsoft Corporation's Terms of Service Agreement</microsoftDataPrivacyPolicy>.",
         "antibot": "ESDC uses hCaptcha anti-bot services for our online tools in accordance with hCaptcha's <hcaptchaTermsOfService>Terms of Service</hcaptchaTermsOfService>."
       },
       "changes-to-these-terms-of-use": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -22,7 +22,7 @@
     }
   },
   "communication-preference": {
-    "page-title": "Préférences en matière de communication",
+    "page-title": "Communication",
     "note": "Si vous êtes admissible, nous communiquerons vos renseignements à la Sun Life du Canada, compagnie d'assurance-vie (Sun Life). La Sun Life sera responsable du traitement de l'adhésion des membres et de l'administration des demandes de réclamations et des prestations du Régime canadien de soins dentaires.",
     "preferred-method": "Quel est votre mode de communication préféré pour la Sun Life?",
     "preferred-language": "Quelle langue officielle de communication préférez-vous",
@@ -387,8 +387,7 @@
     "intro-text": "Merci d'utiliser la demande en ligne du Régime canadien de soins dentaires (RCSD) («\u00a0la demande en ligne\u00a0»). Nous avons établi conditions d'utilisation de ce service («\u00a0conditions d'utilisation\u00a0»). Veuillez les lire attentivement.",
     "terms-and-conditions-of-use": {
       "summary": "Conditions générales d'utilisation",
-      "heading": "Conditions d'utilisation de la demande en ligne du Régime canadien de soins dentaires",
-      "online-application-legal-terms": "<strong>VEUILLEZ LIRE ATTENTIVEMENT.</strong> Les présentes conditions d'utilisation de la demande en ligne du Régime canadien de soins dentaires (RCSD) contiennent des renseignements sur vos droits et obligations juridiques et régissent votre utilisation de la demande en ligne. Les présentes conditions d'utilisation doivent être lues en parallèle avec celles du site Web Canada.ca. En cas de divergence, les présentes conditions d'utilisation ont préséance sur <canadaTermsConditions>celles du site Web Canada.ca</canadaTermsConditions>. En cas de divergence, les présentes conditions générales d'utilisation ont préséance sur celles du site Web Canada.ca.",
+      "online-application-legal-terms": "VEUILLEZ LIRE ATTENTIVEMENT. Les présentes conditions d'utilisation de la demande en ligne du Régime canadien de soins dentaires (RCSD) contiennent des renseignements sur vos droits et obligations juridiques et régissent votre utilisation de la demande en ligne. Les présentes conditions d'utilisation doivent être lues en parallèle avec celles du site Web Canada.ca. En cas de divergence, les présentes conditions d'utilisation ont préséance sur <canadaTermsConditions>celles du site Web Canada.ca</canadaTermsConditions>. En cas de divergence, les présentes conditions générales d'utilisation ont préséance sur celles du site Web Canada.ca.",
       "online-application-access-terms": "Votre accès à la demande en ligne et votre utilisation de celle-ci, y compris tout le contenu, sont assujettis à (1) votre acceptation des présentes conditions d'utilisation et (2) votre respect de celles-ci.",
       "online-application-usage-terms": "Chaque fois que vous utilisez la demande en ligne, ces conditions continuent de s'appliquer. En utilisant la demande en ligne, vous acceptez de respecter les conditions suivantes. Il vous incombe de comprendre et de conserver ces conditions.",
       "online-application-outage": "Il peut arriver que le système soit interrompu pour des raisons de maintenance.",
@@ -400,7 +399,7 @@
         "self-agreement": "Votre utilisation de la demande en ligne signifie que vous avez lu et accepté les présentes conditions d'utilisation et l'énoncé de confidentialité. Si, à tout moment, vous cessez d'accepter l'une ou l'autre des conditions d'utilisation, vous devez renoncer à utiliser la demande en ligne.",
         "on-behalf-of-someone-else": "Si vous utilisez l'Application au nom d'un enfant, en utilisant l'Application en ligne, vous certifiez que vous disposez de toute l'autorité nécessaire pour accepter les Conditions au nom de cette personne, et que vous acceptez les Conditions au nom de l'enfant. personne que vous représentez.",
         "at-your-own-risk": "Si vous utilisez un ordinateur partagé ou une connexion Internet partagée, vous utilisez ce service à vos propres risques et vous devrez protéger toutes vos informations personnelles. Si vous utilisez un ordinateur public, assurez-vous de fermer le navigateur ou de vous déconnecter lorsque vous avez terminé.",
-        "msdc": "EDSC utilise les services de Microsoft Corporation pour exécuter la demande en ligne. Les centres de données Microsoft utilisés par EDSC sont au Canada conformément à l'entente sur les conditions de service d Microsoft Corporation.",
+        "msdc": "EDSC utilise les services de Microsoft Corporation pour exécuter la demande en ligne. Les centres de données Microsoft utilisés par EDSC sont au Canada conformément à l'entente sur <microsoftDataPrivacyPolicy>les conditions de service d Microsoft Corporation</microsoftDataPrivacyPolicy>.",
         "antibot": "EDSC utilise les services de protection contre les robots hCaptcha pour nos outils en ligne conformément aux <hcaptchaTermsOfService>conditions de service</hcaptchaTermsOfService> de hCaptcha."
       },
       "changes-to-these-terms-of-use": {


### PR DESCRIPTION
### Description
Fixed identified en/fr translation bugs for apply flow:
-Communication page fr title
-T&C page en/fr microsoft links
-T&C page removed header and bolding


### Related Azure Boards Work Items
ESDCCM/CDCP #7401
ESDCCM/CDCP #7397
ESDCCM/CDCP #7396
ESDCCM/CDCP #7395

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
visit apply flow pages to confirm text changes

### Additional Notes
n/a