### PR TITLE
3339 Add email to contact information page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -63,7 +63,20 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:communication-preference.page-title') }) };
 
-  return json({ communicationMethodEmail, id: state.id, csrfToken, meta, preferredCommunicationMethods, preferredLanguages, defaultState: state.communicationPreferences, editMode: state.editMode });
+  return json({
+    communicationMethodEmail,
+    id: state.id,
+    csrfToken,
+    meta,
+    preferredCommunicationMethods,
+    preferredLanguages,
+    defaultState: {
+      ...state.communicationPreferences,
+      email: state.communicationPreferences?.email ?? state.personalInformation?.email,
+      confirmEmail: state.communicationPreferences?.confirmEmail ?? state.personalInformation?.confirmEmail,
+    },
+    editMode: state.editMode,
+  });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
@@ -135,7 +148,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState?.preferredMethod ?? '');
+  const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');
   const errorSummaryId = 'error-summary';
 
   const handleOnPreferredMethodChecked: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -171,7 +184,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
     .map((method) => ({
       children: i18n.language === 'fr' ? method.nameFr : method.nameEn,
       value: method.id,
-      defaultChecked: defaultState?.preferredMethod === method.id,
+      defaultChecked: defaultState.preferredMethod === method.id,
       onChange: handleOnPreferredMethodChecked,
     }));
 
@@ -179,13 +192,13 @@ export default function ApplyFlowCommunicationPreferencePage() {
     {
       children: getNameByLanguage(i18n.language, communicationMethodEmail),
       value: communicationMethodEmail.id,
-      defaultChecked: defaultState?.preferredMethod === communicationMethodEmail.id,
+      defaultChecked: defaultState.preferredMethod === communicationMethodEmail.id,
       append: preferredMethodValue === communicationMethodEmail.id && (
         <div className="mb-6 grid gap-6 md:grid-cols-2">
           <p className="md:col-span-2" id="email-note">
             {t('apply:communication-preference.email-note')}
           </p>
-          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} autoComplete="email" defaultValue={defaultState?.email ?? ''} required />
+          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} autoComplete="email" defaultValue={defaultState.email ?? ''} required />
           <InputField
             id="confirm-email"
             type="email"
@@ -195,7 +208,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             name="confirmEmail"
             errorMessage={errorMessages['confirm-email']}
             autoComplete="email"
-            defaultValue={defaultState?.confirmEmail ?? ''}
+            defaultValue={defaultState.confirmEmail ?? ''}
             required
           />
         </div>
@@ -230,7 +243,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 name="preferredLanguage"
                 legend={t('apply:communication-preference.preferred-language')}
                 options={preferredLanguages.map((language) => ({
-                  defaultChecked: defaultState?.preferredLanguage === language.id,
+                  defaultChecked: defaultState.preferredLanguage === language.id,
                   children: getNameByLanguage(i18n.language, language),
                   value: language.id,
                 }))}

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -350,8 +350,12 @@
   "personal-information": {
     "page-title": "Personal information",
     "form-instructions": "Adding a phone number helps Service Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
+    "add-phone": "Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
     "phone-number": "Phone number (optional)",
     "phone-number-alt": "Alternate phone number (optional)",
+    "add-email": "Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
+    "email": "Email address (optional)",
+    "confirm-email": "Confirm email address (optional)",
     "mailing-address": {
       "header": "Mailing address"
     },
@@ -383,7 +387,11 @@
       "province-required": "Select a province, territory, state or region",
       "zip-code-valid": "Enter zip code in the correct format, such as 12345 or 12345-6789",
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
-      "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front"
+      "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com"
     }
   },
   "progress": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -350,8 +350,12 @@
   "personal-information": {
     "page-title": "Renseignements personnels",
     "form-instructions": "L'ajout d'un numéro de téléphone permet à Service Canada de vous contacter en cas de problème avec votre demande. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
+    "add-phone": "(FR) Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
     "phone-number": "Numéro de téléphone (facultatif)",
     "phone-number-alt": "Autre numéro de téléphone (facultatif)",
+    "add-email": "(FR) Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
+    "email": "Adresse courriel (facultatif)",
+    "confirm-email": "Confirmer l'adresse courriel (facultatif)",
     "mailing-address": {
       "header": "Adresse postale"
     },
@@ -383,7 +387,12 @@
       "province-required": "Sélectionnez une province, un territoire, un état ou une région",
       "zip-code-valid": "Entrez un code postal américain dans le bon format, par exemple 12345 ou 12345-6789",
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
-      "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant"
+      "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
+      "email-match": "Les adresses courriel entrées ne concordent pas",
+      "confirm-email-required": "Confirmez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
+      "preferred-language-required": "Sélectionnez la langue de communication préférée"
     }
   },
   "progress": {


### PR DESCRIPTION
### Description
Add email and confirm email fields to `/personal-information`.  The state should persist when the user navigates to `/communication-preference` and vice versa when doing back navigation.

### Related Azure Boards Work Items
[AB#3339](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3339)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`