### PR TITLE
3274 Parent or guardian needs to apply page

### DIFF
--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -220,7 +220,6 @@ describe('useTransformAdobeAnalyticsUrl()', () => {
     render(<RemixStub />);
 
     const element = await waitFor(() => screen.findByTestId('data'));
-    console.log(element.textContent);
     expect(element.textContent).toEqual('{"transformAdobeAnalyticsUrl":true}');
   });
 });

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -232,6 +232,14 @@
                       "en": "/:lang/apply/:id/disability-tax-credit",
                       "fr": "/:lang/appliquer/:id/disability-tax-credit"
                     }
+                  },
+                  {
+                    "id": "$lang+/_public+/apply+/$id+/parent-or-guardian",
+                    "file": "routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx",
+                    "paths": {
+                      "en": "/:lang/apply/:id/parent-or-guardian",
+                      "fr": "/:lang/appliquer/:id/parent-or-guardian"
+                    }
                   }
                 ]
               }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -145,6 +145,10 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/disability-tax-credit', params));
   }
 
+  if (age < 16) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/parent-or-guardian', params));
+  }
+
   if (state.editMode) {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
   }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/disability-tax-credit.tsx
@@ -5,6 +5,7 @@ import { Link, useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { differenceInYears, parse } from 'date-fns';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
@@ -46,6 +47,12 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:disability-tax-credit.page-title') }) };
+
+  const parseDateOfBirth = parse(state.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
+  const age = differenceInYears(new Date(), parseDateOfBirth);
+  if (age < 18 || age > 64) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+  }
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit });
 }
@@ -144,7 +151,7 @@ export default function ApplyFlowDisabilityTaxCredit() {
               {t('apply:disability-tax-credit.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
-            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
               {t('apply:disability-tax-credit.back-btn')}
             </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx
@@ -1,0 +1,98 @@
+import { FormEvent } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { differenceInYears, parse } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.parentOrGuardian,
+  pageTitleI18nKey: 'apply:parent-or-guardian.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const applyRouteHelpers = getApplyRouteHelpers();
+  const state = await applyRouteHelpers.loadState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:parent-or-guardian.page-title') }) };
+
+  const parseDateOfBirth = parse(state.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
+  const age = differenceInYears(new Date(), parseDateOfBirth);
+  if (age > 16) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+  }
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/parent-or-guardian');
+
+  const applyRouteHelpers = getApplyRouteHelpers();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  await applyRouteHelpers.clearState({ params, request, session });
+  return redirect(t('apply:parent-or-guardian.return-btn-link'));
+}
+
+export default function ApplyFlowParentOrGuardian() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    fetcher.submit(event.currentTarget, { method: 'POST' });
+    sessionStorage.removeItem('flow.state');
+  }
+
+  return (
+    <>
+      <div className="mb-8 space-y-4">
+        <p>{t('apply:parent-or-guardian.unable-to-apply')}</p>
+      </div>
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply:parent-or-guardian.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Parent or guardian needs to apply click">
+          {t('apply:parent-or-guardian.return-btn')}
+          {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
+        </Button>
+      </fetcher.Form>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -39,7 +39,8 @@
       "reviewInformation": "CDCP-APPL-0015",
       "exitApplication": "CDCP-APPL-0016",
       "confirmation": "CDCP-APPL-0017",
-      "disabilityTaxCredit": "CDCP-APPL-0018"
+      "disabilityTaxCredit": "CDCP-APPL-0018",
+      "parentOrGuardian": "CDCP-APPL-0019"
     },
     "status": "CDCP-STAT-0001",
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -273,6 +273,13 @@
   "index": {
     "page-title": "Applying for the Canadian Dental Care Plan"
   },
+  "parent-or-guardian": {
+    "page-title": "Parent or guardian needs to apply",
+    "unable-to-apply": "You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Back",
+    "return-btn": "Return to main page",
+    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
   "partner-information": {
     "page-title": "Spouse or Common-law partner information",
     "provide-sin": "Provide information on your current spouse or common-law partner as indicated on their Social Insurance Number (SIN) card or letter.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -273,6 +273,13 @@
   "index": {
     "page-title": "Présentation d'une demande d'adhésion au Régime canadien de soins dentaires"
   },
+  "parent-or-guardian": {
+    "page-title": "(FR) Parent or guardian needs to apply",
+    "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale",
+    "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
   "partner-information": {
     "page-title": "Renseignements sur l'époux/épouse ou le conjoint/conjointe de fait",
     "provide-sin": "Fournissez les renseignements sur votre époux/épouse ou conjoint/conjointe de fait actuel tels qu'ils figurent sur sa carte ou lettre d'assurance sociale (NAS).",


### PR DESCRIPTION
### Description
Add "parent or guardian needs to apply" screen of apply flow. This screen should display if and only if the applicant is under the age of 16 OR if they select "No" and they are living independently from their parents (this screen hasn't been built out yet and will appear in a future PR).  

### Related Azure Boards Work Items
[AB#3274](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3274)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`