### PR TITLE
Fixed french translations on t&c and personal information pages

### DIFF
--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -298,7 +298,7 @@
     },
     "home-address": {
       "header": "Adresse du domicile",
-      "use-mailing-address": "Mon adresse domiciliaire et mon adresse postale sont les mêmes."
+      "use-mailing-address": "Mon adresse postale et mon adresse domiciliaire sont les mêmes."
     },
     "address-field": {
       "address": "Adresse",
@@ -400,7 +400,7 @@
         "self-agreement": "Votre utilisation de la demande en ligne signifie que vous avez lu et accepté les présentes conditions d'utilisation et l'énoncé de confidentialité. Si, à tout moment, vous cessez d'accepter l'une ou l'autre des conditions d'utilisation, vous devez renoncer à utiliser la demande en ligne.",
         "on-behalf-of-someone-else": "Si vous utilisez l'Application au nom d'un enfant, en utilisant l'Application en ligne, vous certifiez que vous disposez de toute l'autorité nécessaire pour accepter les Conditions au nom de cette personne, et que vous acceptez les Conditions au nom de l'enfant. personne que vous représentez.",
         "at-your-own-risk": "Si vous utilisez un ordinateur partagé ou une connexion Internet partagée, vous utilisez ce service à vos propres risques et vous devrez protéger toutes vos informations personnelles. Si vous utilisez un ordinateur public, assurez-vous de fermer le navigateur ou de vous déconnecter lorsque vous avez terminé.",
-        "msdc": "EDSC utilise les services de Microsoft Corporation pour exécuter la demande en ligne. Les centres de données Microsoft utilisés par EDSC sont au Canada conformément à l'entente sur <microsoftDataPrivacyPolicy>les conditions de service d Microsoft Corporation</microsoftDataPrivacyPolicy>.",
+        "msdc": "EDSC utilise les services de Microsoft Corporation pour exécuter la demande en ligne. Les centres de données Microsoft utilisés par EDSC sont au Canada conformément à l'entente sur <microsoftDataPrivacyPolicy>les conditions de service de Microsoft Corporation</microsoftDataPrivacyPolicy>.",
         "antibot": "EDSC utilise les services de protection contre les robots hCaptcha pour nos outils en ligne conformément aux <hcaptchaTermsOfService>conditions de service</hcaptchaTermsOfService> de hCaptcha."
       },
       "changes-to-these-terms-of-use": {


### PR DESCRIPTION
### Description
- Fixed typo in T&C Microsoft French link
- Reverted personal information "use mailing address" French translation

### Related Azure Boards Work Items
n/a

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Confirm changes on T&C and personal information French pages

### Additional Notes
n/a