### PR TITLE
Adding custom click values to letter links for Adobe Analytics

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/letters+/index.tsx
@@ -113,11 +113,19 @@ export default function LettersIndex() {
           <ul className="divide-y border-y">
             {letters.map((letter) => {
               const letterType = letterTypes.find(({ id }) => id === letter.name);
+              const gcAnalyticsCustomClickValue = `ESDC-EDSC:CDCP Letters Click:${letterType?.nameEn ?? letter.name}`;
               const letterName = letterType ? getNameByLanguage(i18n.language, letterType) : letter.name;
 
               return (
                 <li key={letter.id} className="py-4 sm:py-6">
-                  <InlineLink reloadDocument routeId="$lang+/_protected+/letters+/$id.download" params={{ ...params, id: letter.id }} className="external-link font-lato font-semibold" target="_blank">
+                  <InlineLink
+                    reloadDocument
+                    routeId="$lang+/_protected+/letters+/$id.download"
+                    params={{ ...params, id: letter.id }}
+                    className="external-link font-lato font-semibold"
+                    target="_blank"
+                    data-gc-analytics-customclick={gcAnalyticsCustomClickValue}
+                  >
                     {letterName}
                     <NewTabIndicator />
                   </InlineLink>


### PR DESCRIPTION
### Description
Adding `data-gc-analytics-customclick="ESDC-EDSC:CDCP Letters Click:{English Letter Name}"` to the link for each individual letter.

### Related Azure Boards Work Items
[AB#3316](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3316)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/582074cc-0f3c-470f-92bd-bd9545d73a96)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application. Navigate to `/en/letters`. HTML should match the screenshot above.