### PR TITLE
Fixes double push of AA validation error event

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -172,10 +172,11 @@ export default function ApplyFlowApplicationInformation() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   return (
     <>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -194,10 +194,11 @@ export default function ApplyFlowCommunicationPreferencePage() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   const nonEmailOptions: InputRadiosProps['options'] = preferredCommunicationMethods
     .filter((method) => method.id !== communicationMethodEmail.id)

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -175,7 +175,8 @@ export default function ApplyFlowDateOfBirth() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = errorSummaryItems.map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
   }, [errorSummaryItems]);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -106,10 +106,11 @@ export default function AccessToDentalInsuranceQuestion() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   const helpMessage = (
     <ul className="mb-6 list-disc space-y-1 pl-7">

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -230,10 +230,11 @@ export default function AccessToDentalInsuranceQuestion() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
     setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -206,7 +206,8 @@ export default function ApplyFlowApplicationInformation() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = errorSummaryItems.map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
   }, [errorSummaryItems]);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -285,10 +285,11 @@ export default function ApplyFlowPersonalInformation() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   const checkHandler = () => {
     setCopyAddressChecked((curState) => !curState);

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
@@ -109,10 +109,11 @@ export default function ApplyFlowTaxFiling() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   return (
     <>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -112,10 +112,11 @@ export default function ApplyFlowTypeOfApplication() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   return (
     <>

--- a/frontend/app/routes/$lang+/_public+/status+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/index.tsx
@@ -249,10 +249,11 @@ export default function StatusChecker() {
       scrollAndFocusToErrorSummary(errorSummaryId);
 
       if (hasErrors(errorMessages) && adobeAnalytics.isConfigured()) {
-        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
       }
     }
-  }, [errorMessages, errorSummaryItems]);
+  }, [errorMessages]);
 
   useEffect(() => {
     if (fetcher.data && 'status' in fetcher.data) {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request fixes the double validation error events reported by Adobe Analytics team. (This is the danger of useEffect deps)

> In line errors events double fire on the Applicant Information page and those after

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->