### PR TITLE
Delete all session data from session object when calling destroySession()

### DIFF
--- a/frontend/app/services/session-service.server.ts
+++ b/frontend/app/services/session-service.server.ts
@@ -21,7 +21,8 @@
  *
  * @see https://remix.run/docs/en/main/utils/sessions
  */
-import { CookieParseOptions, createCookie, createFileSessionStorage, createSessionStorage } from '@remix-run/node';
+import { CookieParseOptions, Session, createCookie, createFileSessionStorage, createSessionStorage } from '@remix-run/node';
+import type { CookieSerializeOptions } from '@remix-run/node';
 
 import moize from 'moize';
 import { randomUUID } from 'node:crypto';
@@ -56,6 +57,10 @@ async function createSessionService() {
 
       return {
         ...sessionStorage,
+        destroySession: async (session: Session, options?: CookieSerializeOptions) => {
+          Object.keys(session.data).forEach((key) => session.unset(key));
+          return sessionStorage.destroySession(session, options);
+        },
         getSession: async (cookieHeader?: string | null, options?: CookieParseOptions) => {
           // BUG :: GjB :: **POTENTIALLY INCONSISTENT SESSION FILE READS**
           //


### PR DESCRIPTION
### Delete all session data from session object when calling destroySession()

Remix doesn't clear session values when destroying the session (⁉️). This PR does.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
