### PR TITLE
AB#3309 -- Adding Dockerfile to create Maven image for TeamCity and default docker image name

### DIFF
--- a/backend/docker/Dockerfile-MavenBuild
+++ b/backend/docker/Dockerfile-MavenBuild
@@ -1,0 +1,3 @@
+# Dockerfile to create a Maven image that can be used in TeamCity
+# > docker build --file Dockerfile-MavenBuild . --tag dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/maven-builder:v1-mvn3.9-java21
+FROM docker.io/maven:3.9-eclipse-temurin-21

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,7 +20,9 @@
 
 
 	<properties>
+		<image.name>cdcp-api</image.name>
 		<java.version>21</java.version>
+		<spring-boot.build-image.imageName>${image.name}</spring-boot.build-image.imageName>
 		<revision>0.0.0-00000000-0000</revision>
 	</properties>
 


### PR DESCRIPTION
### Description
TeamCity currently uses Java 8 so we must create a Maven image to build an application in TeamCity that runs with more recent versions of Java (21 for our Spring Boot application).

Also defining a default `spring-boot.build-image.imageName` property that can be specified at build time.

### Related Azure Boards Work Items
[AB#3309](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3309)

### Screenshots
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/18ad396b-843f-4ddb-946f-a8cf8cf54d84)

### Test Instructions

1. Navigate to `./backend/docker` and build the Maven builder image by running:
```
docker build --file Dockerfile-MavenBuild . --tag dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/maven-builder:v1-mvn3.9-java21
```

2. Navigate to `./backend` (directory where the `pom.xml` file is) and run the following to tun the Maven builder and build the Spring Boot image named `cdcp-api`:
```
docker run -it --rm --volume $(pwd):/app -w /app --volume /var/run/docker.sock:/var/run/docker.sock dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/maven-builder:v1-mvn3.9-java21 mvn spring-boot:build-image
```