### PR TITLE
Personal information from session is ignored based on the updated flag

### DIFF
--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -67,7 +67,7 @@ db.personalInformation.create({
   lastName: 'Eliot',
   firstName: 'Thomas Stearns',
   emailAddressId: 'rhapsody@domain.ca',
-  primaryTelephoneNumber: '222-555-5555',
+  primaryTelephoneNumber: '807-555-5555',
   alternateTelephoneNumber: '416-555-6666',
   preferredMethodCommunicationCode: '1033',
   sinIdentification: '800011819',

--- a/frontend/app/route-helpers/personal-information-route-helpers.server.ts
+++ b/frontend/app/route-helpers/personal-information-route-helpers.server.ts
@@ -27,7 +27,7 @@ async function getPersonalInformation(userInfoToken: UserinfoToken, params: Para
   }
 
   const personalInformationFromSession: PersonalInfo | undefined = session.get('personalInformation');
-  if (personalInformationFromSession) {
+  if (personalInformationFromSession && !session.get('personal-info-updated')) {
     log.debug('Returning personal information that already exists in session for userId [%s]', userInfoToken.sub);
     return personalInformationFromSession;
   }


### PR DESCRIPTION
### Description
When the personal information is retrieved, personal information saved in the session will be bypassed if the `personal-info-updated` session flag has been set

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->
[AB#3356](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/3356)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
1. Open the personal information page
2. Click one of the change links
3. Make a valid change to information
4. Save the information
5. Confirm that the updated information is displayed

### Additional Notes
As an incidental change the mocked phone number has been updated to use a valid Canadian number.