### PR TITLE
Feature flag banner

### DIFF
--- a/frontend/__tests__/components/banner.test.tsx
+++ b/frontend/__tests__/components/banner.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import { describe, expect, it } from 'vitest';
+
+import { Banner } from '~/components/banner';
+
+describe('Banner', () => {
+  it('should render the Banner', async () => {
+    render(<Banner alert="test" description="test" />);
+    const actual = screen.getByTestId('banner-id');
+    expect(actual).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/banner.tsx
+++ b/frontend/app/components/banner.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+interface BannerProps {
+  alert?: ReactNode;
+  description?: ReactNode;
+}
+
+export function Banner({ alert, description }: BannerProps) {
+  return (
+    <div className="font-body bg-sky-800 text-white" data-testid="banner-id">
+      <div className="container mx-auto flex flex-col space-y-2 p-4 lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0">
+        <div className="w-max whitespace-nowrap border-2 border-current px-4 py-1">{alert}</div>
+        <div>{description}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { AppLink } from '../app-link';
+import { Banner } from '../banner';
 import { Breadcrumbs } from '~/components/breadcrumbs';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '~/components/dropdown-menu';
 import { InlineLink } from '~/components/inline-link';
@@ -16,6 +17,7 @@ import { PageFooter } from '~/components/page-footer';
 import { PageHeaderBrand } from '~/components/page-header-brand';
 import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
+import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -107,6 +109,7 @@ function PageHeader() {
   return (
     <header>
       <SkipNavigationLinks />
+      {useFeature('show-prototype-banner') && <Banner alert={t('gcweb:header.banner.alert')} description={t('gcweb:header.banner.desc')} />}
       <PageHeaderBrand />
       <section className="bg-gray-700 text-white">
         <div className="sm:container">

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -5,6 +5,7 @@ import { Link } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
 
+import { Banner } from '../banner';
 import { Breadcrumbs } from '~/components/breadcrumbs';
 import { InlineLink } from '~/components/inline-link';
 import { PageDetails } from '~/components/page-details';
@@ -12,6 +13,7 @@ import { PageFooter } from '~/components/page-footer';
 import { PageHeaderBrand } from '~/components/page-header-brand';
 import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
+import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
@@ -48,9 +50,12 @@ function AppPageTitle() {
 }
 
 function PageHeader() {
+  const { t } = useTranslation(i18nNamespaces);
+
   return (
     <header className="border-b-[3px] border-slate-700 print:hidden">
       <SkipNavigationLinks />
+      {useFeature('show-prototype-banner') && <Banner alert={t('gcweb:header.banner.alert')} description={t('gcweb:header.banner.desc')} />}
       <PageHeaderBrand />
     </header>
   );

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -22,7 +22,7 @@ function tryOrElseFalse(fn: () => unknown) {
 const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'subscription'] as const;
 export type MockName = (typeof validMockNames)[number];
 
-const validFeatureNames = ['doc-upload', 'email-alerts', 'hcaptcha', 'view-personal-info', 'view-applications', 'view-letters', 'view-messages', 'edit-personal-info', 'status', 'authenticated-status-check'] as const;
+const validFeatureNames = ['doc-upload', 'email-alerts', 'hcaptcha', 'view-personal-info', 'view-applications', 'view-letters', 'view-messages', 'edit-personal-info', 'status', 'authenticated-status-check', 'show-prototype-banner'] as const;
 export type FeatureName = (typeof validFeatureNames)[number];
 
 // refiners

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       AUTH_RAOIDC_BASE_URL: 'http://localhost:3000/auth',
       AUTH_RAOIDC_CLIENT_ID: 'CDCP',
       AUTH_RASCL_LOGOUT_URL: 'http://localhost:3000/',
-      ENABLED_FEATURES: "doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status",
+      ENABLED_FEATURES: "doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status,authenticated-status-check,show-prototype-banner",
       ENABLED_MOCKS: 'cct,lookup,power-platform,raoidc,status-check,wsaddress',
       HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000',
       HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',

--- a/frontend/public/locales/en/gcweb.json
+++ b/frontend/public/locales/en/gcweb.json
@@ -29,7 +29,11 @@
     "menu-security-settings.href": "{{baseUri}}/en/security-settings",
     "menu-contact-us.text": "Contact Us",
     "menu-contact-us.href": "{{baseUri}}/en/contact-us",
-    "menu-sign-out.text": "Sign Out"
+    "menu-sign-out.text": "Sign Out",
+    "banner": {
+      "alert": "Info",
+      "desc": "This is a prototype environment. No data is kept."
+    }
   },
   "footer": {
     "about-site": "About this site",

--- a/frontend/public/locales/fr/gcweb.json
+++ b/frontend/public/locales/fr/gcweb.json
@@ -29,7 +29,11 @@
     "menu-security-settings.href": "{{baseUri}}/fr/parametres-securite",
     "menu-contact-us.text": "Contactez-nous",
     "menu-contact-us.href": "{{baseUri}}/fr/contactez-nous",
-    "menu-sign-out.text": "Se déconnecter"
+    "menu-sign-out.text": "Se déconnecter",
+    "banner": {
+      "alert": "Info",
+      "desc": "Il s'agit d'un environnement prototype. Aucune donnée n'est conservée."
+    }
   },
   "footer": {
     "about-site": "À propos de ce site",

--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -11,7 +11,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status
+ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status,authenticated-status-check,show-prototype-banner
 
 #
 # Global mock configuration

--- a/gitops/overlays/int/configs/frontend/config.conf
+++ b/gitops/overlays/int/configs/frontend/config.conf
@@ -11,7 +11,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status
+ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status,authenticated-status-check,show-prototype-banner
 
 #
 # Session/redis configuration


### PR DESCRIPTION
### Description
Adding conditionnal banner.

The goal is to have this displayed on a feature_flag. 

Couldn't figure out how to only display this when `NODE_ENV === 'prototype'`. Then again, maybe we want it in different environments so this could be okay.

### Related Azure Boards Work Items
[AB#3358](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3358)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/77116011/90fa0e4b-7bad-4e29-8752-1829c1586cd2)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
`show-banner` must be added to the FEATURE_FLAGS env.