### PR TITLE
[gitops] Add `fluentd-archiver` to `base/`

### DIFF
--- a/gitops/base/fluentd-archiver/configs/fluentd.conf
+++ b/gitops/base/fluentd-archiver/configs/fluentd.conf
@@ -1,0 +1,15 @@
+<source>
+  @type forward
+  tag audit-events
+</source>
+
+<match audit-events>
+  @type file
+
+  append true
+  path /logs/audit-%Y-%m-%d
+
+  <buffer>
+    flush_mode immediate
+  </buffer>
+</match>

--- a/gitops/base/fluentd-archiver/deployments.yaml
+++ b/gitops/base/fluentd-archiver/deployments.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fluentd-archiver
+  labels:
+    app.kubernetes.io/name: fluentd-archiver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluentd-archiver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluentd-archiver
+    spec:
+      containers:
+        - name: fluentd-archiver
+          image: docker.io/fluentd
+          args: [--config, /etc/fluentd.conf]
+          ports:
+            - name: fluentd
+              containerPort: 24224
+          volumeMounts:
+            - name: audit-logs
+              mountPath: /logs
+            - name: fluentd-conf
+              mountPath: /etc/fluentd.conf
+              subPath: fluentd.conf
+      securityContext:
+        fsGroup: 101 # `fluent` gid
+      volumes:
+        - name: audit-logs
+          persistentVolumeClaim:
+            claimName: audit-logs
+        - name: fluentd-conf
+          configMap:
+            name: fluentd-archiver

--- a/gitops/base/fluentd-archiver/kustomization.yaml
+++ b/gitops/base/fluentd-archiver/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+resources:
+  - ./deployments.yaml
+  - ./pvcs.yaml
+  - ./services.yaml
+configMapGenerator:
+  - name: fluentd-archiver
+    files:
+      - ./configs/fluentd.conf

--- a/gitops/base/fluentd-archiver/pvcs.yaml
+++ b/gitops/base/fluentd-archiver/pvcs.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audit-logs
+  labels:
+    app.kubernetes.io/name: audit-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 256Mi

--- a/gitops/base/fluentd-archiver/services.yaml
+++ b/gitops/base/fluentd-archiver/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd-archiver
+  labels:
+    app.kubernetes.io/name: fluentd-archiver
+spec:
+  ports:
+    - name: fluentd
+      port: 24224
+      targetPort: fluentd
+  selector:
+    app.kubernetes.io/name: fluentd-archiver


### PR DESCRIPTION
First of a few PRs that will reconfigure the fluentd archiver component in the gitops subproject.

**Note to reviewer:** I tested this by deploying to the dev environment from my localhost. It works as expected.