### PR TITLE
ensure any country is displayed in the Address component

### DIFF
--- a/frontend/__tests__/components/address.test.tsx
+++ b/frontend/__tests__/components/address.test.tsx
@@ -6,44 +6,44 @@ import { Address } from '~/components/address';
 
 describe('Address', () => {
   it('should render apartment with hypen at beginning of address if apartment number is a chunk of alphanumeric chars', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should render apartment at end of address if apartment number is not a chunk of alphanumeric chars', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="Apt 123" isCanadianAddress={false} />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="Apt 123" />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123 Fake Street Apt 123\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should render apartment with hypen at beginning if there is no space in the apartment number', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should render country when not a Canadian address', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" isCanadianAddress={false} />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" apartment="123" />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123-123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should not render apartment number when it is undefined', async () => {
-    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" isCanadianAddress={false} />);
+    render(<Address address="123 Fake Street" city="Beverly Hills" provinceState="CA" postalZipCode="90210" country="USA" />);
     const actual = screen.getByTestId('address-id');
     expect(actual.textContent).toBe('123 Fake Street\nBeverly Hills CA  90210\nUSA');
   });
 
   it('should not render country when address is Canadian', async () => {
-    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" isCanadianAddress={true} />);
+    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" />);
     const actual = screen.getByTestId('address-id');
-    expect(actual.textContent).toBe('123 Fake Street\nOttawa ON  K2K 2K2');
+    expect(actual.textContent).toBe('123 Fake Street\nOttawa ON  K2K 2K2\nCanada');
   });
 
   it('should render apartment number if supplied and not render country when address is Canadian', async () => {
-    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" apartment="123" isCanadianAddress={true} />);
+    render(<Address address="123 Fake Street" city="Ottawa" provinceState="ON" postalZipCode="K2K 2K2" country="Canada" apartment="123" />);
     const actual = screen.getByTestId('address-id');
-    expect(actual.textContent).toBe('123-123 Fake Street\nOttawa ON  K2K 2K2');
+    expect(actual.textContent).toBe('123-123 Fake Street\nOttawa ON  K2K 2K2\nCanada');
   });
 });

--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -6,21 +6,20 @@ export interface AddressProps extends ComponentProps<'address'> {
   address: string;
   city: string;
   country: string;
-  isCanadianAddress: boolean;
   provinceState?: string;
   postalZipCode?: string;
   apartment?: string;
   altFormat?: boolean;
 }
 
-function formatAddress(address: string, city: string, country: string, isCanadianAddress: boolean, provinceState?: string, postalZipCode?: string, apartment?: string, altFormat?: boolean) {
+function formatAddress(address: string, city: string, country: string, provinceState?: string, postalZipCode?: string, apartment?: string, altFormat?: boolean) {
   const formattedAddress = apartment ? (/^[a-z\d]+$/i.test(apartment) ? `${apartment}-${address}` : `${address} ${apartment}`) : address;
 
   // prettier-ignore
   const lines = [
     formattedAddress,
     `${city}${provinceState ? ` ${provinceState}` : ''}${postalZipCode ? `  ${postalZipCode}` : ''}`,
-    `${isCanadianAddress ? '' : country}`
+    `${country}`
   ];
 
   // prettier-ignore
@@ -28,7 +27,7 @@ function formatAddress(address: string, city: string, country: string, isCanadia
     formattedAddress,
     `${city}${provinceState ? ` ${provinceState}` : ''}`,
     `${postalZipCode ? `${postalZipCode}` : ''}`,
-    `${isCanadianAddress ? '' : country}`
+    `${country}`
   ];
 
   return (altFormat ? linesAlt : lines)
@@ -38,8 +37,8 @@ function formatAddress(address: string, city: string, country: string, isCanadia
 }
 
 export function Address(props: AddressProps) {
-  const { address, city, provinceState, postalZipCode, country, isCanadianAddress, className, altFormat, apartment, ...restProps } = props;
-  const formattedAddress = formatAddress(address, city, country, isCanadianAddress, provinceState, postalZipCode, apartment, altFormat);
+  const { address, city, provinceState, postalZipCode, country, className, altFormat, apartment, ...restProps } = props;
+  const formattedAddress = formatAddress(address, city, country, provinceState, postalZipCode, apartment, altFormat);
 
   return (
     <address className={cn('whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...restProps}>

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/index.tsx
@@ -15,7 +15,7 @@ import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-inf
 import { getAuditService } from '~/services/audit-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
-import { featureEnabled, getEnv } from '~/utils/env.server';
+import { featureEnabled } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -50,17 +50,16 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const countryList = await getLookupService().getAllCountries();
   const regionList = await getLookupService().getAllRegions();
   const preferredLanguage = personalInformation.preferredLanguageId ? await getLookupService().getPreferredLanguage(personalInformation.preferredLanguageId) : undefined;
-  const { CANADA_COUNTRY_ID } = getEnv();
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('personal-information:index.page-title') }) };
   const updatedInfo = session.get('personal-info-updated');
   session.unset('personal-info-updated');
-  return json({ preferredLanguage, countryList, personalInformation, meta, regionList, updatedInfo, CANADA_COUNTRY_ID });
+  return json({ preferredLanguage, countryList, personalInformation, meta, regionList, updatedInfo });
 }
 
 export default function PersonalInformationIndex() {
-  const { personalInformation, preferredLanguage, countryList, regionList, updatedInfo, CANADA_COUNTRY_ID } = useLoaderData<typeof loader>();
+  const { personalInformation, preferredLanguage, countryList, regionList, updatedInfo } = useLoaderData<typeof loader>();
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const params = useParams();
 
@@ -91,7 +90,6 @@ export default function PersonalInformationIndex() {
               provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.homeAddress!.provinceTerritoryStateId)?.abbr}
               postalZipCode={personalInformation.homeAddress.postalCode}
               country={countryList.find((country) => country.countryId === personalInformation.homeAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '}
-              isCanadianAddress={personalInformation.homeAddress.countryId === CANADA_COUNTRY_ID}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>
@@ -112,7 +110,6 @@ export default function PersonalInformationIndex() {
               provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.mailingAddress!.provinceTerritoryStateId)?.abbr}
               postalZipCode={personalInformation.mailingAddress.postalCode}
               country={countryList.find((country) => country.countryId === personalInformation.mailingAddress!.countryId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ''}
-              isCanadianAddress={personalInformation.mailingAddress.countryId === CANADA_COUNTRY_ID}
             />
           ) : (
             <p>{t('personal-information:index.no-address-on-file')}</p>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/confirmation.tsx
@@ -15,7 +15,6 @@ import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import { toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -41,7 +40,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const state = await applyRouteHelpers.loadState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID } = getEnv();
 
   // prettier-ignore
   if (state.applicantInformation === undefined ||
@@ -117,7 +115,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     postalCode: state.personalInformation.mailingPostalCode,
     country: countryMailing,
     apartment: state.personalInformation.mailingApartment,
-    isCanadianAddress: state.personalInformation.mailingCountry === CANADA_COUNTRY_ID,
   };
 
   const homeAddressInfo = {
@@ -127,7 +124,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     postalCode: state.personalInformation.homePostalCode,
     country: countryHome,
     apartment: state.personalInformation.homeApartment,
-    isCanadianAddress: state.personalInformation.homeCountry === CANADA_COUNTRY_ID,
   };
 
   const dentalInsurance = {
@@ -283,7 +279,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={mailingAddressInfo.postalCode}
                 country={i18n.language === 'en' ? mailingAddressInfo.country?.nameEn ?? '' : mailingAddressInfo.country?.nameFr ?? ''}
                 apartment={mailingAddressInfo.apartment}
-                isCanadianAddress={mailingAddressInfo.isCanadianAddress}
                 altFormat={true}
               />
             </DescriptionListItem>
@@ -295,7 +290,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={homeAddressInfo.postalCode ?? ''}
                 country={i18n.language === 'en' ? homeAddressInfo.country?.nameEn ?? '' : homeAddressInfo.country?.nameFr ?? ''}
                 apartment={homeAddressInfo.apartment}
-                isCanadianAddress={homeAddressInfo.isCanadianAddress}
                 altFormat={true}
               />
             </DescriptionListItem>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -61,7 +61,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   const applyRouteHelpers = getApplyRouteHelpers();
   const lookupService = getLookupService();
-  const { CANADA_COUNTRY_ID } = getEnv();
 
   const state = await applyRouteHelpers.loadState({ params, request, session });
   applyRouteHelpers.validateStateForReview({ params, state });
@@ -135,7 +134,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     postalCode: state.personalInformation.mailingPostalCode,
     country: countryMailing,
     apartment: state.personalInformation.mailingApartment,
-    isCanadianAddress: state.personalInformation.mailingCountry === CANADA_COUNTRY_ID,
   };
 
   const homeAddressInfo = {
@@ -145,7 +143,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     postalCode: state.personalInformation.homePostalCode,
     country: countryHome,
     apartment: state.personalInformation.mailingApartment,
-    isCanadianAddress: state.personalInformation.homeCountry === CANADA_COUNTRY_ID,
   };
 
   const dentalInsurance = state.dentalInsurance;
@@ -406,7 +403,6 @@ export default function ReviewInformation() {
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={i18n.language === 'en' ? mailingAddressInfo.country.nameEn : mailingAddressInfo.country.nameFr}
                   apartment={mailingAddressInfo.apartment}
-                  isCanadianAddress={mailingAddressInfo.isCanadianAddress}
                   altFormat={true}
                 />
                 <p className="mt-4">
@@ -423,7 +419,6 @@ export default function ReviewInformation() {
                   postalZipCode={homeAddressInfo.postalCode}
                   country={i18n.language === 'en' ? homeAddressInfo.country.nameEn : homeAddressInfo.country.nameFr}
                   apartment={homeAddressInfo.apartment}
-                  isCanadianAddress={homeAddressInfo.isCanadianAddress}
                   altFormat={true}
                 />
                 <p className="mt-4">


### PR DESCRIPTION
### Description
Previously it was thought that if the applicants address was a Canadian address, the country shouldn't have been displayed.  This was incorrect thinking and it's now been fixed in this PR.

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/8e57c5d8-4bab-42eb-9861-f025ca3abc79)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
