### PR TITLE
3361 SYSTEST - Confirmation page not showing Appt / Suite + Canada not showing

### DIFF
--- a/frontend/__tests__/components/address.test.tsx
+++ b/frontend/__tests__/components/address.test.tsx
@@ -5,15 +5,45 @@ import { describe, expect, it } from 'vitest';
 import { Address } from '~/components/address';
 
 describe('Address', () => {
+  it('should render apartment with hypen at beginning of address if apartment number is a chunk of alphanumeric chars', async () => {
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
+  });
+
+  it('should render apartment at end of address if apartment number is not a chunk of alphanumeric chars', async () => {
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="Apt 123" isCanadianAddress={false} />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual.textContent).toBe('123 Fake Street Apt 123\nBeverly Hills CA  90210\nUSA');
+  });
+
+  it('should render apartment with hypen at beginning if there is no space in the apartment number', async () => {
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
+  });
+
   it('should render country when not a Canadian address', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
+  });
+
+  it('should not render apartment number when it is undefined', async () => {
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" isCanadianAddress={false} />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should not render country when address is Canadian', async () => {
-    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />);
+    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" isCanadianAddress={true} />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123 Fake Street\nOttawa ON  K2K 2K2');
+  });
+
+  it('should render apartment number if supplied and not render country when address is Canadian', async () => {
+    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" apartment="123" isCanadianAddress={true} />);
+    const actual = screen.getByTestId('address-id');
+    expect(actual.textContent).toBe('123-123 Fake Street\nOttawa ON  K2K 2K2');
   });
 });

--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -220,7 +220,6 @@ describe('useTransformAdobeAnalyticsUrl()', () => {
     render(<RemixStub />);
 
     const element = await waitFor(() => screen.findByTestId('data'));
-    console.log(element.textContent);
     expect(element.textContent).toEqual('{"transformAdobeAnalyticsUrl":true}');
   });
 });

--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -5,26 +5,31 @@ import { cn } from '~/utils/tw-utils';
 export interface AddressProps extends ComponentProps<'address'> {
   address: string;
   city: string;
+  country: string;
+  isCanadianAddress: boolean;
   provinceState?: string;
   postalZipCode?: string;
-  country: string;
+  apartment?: string;
   altFormat?: boolean;
 }
 
-function formatAddress(address: string, city: string, country: string, provinceState?: string, postalZipCode?: string, altFormat?: boolean) {
-  // TODO 'canada' shouldn't be hardcoded as we may deal with different values of the country field such as abbreviations
-  const isNotCanadianAddress = 'canada' !== country.toLowerCase();
+function formatAddress(address: string, city: string, country: string, isCanadianAddress: boolean, provinceState?: string, postalZipCode?: string, apartment?: string, altFormat?: boolean) {
+  const formattedAddress = apartment ? (/^[a-z\d]+$/i.test(apartment) ? `${apartment}-${address}` : `${address} ${apartment}`) : address;
 
   // prettier-ignore
-  const lines = [`${address}`,
+  const lines = [
+    formattedAddress,
     `${city}${provinceState ? ` ${provinceState}` : ''}${postalZipCode ? `  ${postalZipCode}` : ''}`,
-    `${isNotCanadianAddress ? country : ''}`];
+    `${isCanadianAddress ? '' : country}`
+  ];
 
   // prettier-ignore
-  const linesAlt = [`${address}`,
-  `${city}${provinceState ? ` ${provinceState}` : ''}`,
-  `${postalZipCode ? `${postalZipCode}` : ''}`,
-  `${isNotCanadianAddress ? country : ''}`];
+  const linesAlt = [
+    formattedAddress,
+    `${city}${provinceState ? ` ${provinceState}` : ''}`,
+    `${postalZipCode ? `${postalZipCode}` : ''}`,
+    `${isCanadianAddress ? '' : country}`
+  ];
 
   return (altFormat ? linesAlt : lines)
     .map((line) => line.trim())
@@ -33,8 +38,8 @@ function formatAddress(address: string, city: string, country: string, provinceS
 }
 
 export function Address(props: AddressProps) {
-  const { address, city, provinceState, postalZipCode, country, className, altFormat, ...restProps } = props;
-  const formattedAddress = formatAddress(address, city, country, provinceState, postalZipCode, altFormat);
+  const { address, city, provinceState, postalZipCode, country, isCanadianAddress, className, altFormat, apartment, ...restProps } = props;
+  const formattedAddress = formatAddress(address, city, country, isCanadianAddress, provinceState, postalZipCode, apartment, altFormat);
 
   return (
     <address className={cn('whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...restProps}>

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -15,7 +15,7 @@ import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-inf
 import { getAuditService } from '~/services/audit-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { featureEnabled } from '~/utils/env.server';
+import { featureEnabled, getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -50,16 +50,17 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
   const preferredLanguage = personalInformation.preferredLanguageId ? await getLookupService().getPreferredLanguage(personalInformation.preferredLanguageId) : undefined;
+  const { CANADA_COUNTRY_ID } = getEnv();
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('personal-information:index.page-title') }) };
   const updatedInfo = session.get('personal-info-updated');
   session.unset('personal-info-updated');
-  return json({ preferredLanguage, countryList, personalInformation, meta, regionList, updatedInfo });
+  return json({ preferredLanguage, countryList, personalInformation, meta, regionList, updatedInfo, CANADA_COUNTRY_ID });
 }
 
 export default function PersonalInformationIndex() {
-  const { personalInformation, preferredLanguage, countryList, regionList, updatedInfo } = useLoaderData<typeof loader>();
+  const { personalInformation, preferredLanguage, countryList, regionList, updatedInfo, CANADA_COUNTRY_ID } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const params = useParams();
 
@@ -90,6 +91,7 @@ export default function PersonalInformationIndex() {
               provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.homeAddress!.provinceTerritoryStateId)?.abbr}
               postalZipCode={personalInformation.homeAddress.postalCode}
               country={countryList.find((country) => country.countryId === personalInformation.homeAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
+              isCanadianAddress={personalInformation.homeAddress.countryId === CANADA_COUNTRY_ID}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
@@ -110,6 +112,7 @@ export default function PersonalInformationIndex() {
               provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.mailingAddress!.provinceTerritoryStateId)?.abbr}
               postalZipCode={personalInformation.mailingAddress.postalCode}
               country={countryList.find((country) => country.countryId === personalInformation.mailingAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
+              isCanadianAddress={personalInformation.mailingAddress.countryId === CANADA_COUNTRY_ID}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -15,6 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { toLocaleDateString } from '~/utils/date-utils';
+import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -40,6 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const state = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
+  const { CANADA_COUNTRY_ID } = getEnv();
 
   // prettier-ignore
   if (state.applicantInformation === undefined ||
@@ -114,6 +116,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     province: provinceMailing,
     postalCode: state.personalInformation.mailingPostalCode,
     country: countryMailing,
+    apartment: state.personalInformation.mailingApartment,
+    isCanadianAddress: state.personalInformation.mailingCountry === CANADA_COUNTRY_ID,
   };
 
   const homeAddressInfo = {
@@ -122,6 +126,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     province: provinceHome,
     postalCode: state.personalInformation.homePostalCode,
     country: countryHome,
+    apartment: state.personalInformation.homeApartment,
+    isCanadianAddress: state.personalInformation.homeCountry === CANADA_COUNTRY_ID,
   };
 
   const dentalInsurance = {
@@ -276,6 +282,8 @@ export default function ApplyFlowConfirm() {
                 provinceState={i18n.language === 'en' ? mailingAddressInfo.province?.nameEn : mailingAddressInfo.province?.nameFr}
                 postalZipCode={mailingAddressInfo.postalCode}
                 country={i18n.language === 'en' ? mailingAddressInfo.country?.nameEn ?? '' : mailingAddressInfo.country?.nameFr ?? ''}
+                apartment={mailingAddressInfo.apartment}
+                isCanadianAddress={mailingAddressInfo.isCanadianAddress}
                 altFormat={true}
               />
             </DescriptionListItem>
@@ -286,6 +294,8 @@ export default function ApplyFlowConfirm() {
                 provinceState={i18n.language === 'en' ? homeAddressInfo.province?.nameEn : homeAddressInfo.province?.nameFr}
                 postalZipCode={homeAddressInfo.postalCode ?? ''}
                 country={i18n.language === 'en' ? homeAddressInfo.country?.nameEn ?? '' : homeAddressInfo.country?.nameFr ?? ''}
+                apartment={homeAddressInfo.apartment}
+                isCanadianAddress={homeAddressInfo.isCanadianAddress}
                 altFormat={true}
               />
             </DescriptionListItem>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -61,6 +61,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
   const lookupService = getLookupService();
+  const { CANADA_COUNTRY_ID } = getEnv();
 
   const state = await applyRouteHelpers.loadState({ params, request, session });
   applyRouteHelpers.validateStateForReview({ params, state });
@@ -129,21 +130,24 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const mailingAddressInfo = {
     address: state.personalInformation.mailingAddress,
-    appartment: state.personalInformation.mailingApartment,
     city: state.personalInformation.mailingCity,
     province: provinceMailing,
     postalCode: state.personalInformation.mailingPostalCode,
     country: countryMailing,
+    apartment: state.personalInformation.mailingApartment,
+    isCanadianAddress: state.personalInformation.mailingCountry === CANADA_COUNTRY_ID,
   };
 
   const homeAddressInfo = {
     address: state.personalInformation.homeAddress,
-    appartment: state.personalInformation.homeApartment,
     city: state.personalInformation.homeCity,
     province: provinceHome,
     postalCode: state.personalInformation.homePostalCode,
     country: countryHome,
+    apartment: state.personalInformation.mailingApartment,
+    isCanadianAddress: state.personalInformation.homeCountry === CANADA_COUNTRY_ID,
   };
+
   const dentalInsurance = state.dentalInsurance;
 
   const dentalBenefit = {
@@ -401,6 +405,8 @@ export default function ReviewInformation() {
                   provinceState={i18n.language === 'en' ? mailingAddressInfo.province?.nameEn : mailingAddressInfo.province?.nameFr}
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={i18n.language === 'en' ? mailingAddressInfo.country.nameEn : mailingAddressInfo.country.nameFr}
+                  apartment={mailingAddressInfo.apartment}
+                  isCanadianAddress={mailingAddressInfo.isCanadianAddress}
                   altFormat={true}
                 />
                 <p className="mt-4">
@@ -416,6 +422,8 @@ export default function ReviewInformation() {
                   provinceState={i18n.language === 'en' ? homeAddressInfo.province?.nameEn : homeAddressInfo.province?.nameFr}
                   postalZipCode={homeAddressInfo.postalCode}
                   country={i18n.language === 'en' ? homeAddressInfo.country.nameEn : homeAddressInfo.country.nameFr}
+                  apartment={homeAddressInfo.apartment}
+                  isCanadianAddress={homeAddressInfo.isCanadianAddress}
                   altFormat={true}
                 />
                 <p className="mt-4">


### PR DESCRIPTION
### Description
If an apartment number has been supplied by the user, make sure it's displayed.  

### Related Azure Boards Work Items
[AB#3361](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3361)

### Screenshot
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/497222ba-bf43-450a-8b16-7ad1711f522b)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`