### PR TITLE
Add style-src 'unsafe-inline'

### DIFF
--- a/frontend/__tests__/utils/csp-utils.server.test.ts
+++ b/frontend/__tests__/utils/csp-utils.server.test.ts
@@ -32,7 +32,7 @@ describe('csp.server', () => {
       expect(csp).toContain(`frame-src 'self' ${hcaptchaCSP.frameSrc} ${adobeAnalyticsCSP.frameSrc};`);
       expect(csp).toContain(`img-src 'self' data: ${adobeAnalyticsCSP.imgSrc} https://purecatamphetamine.github.io;`);
       expect(csp).toContain(`script-src 'self' 'unsafe-inline' ${hcaptchaCSP.scriptSrc} ${adobeAnalyticsCSP.scriptSrc}`);
-      expect(csp).toContain(`style-src 'self' ${hcaptchaCSP.styleSrc}`);
+      expect(csp).toContain(`style-src 'self' 'unsafe-inline' ${hcaptchaCSP.styleSrc}`);
     });
 
     it('should allow HMR websocket connections when NODE_ENV=development', () => {

--- a/frontend/app/utils/csp-utils.server.ts
+++ b/frontend/app/utils/csp-utils.server.ts
@@ -37,7 +37,8 @@ export function generateContentSecurityPolicy(nonce: string) {
     `img-src 'self' data: ${adobeAnalyticsCSP.imgSrc} https://purecatamphetamine.github.io`,
     // unsafe-inline is required by Adobe Analytics 💩
     `script-src 'self' 'unsafe-inline' ${hcaptchaCSP.scriptSrc} ${adobeAnalyticsCSP.scriptSrc}`,
-    `style-src 'self' ${hcaptchaCSP.styleSrc}`,
+    // unsafe-inline is required by Radix Primitives 💩
+    `style-src 'self' 'unsafe-inline' ${hcaptchaCSP.styleSrc}`,
   ].join('; ');
 
   log.debug(`Generated content security policy: [${contentSecurityPolicy}]`);


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add style-src 'unsafe-inline' requires by Radix Primitives components. The 'unsafe-inline' was remove in PR #1081. It causes a bug with Radix Progress component going to 100% if the user refreshes the page.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->