### PR TITLE
move adult flow to its own folder

### DIFF
--- a/frontend/__tests__/route-helpers/apply-route-helpers.server.test.ts
+++ b/frontend/__tests__/route-helpers/apply-route-helpers.server.test.ts
@@ -72,7 +72,7 @@ describe('apply-route-helpers.server', () => {
         typeOfApplication: 'delegate',
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if taxFiling2023 is undefined', () => {
@@ -82,7 +82,7 @@ describe('apply-route-helpers.server', () => {
         taxFiling2023: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/tax-filing, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/tax-filing, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if taxFiling2023 is no', () => {
@@ -92,7 +92,7 @@ describe('apply-route-helpers.server', () => {
         taxFiling2023: 'no',
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/file-taxes, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/file-taxes, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if dateOfBirth is undefined', () => {
@@ -103,7 +103,7 @@ describe('apply-route-helpers.server', () => {
         dateOfBirth: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/date-of-birth, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/date-of-birth, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it("should redirect if applicantInformation is undefined'", () => {
@@ -115,7 +115,7 @@ describe('apply-route-helpers.server', () => {
         applicantInformation: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if partnerInformation is undefined and applicant has partner', () => {
@@ -133,7 +133,7 @@ describe('apply-route-helpers.server', () => {
         partnerInformation: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/partner-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/partner-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if partnerInformation is not undefined and applicant has no partner', () => {
@@ -157,7 +157,7 @@ describe('apply-route-helpers.server', () => {
         },
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if personalInformation is undefined', () => {
@@ -182,7 +182,7 @@ describe('apply-route-helpers.server', () => {
         personalInformation: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/personal-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/personal-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if communicationPreferences is undefined', () => {
@@ -213,7 +213,7 @@ describe('apply-route-helpers.server', () => {
         communicationPreferences: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/communication-preference, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/communication-preference, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if dentalInsurance is undefined', () => {
@@ -248,7 +248,7 @@ describe('apply-route-helpers.server', () => {
         dentalInsurance: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/dental-insurance, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/dental-insurance, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if dentalBenefits is undefined', () => {
@@ -284,7 +284,7 @@ describe('apply-route-helpers.server', () => {
         dentalBenefits: undefined,
       };
 
-      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should not redirect if state is completed', () => {

--- a/frontend/__tests__/routes/_public+/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/_public+/application-delegate.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { loader } from '~/routes/$lang+/_public+/apply+/$id+/application-delegate';
+import { loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/application-delegate';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/_public+/communication-preference.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/communication-preference';
+import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/communication-preference';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
+++ b/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
@@ -3,7 +3,7 @@ import { createMemorySessionStorage, redirect } from '@remix-run/node';
 import { differenceInYears, isPast, isValid, parse } from 'date-fns';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/date-of-birth';
+import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth';
 
 vi.mock('date-fns');
 
@@ -27,7 +27,7 @@ vi.mock('~/utils/locale-utils.server', async (importOriginal) => {
   return {
     ...actual,
     getFixedT: vi.fn().mockResolvedValue(vi.fn()),
-    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/applicant-information')).mockResolvedValueOnce(redirect('/en/apply/123/dob-eligibility')),
+    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/adult/applicant-information')).mockResolvedValueOnce(redirect('/en/apply/123/adult/dob-eligibility')),
   };
 });
 
@@ -42,7 +42,7 @@ describe('_public.apply.id.date-of-birth', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const response = await loader({
-        request: new Request('http://localhost:3000/en/apply/123/date-of-birth'),
+        request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth'),
         context: { session },
         params: {},
       });
@@ -69,7 +69,7 @@ describe('_public.apply.id.date-of-birth', () => {
       formData.append('_csrf', 'csrfToken');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth', { method: 'POST', body: formData }),
         context: { session },
         params: {},
       });
@@ -100,13 +100,13 @@ describe('_public.apply.id.date-of-birth', () => {
       vi.mocked(differenceInYears).mockReturnValueOnce(65).mockReturnValueOnce(65);
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/applicant-information');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/applicant-information');
     });
 
     it('should redirect to disability tax credit page if dob is under 65 years', async () => {
@@ -126,7 +126,7 @@ describe('_public.apply.id.date-of-birth', () => {
       vi.mocked(differenceInYears).mockReturnValueOnce(64).mockReturnValueOnce(64);
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/date-of-birth', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });

--- a/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
+++ b/frontend/__tests__/routes/_public+/dob-eligibility.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { loader } from '~/routes/$lang+/_public+/apply+/$id+/dob-eligibility';
+import { loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/dob-eligibility';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/file-taxes.test.tsx
+++ b/frontend/__tests__/routes/_public+/file-taxes.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { loader } from '~/routes/$lang+/_public+/apply+/$id+/file-taxes';
+import { loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/file-taxes';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/personal-information.test.tsx
+++ b/frontend/__tests__/routes/_public+/personal-information.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { loader } from '~/routes/$lang+/_public+/apply+/$id+/personal-information';
+import { loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/_public+/tax-filing.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage, redirect } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/tax-filing';
+import { action, loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/tax-filing';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   getApplyRouteHelpers: vi.fn().mockReturnValue({
@@ -23,7 +23,7 @@ vi.mock('~/utils/locale-utils.server', async (importOriginal) => {
   return {
     ...actual,
     getFixedT: vi.fn().mockResolvedValue(vi.fn()),
-    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/date-of-birth')).mockResolvedValueOnce(redirect('/en/apply/123/file-your-taxes')),
+    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/adult/date-of-birth')).mockResolvedValueOnce(redirect('/en/apply/123/file-your-taxes')),
   };
 });
 
@@ -38,7 +38,7 @@ describe('_public.apply.id.tax-filing', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const response = await loader({
-        request: new Request('http://localhost:3000/en/apply/123/tax-filing'),
+        request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing'),
         context: { session },
         params: {},
       });
@@ -62,7 +62,7 @@ describe('_public.apply.id.tax-filing', () => {
       formData.append('_csrf', 'csrfToken');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing', { method: 'POST', body: formData }),
         context: { session },
         params: {},
       });
@@ -81,13 +81,13 @@ describe('_public.apply.id.tax-filing', () => {
       formData.append('taxFiling2023', 'yes');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/date-of-birth');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/date-of-birth');
     });
 
     it('should redirect to error page if tax filing is incompleted', async () => {
@@ -99,13 +99,13 @@ describe('_public.apply.id.tax-filing', () => {
       formData.append('taxFiling2023', 'no');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/file-taxes');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/file-taxes');
     });
   });
 });

--- a/frontend/__tests__/routes/_public+/type-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-application.test.tsx
@@ -24,7 +24,7 @@ vi.mock('~/utils/locale-utils.server', async (importOriginal) => {
   return {
     ...actual,
     getFixedT: vi.fn().mockResolvedValue(tMockFn),
-    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/application-delegate')).mockResolvedValueOnce(redirect('/en/apply/123/tax-filing')),
+    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/adult/application-delegate')).mockResolvedValueOnce(redirect('/en/apply/123/tax-filing')),
   };
 });
 
@@ -39,7 +39,7 @@ describe('_public.apply.id.type-of-application', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const response = await loader({
-        request: new Request('http://localhost:3000/en/apply/123/type-of-application'),
+        request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application'),
         context: { session },
         params: {},
       });
@@ -63,7 +63,7 @@ describe('_public.apply.id.type-of-application', () => {
       formData.append('_csrf', 'csrfToken');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: formData }),
         context: { session },
         params: {},
       });
@@ -82,13 +82,13 @@ describe('_public.apply.id.type-of-application', () => {
       formData.append('typeOfApplication', 'delegate');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/application-delegate');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/application-delegate');
     });
 
     it('should redirect to tax filing page if personal is selected', async () => {
@@ -100,13 +100,13 @@ describe('_public.apply.id.type-of-application', () => {
       formData.append('typeOfApplication', 'personal');
 
       const response = await action({
-        request: new Request('http://localhost:3000/en/apply/123/type-of-application', { method: 'POST', body: formData }),
+        request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: formData }),
         context: { session },
         params: { lang: 'en', id: '123' },
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/tax-filing');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/tax-filing');
     });
   });
 });

--- a/frontend/app/mappers/benefit-application-service-mappers.server.ts
+++ b/frontend/app/mappers/benefit-application-service-mappers.server.ts
@@ -1,13 +1,13 @@
 import { lightFormat, parse } from 'date-fns';
 import validator from 'validator';
 
-import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/applicant-information';
-import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/communication-preference';
-import { DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/date-of-birth';
-import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/dental-insurance';
-import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits';
-import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/partner-information';
-import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/personal-information';
+import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/applicant-information';
+import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/adult/communication-preference';
+import { DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth';
+import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance';
+import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits';
+import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/partner-information';
+import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
 import { BenefitApplicationRequest } from '~/schemas/benefit-application-service-schemas.server';
 
 interface ToBenefitApplicationRequestArgs {

--- a/frontend/app/route-helpers/apply-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-route-helpers.server.ts
@@ -4,17 +4,17 @@ import { Params } from '@remix-run/react';
 import { differenceInMinutes } from 'date-fns';
 import { z } from 'zod';
 
-import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/applicant-information';
-import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/communication-preference';
-import { AllChildrenUnder18State, DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/date-of-birth';
-import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/dental-insurance';
+import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/applicant-information';
+import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/adult/communication-preference';
+import { AllChildrenUnder18State, DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth';
+import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance';
+import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits';
+import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/partner-information';
+import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
+import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/adult/review-information';
+import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/adult/tax-filing';
 import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/disability-tax-credit';
-import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits';
 import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/living-independently';
-import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/partner-information';
-import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/personal-information';
-import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/review-information';
-import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/tax-filing';
 import { TypeOfApplicationState } from '~/routes/$lang+/_public+/apply+/$id+/type-application';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
@@ -97,7 +97,7 @@ async function loadState({ params, request, session }: LoadStateArgs) {
 
   // Redirect to the confirmation page if the application has been submitted and
   // the current route is not the confirmation page.
-  const confirmationRouteUrl = getPathById('$lang+/_public+/apply+/$id+/confirmation', params);
+  const confirmationRouteUrl = getPathById('$lang+/_public+/apply+/$id+/adult/confirmation', params);
   if (state.submissionInfo && !pathname.endsWith(confirmationRouteUrl)) {
     log.warn('Redirecting user to "%s" since the application has been submitted; sessionName: [%s], ', sessionName, confirmationRouteUrl);
     throw redirect(confirmationRouteUrl);
@@ -214,47 +214,47 @@ function validateStateForReview({ params, state }: ValidateStateForReviewArgs) {
   }
 
   if (state.typeOfApplication === 'delegate') {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
   }
 
   if (state.taxFiling2023 === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/tax-filing', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/tax-filing', params));
   }
 
   if (state.taxFiling2023 === 'no') {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/file-taxes', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/file-taxes', params));
   }
 
   if (state.dateOfBirth === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
   }
 
   if (state.applicantInformation === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
   }
 
   if (state.partnerInformation === undefined && hasPartner(state.applicantInformation)) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/partner-information', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/partner-information', params));
   }
 
   if (state.partnerInformation !== undefined && !hasPartner(state.applicantInformation)) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
   }
 
   if (state.personalInformation === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/personal-information', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/personal-information', params));
   }
 
   if (state.communicationPreferences === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/communication-preference', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/communication-preference', params));
   }
 
   if (state.dentalInsurance === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/dental-insurance', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/dental-insurance', params));
   }
 
   if (state.dentalBenefits === undefined) {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits', params));
   }
 }
 

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -98,115 +98,115 @@
                 },
                 "children": [
                   {
-                    "id": "$lang+/_public+/apply+/$id+/applicant-information",
-                    "file": "routes/$lang+/_public+/apply+/$id+/applicant-information.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/applicant-information",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/applicant-information.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/applicant-information",
-                      "fr": "/:lang/appliquer/:id/renseignements-demandeur"
+                      "en": "/:lang/apply/:id/adult/applicant-information",
+                      "fr": "/:lang/appliquer/:id/adulte/renseignements-demandeur"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/application-delegate",
-                    "file": "routes/$lang+/_public+/apply+/$id+/application-delegate.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/application-delegate",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/application-delegate",
-                      "fr": "/:lang/appliquer/:id/delegue-demande"
+                      "en": "/:lang/apply/:id/adult/application-delegate",
+                      "fr": "/:lang/appliquer/:id/adulte/delegue-demande"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/communication-preference",
-                    "file": "routes/$lang+/_public+/apply+/$id+/communication-preference.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/communication-preference",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/communication-preference",
-                      "fr": "/:lang/appliquer/:id/preference-communication"
+                      "en": "/:lang/apply/:id/adult/communication-preference",
+                      "fr": "/:lang/appliquer/:id/adult/preference-communication"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/confirmation",
-                    "file": "routes/$lang+/_public+/apply+/$id+/confirmation.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/confirmation",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/confirmation",
-                      "fr": "/:lang/appliquer/:id/confirmation"
+                      "en": "/:lang/apply/:id/adult/confirmation",
+                      "fr": "/:lang/appliquer/:id/adulte/confirmation"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/date-of-birth",
-                    "file": "routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/date-of-birth",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/date-of-birth",
-                      "fr": "/:lang/appliquer/:id/date-de-naissance"
+                      "en": "/:lang/apply/:id/adult/date-of-birth",
+                      "fr": "/:lang/appliquer/:id/adulte/date-de-naissance"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/dental-insurance",
-                    "file": "routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/dental-insurance",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/dental-insurance.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/dental-insurance",
-                      "fr": "/:lang/appliquer/:id/assurance-dentaire"
+                      "en": "/:lang/apply/:id/adult/dental-insurance",
+                      "fr": "/:lang/appliquer/:id/adulte/assurance-dentaire"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/dob-eligibility",
-                    "file": "routes/$lang+/_public+/apply+/$id+/dob-eligibility.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/dob-eligibility",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/dob-eligibility.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/dob-eligibility",
-                      "fr": "/:lang/appliquer/:id/ddn-admissibilite"
+                      "en": "/:lang/apply/:id/adult/dob-eligibility",
+                      "fr": "/:lang/appliquer/:id/adulte/ddn-admissibilite"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/exit-application",
-                    "file": "routes/$lang+/_public+/apply+/$id+/exit-application.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/exit-application",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/exit-application.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/exit-application",
-                      "fr": "/:lang/appliquer/:id/quitter-demande"
+                      "en": "/:lang/apply/:id/adult/exit-application",
+                      "fr": "/:lang/appliquer/:id/adulte/quitter-demande"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits",
-                    "file": "routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/federal-provincial-territorial-benefits",
-                      "fr": "/:lang/appliquer/:id/prestations-dentaires-federales-provinciales-territoriales"
+                      "en": "/:lang/apply/:id/adult/federal-provincial-territorial-benefits",
+                      "fr": "/:lang/appliquer/:id/adulte/prestations-dentaires-federales-provinciales-territoriales"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/file-taxes",
-                    "file": "routes/$lang+/_public+/apply+/$id+/file-taxes.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/file-taxes",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/file-taxes.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/file-taxes",
-                      "fr": "/:lang/appliquer/:id/produire-declaration-revenus"
+                      "en": "/:lang/apply/:id/adult/file-taxes",
+                      "fr": "/:lang/appliquer/:id/adulte/produire-declaration-revenus"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/partner-information",
-                    "file": "routes/$lang+/_public+/apply+/$id+/partner-information.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/partner-information",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/partner-information",
-                      "fr": "/:lang/appliquer/:id/renseignements-partenaire"
+                      "en": "/:lang/apply/:id/adult/partner-information",
+                      "fr": "/:lang/appliquer/:id/adulte/renseignements-partenaire"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/personal-information",
-                    "file": "routes/$lang+/_public+/apply+/$id+/personal-information.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/personal-information",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/personal-information",
-                      "fr": "/:lang/appliquer/:id/renseignements-personnels"
+                      "en": "/:lang/apply/:id/adult/personal-information",
+                      "fr": "/:lang/appliquer/:id/adulte/renseignements-personnels"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/review-information",
-                    "file": "routes/$lang+/_public+/apply+/$id+/review-information.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/review-information",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/review-information.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/review-information",
-                      "fr": "/:lang/appliquer/:id/revue-renseignements"
+                      "en": "/:lang/apply/:id/adult/review-information",
+                      "fr": "/:lang/appliquer/:id/adulte/revue-renseignements"
                     }
                   },
                   {
-                    "id": "$lang+/_public+/apply+/$id+/tax-filing",
-                    "file": "routes/$lang+/_public+/apply+/$id+/tax-filing.tsx",
+                    "id": "$lang+/_public+/apply+/$id+/adult/tax-filing",
+                    "file": "routes/$lang+/_public+/apply+/$id+/adult/tax-filing.tsx",
                     "paths": {
-                      "en": "/:lang/apply/:id/tax-filing",
-                      "fr": "/:lang/appliquer/:id/declaration-impot"
+                      "en": "/:lang/apply/:id/adult/tax-filing",
+                      "fr": "/:lang/appliquer/:id/adulte/declaration-impot"
                     }
                   },
                   {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/applicant-information.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
@@ -91,7 +91,7 @@ export async function action({ context: { session }, params, request }: ActionFu
       return json({ errors });
     }
 
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
   // Form action Continue & Save
@@ -137,14 +137,14 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, remove, request, session, state: { applicantInformation: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
   if (hasPartner) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/partner-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/partner-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/personal-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/personal-information', params));
 }
 
 export default function ApplyFlowApplicationInformation() {
@@ -263,7 +263,7 @@ export default function ApplyFlowApplicationInformation() {
                 {t('apply:applicant-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:applicant-information.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx
@@ -1,12 +1,15 @@
+import { FormEvent } from 'react';
+
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
+import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -17,8 +20,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.exitApplication,
-  pageTitleI18nKey: 'apply:exit-application.page-title',
+  pageIdentifier: pageIds.public.apply.applicationDelegate,
+  pageTitleI18nKey: 'apply:eligibility.application-delegate.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -32,13 +35,13 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.application-delegate.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/exit-application');
+  const log = getLogger('apply/application-delegate');
   const applyRouteHelpers = getApplyRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -52,33 +55,48 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirect(t('exit-application.exit-link'));
+
+  return redirect(t('apply:eligibility.application-delegate.return-btn-link'));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowApplicationDelegate() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
+  const contactServiceCanada = <InlineLink to={t('apply:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const preparingToApply = <InlineLink to={t('apply:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const span = <span className="whitespace-nowrap" />;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    fetcher.submit(event.currentTarget, { method: 'POST' });
+    sessionStorage.removeItem('flow.state');
+  }
+
   return (
-    <div className="max-w-prose">
+    <>
       <div className="mb-8 space-y-4">
-        <p>{t('apply:exit-application.are-you-sure')}</p>
-        <p>{t('apply:exit-application.click-back')}</p>
+        <p>
+          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
+        </p>
+        <p>
+          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
+        </p>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Exit Application click">
+        <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applying on behalf of someone click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:exit-application.back-btn')}
+          {t('apply:eligibility.application-delegate.back-btn')}
         </ButtonLink>
-        <Button variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Exit Application click">
-          {t('apply:exit-application.exit-btn')}
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Applying on behalf of someone click">
+          {t('apply:eligibility.application-delegate.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
@@ -136,10 +136,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { communicationPreferences: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/dental-insurance', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/dental-insurance', params));
 }
 
 export default function ApplyFlowCommunicationPreferencePage() {
@@ -260,7 +260,13 @@ export default function ApplyFlowCommunicationPreferencePage() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Communication preference click">
                 {t('apply:communication-preference.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Communication preference click">
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult/review-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Communication preference click"
+              >
                 {t('apply:communication-preference.cancel-btn')}
               </ButtonLink>
             </div>
@@ -270,7 +276,13 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 {t('apply:communication-preference.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Communication preference click">
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult/personal-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Communication preference click"
+              >
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:communication-preference.back')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
@@ -6,7 +6,7 @@ import { parse } from 'date-fns';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
@@ -9,7 +9,7 @@ import { differenceInYears, isPast, isValid, parse } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
@@ -155,11 +155,11 @@ export async function action({ context: { session }, params, request }: ActionFu
   const allChildrenUnder18 = parsedDataResult.data.allChildrenUnder18;
 
   if (age < 16 && allChildrenUnder18 === 'yes') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/parent-or-guardian', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));
   }
 
   if ((age === 16 || age === 17) && allChildrenUnder18 === 'yes') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/living-independently', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/living-independently', params));
   }
 
   if (age >= 18 && age < 65) {
@@ -167,14 +167,14 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   if (age >= 65 && allChildrenUnder18 === 'no') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/apply-for-yourself', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/apply-for-yourself', params));
   }
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
 }
 
 export default function ApplyFlowDateOfBirth() {
@@ -265,7 +265,7 @@ export default function ApplyFlowDateOfBirth() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Date of birth click">
                 {t('apply:eligibility.date-of-birth.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Date of birth click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Date of birth click">
                 {t('apply:eligibility.date-of-birth.cancel-btn')}
               </ButtonLink>
             </div>
@@ -275,7 +275,7 @@ export default function ApplyFlowDateOfBirth() {
                 {t('apply:eligibility.date-of-birth.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Date of birth click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Date of birth click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply:eligibility.date-of-birth.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance.tsx
@@ -9,7 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
@@ -77,10 +77,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { dentalInsurance: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits', params));
 }
 
 export default function AccessToDentalInsuranceQuestion() {
@@ -180,7 +180,7 @@ export default function AccessToDentalInsuranceQuestion() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang+/_public+/apply+/$id+/review-information"
+                routeId="$lang+/_public+/apply+/$id+/adult/review-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Access to other dental insurance click"
@@ -196,7 +196,7 @@ export default function AccessToDentalInsuranceQuestion() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang+/_public+/apply+/$id+/communication-preference"
+                routeId="$lang+/_public+/apply+/$id+/adult/communication-preference"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Access to other dental insurance click"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/exit-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/exit-application.tsx
@@ -1,15 +1,12 @@
-import { FormEvent } from 'react';
-
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
-import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -20,8 +17,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.applicationDelegate,
-  pageTitleI18nKey: 'apply:eligibility.application-delegate.page-title',
+  pageIdentifier: pageIds.public.apply.exitApplication,
+  pageTitleI18nKey: 'apply:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,13 +32,13 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.application-delegate.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/application-delegate');
+  const log = getLogger('apply/exit-application');
   const applyRouteHelpers = getApplyRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,48 +52,33 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   await applyRouteHelpers.clearState({ params, request, session });
-
-  return redirect(t('apply:eligibility.application-delegate.return-btn-link'));
+  return redirect(t('exit-application.exit-link'));
 }
 
-export default function ApplyFlowApplicationDelegate() {
+export default function ApplyFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const contactServiceCanada = <InlineLink to={t('apply:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" target="_blank" />;
-  const preparingToApply = <InlineLink to={t('apply:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" target="_blank" />;
-  const span = <span className="whitespace-nowrap" />;
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    fetcher.submit(event.currentTarget, { method: 'POST' });
-    sessionStorage.removeItem('flow.state');
-  }
-
   return (
-    <>
+    <div className="max-w-prose">
       <div className="mb-8 space-y-4">
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
-        </p>
+        <p>{t('apply:exit-application.are-you-sure')}</p>
+        <p>{t('apply:exit-application.click-back')}</p>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applying on behalf of someone click">
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Exit Application click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:eligibility.application-delegate.back-btn')}
+          {t('apply:exit-application.back-btn')}
         </ButtonLink>
-        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Applying on behalf of someone click">
-          {t('apply:eligibility.application-delegate.return-btn')}
+        <Button variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Exit Application click">
+          {t('apply:exit-application.exit-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>
-    </>
+    </div>
   );
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits.tsx
@@ -10,7 +10,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -180,7 +180,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
 }
 
 export default function AccessToDentalInsuranceQuestion() {
@@ -388,7 +388,7 @@ export default function AccessToDentalInsuranceQuestion() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang+/_public+/apply+/$id+/review-information"
+                routeId="$lang+/_public+/apply+/$id+/adult/review-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Access to other federal, provincial or territorial dental benefits click"
@@ -404,7 +404,7 @@ export default function AccessToDentalInsuranceQuestion() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang+/_public+/apply+/$id+/dental-insurance"
+                routeId="$lang+/_public+/apply+/$id+/adult/dental-insurance"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Access to other federal, provincial or territorial dental benefits click"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/file-taxes.tsx
@@ -7,21 +7,21 @@ import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
-import pageIds from '../../../page-ids.json';
-import { ButtonLink } from '~/components/buttons';
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getApplyRouteHelpers } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.dateOfBirthEligibility,
-  pageTitleI18nKey: 'apply:eligibility.dob-eligibility.page-title',
+  pageIdentifier: pageIds.public.apply.fileYourTaxes,
+  pageTitleI18nKey: 'apply:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,14 +35,15 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.dob-eligibility.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.file-your-taxes.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/dob-eligibility');
+  const log = getLogger('apply/file-taxes');
   const applyRouteHelpers = getApplyRouteHelpers();
+  const t = await getFixedT(request, handle.i18nNamespaces);
 
   const formData = await request.formData();
   const expectedCsrfToken = String(session.get('csrfToken'));
@@ -53,19 +54,18 @@ export async function action({ context: { session }, params, request }: ActionFu
     throw new Response('Invalid CSRF token', { status: 400 });
   }
 
-  await applyRouteHelpers.loadState({ params, request, session });
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirect(getPathById('index', params));
+  return redirect(t('apply:eligibility.file-your-taxes.return-btn-link'));
 }
 
-export default function ApplyFlowDobEligibility() {
+export default function ApplyFlowFileYourTaxes() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const eligibilityInfo = <InlineLink to={t('apply:eligibility.dob-eligibility.eligibility-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const taxInfo = <InlineLink to={t('apply:eligibility.file-your-taxes.tax-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -74,32 +74,27 @@ export default function ApplyFlowDobEligibility() {
   }
 
   return (
-    <div className="max-w-prose">
+    <>
       <div className="mb-8 space-y-4">
-        <p>{t('apply:eligibility.dob-eligibility.ineligible-to-apply')}</p>
-        <p>{t('apply:eligibility.dob-eligibility.currently-accepting')}</p>
-        <p>{t('apply:eligibility.dob-eligibility.later-date')}</p>
+        <p>{t('apply:eligibility.file-your-taxes.ineligible-to-apply')}</p>
+        <p>{t('apply:eligibility.file-your-taxes.tax-not-filed')}</p>
+        <p>{t('apply:eligibility.file-your-taxes.unable-to-assess')}</p>
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.file-your-taxes.tax-info" components={{ taxInfo }} />
         </p>
+        <p>{t('apply:eligibility.file-your-taxes.apply-after')}</p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Find out when you can apply click">
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - File your taxes click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:eligibility.dob-eligibility.back-btn')}
+          {t('apply:eligibility.file-your-taxes.back-btn')}
         </ButtonLink>
-        <ButtonLink
-          type="submit"
-          variant="primary"
-          onClick={() => sessionStorage.removeItem('flow.state')}
-          to={t('apply:eligibility.dob-eligibility.return-btn-link')}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Find out when you can apply click"
-        >
-          {t('apply:eligibility.dob-eligibility.return-btn')}
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - File your taxes click">
+          {t('apply:eligibility.file-your-taxes.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
-        </ButtonLink>
+        </Button>
       </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
@@ -9,7 +9,7 @@ import { differenceInYears, isPast, isValid, parse } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
@@ -53,7 +53,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   if (state.applicantInformation === undefined || !applyRouteHelpers.hasPartner(state.applicantInformation)) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
   }
 
   const csrfToken = String(session.get('csrfToken'));
@@ -165,10 +165,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { partnerInformation: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/personal-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/personal-information', params));
 }
 
 export default function ApplyFlowApplicationInformation() {
@@ -301,7 +301,7 @@ export default function ApplyFlowApplicationInformation() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId={defaultState ? '$lang+/_public+/apply+/$id+/review-information' : '$lang+/_public+/apply+/$id+/applicant-information'}
+                routeId={defaultState ? '$lang+/_public+/apply+/$id+/adult/review-information' : '$lang+/_public+/apply+/$id+/adult/applicant-information'}
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Spouse or Common-law partner information click"
@@ -317,7 +317,7 @@ export default function ApplyFlowApplicationInformation() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang+/_public+/apply+/$id+/applicant-information"
+                routeId="$lang+/_public+/apply+/$id+/adult/applicant-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Spouse or Common-law partner information click"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -248,10 +248,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { personalInformation: updatedData } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/communication-preference', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/communication-preference', params));
 }
 
 export default function ApplyFlowPersonalInformation() {
@@ -611,7 +611,7 @@ export default function ApplyFlowPersonalInformation() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Personal information click">
                 {t('apply:personal-information.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Personal information click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Personal information click">
                 {t('apply:personal-information.cancel-btn')}
               </ButtonLink>
             </div>
@@ -623,7 +623,7 @@ export default function ApplyFlowPersonalInformation() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId={[MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED].includes(Number(maritalStatus)) ? '$lang+/_public+/apply+/$id+/partner-information' : '$lang+/_public+/apply+/$id+/applicant-information'}
+                routeId={[MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED].includes(Number(maritalStatus)) ? '$lang+/_public+/apply+/$id+/adult/partner-information' : '$lang+/_public+/apply+/$id+/adult/applicant-information'}
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Personal information click"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/review-information.tsx
@@ -10,7 +10,7 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { parse } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -243,7 +243,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   };
 
   await applyRouteHelpers.saveState({ params, request, session, state: { submissionInfo } });
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/confirmation', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/confirmation', params));
 }
 
 export default function ReviewInformation() {
@@ -313,7 +313,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.full-name-title')}>
                 {`${userInfo.firstName} ${userInfo.lastName}`}
                 <p className="mt-4">
-                  <InlineLink id="change-full-name" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
+                  <InlineLink id="change-full-name" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
                     {t('apply:review-information.full-name-change')}
                   </InlineLink>
                 </p>
@@ -321,7 +321,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.dob-title')}>
                 {userInfo.birthday}
                 <p className="mt-4">
-                  <InlineLink id="change-date-of-birth" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params}>
+                  <InlineLink id="change-date-of-birth" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params}>
                     {t('apply:review-information.dob-change')}
                   </InlineLink>
                 </p>
@@ -329,7 +329,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.sin-title')}>
                 {formatSin(userInfo.sin)}
                 <p className="mt-4">
-                  <InlineLink id="change-sin" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
+                  <InlineLink id="change-sin" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
                     {t('apply:review-information.sin-change')}
                   </InlineLink>
                 </p>
@@ -337,7 +337,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.marital-title')}>
                 {maritalStatus}
                 <p className="mt-4">
-                  <InlineLink id="change-martial-status" routeId="$lang+/_public+/apply+/$id+/applicant-information" params={params}>
+                  <InlineLink id="change-martial-status" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
                     {t('apply:review-information.marital-change')}
                   </InlineLink>
                 </p>
@@ -351,7 +351,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.full-name-title')}>
                   {`${spouseInfo.firstName} ${spouseInfo.lastName}`}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-full-name" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
+                    <InlineLink id="change-spouse-full-name" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
                       {t('apply:review-information.full-name-change')}
                     </InlineLink>
                   </p>
@@ -359,7 +359,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.dob-title')}>
                   {spouseInfo.birthday}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
+                    <InlineLink id="change-spouse-date-of-birth" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
                       {t('apply:review-information.dob-change')}
                     </InlineLink>
                   </p>
@@ -367,7 +367,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.sin-title')}>
                   {formatSin(spouseInfo.sin)}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-sin" routeId="$lang+/_public+/apply+/$id+/partner-information" params={params}>
+                    <InlineLink id="change-spouse-sin" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
                       {t('apply:review-information.sin-change')}
                     </InlineLink>
                   </p>
@@ -382,7 +382,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.phone-title')}>
                 {userInfo.phoneNumber}
                 <p className="mt-4">
-                  <InlineLink id="change-phone-number" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
+                  <InlineLink id="change-phone-number" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
                     {t('apply:review-information.phone-change')}
                   </InlineLink>
                 </p>
@@ -390,7 +390,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.alt-phone-title')}>
                 {userInfo.altPhoneNumber}
                 <p className="mt-4">
-                  <InlineLink id="change-alternate-phone-number" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
+                  <InlineLink id="change-alternate-phone-number" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
                     {t('apply:review-information.alt-phone-change')}
                   </InlineLink>
                 </p>
@@ -406,7 +406,7 @@ export default function ReviewInformation() {
                   altFormat={true}
                 />
                 <p className="mt-4">
-                  <InlineLink id="change-mailing-address" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
+                  <InlineLink id="change-mailing-address" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
                     {t('apply:review-information.mailing-change')}
                   </InlineLink>
                 </p>
@@ -422,7 +422,7 @@ export default function ReviewInformation() {
                   altFormat={true}
                 />
                 <p className="mt-4">
-                  <InlineLink id="change-home-address" routeId="$lang+/_public+/apply+/$id+/personal-information" params={params}>
+                  <InlineLink id="change-home-address" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
                     {t('apply:review-information.home-change')}
                   </InlineLink>
                 </p>
@@ -443,7 +443,7 @@ export default function ReviewInformation() {
                   </div>
                 )}
                 <p className="mt-4">
-                  <InlineLink id="change-communication-preference" routeId="$lang+/_public+/apply+/$id+/communication-preference" params={params}>
+                  <InlineLink id="change-communication-preference" routeId="$lang+/_public+/apply+/$id+/adult/communication-preference" params={params}>
                     {t('apply:review-information.comm-pref-change')}
                   </InlineLink>
                 </p>
@@ -452,7 +452,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply:review-information.lang-pref-title')}>
                   {getNameByLanguage(i18n.language, preferredLanguage)}
                   <p className="mt-4">
-                    <InlineLink id="change-language-preference" routeId="$lang+/_public+/apply+/$id+/communication-preference" params={params}>
+                    <InlineLink id="change-language-preference" routeId="$lang+/_public+/apply+/$id+/adult/communication-preference" params={params}>
                       {t('apply:review-information.lang-pref-change')}
                     </InlineLink>
                   </p>
@@ -466,7 +466,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply:review-information.dental-insurance-title')}>
                 {dentalInsurance ? t('apply:review-information.yes') : t('apply:review-information.no')}
                 <p className="mt-4">
-                  <InlineLink id="change-access-dental" routeId="$lang+/_public+/apply+/$id+/dental-insurance" params={params}>
+                  <InlineLink id="change-access-dental" routeId="$lang+/_public+/apply+/$id+/adult/dental-insurance" params={params}>
                     {t('apply:review-information.dental-insurance-change')}
                   </InlineLink>
                 </p>
@@ -487,7 +487,7 @@ export default function ReviewInformation() {
                   <>{t('apply:review-information.no')}</>
                 )}
                 <p className="mt-4">
-                  <InlineLink id="change-dental-benefits" routeId="$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits" params={params}>
+                  <InlineLink id="change-dental-benefits" routeId="$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits" params={params}>
                     {t('apply:review-information.dental-benefit-change')}
                   </InlineLink>
                 </p>
@@ -506,7 +506,7 @@ export default function ReviewInformation() {
             {t('apply:review-information.submit-button')}
             {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
           </Button>
-          <ButtonLink routeId="$lang+/_public+/apply+/$id+/exit-application" params={params} variant="alternative" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Review Information click">
+          <ButtonLink routeId="$lang+/_public+/apply+/$id+/adult/exit-application" params={params} variant="alternative" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Review Information click">
             {t('apply:review-information.exit-button')}
             <FontAwesomeIcon icon={faX} className="ms-3 block size-4" />
           </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/tax-filing.tsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -80,10 +80,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { taxFiling2023: parsedDataResult.data } });
 
   if (parsedDataResult.data === TaxFilingOption.No) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/file-taxes', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/file-taxes', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
 }
 
 export default function ApplyFlowTaxFiling() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/disability-tax-credit.tsx
@@ -51,7 +51,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const parseDateOfBirth = parse(state.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);
   if (age < 18 || age > 64) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
   }
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit });
@@ -86,10 +86,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { disabilityTaxCredit: parsedDataResult.data } });
 
   if (parsedDataResult.data === DisabilityTaxCreditOption.No) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/dob-eligibility', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/dob-eligibility', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/applicant-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
 }
 
 export default function ApplyFlowDisabilityTaxCredit() {
@@ -151,7 +151,7 @@ export default function ApplyFlowDisabilityTaxCredit() {
               {t('apply:disability-tax-credit.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
-            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
               {t('apply:disability-tax-credit.back-btn')}
             </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/living-independently.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/living-independently.tsx
@@ -83,10 +83,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { livingIndependently: parsedDataResult.data } });
 
   if (parsedDataResult.data === LivingIndependentlyOption.Yes) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/parent-or-guardian', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));
 }
 
 export default function ApplyFlowLivingIndependently() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const parseDateOfBirth = parse(state.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);
   if (age > 16) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
   }
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit });
@@ -84,7 +84,7 @@ export default function ApplyFlowParentOrGuardian() {
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply:parent-or-guardian.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -86,10 +86,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   await applyRouteHelpers.saveState({ params, request, session, state: { typeOfApplication: parsedDataResult.data } });
 
   if (parsedDataResult.data === ApplicantType.Delegate) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/tax-filing', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/tax-filing', params));
 }
 
 export default function ApplyFlowTypeOfApplication() {


### PR DESCRIPTION
### Description
This PR moves the adult flow to `/apply/$id+/adult+/`.  

Locales have not been moved.  

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`