### PR TITLE
Add alert confirm page AB#3325

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -436,8 +436,8 @@
                 "id": "$lang+/_protected+/alerts+/subscribe+/confirm",
                 "file": "routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx",
                 "paths": {
-                  "en": "/:lang/subscribe/confirm",
-                  "fr": "/:lang/abonner/confirmer"
+                  "en": "/:lang/alerts/subscribe/confirm",
+                  "fr": "/:lang/alertes/abonner/confirmer"
                 }
               }
             ]

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -436,8 +436,8 @@
                 "id": "$lang+/_protected+/alerts+/subscribe+/confirm",
                 "file": "routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx",
                 "paths": {
-                  "en": "/:lang/alerts/confirm",
-                  "fr": "/:lang/alertes/confirmer"
+                  "en": "/:lang/subscribe/confirm",
+                  "fr": "/:lang/abonner/confirmer"
                 }
               }
             ]

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -431,6 +431,14 @@
                   "en": "/:lang/alerts/subscribe",
                   "fr": "/:lang/alertes/abonner"
                 }
+              },
+              {
+                "id": "$lang+/_protected+/alerts+/subscribe+/confirm",
+                "file": "routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx",
+                "paths": {
+                  "en": "/:lang/alerts/confirm",
+                  "fr": "/:lang/alertes/confirmer"
+                }
               }
             ]
           },

--- a/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
@@ -88,13 +88,13 @@ export default function ConfirmSubscription() {
           <InputField id="confirmationCode" className="w-full" label={t('alerts:confirm.confirmation-code-label')} maxLength={100} name="confirmationCode" required />
         </div>
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to={userOrigin?.to} params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Subscribe - Confirm - Back">
+          <ButtonLink id="back-button" to={userOrigin?.to} params={params}>
             {t('alerts:confirm.back')}
           </ButtonLink>
-          <Button id="new-code-button" name="action" value={ConfirmSubscriptionCode.NewCode} variant="alternative" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Subscribe - Confirm - New Code requested">
+          <Button id="new-code-button" name="action" value={ConfirmSubscriptionCode.NewCode} variant="alternative">
             {t('alerts:confirm.request-new-code')}
           </Button>
-          <Button id="submit-button" name="action" value={ConfirmSubscriptionCode.Submit} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Subscribe - Confirm - Submit">
+          <Button id="submit-button" name="action" value={ConfirmSubscriptionCode.Submit} variant="primary">
             {t('alerts:confirm.submit-code')}
           </Button>
         </div>

--- a/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
@@ -9,6 +9,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { InputField } from '~/components/input-field';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
+import { getRaoidcService } from '~/services/raoidc-service.server';
 import { featureEnabled } from '~/utils/env.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -34,7 +35,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('email-alerts');
-
+  const raoidcService = await getRaoidcService();
+  await raoidcService.handleSessionValidation(request, session);
   const instrumentationService = getInstrumentationService();
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -78,7 +80,7 @@ export default function ConfirmSubscription() {
               {t('alerts:confirm.confirmation-completed-text')}
             </p>
             <div className="grid gap-12 md:grid-cols-2">
-              <p id="confirmation-language" className="mb-4">
+              <p id="confirmation-language" className="mb-4 font-bold">
                 {t('alerts:confirm.confirmation-selected-language')}
               </p>
 

--- a/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
@@ -1,0 +1,39 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+
+import pageIds from '../../../page-ids.json';
+import { getAuditService } from '~/services/audit-service.server';
+import { getInstrumentationService } from '~/services/instrumentation-service.server';
+import { getLookupService } from '~/services/lookup-service.server';
+import { featureEnabled } from '~/utils/env.server';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  breadcrumbs: [{ labelI18nKey: 'alerts:confirm.page-title' }],
+  i18nNamespaces: getTypedI18nNamespaces('alerts', 'gcweb'),
+  pageIdentifier: pageIds.protected.alerts.subscribe,
+  pageTitleI18nKey: 'alerts:confirm.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  featureEnabled('email-alerts');
+
+  const instrumentationService = getInstrumentationService();
+  const lookupService = getLookupService();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const preferredLanguages = await lookupService.getAllPreferredLanguages();
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('alerts:confirm.page-title') }) };
+
+  instrumentationService.countHttpStatus('alerts.subscibe', 302);
+  return json({ csrfToken, meta, preferredLanguages });
+}

--- a/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/subscribe+/confirm.tsx
@@ -1,7 +1,14 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
 
 import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { InputField } from '~/components/input-field';
+import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-information-route-helpers.server';
+import { PersonalInfo } from '~/schemas/personal-informaton-service-schemas.server';
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
@@ -10,13 +17,15 @@ import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils'
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
+import type { UserinfoToken } from '~/utils/raoidc-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { useUserOrigin } from '~/utils/user-origin-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'alerts:confirm.page-title' }],
   i18nNamespaces: getTypedI18nNamespaces('alerts', 'gcweb'),
-  pageIdentifier: pageIds.protected.alerts.subscribe,
+  pageIdentifier: pageIds.protected.alerts.confirm,
   pageTitleI18nKey: 'alerts:confirm.page-title',
 } as const satisfies RouteHandleData;
 
@@ -25,15 +34,70 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('email-alerts');
-
-  const instrumentationService = getInstrumentationService();
   const lookupService = getLookupService();
+  const instrumentationService = getInstrumentationService();
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const preferredLanguages = await lookupService.getAllPreferredLanguages();
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('alerts:confirm.page-title') }) };
 
+  const personalInformationRouteHelper = getPersonalInformationRouteHelpers();
+  const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  const personalInformation: PersonalInfo = await personalInformationRouteHelper.getPersonalInformation(userInfoToken, params, request, session);
+  const preferredLanguage = personalInformation.preferredLanguageId ? await getLookupService().getPreferredLanguage(personalInformation.preferredLanguageId) : undefined;
+
   instrumentationService.countHttpStatus('alerts.subscibe', 302);
-  return json({ csrfToken, meta, preferredLanguages });
+  return json({ csrfToken, meta, personalInformation, preferredLanguage });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('alerts/subscribe');
+
+  const instrumentationService = getInstrumentationService();
+  const auditService = getAuditService();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  return '';
+}
+
+export default function confirmSubscription() {
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, personalInformation, preferredLanguage } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const userOrigin = useUserOrigin();
+  const errorSummaryId = 'error-summary';
+
+  return (
+    <>
+      <fetcher.Form className="max-w-prose" method="post" noValidate>
+        <div className="mb-8 space-y-6">
+          <p id="confirmation-information" className="mb-4">
+            {t('alerts:confirm.confirmation-information-text')}
+          </p>
+          <p id="confirmation-completed" className="mb-4">
+            {t('alerts:confirm.confirmation-completed-text')}
+          </p>
+          <div className="grid gap-12 md:grid-cols-2">
+            <p id="confirmation-language" className="mb-4">
+              {t('alerts:confirm.confirmation-selected-language')}
+            </p>
+            <p>{preferredLanguage ? getNameByLanguage(i18n.language, preferredLanguage) : t('alerts:confirm.no-preferred-language-on-file')}</p>
+          </div>
+          <InputField id="confirmationCode" className="w-full" label={t('alerts:confirm.confirmation-code-label')} maxLength={100} name="confirmationCode" required />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <ButtonLink id="back-button" to={userOrigin?.to} params={params}>
+            {t('alerts:confirm.back')}
+          </ButtonLink>
+          <Button id="new-code-button" variant="alternative">
+            {t('alerts:confirm.request-new-code')}
+          </Button>
+          <Button id="submit-button" variant="primary">
+            {t('alerts:confirm.submit-code')}
+          </Button>
+        </div>
+      </fetcher.Form>
+    </>
+  );
 }

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -17,7 +17,7 @@
     },
     "alerts": {
       "subscribe": "CDCP-PROT-0016",
-      "confirm":"CDCP-PROT-0017"
+      "confirm": "CDCP-PROT-0017"
     },
     "status-check": {
       "index": "CDCP-PROT-0017"

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -16,7 +16,8 @@
       "index": "CDCP-PROT-0015"
     },
     "alerts": {
-      "subscribe": "CDCP-PROT-0016"
+      "subscribe": "CDCP-PROT-0016",
+      "confirm":"CDCP-PROT-0017"
     },
     "status-check": {
       "index": "CDCP-PROT-0017"

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -25,7 +25,7 @@
       "subscribe": "Confirm to subscribe to CDCP email alerts"
     },
     "no-preferred-language-on-file": "No preferred language on file",
-    "confirmation-information-text": "A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-information-text": "A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within the next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "Selected language preference:",
     "confirmation-code-label": "Confimation Code",

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -19,7 +19,7 @@
       "preferred-language-required": "Select preferred language of communication"
     }
   },
-  "confirm":{
+  "confirm": {
     "page-title": "Submission Confirmation",
     "breadcrumbs": {
       "subscribe": "Confirm to subscribe to CDCP email alerts"

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -18,5 +18,15 @@
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "preferred-language-required": "Select preferred language of communication"
     }
+  },
+  "confirm":{
+    "page-title": "Submission Confirmation",
+    "breadcrumbs": {
+      "subscribe": "Confirm to subscribe to CDCP email alerts"
+    },
+    "confirmation-code-label": "Confimation Code",
+    "submit-code": "Submit Confirmation Code",
+    "request-new-code": "Request New Confirmation Code",
+    "back": "Back"
   }
 }

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -25,7 +25,7 @@
       "subscribe": "Confirm to subscribe to CDCP email alerts"
     },
     "no-preferred-language-on-file": "No preferred language on file",
-    "confirmation-information-text": "A confirmation code, required to finist the registration process, will be sent to clientsname@domain.com. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-information-text": "A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "Selected Alert Me language preference:",
     "confirmation-code-label": "Confimation Code",

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -24,6 +24,10 @@
     "breadcrumbs": {
       "subscribe": "Confirm to subscribe to CDCP email alerts"
     },
+    "no-preferred-language-on-file": "No preferred language on file",
+    "confirmation-information-text": "A confirmation code, required to finist the registration process, will be sent to clientsname@domain.com. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-completed-text": "Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
+    "confirmation-selected-language": "Selected Alert Me language preference:",
     "confirmation-code-label": "Confimation Code",
     "submit-code": "Submit Confirmation Code",
     "request-new-code": "Request New Confirmation Code",

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -27,7 +27,7 @@
     "no-preferred-language-on-file": "No preferred language on file",
     "confirmation-information-text": "A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
-    "confirmation-selected-language": "Selected Alert Me language preference:",
+    "confirmation-selected-language": "Selected language preference:",
     "confirmation-code-label": "Confimation Code",
     "submit-code": "Submit Confirmation Code",
     "request-new-code": "Request New Confirmation Code",

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -18,5 +18,16 @@
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "preferred-language-required": "Sélectionnez la langue de communication préférée"
     }
+  },
+  "confirm":{
+    "page-title": "(FR) Submission Confirmation",
+    "breadcrumbs": {
+      "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
+    },
+    "confirmation-code-label": "(FR) Confimation Code",
+    "submit-code": "(FR) Submit Confirmation Code",
+    "request-new-code": "(FR) Request New Confirmation Code",
+    "back": "(FR) Back"
   }
+  
 }

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -25,7 +25,7 @@
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
     "no-preferred-language-on-file": "(FR) No preferred language on file",
-    "confirmation-information-text": "(FR) A confirmation code, required to finist the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-information-text": "(FR) A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "(FR) Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "(FR) Selected language preference:",
     "confirmation-code-label": "(FR) Confimation Code",

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -24,6 +24,10 @@
     "breadcrumbs": {
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
+    "no-preferred-language-on-file": "(FR) No preferred language on file",
+    "confirmation-information-text": "(FR) A confirmation code, required to finist the registration process, will be sent to clientsname@domain.com. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-completed-text": "(FR) Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
+    "confirmation-selected-language": "(FR) Selected Alert Me language preference:",
     "confirmation-code-label": "(FR) Confimation Code",
     "submit-code": "(FR) Submit Confirmation Code",
     "request-new-code": "(FR) Request New Confirmation Code",

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -25,7 +25,7 @@
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
     "no-preferred-language-on-file": "(FR) No preferred language on file",
-    "confirmation-information-text": "(FR) A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-information-text": "(FR) A confirmation code, required to finish the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within the next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "(FR) Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "(FR) Selected language preference:",
     "confirmation-code-label": "(FR) Confimation Code",

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -19,7 +19,7 @@
       "preferred-language-required": "Sélectionnez la langue de communication préférée"
     }
   },
-  "confirm":{
+  "confirm": {
     "page-title": "(FR) Submission Confirmation",
     "breadcrumbs": {
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
@@ -33,5 +33,4 @@
     "request-new-code": "(FR) Request New Confirmation Code",
     "back": "(FR) Back"
   }
-  
 }

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -25,9 +25,9 @@
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
     "no-preferred-language-on-file": "(FR) No preferred language on file",
-    "confirmation-information-text": "(FR) A confirmation code, required to finist the registration process, will be sent to clientsname@domain.com. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
+    "confirmation-information-text": "(FR) A confirmation code, required to finist the registration process, will be sent to ||TODO insert email Address when feature completed||. This step must be completed within teh next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "(FR) Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
-    "confirmation-selected-language": "(FR) Selected Alert Me language preference:",
+    "confirmation-selected-language": "(FR) Selected language preference:",
     "confirmation-code-label": "(FR) Confimation Code",
     "submit-code": "(FR) Submit Confirmation Code",
     "request-new-code": "(FR) Request New Confirmation Code",


### PR DESCRIPTION
### Description
Confirm page added to subscribe to the alert me feature of CDCP. There are some missing pieces as showed with the TODO comments. This is just to add the page and the presentation to the users. This feature is not fully complete with this PR.

### Related Azure Boards Work Items
[AB#3325](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3325)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

