### PR TITLE
Adding newTab functionality and indicator.

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
+++ b/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
@@ -40,10 +40,10 @@ export default function DataUnavailable() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const userOrigin = useUserOrigin();
 
-  const doyouqualify = <InlineLink to={t('data-unavailable:do-you-qualify.href')} />;
-  const howtoapply = <InlineLink to={t('data-unavailable:how-to-apply.href')} />;
-  const contactus = <InlineLink to={t('data-unavailable:contact-us.href')} />;
-  const statuschecker = <InlineLink to={t('data-unavailable:status-checker.href')} />;
+  const doyouqualify = <InlineLink to={t('data-unavailable:do-you-qualify.href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const howtoapply = <InlineLink to={t('data-unavailable:how-to-apply.href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const contactus = <InlineLink to={t('data-unavailable:contact-us.href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const statuschecker = <InlineLink to={t('data-unavailable:status-checker.href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   return (
     <>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -66,8 +66,8 @@ export default function ApplyFlowApplicationDelegate() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const contactServiceCanada = <InlineLink to={t('apply:eligibility.application-delegate.contact-service-canada-href')} />;
-  const preparingToApply = <InlineLink to={t('apply:eligibility.application-delegate.preparing-to-apply-href')} />;
+  const contactServiceCanada = <InlineLink to={t('apply:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const preparingToApply = <InlineLink to={t('apply:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" target="_blank" />;
   const span = <span className="whitespace-nowrap" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -174,13 +174,13 @@ export default function ApplyFlowConfirm() {
   const fetcher = useFetcher<typeof action>();
   const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, csrfToken } = useLoaderData<typeof loader>();
 
-  const mscaLink = <InlineLink to={t('confirm.msca-link')} />;
-  const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} />;
-  const moreInfoLink = <InlineLink to={t('confirm.more-info-link')} />;
-  const cdcpLink = <InlineLink to={t('apply:confirm.status-checker-link')} />;
+  const mscaLink = <InlineLink to={t('confirm.msca-link')} className="external-link font-lato font-semibold" target="_blank" />;
+  const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} className="external-link font-lato font-semibold" target="_blank" />;
+  const moreInfoLink = <InlineLink to={t('confirm.more-info-link')} className="external-link font-lato font-semibold" target="_blank" />;
+  const cdcpLink = <InlineLink to={t('apply:confirm.status-checker-link')} className="external-link font-lato font-semibold" target="_blank" />;
 
   // this link will be used in a future release
-  // const cdcpLink = <InlineLink routeId="$lang+/_public+/status+/index" params={params} />;
+  // const cdcpLink = <InlineLink routeId="$lang+/_public+/status+/index" params={params} className="external-link font-lato font-semibold" target='_blank' />;
 
   return (
     <div className="max-w-prose">

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx
@@ -65,7 +65,7 @@ export default function ApplyFlowDobEligibility() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const eligibilityInfo = <InlineLink to={t('apply:eligibility.dob-eligibility.eligibility-info-href')} />;
+  const eligibilityInfo = <InlineLink to={t('apply:eligibility.dob-eligibility.eligibility-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/file-taxes.tsx
@@ -65,7 +65,7 @@ export default function ApplyFlowFileYourTaxes() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const taxInfo = <InlineLink to={t('apply:eligibility.file-your-taxes.tax-info-href')} />;
+  const taxInfo = <InlineLink to={t('apply:eligibility.file-your-taxes.tax-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -9,7 +9,6 @@ import pageIds from '../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { InlineLink } from '~/components/inline-link';
-import { NewTabIndicator } from '~/components/new-tab-indicator';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/terms-and-conditions.tsx
@@ -9,6 +9,7 @@ import pageIds from '../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { InlineLink } from '~/components/inline-link';
+import { NewTabIndicator } from '~/components/new-tab-indicator';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -62,11 +63,11 @@ export default function ApplyIndex() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const canadaTermsConditions = <InlineLink to={t('apply:terms-and-conditions.links.canada-ca-terms-and-conditions')} />;
-  const fileacomplaint = <InlineLink to={t('apply:terms-and-conditions.links.file-complaint')} />;
-  const hcaptchaTermsOfService = <InlineLink to={t('apply:terms-and-conditions.links.hcaptcha')} />;
-  const infosource = <InlineLink to={t('apply:terms-and-conditions.links.info-source')} />;
-  const microsoftDataPrivacyPolicy = <InlineLink to={t('apply:terms-and-conditions.links.microsoft-data-privacy-policy')} />;
+  const canadaTermsConditions = <InlineLink to={t('apply:terms-and-conditions.links.canada-ca-terms-and-conditions')} className="external-link font-lato font-semibold" target="_blank" />;
+  const fileacomplaint = <InlineLink to={t('apply:terms-and-conditions.links.file-complaint')} className="external-link font-lato font-semibold" target="_blank" />;
+  const hcaptchaTermsOfService = <InlineLink to={t('apply:terms-and-conditions.links.hcaptcha')} className="external-link font-lato font-semibold" target="_blank" />;
+  const infosource = <InlineLink to={t('apply:terms-and-conditions.links.info-source')} className="external-link font-lato font-semibold" target="_blank" />;
+  const microsoftDataPrivacyPolicy = <InlineLink to={t('apply:terms-and-conditions.links.microsoft-data-privacy-policy')} className="external-link font-lato font-semibold" target="_blank" />;
 
   return (
     <div className="max-w-prose">

--- a/frontend/app/routes/$lang+/_public+/status+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/index.tsx
@@ -222,10 +222,10 @@ export default function StatusChecker() {
     fetcher.submit(formData, { method: 'POST' });
   }
 
-  const hcaptchaTermsOfService = <InlineLink to={t('status:links.hcaptcha')} />;
-  const microsoftDataPrivacyPolicy = <InlineLink to={t('status:links.microsoft-data-privacy-policy')} />;
-  const microsoftServiceAgreement = <InlineLink to={t('status:links.microsoft-service-agreement')} />;
-  const fileacomplaint = <InlineLink to={t('status:links.file-complaint')} />;
+  const hcaptchaTermsOfService = <InlineLink to={t('status:links.hcaptcha')} className="external-link font-lato font-semibold" target="_blank" />;
+  const microsoftDataPrivacyPolicy = <InlineLink to={t('status:links.microsoft-data-privacy-policy')} className="external-link font-lato font-semibold" target="_blank" />;
+  const microsoftServiceAgreement = <InlineLink to={t('status:links.microsoft-service-agreement')} className="external-link font-lato font-semibold" target="_blank" />;
+  const fileacomplaint = <InlineLink to={t('status:links.file-complaint')} className="external-link font-lato font-semibold" target="_blank" />;
 
   const errorSummaryId = 'error-summary';
 

--- a/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
+++ b/frontend/app/routes/$lang+/_public+/unable-to-process-request.tsx
@@ -32,8 +32,8 @@ export default function UnableToProcessRequest() {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const noWrap = <span className="whitespace-nowrap" />;
-  const eServiceCanadaLink = <InlineLink to={t('unable-to-process-request:e-service-canada-link')} />;
-  const cdcpLink = <InlineLink to={t('unable-to-process-request:cdcp-link')} />;
+  const eServiceCanadaLink = <InlineLink to={t('unable-to-process-request:e-service-canada-link')} className="external-link font-lato font-semibold" target="_blank" />;
+  const cdcpLink = <InlineLink to={t('unable-to-process-request:cdcp-link')} className="external-link font-lato font-semibold" target="_blank" />;
 
   return (
     <PublicLayout>


### PR DESCRIPTION
### Description
Adding `target='_blank'` and newTab indicator to all links missing it.

### Related Azure Boards Work Items
[AB#3368](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3368)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to the affected files to ensure the links look and behave how they should. (By opening a new tab)