### PR TITLE
clean up locales for adult apply flow

### DIFF
--- a/frontend/__tests__/routes/_public+/type-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-application.test.tsx
@@ -70,7 +70,7 @@ describe('_public.apply.id.type-of-application', () => {
 
       const data = await response.json();
       expect(response.status).toBe(200);
-      expect(data.errors).toContain('apply:eligibility.type-of-application.error-message.type-of-application-required');
+      expect(data.errors).toContain('apply:type-of-application.error-message.type-of-application-required');
     });
 
     it('should redirect to error page if delegate is selected', async () => {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/applicant-information.tsx
@@ -42,9 +42,9 @@ export type ApplicantInformationState = {
 };
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.applicantInformation,
-  pageTitleI18nKey: 'apply:applicant-information.page-title',
+  pageTitleI18nKey: 'adult-apply:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -59,7 +59,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const maritalStatuses = await lookupService.getAllMaritalStatuses();
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:applicant-information.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:applicant-information.page-title') }) };
 
   return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, editMode: state.editMode });
 }
@@ -86,7 +86,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
 
     if (applyRouteHelpers.hasPartner(state.applicantInformation) && state.partnerInformation === undefined) {
-      const errorMessage = t('apply:applicant-information.error-message.marital-status-no-partner-information');
+      const errorMessage = t('adult-apply:applicant-information.error-message.marital-status-no-partner-information');
       const errors: z.ZodFormattedError<ApplicantInformationState, string> = { _errors: [errorMessage], maritalStatus: { _errors: [errorMessage] } };
       return json({ errors });
     }
@@ -100,24 +100,24 @@ export async function action({ context: { session }, params, request }: ActionFu
     socialInsuranceNumber: z
       .string()
       .trim()
-      .min(1, t('apply:applicant-information.error-message.sin-required'))
+      .min(1, t('adult-apply:applicant-information.error-message.sin-required'))
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:applicant-information.error-message.sin-valid'), fatal: true });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:applicant-information.error-message.sin-valid'), fatal: true });
           return z.NEVER;
         }
 
         if (state.partnerInformation && formatSin(sin) === formatSin(state.partnerInformation.socialInsuranceNumber)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:applicant-information.error-message.sin-unique'), fatal: true });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:applicant-information.error-message.sin-unique'), fatal: true });
           return z.NEVER;
         }
       }),
-    firstName: z.string().trim().min(1, t('apply:applicant-information.error-message.first-name-required')).max(100),
-    lastName: z.string().trim().min(1, t('apply:applicant-information.error-message.last-name-required')).max(100),
+    firstName: z.string().trim().min(1, t('adult-apply:applicant-information.error-message.first-name-required')).max(100),
+    lastName: z.string().trim().min(1, t('adult-apply:applicant-information.error-message.last-name-required')).max(100),
     maritalStatus: z
-      .string({ errorMap: () => ({ message: t('apply:applicant-information.error-message.marital-status-required') }) })
+      .string({ errorMap: () => ({ message: t('adult-apply:applicant-information.error-message.marital-status-required') }) })
       .trim()
-      .min(1, t('apply:applicant-information.error-message.marital-status-required')),
+      .min(1, t('adult-apply:applicant-information.error-message.marital-status-required')),
   }) satisfies z.ZodType<ApplicantInformationState>;
 
   const data = {
@@ -251,21 +251,21 @@ export default function ApplyFlowApplicationInformation() {
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Applicant Information click">
-                {t('apply:applicant-information.save-btn')}
+                {t('adult-apply:applicant-information.save-btn')}
               </Button>
               <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Applicant Information click">
-                {t('apply:applicant-information.cancel-btn')}
+                {t('adult-apply:applicant-information.cancel-btn')}
               </Button>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button id="continue-button" name="_action" value={FormAction.Continue} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Applicant Information click">
-                {t('apply:applicant-information.continue-btn')}
+                {t('adult-apply:applicant-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:applicant-information.back-btn')}
+                {t('adult-apply:applicant-information.back-btn')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx
@@ -19,9 +19,9 @@ import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.applicationDelegate,
-  pageTitleI18nKey: 'apply:eligibility.application-delegate.page-title',
+  pageTitleI18nKey: 'adult-apply:eligibility.application-delegate.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,7 +35,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.application-delegate.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:eligibility.application-delegate.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
@@ -56,7 +56,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   await applyRouteHelpers.clearState({ params, request, session });
 
-  return redirect(t('apply:eligibility.application-delegate.return-btn-link'));
+  return redirect(t('adult-apply:eligibility.application-delegate.return-btn-link'));
 }
 
 export default function ApplyFlowApplicationDelegate() {
@@ -66,8 +66,8 @@ export default function ApplyFlowApplicationDelegate() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const contactServiceCanada = <InlineLink to={t('apply:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" target="_blank" />;
-  const preparingToApply = <InlineLink to={t('apply:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const contactServiceCanada = <InlineLink to={t('adult-apply:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const preparingToApply = <InlineLink to={t('adult-apply:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" target="_blank" />;
   const span = <span className="whitespace-nowrap" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -80,20 +80,20 @@ export default function ApplyFlowApplicationDelegate() {
     <>
       <div className="mb-8 space-y-4">
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:eligibility.application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
         </p>
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applying on behalf of someone click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:eligibility.application-delegate.back-btn')}
+          {t('adult-apply:eligibility.application-delegate.back-btn')}
         </ButtonLink>
         <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Applying on behalf of someone click">
-          {t('apply:eligibility.application-delegate.return-btn')}
+          {t('adult-apply:eligibility.application-delegate.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -37,9 +37,9 @@ export interface CommunicationPreferencesState {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.communicationPreference,
-  pageTitleI18nKey: 'apply:communication-preference.page-title',
+  pageTitleI18nKey: 'adult-apply:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -61,7 +61,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   }
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:communication-preference.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:communication-preference.page-title') }) };
 
   return json({
     communicationMethodEmail,
@@ -89,25 +89,25 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   const formSchema = z
     .object({
-      preferredLanguage: z.string().trim().min(1, t('apply:communication-preference.error-message.preferred-language-required')),
-      preferredMethod: z.string().trim().min(1, t('apply:communication-preference.error-message.preferred-method-required')),
+      preferredLanguage: z.string().trim().min(1, t('adult-apply:communication-preference.error-message.preferred-language-required')),
+      preferredMethod: z.string().trim().min(1, t('adult-apply:communication-preference.error-message.preferred-method-required')),
       email: z.string().trim().max(100).optional(),
       confirmEmail: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:communication-preference.error-message.email-required'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:communication-preference.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:communication-preference.error-message.email-valid'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
         if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
         } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
         } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
     }) satisfies z.ZodType<CommunicationPreferencesState>;
@@ -196,14 +196,25 @@ export default function ApplyFlowCommunicationPreferencePage() {
       append: preferredMethodValue === communicationMethodEmail.id && (
         <div className="mb-6 grid gap-6 md:grid-cols-2">
           <p className="md:col-span-2" id="email-note">
-            {t('apply:communication-preference.email-note')}
+            {t('adult-apply:communication-preference.email-note')}
           </p>
-          <InputField id="email" type="email" className="w-full" label={t('apply:communication-preference.email')} maxLength={100} name="email" errorMessage={errorMessages.email} autoComplete="email" defaultValue={defaultState.email ?? ''} required />
+          <InputField
+            id="email"
+            type="email"
+            className="w-full"
+            label={t('adult-apply:communication-preference.email')}
+            maxLength={100}
+            name="email"
+            errorMessage={errorMessages.email}
+            autoComplete="email"
+            defaultValue={defaultState.email ?? ''}
+            required
+          />
           <InputField
             id="confirm-email"
             type="email"
             className="w-full"
-            label={t('apply:communication-preference.confirm-email')}
+            label={t('adult-apply:communication-preference.confirm-email')}
             maxLength={100}
             name="confirmEmail"
             errorMessage={errorMessages['confirm-email']}
@@ -229,7 +240,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <p className="mb-6" id="form-instructions-note">
-          {t('apply:communication-preference.note')}
+          {t('adult-apply:communication-preference.note')}
         </p>
         <p className="mb-6 italic" id="form-instructions">
           {t('apply:required-label')}
@@ -241,7 +252,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
               <InputRadios
                 id="preferred-language"
                 name="preferredLanguage"
-                legend={t('apply:communication-preference.preferred-language')}
+                legend={t('adult-apply:communication-preference.preferred-language')}
                 options={preferredLanguages.map((language) => ({
                   defaultChecked: defaultState.preferredLanguage === language.id,
                   children: getNameByLanguage(i18n.language, language),
@@ -252,13 +263,13 @@ export default function ApplyFlowCommunicationPreferencePage() {
               />
             )}
             {preferredCommunicationMethods.length > 0 && (
-              <InputRadios id="preferred-methods" legend={t('apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages['input-radio-preferred-methods-option-0']} required />
+              <InputRadios id="preferred-methods" legend={t('adult-apply:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages['input-radio-preferred-methods-option-0']} required />
             )}
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Communication preference click">
-                {t('apply:communication-preference.save-btn')}
+                {t('adult-apply:communication-preference.save-btn')}
               </Button>
               <ButtonLink
                 id="back-button"
@@ -267,13 +278,13 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Communication preference click"
               >
-                {t('apply:communication-preference.cancel-btn')}
+                {t('adult-apply:communication-preference.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Communication preference click">
-                {t('apply:communication-preference.continue')}
+                {t('adult-apply:communication-preference.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink
@@ -284,7 +295,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Communication preference click"
               >
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:communication-preference.back')}
+                {t('adult-apply:communication-preference.back')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
@@ -26,9 +26,9 @@ import { formatSin } from '~/utils/sin-utils';
 export const applyIdParamSchema = z.string().uuid();
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.confirmation,
-  pageTitleI18nKey: 'apply:confirm.page-title',
+  pageTitleI18nKey: 'adult-apply:confirm.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -132,7 +132,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   };
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:confirm.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:confirm.page-title') }) };
 
   return json({
     dentalInsurance,
@@ -173,7 +173,7 @@ export default function ApplyFlowConfirm() {
   const mscaLink = <InlineLink to={t('confirm.msca-link')} className="external-link font-lato font-semibold" target="_blank" />;
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} className="external-link font-lato font-semibold" target="_blank" />;
   const moreInfoLink = <InlineLink to={t('confirm.more-info-link')} className="external-link font-lato font-semibold" target="_blank" />;
-  const cdcpLink = <InlineLink to={t('apply:confirm.status-checker-link')} className="external-link font-lato font-semibold" target="_blank" />;
+  const cdcpLink = <InlineLink to={t('adult-apply:confirm.status-checker-link')} className="external-link font-lato font-semibold" target="_blank" />;
 
   // this link will be used in a future release
   // const cdcpLink = <InlineLink routeId="$lang+/_public+/status+/index" params={params} className="external-link font-lato font-semibold" target='_blank' />;
@@ -313,8 +313,8 @@ export default function ApplyFlowConfirm() {
             <DescriptionListItem term={t('confirm.dental-public')}>
               {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
                 <>
-                  <p>{t('apply:review-information.yes')}</p>
-                  <p>{t('apply:review-information.dental-benefit-has-access')}</p>
+                  <p>{t('adult-apply:review-information.yes')}</p>
+                  <p>{t('adult-apply:review-information.dental-benefit-has-access')}</p>
                   <div>
                     <ul className="ml-6 list-disc">
                       {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
@@ -346,7 +346,7 @@ export default function ApplyFlowConfirm() {
       <fetcher.Form method="post" noValidate className="mt-5 flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <Button variant="primary" onClick={() => sessionStorage.removeItem('flow.state')} size="lg" className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Confirmation click">
-          {t('apply:confirm.exit')}
+          {t('adult-apply:confirm.exit')}
         </Button>
       </fetcher.Form>
     </div>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
@@ -35,9 +35,9 @@ enum AllChildrenUnder18Option {
 export type AllChildrenUnder18State = `${AllChildrenUnder18Option}`;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.dateOfBirth,
-  pageTitleI18nKey: 'apply:eligibility.date-of-birth.page-title',
+  pageTitleI18nKey: 'adult-apply:eligibility.date-of-birth.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -50,7 +50,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.date-of-birth.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:eligibility.date-of-birth.page-title') }) };
 
   const { dateOfBirth, allChildrenUnder18 } = state;
   return json({ id: state.id, csrfToken, meta, defaultState: { dateOfBirth, allChildrenUnder18 }, editMode: state.editMode });
@@ -76,27 +76,27 @@ export async function action({ context: { session }, params, request }: ActionFu
     .object({
       dateOfBirthYear: z
         .number({
-          required_error: t('apply:eligibility.date-of-birth.error-message.date-of-birth-year-required'),
-          invalid_type_error: t('apply:eligibility.date-of-birth.error-message.date-of-birth-year-number'),
+          required_error: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-year-required'),
+          invalid_type_error: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-year-number'),
         })
         .int()
         .positive(),
       dateOfBirthMonth: z
         .number({
-          required_error: t('apply:eligibility.date-of-birth.error-message.date-of-birth-month-required'),
+          required_error: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-month-required'),
         })
         .int()
         .positive(),
       dateOfBirthDay: z
         .number({
-          required_error: t('apply:eligibility.date-of-birth.error-message.date-of-birth-day-required'),
-          invalid_type_error: t('apply:eligibility.date-of-birth.error-message.date-of-birth-day-number'),
+          required_error: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-day-required'),
+          invalid_type_error: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-day-number'),
         })
         .int()
         .positive(),
       dateOfBirth: z.string(),
       allChildrenUnder18: z.nativeEnum(AllChildrenUnder18Option, {
-        errorMap: () => ({ message: t('apply:eligibility.date-of-birth.error-message.child-age-required') }),
+        errorMap: () => ({ message: t('adult-apply:eligibility.date-of-birth.error-message.child-age-required') }),
       }),
     })
     .superRefine((val, ctx) => {
@@ -108,19 +108,19 @@ export async function action({ context: { session }, params, request }: ActionFu
       if (!isValid(parsedDateOfBirth)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('apply:eligibility.date-of-birth.error-message.date-of-birth-valid'),
+          message: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-valid'),
           path: ['dateOfBirth'],
         });
       } else if (!isPast(parsedDateOfBirth)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('apply:eligibility.date-of-birth.error-message.date-of-birth-is-past'),
+          message: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-is-past'),
           path: ['dateOfBirth'],
         });
       } else if (differenceInYears(new Date(), parsedDateOfBirth) > 150) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('apply:eligibility.date-of-birth.error-message.date-of-birth-is-past-valid'),
+          message: t('adult-apply:eligibility.date-of-birth.error-message.date-of-birth-is-past-valid'),
           path: ['dateOfBirth'],
         });
       }
@@ -218,7 +218,7 @@ export default function ApplyFlowDateOfBirth() {
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <p className="mb-6" id="dob-desc">
-          {t('apply:eligibility.date-of-birth.description')}
+          {t('adult-apply:eligibility.date-of-birth.description')}
         </p>
         <p className="mb-2 italic" id="form-instructions">
           {t('apply:required-label')}
@@ -226,7 +226,7 @@ export default function ApplyFlowDateOfBirth() {
         <fetcher.Form method="post" aria-describedby="dob-desc form-instructions" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-6 space-y-4">
-            <h2 className="text-xl font-bold">{t('apply:eligibility.date-of-birth.age-heading')}</h2>
+            <h2 className="text-xl font-bold">{t('adult-apply:eligibility.date-of-birth.age-heading')}</h2>
             <DatePickerField
               id="date-of-birth"
               names={{
@@ -235,7 +235,7 @@ export default function ApplyFlowDateOfBirth() {
                 year: 'dateOfBirthYear',
               }}
               defaultValue={defaultState.dateOfBirth ?? ''}
-              legend={t('apply:eligibility.date-of-birth.form-instructions')}
+              legend={t('adult-apply:eligibility.date-of-birth.form-instructions')}
               errorMessages={{
                 all: fetcher.data?.errors.dateOfBirth?._errors[0],
                 year: fetcher.data?.errors.dateOfBirthYear?._errors[0],
@@ -244,40 +244,40 @@ export default function ApplyFlowDateOfBirth() {
               }}
               required
             />
-            <h2 className="text-xl font-bold">{t('apply:eligibility.date-of-birth.child-age-heading')}</h2>
+            <h2 className="text-xl font-bold">{t('adult-apply:eligibility.date-of-birth.child-age-heading')}</h2>
             <InputRadios
               id="child-under-18"
               name="allChildrenUnder18"
-              legend={t('apply:eligibility.date-of-birth.child-age-instruction')}
+              legend={t('adult-apply:eligibility.date-of-birth.child-age-instruction')}
               options={[
-                { value: AllChildrenUnder18Option.Yes, children: t('apply:eligibility.date-of-birth.yes'), defaultChecked: defaultState.allChildrenUnder18 === AllChildrenUnder18Option.Yes },
-                { value: AllChildrenUnder18Option.No, children: t('apply:eligibility.date-of-birth.no'), defaultChecked: defaultState.allChildrenUnder18 === AllChildrenUnder18Option.No },
+                { value: AllChildrenUnder18Option.Yes, children: t('adult-apply:eligibility.date-of-birth.yes'), defaultChecked: defaultState.allChildrenUnder18 === AllChildrenUnder18Option.Yes },
+                { value: AllChildrenUnder18Option.No, children: t('adult-apply:eligibility.date-of-birth.no'), defaultChecked: defaultState.allChildrenUnder18 === AllChildrenUnder18Option.No },
               ]}
               errorMessage={fetcher.data?.errors.allChildrenUnder18?._errors[0]}
               required
             />
-            <Collapsible summary={t('apply:eligibility.date-of-birth.collapsible-content-summary')}>
-              <p>{t('apply:eligibility.date-of-birth.collapsible-content-detail')}</p>
+            <Collapsible summary={t('adult-apply:eligibility.date-of-birth.collapsible-content-summary')}>
+              <p>{t('adult-apply:eligibility.date-of-birth.collapsible-content-detail')}</p>
             </Collapsible>
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Date of birth click">
-                {t('apply:eligibility.date-of-birth.save-btn')}
+                {t('adult-apply:eligibility.date-of-birth.save-btn')}
               </Button>
               <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Date of birth click">
-                {t('apply:eligibility.date-of-birth.cancel-btn')}
+                {t('adult-apply:eligibility.date-of-birth.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Date of birth click">
-                {t('apply:eligibility.date-of-birth.continue-btn')}
+                {t('adult-apply:eligibility.date-of-birth.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Date of birth click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:eligibility.date-of-birth.back-btn')}
+                {t('adult-apply:eligibility.date-of-birth.back-btn')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance.tsx
@@ -28,9 +28,9 @@ import { cn } from '~/utils/tw-utils';
 export type DentalInsuranceState = boolean;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.dentalInsurance,
-  pageTitleI18nKey: 'apply:dental-insurance.title',
+  pageTitleI18nKey: 'adult-apply:dental-insurance.title',
 };
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -43,7 +43,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:dental-insurance.title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:dental-insurance.title') }) };
 
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
@@ -56,7 +56,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema
-  const dentalInsuranceSchema: z.ZodType<DentalInsuranceState> = z.boolean({ errorMap: () => ({ message: t('apply:dental-insurance.error-message.dental-insurance-required') }) });
+  const dentalInsuranceSchema: z.ZodType<DentalInsuranceState> = z.boolean({ errorMap: () => ({ message: t('adult-apply:dental-insurance.error-message.dental-insurance-required') }) });
 
   const formData = await request.formData();
   const expectedCsrfToken = String(session.get('csrfToken'));

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/dob-eligibility.tsx
@@ -19,9 +19,9 @@ import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.dateOfBirthEligibility,
-  pageTitleI18nKey: 'apply:eligibility.dob-eligibility.page-title',
+  pageTitleI18nKey: 'adult-apply:eligibility.dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,7 +35,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.dob-eligibility.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:eligibility.dob-eligibility.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
@@ -65,7 +65,7 @@ export default function ApplyFlowDobEligibility() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const eligibilityInfo = <InlineLink to={t('apply:eligibility.dob-eligibility.eligibility-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const eligibilityInfo = <InlineLink to={t('adult-apply:eligibility.dob-eligibility.eligibility-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -76,27 +76,27 @@ export default function ApplyFlowDobEligibility() {
   return (
     <div className="max-w-prose">
       <div className="mb-8 space-y-4">
-        <p>{t('apply:eligibility.dob-eligibility.ineligible-to-apply')}</p>
-        <p>{t('apply:eligibility.dob-eligibility.currently-accepting')}</p>
-        <p>{t('apply:eligibility.dob-eligibility.later-date')}</p>
+        <p>{t('adult-apply:eligibility.dob-eligibility.ineligible-to-apply')}</p>
+        <p>{t('adult-apply:eligibility.dob-eligibility.currently-accepting')}</p>
+        <p>{t('adult-apply:eligibility.dob-eligibility.later-date')}</p>
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:eligibility.dob-eligibility.eligibility-info" components={{ eligibilityInfo }} />
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Find out when you can apply click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:eligibility.dob-eligibility.back-btn')}
+          {t('adult-apply:eligibility.dob-eligibility.back-btn')}
         </ButtonLink>
         <ButtonLink
           type="submit"
           variant="primary"
           onClick={() => sessionStorage.removeItem('flow.state')}
-          to={t('apply:eligibility.dob-eligibility.return-btn-link')}
+          to={t('adult-apply:eligibility.dob-eligibility.return-btn-link')}
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Find out when you can apply click"
         >
-          {t('apply:eligibility.dob-eligibility.return-btn')}
+          {t('adult-apply:eligibility.dob-eligibility.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </ButtonLink>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/exit-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/exit-application.tsx
@@ -16,9 +16,9 @@ import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.exitApplication,
-  pageTitleI18nKey: 'apply:exit-application.page-title',
+  pageTitleI18nKey: 'adult-apply:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -32,7 +32,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:exit-application.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:exit-application.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
@@ -65,17 +65,17 @@ export default function ApplyFlowTaxFiling() {
   return (
     <div className="max-w-prose">
       <div className="mb-8 space-y-4">
-        <p>{t('apply:exit-application.are-you-sure')}</p>
-        <p>{t('apply:exit-application.click-back')}</p>
+        <p>{t('adult-apply:exit-application.are-you-sure')}</p>
+        <p>{t('adult-apply:exit-application.click-back')}</p>
       </div>
       <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Exit Application click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:exit-application.back-btn')}
+          {t('adult-apply:exit-application.back-btn')}
         </ButtonLink>
         <Button variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Exit Application click">
-          {t('apply:exit-application.exit-btn')}
+          {t('adult-apply:exit-application.exit-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits.tsx
@@ -52,9 +52,9 @@ interface ProvincialTerritorialBenefitsState {
 export type DentalBenefitsState = FederalBenefitsState & ProvincialTerritorialBenefitsState;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.federalProvincialTerritorialBenefits,
-  pageTitleI18nKey: 'apply:dental-benefits.title',
+  pageTitleI18nKey: 'adult-apply:dental-benefits.title',
 };
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -74,7 +74,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const regions = allRegions.filter((region) => region.countryId === CANADA_COUNTRY_ID);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:dental-benefits.title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:dental-benefits.title') }) };
 
   return json({
     csrfToken,
@@ -98,13 +98,13 @@ export async function action({ context: { session }, params, request }: ActionFu
   // both question first before the superRefine can be executed
   const federalBenefitsSchema = z
     .object({
-      hasFederalBenefits: z.boolean({ errorMap: () => ({ message: t('apply:dental-benefits.error-message.federal-benefit-required') }) }),
+      hasFederalBenefits: z.boolean({ errorMap: () => ({ message: t('adult-apply:dental-benefits.error-message.federal-benefit-required') }) }),
       federalSocialProgram: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
       if (val.hasFederalBenefits) {
         if (!val.federalSocialProgram || validator.isEmpty(val.federalSocialProgram)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.program-required'), path: ['federalSocialProgram'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:dental-benefits.error-message.program-required'), path: ['federalSocialProgram'] });
         }
       }
     })
@@ -117,16 +117,16 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   const provincialTerritorialBenefitsSchema = z
     .object({
-      hasProvincialTerritorialBenefits: z.boolean({ errorMap: () => ({ message: t('apply:dental-benefits.error-message.provincial-benefit-required') }) }),
+      hasProvincialTerritorialBenefits: z.boolean({ errorMap: () => ({ message: t('adult-apply:dental-benefits.error-message.provincial-benefit-required') }) }),
       provincialTerritorialSocialProgram: z.string().trim().optional(),
       province: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
       if (val.hasProvincialTerritorialBenefits) {
         if (!val.province || validator.isEmpty(val.province)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.provincial-territorial-required'), path: ['province'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:dental-benefits.error-message.provincial-territorial-required'), path: ['province'] });
         } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:dental-benefits.error-message.program-required'), path: ['provincialTerritorialSocialProgram'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:dental-benefits.error-message.program-required'), path: ['provincialTerritorialSocialProgram'] });
         }
       }
     })
@@ -271,28 +271,28 @@ export default function AccessToDentalInsuranceQuestion() {
           <input type="hidden" name="_csrf" value={csrfToken} />
           <section>
             <p className="mb-4" id="access-to-benefits-note">
-              {t('apply:dental-benefits.access-to-dental')}
+              {t('adult-apply:dental-benefits.access-to-dental')}
             </p>
             <p className="mb-4" id="eligibility-note">
-              {t('apply:dental-benefits.eligibility-criteria')}
+              {t('adult-apply:dental-benefits.eligibility-criteria')}
             </p>
             <p className="mb-6 italic" id="form-instructions">
               {t('apply:required-label')}
             </p>
-            <h2 className="my-6 font-lato text-2xl font-bold">{t('apply:dental-benefits.federal-benefits.title')}</h2>
+            <h2 className="my-6 font-lato text-2xl font-bold">{t('adult-apply:dental-benefits.federal-benefits.title')}</h2>
             <InputRadios
               id="has-federal-benefits"
               name="hasFederalBenefits"
-              legend={t('apply:dental-benefits.federal-benefits.legend')}
+              legend={t('adult-apply:dental-benefits.federal-benefits.legend')}
               options={[
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:dental-benefits.federal-benefits.option-no" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:dental-benefits.federal-benefits.option-no" />,
                   value: HasFederalBenefitsOption.No,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:dental-benefits.federal-benefits.option-yes" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:dental-benefits.federal-benefits.option-yes" />,
                   value: HasFederalBenefitsOption.Yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
@@ -300,7 +300,7 @@ export default function AccessToDentalInsuranceQuestion() {
                     <InputRadios
                       id="federal-social-programs"
                       name="federalSocialProgram"
-                      legend={t('apply:dental-benefits.federal-benefits.social-programs.legend')}
+                      legend={t('adult-apply:dental-benefits.federal-benefits.social-programs.legend')}
                       options={federalSocialPrograms.map((option) => ({
                         children: getNameByLanguage(i18n.language, option),
                         defaultChecked: defaultState?.federalSocialProgram === option.id,
@@ -317,21 +317,21 @@ export default function AccessToDentalInsuranceQuestion() {
             />
           </section>
           <section>
-            <h2 className="my-6 font-lato text-2xl font-bold">{t('apply:dental-benefits.provincial-territorial-benefits.title')}</h2>
+            <h2 className="my-6 font-lato text-2xl font-bold">{t('adult-apply:dental-benefits.provincial-territorial-benefits.title')}</h2>
 
             <InputRadios
               id="has-provincial-territorial-benefits"
               name="hasProvincialTerritorialBenefits"
-              legend={t('apply:dental-benefits.provincial-territorial-benefits.legend')}
+              legend={t('adult-apply:dental-benefits.provincial-territorial-benefits.legend')}
               options={[
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:dental-benefits.provincial-territorial-benefits.option-no" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:dental-benefits.provincial-territorial-benefits.option-no" />,
                   value: HasProvincialTerritorialBenefitsOption.No,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:dental-benefits.provincial-territorial-benefits.option-yes" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:dental-benefits.provincial-territorial-benefits.option-yes" />,
                   value: HasProvincialTerritorialBenefitsOption.Yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
@@ -341,10 +341,10 @@ export default function AccessToDentalInsuranceQuestion() {
                         id="province"
                         name="province"
                         className="w-full sm:w-1/2"
-                        label={t('apply:dental-benefits.provincial-territorial-benefits.social-programs.input-legend')}
+                        label={t('adult-apply:dental-benefits.provincial-territorial-benefits.social-programs.input-legend')}
                         onChange={handleOnRegionChanged}
                         options={[
-                          { children: t('apply:dental-benefits.select-one'), value: '', hidden: true },
+                          { children: t('adult-apply:dental-benefits.select-one'), value: '', hidden: true },
                           ...sortedRegions.map((region) => ({
                             key: region.provinceTerritoryStateId,
                             id: region.provinceTerritoryStateId,
@@ -360,7 +360,7 @@ export default function AccessToDentalInsuranceQuestion() {
                         <InputRadios
                           id="provincial-territorial-social-programs"
                           name="provincialTerritorialSocialProgram"
-                          legend={t('apply:dental-benefits.provincial-territorial-benefits.social-programs.radio-legend')}
+                          legend={t('adult-apply:dental-benefits.provincial-territorial-benefits.social-programs.radio-legend')}
                           errorMessage={errorMessages['input-radio-provincial-territorial-social-programs-option-0']}
                           options={provincialTerritorialSocialPrograms
                             .filter((program) => program.provinceTerritoryStateId === provinceValue)
@@ -384,7 +384,7 @@ export default function AccessToDentalInsuranceQuestion() {
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Access to other federal, provincial or territorial dental benefits click">
-                {t('apply:dental-benefits.button.save-btn')}
+                {t('adult-apply:dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
                 id="back-button"
@@ -393,13 +393,13 @@ export default function AccessToDentalInsuranceQuestion() {
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Access to other federal, provincial or territorial dental benefits click"
               >
-                {t('apply:dental-benefits.button.cancel-btn')}
+                {t('adult-apply:dental-benefits.button.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Access to other federal, provincial or territorial dental benefits click">
-                {t('apply:dental-benefits.button.continue')}
+                {t('adult-apply:dental-benefits.button.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink
@@ -410,7 +410,7 @@ export default function AccessToDentalInsuranceQuestion() {
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Access to other federal, provincial or territorial dental benefits click"
               >
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:dental-benefits.button.back')}
+                {t('adult-apply:dental-benefits.button.back')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/file-taxes.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/file-taxes.tsx
@@ -19,9 +19,9 @@ import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.fileYourTaxes,
-  pageTitleI18nKey: 'apply:eligibility.file-your-taxes.page-title',
+  pageTitleI18nKey: 'adult-apply:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,7 +35,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.file-your-taxes.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:eligibility.file-your-taxes.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
@@ -55,7 +55,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   await applyRouteHelpers.clearState({ params, request, session });
-  return redirect(t('apply:eligibility.file-your-taxes.return-btn-link'));
+  return redirect(t('adult-apply:eligibility.file-your-taxes.return-btn-link'));
 }
 
 export default function ApplyFlowFileYourTaxes() {
@@ -65,7 +65,7 @@ export default function ApplyFlowFileYourTaxes() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const taxInfo = <InlineLink to={t('apply:eligibility.file-your-taxes.tax-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
+  const taxInfo = <InlineLink to={t('adult-apply:eligibility.file-your-taxes.tax-info-href')} className="external-link font-lato font-semibold" target="_blank" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -76,22 +76,22 @@ export default function ApplyFlowFileYourTaxes() {
   return (
     <>
       <div className="mb-8 space-y-4">
-        <p>{t('apply:eligibility.file-your-taxes.ineligible-to-apply')}</p>
-        <p>{t('apply:eligibility.file-your-taxes.tax-not-filed')}</p>
-        <p>{t('apply:eligibility.file-your-taxes.unable-to-assess')}</p>
+        <p>{t('adult-apply:eligibility.file-your-taxes.ineligible-to-apply')}</p>
+        <p>{t('adult-apply:eligibility.file-your-taxes.tax-not-filed')}</p>
+        <p>{t('adult-apply:eligibility.file-your-taxes.unable-to-assess')}</p>
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.file-your-taxes.tax-info" components={{ taxInfo }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="adult-apply:eligibility.file-your-taxes.tax-info" components={{ taxInfo }} />
         </p>
-        <p>{t('apply:eligibility.file-your-taxes.apply-after')}</p>
+        <p>{t('adult-apply:eligibility.file-your-taxes.apply-after')}</p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - File your taxes click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:eligibility.file-your-taxes.back-btn')}
+          {t('adult-apply:eligibility.file-your-taxes.back-btn')}
         </ButtonLink>
         <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - File your taxes click">
-          {t('apply:eligibility.file-your-taxes.return-btn')}
+          {t('adult-apply:eligibility.file-your-taxes.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
@@ -38,9 +38,9 @@ export interface PartnerInformationState {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.partnerInformation,
-  pageTitleI18nKey: 'apply:partner-information.page-title',
+  pageTitleI18nKey: 'adult-apply:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -57,7 +57,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   }
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:partner-information.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:partner-information.page-title') }) };
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
@@ -72,44 +72,44 @@ export async function action({ context: { session }, params, request }: ActionFu
   // state validation schema
   const partnerInformationSchema = z
     .object({
-      confirm: z.boolean().refine((val) => val === true, t('apply:partner-information.error-message.confirm-required')),
+      confirm: z.boolean().refine((val) => val === true, t('adult-apply:partner-information.error-message.confirm-required')),
       dateOfBirthYear: z
         .number({
-          required_error: t('apply:partner-information.error-message.date-of-birth-year-required'),
-          invalid_type_error: t('apply:partner-information.error-message.date-of-birth-year-number'),
+          required_error: t('adult-apply:partner-information.error-message.date-of-birth-year-required'),
+          invalid_type_error: t('adult-apply:partner-information.error-message.date-of-birth-year-number'),
         })
         .int()
         .positive(),
       dateOfBirthMonth: z
         .number({
-          required_error: t('apply:partner-information.error-message.date-of-birth-month-required'),
+          required_error: t('adult-apply:partner-information.error-message.date-of-birth-month-required'),
         })
         .int()
         .positive(),
       dateOfBirthDay: z
         .number({
-          required_error: t('apply:partner-information.error-message.date-of-birth-day-required'),
-          invalid_type_error: t('apply:partner-information.error-message.date-of-birth-day-number'),
+          required_error: t('adult-apply:partner-information.error-message.date-of-birth-day-required'),
+          invalid_type_error: t('adult-apply:partner-information.error-message.date-of-birth-day-number'),
         })
         .int()
         .positive(),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply:partner-information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply:partner-information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('adult-apply:partner-information.error-message.first-name-required')).max(100),
+      lastName: z.string().trim().min(1, t('adult-apply:partner-information.error-message.last-name-required')).max(100),
       socialInsuranceNumber: z
         .string()
         .trim()
-        .min(1, t('apply:partner-information.error-message.sin-required'))
-        .refine(isValidSin, t('apply:partner-information.error-message.sin-valid'))
-        .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.applicantInformation?.socialInsuranceNumber, t('apply:partner-information.error-message.sin-unique'))
+        .min(1, t('adult-apply:partner-information.error-message.sin-required'))
+        .refine(isValidSin, t('adult-apply:partner-information.error-message.sin-valid'))
+        .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.applicantInformation?.socialInsuranceNumber, t('adult-apply:partner-information.error-message.sin-unique'))
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:partner-information.error-message.sin-valid'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:partner-information.error-message.sin-valid'), fatal: true });
             return z.NEVER;
           }
 
           if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:partner-information.error-message.sin-unique'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:partner-information.error-message.sin-unique'), fatal: true });
             return z.NEVER;
           }
         }),
@@ -121,11 +121,11 @@ export async function action({ context: { session }, params, request }: ActionFu
       const parsedDateOfBirth = parse(dateOfBirth, 'yyyy-MM-dd', new Date());
 
       if (!isValid(parsedDateOfBirth)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:partner-information.error-message.date-of-birth-valid'), path: ['dateOfBirth'] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:partner-information.error-message.date-of-birth-valid'), path: ['dateOfBirth'] });
       } else if (!isPast(parsedDateOfBirth)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:partner-information.error-message.date-of-birth-is-past'), path: ['dateOfBirth'] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:partner-information.error-message.date-of-birth-is-past'), path: ['dateOfBirth'] });
       } else if (differenceInYears(new Date(), parsedDateOfBirth) > 150) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:partner-information.error-message.date-of-birth-is-past-valid'), path: ['dateOfBirth'] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:partner-information.error-message.date-of-birth-is-past-valid'), path: ['dateOfBirth'] });
       }
     })
     .transform((val) => {
@@ -243,7 +243,7 @@ export default function ApplyFlowApplicationInformation() {
                 id="first-name"
                 name="firstName"
                 className="w-full"
-                label={t('apply:partner-information.first-name')}
+                label={t('adult-apply:partner-information.first-name')}
                 maxLength={100}
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
@@ -255,7 +255,7 @@ export default function ApplyFlowApplicationInformation() {
                 id="last-name"
                 name="lastName"
                 className="w-full"
-                label={t('apply:partner-information.last-name')}
+                label={t('adult-apply:partner-information.last-name')}
                 maxLength={100}
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
@@ -272,7 +272,7 @@ export default function ApplyFlowApplicationInformation() {
                 year: 'dateOfBirthYear',
               }}
               defaultValue={defaultState?.dateOfBirth ?? ''}
-              legend={t('apply:partner-information.date-of-birth')}
+              legend={t('adult-apply:partner-information.date-of-birth')}
               errorMessages={{
                 all: fetcher.data?.errors.dateOfBirth?._errors[0],
                 year: fetcher.data?.errors.dateOfBirthYear?._errors[0],
@@ -284,7 +284,7 @@ export default function ApplyFlowApplicationInformation() {
             <InputField
               id="social-insurance-number"
               name="socialInsuranceNumber"
-              label={t('apply:partner-information.sin')}
+              label={t('adult-apply:partner-information.sin')}
               placeholder="000-000-000"
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={fetcher.data?.errors.socialInsuranceNumber?._errors[0]}
@@ -297,7 +297,7 @@ export default function ApplyFlowApplicationInformation() {
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Spouse or Common-law partner information click">
-                {t('apply:partner-information.save-btn')}
+                {t('adult-apply:partner-information.save-btn')}
               </Button>
               <ButtonLink
                 id="back-button"
@@ -306,13 +306,13 @@ export default function ApplyFlowApplicationInformation() {
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Spouse or Common-law partner information click"
               >
-                {t('apply:partner-information.cancel-btn')}
+                {t('adult-apply:partner-information.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Spouse or Common-law partner information click">
-                {t('apply:partner-information.continue-btn')}
+                {t('adult-apply:partner-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink
@@ -323,7 +323,7 @@ export default function ApplyFlowApplicationInformation() {
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Spouse or Common-law partner information click"
               >
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:partner-information.back-btn')}
+                {t('adult-apply:partner-information.back-btn')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
@@ -52,9 +52,9 @@ export type PersonalInformationState = {
 };
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.personalInformation,
-  pageTitleI18nKey: 'apply:personal-information.page-title',
+  pageTitleI18nKey: 'adult-apply:personal-information.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -72,7 +72,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const regionList = await lookupService.getAllRegions();
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:personal-information.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:personal-information.page-title') }) };
 
   return json({
     id: state.id,
@@ -108,21 +108,21 @@ export async function action({ context: { session }, params, request }: ActionFu
         .string()
         .trim()
         .max(100)
-        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('apply:personal-information.error-message.phone-number-valid'))
+        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('adult-apply:personal-information.error-message.phone-number-valid'))
         .optional(),
       phoneNumberAlt: z
         .string()
         .trim()
         .max(100)
-        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('apply:personal-information.error-message.phone-number-alt-valid'))
+        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('adult-apply:personal-information.error-message.phone-number-alt-valid'))
         .optional(),
       email: z.string().trim().max(100).optional(),
       confirmEmail: z.string().trim().max(100).optional(),
-      mailingAddress: z.string().trim().min(1, t('apply:personal-information.error-message.address-required')).max(30),
+      mailingAddress: z.string().trim().min(1, t('adult-apply:personal-information.error-message.address-required')).max(30),
       mailingApartment: z.string().trim().max(30).optional(),
-      mailingCountry: z.string().trim().min(1, t('apply:personal-information.error-message.country-required')),
-      mailingProvince: z.string().trim().min(1, t('apply:personal-information.error-message.province-required')).optional(),
-      mailingCity: z.string().trim().min(1, t('apply:personal-information.error-message.city-required')).max(100),
+      mailingCountry: z.string().trim().min(1, t('adult-apply:personal-information.error-message.country-required')),
+      mailingProvince: z.string().trim().min(1, t('adult-apply:personal-information.error-message.province-required')).optional(),
+      mailingCity: z.string().trim().min(1, t('adult-apply:personal-information.error-message.city-required')).max(100),
       mailingPostalCode: z.string().trim().max(100).optional(),
       copyMailingAddress: z.boolean(),
       homeAddress: z.string().trim().max(30).optional(),
@@ -136,55 +136,55 @@ export async function action({ context: { session }, params, request }: ActionFu
       console.log(val);
       if (val.email) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.email-required'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.email-valid'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.email-valid'), path: ['email'] });
         }
 
         if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.confirm-email-required'), path: ['confirmEmail'] });
         } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.email-valid'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.email-valid'), path: ['confirmEmail'] });
         } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.email-match'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
 
       if (val.mailingCountry === CANADA_COUNTRY_ID || val.mailingCountry === USA_COUNTRY_ID) {
         if (!val.mailingProvince || validator.isEmpty(val.mailingProvince)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.province-required'), path: ['mailingProvince'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.province-required'), path: ['mailingProvince'] });
         }
 
         if (!val.mailingPostalCode || validator.isEmpty(val.mailingPostalCode)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.postal-code-required'), path: ['mailingPostalCode'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.postal-code-required'), path: ['mailingPostalCode'] });
         } else if (!isValidPostalCode(val.mailingCountry, val.mailingPostalCode)) {
-          const message = val.mailingCountry === CANADA_COUNTRY_ID ? t('apply:personal-information.error-message.postal-code-valid') : t('apply:personal-information.error-message.zip-code-valid');
+          const message = val.mailingCountry === CANADA_COUNTRY_ID ? t('adult-apply:personal-information.error-message.postal-code-valid') : t('adult-apply:personal-information.error-message.zip-code-valid');
           ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['mailingPostalCode'] });
         }
       }
 
       if (val.copyMailingAddress === false) {
         if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.address-required'), path: ['homeAddress'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.address-required'), path: ['homeAddress'] });
         }
 
         if (!val.homeCountry || validator.isEmpty(val.homeCountry)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.country-required'), path: ['homeCountry'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.country-required'), path: ['homeCountry'] });
         }
 
         if (!val.homeCity || validator.isEmpty(val.homeCity)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.city-required'), path: ['homeCity'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.city-required'), path: ['homeCity'] });
         }
 
         if (val.homeCountry === CANADA_COUNTRY_ID || val.homeCountry === USA_COUNTRY_ID) {
           if (!val.homeProvince || validator.isEmpty(val.homeProvince)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.province-required'), path: ['homeProvince'] });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.province-required'), path: ['homeProvince'] });
           }
 
           if (!val.homePostalCode || validator.isEmpty(val.homePostalCode)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:personal-information.error-message.postal-code-required'), path: ['homePostalCode'] });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('adult-apply:personal-information.error-message.postal-code-required'), path: ['homePostalCode'] });
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
-            const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply:personal-information.error-message.postal-code-valid') : t('apply:personal-information.error-message.zip-code-valid');
+            const message = val.homeCountry === CANADA_COUNTRY_ID ? t('adult-apply:personal-information.error-message.postal-code-valid') : t('adult-apply:personal-information.error-message.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
           }
         }
@@ -374,7 +374,7 @@ export default function ApplyFlowPersonalInformation() {
     })
     .sort((region1, region2) => region1.children.localeCompare(region2.children));
 
-  const dummyOption: InputOptionProps = { children: t('apply:personal-information.address-field.select-one'), value: '' };
+  const dummyOption: InputOptionProps = { children: t('adult-apply:personal-information.address-field.select-one'), value: '' };
 
   return (
     <>
@@ -387,7 +387,7 @@ export default function ApplyFlowPersonalInformation() {
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <p id="form-instructions-info" className="mb-6">
-          {t('apply:personal-information.form-instructions')}
+          {t('adult-apply:personal-information.form-instructions')}
         </p>
         <p className="mb-6 italic" id="form-instructions">
           {t('apply:required-label')}
@@ -395,7 +395,7 @@ export default function ApplyFlowPersonalInformation() {
         <fetcher.Form method="post" noValidate aria-describedby="form-instructions-info form-instructions">
           <input type="hidden" name="_csrf" value={csrfToken} />
           <p id="adding-phone" className="mb-2">
-            {t('apply:personal-information.add-phone')}
+            {t('adult-apply:personal-information.add-phone')}
           </p>
           <div className="mb-6 grid gap-6 md:grid-cols-2">
             <InputField
@@ -405,7 +405,7 @@ export default function ApplyFlowPersonalInformation() {
               autoComplete="tel"
               defaultValue={defaultState.phoneNumber ?? ''}
               errorMessage={errorMessages['phone-number']}
-              label={t('apply:personal-information.phone-number')}
+              label={t('adult-apply:personal-information.phone-number')}
               maxLength={100}
               aria-describedby="adding-phone"
             />
@@ -416,13 +416,13 @@ export default function ApplyFlowPersonalInformation() {
               autoComplete="tel"
               defaultValue={defaultState.phoneNumberAlt ?? ''}
               errorMessage={errorMessages['phone-number-alt']}
-              label={t('apply:personal-information.phone-number-alt')}
+              label={t('adult-apply:personal-information.phone-number-alt')}
               maxLength={100}
               aria-describedby="adding-phone"
             />
           </div>
           <p id="adding-email" className="mb-2">
-            {t('apply:personal-information.add-email')}
+            {t('adult-apply:personal-information.add-email')}
           </p>
           <div className="mb-6 grid gap-6 md:grid-cols-2">
             <InputField
@@ -432,7 +432,7 @@ export default function ApplyFlowPersonalInformation() {
               autoComplete="email"
               defaultValue={defaultState.email ?? ''}
               errorMessage={errorMessages['email']}
-              label={t('apply:personal-information.email')}
+              label={t('adult-apply:personal-information.email')}
               maxLength={100}
               aria-describedby="adding-email"
             />
@@ -443,20 +443,20 @@ export default function ApplyFlowPersonalInformation() {
               autoComplete="email"
               defaultValue={defaultState.confirmEmail ?? ''}
               errorMessage={errorMessages['confirm-email']}
-              label={t('apply:personal-information.confirm-email')}
+              label={t('adult-apply:personal-information.confirm-email')}
               maxLength={100}
               aria-describedby="adding-email"
             />
           </div>
-          <h2 className="mb-4 font-lato text-2xl font-bold">{t('apply:personal-information.mailing-address.header')}</h2>
+          <h2 className="mb-4 font-lato text-2xl font-bold">{t('adult-apply:personal-information.mailing-address.header')}</h2>
           <div className="my-6 space-y-6">
             <InputField
               id="mailing-address"
               name="mailingAddress"
               className="w-full"
-              label={t('apply:personal-information.address-field.address')}
+              label={t('adult-apply:personal-information.address-field.address')}
               maxLength={30}
-              helpMessagePrimary={t('apply:personal-information.address-field.address-note')}
+              helpMessagePrimary={t('adult-apply:personal-information.address-field.address-note')}
               helpMessagePrimaryClassName="text-black"
               autoComplete="address-line1"
               defaultValue={defaultState.mailingAddress ?? ''}
@@ -467,7 +467,7 @@ export default function ApplyFlowPersonalInformation() {
               id="mailing-apartment"
               name="mailingApartment"
               className="w-full"
-              label={t('apply:personal-information.address-field.apartment')}
+              label={t('adult-apply:personal-information.address-field.apartment')}
               maxLength={30}
               autoComplete="address-line2"
               defaultValue={defaultState.mailingApartment ?? ''}
@@ -478,7 +478,7 @@ export default function ApplyFlowPersonalInformation() {
               id="mailing-country"
               name="mailingCountry"
               className="w-full sm:w-1/2"
-              label={t('apply:personal-information.address-field.country')}
+              label={t('adult-apply:personal-information.address-field.country')}
               autoComplete="country"
               defaultValue={defaultState.mailingCountry ?? ''}
               errorMessage={errorMessages['mailing-country']}
@@ -491,7 +491,7 @@ export default function ApplyFlowPersonalInformation() {
                 id="mailing-province"
                 name="mailingProvince"
                 className="w-full sm:w-1/2"
-                label={t('apply:personal-information.address-field.province')}
+                label={t('adult-apply:personal-information.address-field.province')}
                 defaultValue={defaultState.mailingProvince ?? ''}
                 errorMessage={errorMessages['mailing-province']}
                 options={[dummyOption, ...mailingRegions]}
@@ -503,7 +503,7 @@ export default function ApplyFlowPersonalInformation() {
                 id="mailing-city"
                 name="mailingCity"
                 className="w-full"
-                label={t('apply:personal-information.address-field.city')}
+                label={t('adult-apply:personal-information.address-field.city')}
                 maxLength={100}
                 autoComplete="address-level2"
                 defaultValue={defaultState.mailingCity ?? ''}
@@ -514,7 +514,7 @@ export default function ApplyFlowPersonalInformation() {
                 id="mailing-postal-code"
                 name="mailingPostalCode"
                 className="w-full"
-                label={selectedMailingCountry === CANADA_COUNTRY_ID || selectedMailingCountry === USA_COUNTRY_ID ? t('apply:personal-information.address-field.postal-code') : t('apply:personal-information.address-field.postal-code-optional')}
+                label={selectedMailingCountry === CANADA_COUNTRY_ID || selectedMailingCountry === USA_COUNTRY_ID ? t('adult-apply:personal-information.address-field.postal-code') : t('adult-apply:personal-information.address-field.postal-code-optional')}
                 maxLength={100}
                 autoComplete="postal-code"
                 defaultValue={defaultState.mailingPostalCode}
@@ -524,10 +524,10 @@ export default function ApplyFlowPersonalInformation() {
             </div>
           </div>
 
-          <h2 className="mb-6 font-lato text-2xl font-bold">{t('apply:personal-information.home-address.header')}</h2>
+          <h2 className="mb-6 font-lato text-2xl font-bold">{t('adult-apply:personal-information.home-address.header')}</h2>
           <div className="mb-8 space-y-6">
             <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
-              {t('apply:personal-information.home-address.use-mailing-address')}
+              {t('adult-apply:personal-information.home-address.use-mailing-address')}
             </InputCheckbox>
             {!copyAddressChecked && (
               <>
@@ -535,8 +535,8 @@ export default function ApplyFlowPersonalInformation() {
                   id="home-address"
                   name="homeAddress"
                   className="w-full"
-                  label={t('apply:personal-information.address-field.address')}
-                  helpMessagePrimary={t('apply:personal-information.address-field.address-note')}
+                  label={t('adult-apply:personal-information.address-field.address')}
+                  helpMessagePrimary={t('adult-apply:personal-information.address-field.address-note')}
                   helpMessagePrimaryClassName="text-black"
                   maxLength={30}
                   autoComplete="address-line1"
@@ -548,7 +548,7 @@ export default function ApplyFlowPersonalInformation() {
                   id="home-apartment"
                   name="homeApartment"
                   className="w-full"
-                  label={t('apply:personal-information.address-field.apartment')}
+                  label={t('adult-apply:personal-information.address-field.apartment')}
                   maxLength={30}
                   autoComplete="address-line2"
                   defaultValue={defaultState.homeApartment ?? ''}
@@ -559,7 +559,7 @@ export default function ApplyFlowPersonalInformation() {
                   id="home-country"
                   name="homeCountry"
                   className="w-full sm:w-1/2"
-                  label={t('apply:personal-information.address-field.country')}
+                  label={t('adult-apply:personal-information.address-field.country')}
                   autoComplete="country"
                   defaultValue={defaultState.homeCountry ?? ''}
                   errorMessage={errorMessages['home-country']}
@@ -572,7 +572,7 @@ export default function ApplyFlowPersonalInformation() {
                     id="home-province"
                     name="homeProvince"
                     className="w-full sm:w-1/2"
-                    label={t('apply:personal-information.address-field.province')}
+                    label={t('adult-apply:personal-information.address-field.province')}
                     defaultValue={defaultState.homeProvince ?? ''}
                     errorMessage={errorMessages['home-province']}
                     options={[dummyOption, ...homeRegions]}
@@ -584,7 +584,7 @@ export default function ApplyFlowPersonalInformation() {
                     id="home-city"
                     name="homeCity"
                     className="w-full"
-                    label={t('apply:personal-information.address-field.city')}
+                    label={t('adult-apply:personal-information.address-field.city')}
                     maxLength={100}
                     autoComplete="address-level2"
                     defaultValue={defaultState.homeCity ?? ''}
@@ -595,7 +595,7 @@ export default function ApplyFlowPersonalInformation() {
                     id="home-postal-code"
                     name="homePostalCode"
                     className="w-full"
-                    label={selectedHomeCountry === CANADA_COUNTRY_ID || selectedHomeCountry === USA_COUNTRY_ID ? t('apply:personal-information.address-field.postal-code') : t('apply:personal-information.address-field.postal-code-optional')}
+                    label={selectedHomeCountry === CANADA_COUNTRY_ID || selectedHomeCountry === USA_COUNTRY_ID ? t('adult-apply:personal-information.address-field.postal-code') : t('adult-apply:personal-information.address-field.postal-code-optional')}
                     maxLength={100}
                     autoComplete="postal-code"
                     defaultValue={defaultState.homePostalCode ?? ''}
@@ -609,16 +609,16 @@ export default function ApplyFlowPersonalInformation() {
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Personal information click">
-                {t('apply:personal-information.save-btn')}
+                {t('adult-apply:personal-information.save-btn')}
               </Button>
               <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Personal information click">
-                {t('apply:personal-information.cancel-btn')}
+                {t('adult-apply:personal-information.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Personal information click">
-                {t('apply:personal-information.continue')}
+                {t('adult-apply:personal-information.continue')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
               <ButtonLink
@@ -629,7 +629,7 @@ export default function ApplyFlowPersonalInformation() {
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Personal information click"
               >
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-                {t('apply:personal-information.back')}
+                {t('adult-apply:personal-information.back')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/review-information.tsx
@@ -49,9 +49,9 @@ export interface SubmissionInfoState {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.reviewInformation,
-  pageTitleI18nKey: 'apply:review-information.page-title',
+  pageTitleI18nKey: 'adult-apply:review-information.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -162,7 +162,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:review-information.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:review-information.page-title') }) };
 
   return json({
     id: state.id,
@@ -305,40 +305,40 @@ export default function ReviewInformation() {
         <Progress aria-labelledby="progress-label" value={100} size="lg" />
       </div>
       <div className="max-w-prose">
-        <p className="my-4 text-lg">{t('apply:review-information.read-carefully')}</p>
+        <p className="my-4 text-lg">{t('adult-apply:review-information.read-carefully')}</p>
         <div className="space-y-10">
           <div>
-            <h2 className="text-2xl font-semibold">{t('apply:review-information.page-sub-title')}</h2>
+            <h2 className="text-2xl font-semibold">{t('adult-apply:review-information.page-sub-title')}</h2>
             <dl className="mt-6 divide-y border-y">
-              <DescriptionListItem term={t('apply:review-information.full-name-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.full-name-title')}>
                 {`${userInfo.firstName} ${userInfo.lastName}`}
                 <p className="mt-4">
                   <InlineLink id="change-full-name" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
-                    {t('apply:review-information.full-name-change')}
+                    {t('adult-apply:review-information.full-name-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.dob-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.dob-title')}>
                 {userInfo.birthday}
                 <p className="mt-4">
                   <InlineLink id="change-date-of-birth" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params}>
-                    {t('apply:review-information.dob-change')}
+                    {t('adult-apply:review-information.dob-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.sin-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.sin-title')}>
                 {formatSin(userInfo.sin)}
                 <p className="mt-4">
                   <InlineLink id="change-sin" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
-                    {t('apply:review-information.sin-change')}
+                    {t('adult-apply:review-information.sin-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.marital-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.marital-title')}>
                 {maritalStatus}
                 <p className="mt-4">
                   <InlineLink id="change-martial-status" routeId="$lang+/_public+/apply+/$id+/adult/applicant-information" params={params}>
-                    {t('apply:review-information.marital-change')}
+                    {t('adult-apply:review-information.marital-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
@@ -346,56 +346,56 @@ export default function ReviewInformation() {
           </div>
           {spouseInfo && (
             <div>
-              <h2 className="mt-8 text-2xl font-semibold ">{t('apply:review-information.spouse-title')}</h2>
+              <h2 className="mt-8 text-2xl font-semibold ">{t('adult-apply:review-information.spouse-title')}</h2>
               <dl className="mt-6 divide-y border-y">
-                <DescriptionListItem term={t('apply:review-information.full-name-title')}>
+                <DescriptionListItem term={t('adult-apply:review-information.full-name-title')}>
                   {`${spouseInfo.firstName} ${spouseInfo.lastName}`}
                   <p className="mt-4">
                     <InlineLink id="change-spouse-full-name" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
-                      {t('apply:review-information.full-name-change')}
+                      {t('adult-apply:review-information.full-name-change')}
                     </InlineLink>
                   </p>
                 </DescriptionListItem>
-                <DescriptionListItem term={t('apply:review-information.dob-title')}>
+                <DescriptionListItem term={t('adult-apply:review-information.dob-title')}>
                   {spouseInfo.birthday}
                   <p className="mt-4">
                     <InlineLink id="change-spouse-date-of-birth" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
-                      {t('apply:review-information.dob-change')}
+                      {t('adult-apply:review-information.dob-change')}
                     </InlineLink>
                   </p>
                 </DescriptionListItem>
-                <DescriptionListItem term={t('apply:review-information.sin-title')}>
+                <DescriptionListItem term={t('adult-apply:review-information.sin-title')}>
                   {formatSin(spouseInfo.sin)}
                   <p className="mt-4">
                     <InlineLink id="change-spouse-sin" routeId="$lang+/_public+/apply+/$id+/adult/partner-information" params={params}>
-                      {t('apply:review-information.sin-change')}
+                      {t('adult-apply:review-information.sin-change')}
                     </InlineLink>
                   </p>
                 </DescriptionListItem>
-                <DescriptionListItem term={t('apply:review-information.spouse-consent.label')}>{spouseInfo.consent ? t('apply:review-information.spouse-consent.yes') : t('apply:review-information.spouse-consent.no')}</DescriptionListItem>
+                <DescriptionListItem term={t('adult-apply:review-information.spouse-consent.label')}>{spouseInfo.consent ? t('adult-apply:review-information.spouse-consent.yes') : t('adult-apply:review-information.spouse-consent.no')}</DescriptionListItem>
               </dl>
             </div>
           )}
           <div>
-            <h2 className="mt-2 text-2xl font-semibold ">{t('apply:review-information.personal-info-title')}</h2>
+            <h2 className="mt-2 text-2xl font-semibold ">{t('adult-apply:review-information.personal-info-title')}</h2>
             <dl className="mt-6 divide-y border-y">
-              <DescriptionListItem term={t('apply:review-information.phone-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.phone-title')}>
                 {userInfo.phoneNumber}
                 <p className="mt-4">
                   <InlineLink id="change-phone-number" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
-                    {t('apply:review-information.phone-change')}
+                    {t('adult-apply:review-information.phone-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.alt-phone-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.alt-phone-title')}>
                 {userInfo.altPhoneNumber}
                 <p className="mt-4">
                   <InlineLink id="change-alternate-phone-number" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
-                    {t('apply:review-information.alt-phone-change')}
+                    {t('adult-apply:review-information.alt-phone-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.mailing-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.mailing-title')}>
                 <Address
                   address={mailingAddressInfo.address}
                   city={mailingAddressInfo.city}
@@ -407,11 +407,11 @@ export default function ReviewInformation() {
                 />
                 <p className="mt-4">
                   <InlineLink id="change-mailing-address" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
-                    {t('apply:review-information.mailing-change')}
+                    {t('adult-apply:review-information.mailing-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.home-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.home-title')}>
                 <Address
                   address={homeAddressInfo.address ?? ''}
                   city={homeAddressInfo.city ?? ''}
@@ -423,37 +423,37 @@ export default function ReviewInformation() {
                 />
                 <p className="mt-4">
                   <InlineLink id="change-home-address" routeId="$lang+/_public+/apply+/$id+/adult/personal-information" params={params}>
-                    {t('apply:review-information.home-change')}
+                    {t('adult-apply:review-information.home-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
             </dl>
           </div>
           <div>
-            <h2 className="mt-8 text-2xl font-semibold">{t('apply:review-information.comm-title')}</h2>
+            <h2 className="mt-8 text-2xl font-semibold">{t('adult-apply:review-information.comm-title')}</h2>
             <dl className="mt-6 divide-y border-y">
-              <DescriptionListItem term={t('apply:review-information.comm-pref-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.comm-pref-title')}>
                 {userInfo.communicationPreference.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID ? (
                   <div className="grid grid-cols-1">
-                    <p className="mt-4">{t('apply:review-information.comm-electronic')}</p> <span>{userInfo.email}</span>
+                    <p className="mt-4">{t('adult-apply:review-information.comm-electronic')}</p> <span>{userInfo.email}</span>
                   </div>
                 ) : (
                   <div className="grid grid-cols-1">
-                    <p className="mt-4">{t('apply:review-information.comm-mail')}</p>
+                    <p className="mt-4">{t('adult-apply:review-information.comm-mail')}</p>
                   </div>
                 )}
                 <p className="mt-4">
                   <InlineLink id="change-communication-preference" routeId="$lang+/_public+/apply+/$id+/adult/communication-preference" params={params}>
-                    {t('apply:review-information.comm-pref-change')}
+                    {t('adult-apply:review-information.comm-pref-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
               {preferredLanguage && (
-                <DescriptionListItem term={t('apply:review-information.lang-pref-title')}>
+                <DescriptionListItem term={t('adult-apply:review-information.lang-pref-title')}>
                   {getNameByLanguage(i18n.language, preferredLanguage)}
                   <p className="mt-4">
                     <InlineLink id="change-language-preference" routeId="$lang+/_public+/apply+/$id+/adult/communication-preference" params={params}>
-                      {t('apply:review-information.lang-pref-change')}
+                      {t('adult-apply:review-information.lang-pref-change')}
                     </InlineLink>
                   </p>
                 </DescriptionListItem>
@@ -461,21 +461,21 @@ export default function ReviewInformation() {
             </dl>
           </div>
           <div>
-            <h2 className="mt-8 text-2xl font-semibold">{t('apply:review-information.dental-title')}</h2>
+            <h2 className="mt-8 text-2xl font-semibold">{t('adult-apply:review-information.dental-title')}</h2>
             <dl className="mt-6 divide-y border-y">
-              <DescriptionListItem term={t('apply:review-information.dental-insurance-title')}>
-                {dentalInsurance ? t('apply:review-information.yes') : t('apply:review-information.no')}
+              <DescriptionListItem term={t('adult-apply:review-information.dental-insurance-title')}>
+                {dentalInsurance ? t('adult-apply:review-information.yes') : t('adult-apply:review-information.no')}
                 <p className="mt-4">
                   <InlineLink id="change-access-dental" routeId="$lang+/_public+/apply+/$id+/adult/dental-insurance" params={params}>
-                    {t('apply:review-information.dental-insurance-change')}
+                    {t('adult-apply:review-information.dental-insurance-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
-              <DescriptionListItem term={t('apply:review-information.dental-benefit-title')}>
+              <DescriptionListItem term={t('adult-apply:review-information.dental-benefit-title')}>
                 {dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
                   <>
-                    <p>{t('apply:review-information.yes')}</p>
-                    <p>{t('apply:review-information.dental-benefit-has-access')}</p>
+                    <p>{t('adult-apply:review-information.yes')}</p>
+                    <p>{t('adult-apply:review-information.dental-benefit-has-access')}</p>
                     <div>
                       <ul className="ml-6 list-disc">
                         {dentalBenefit.federalBenefit.access && <li>{federalSocialProgram}</li>}
@@ -484,30 +484,30 @@ export default function ReviewInformation() {
                     </div>
                   </>
                 ) : (
-                  <>{t('apply:review-information.no')}</>
+                  <>{t('adult-apply:review-information.no')}</>
                 )}
                 <p className="mt-4">
                   <InlineLink id="change-dental-benefits" routeId="$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits" params={params}>
-                    {t('apply:review-information.dental-benefit-change')}
+                    {t('adult-apply:review-information.dental-benefit-change')}
                   </InlineLink>
                 </p>
               </DescriptionListItem>
             </dl>
           </div>
         </div>
-        <h2 className="mb-5 mt-8 text-2xl font-semibold">{t('apply:review-information.submit-app-title')}</h2>
-        <p className="mb-4">{t('apply:review-information.submit-p-proceed')}</p>
-        <p className="mb-4">{t('apply:review-information.submit-p-false-info')}</p>
-        <p className="mb-4">{t('apply:review-information.submit-p-repayment')}</p>
+        <h2 className="mb-5 mt-8 text-2xl font-semibold">{t('adult-apply:review-information.submit-app-title')}</h2>
+        <p className="mb-4">{t('adult-apply:review-information.submit-p-proceed')}</p>
+        <p className="mb-4">{t('adult-apply:review-information.submit-p-false-info')}</p>
+        <p className="mb-4">{t('adult-apply:review-information.submit-p-repayment')}</p>
         <fetcher.Form method="post" onSubmit={handleSubmit} className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <input type="hidden" name="_csrf" value={csrfToken} />
           {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
           <Button id="confirm-button" variant="green" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Submit - Review Information click">
-            {t('apply:review-information.submit-button')}
+            {t('adult-apply:review-information.submit-button')}
             {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
           </Button>
           <ButtonLink routeId="$lang+/_public+/apply+/$id+/adult/exit-application" params={params} variant="alternative" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Review Information click">
-            {t('apply:review-information.exit-button')}
+            {t('adult-apply:review-information.exit-button')}
             <FontAwesomeIcon icon={faX} className="ms-3 block size-4" />
           </ButtonLink>
         </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/tax-filing.tsx
@@ -31,9 +31,9 @@ enum TaxFilingOption {
 export type TaxFilingState = `${TaxFilingOption}`;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('adult-apply', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.taxFiling,
-  pageTitleI18nKey: 'apply:eligibility.tax-filing.page-title',
+  pageTitleI18nKey: 'adult-apply:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -46,7 +46,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.tax-filing.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('adult-apply:eligibility.tax-filing.page-title') }) };
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
@@ -58,7 +58,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema: z.ZodType<TaxFilingState> = z.nativeEnum(TaxFilingOption, {
-    errorMap: () => ({ message: t('apply:eligibility.tax-filing.error-message.tax-filing-required') }),
+    errorMap: () => ({ message: t('adult-apply:eligibility.tax-filing.error-message.tax-filing-required') }),
   });
 
   const formData = await request.formData();
@@ -133,22 +133,22 @@ export default function ApplyFlowTaxFiling() {
           <InputRadios
             id="tax-filing-2023"
             name="taxFiling2023"
-            legend={t('apply:eligibility.tax-filing.form-instructions')}
+            legend={t('adult-apply:eligibility.tax-filing.form-instructions')}
             options={[
-              { value: TaxFilingOption.Yes, children: t('apply:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === TaxFilingOption.Yes },
-              { value: TaxFilingOption.No, children: t('apply:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === TaxFilingOption.No },
+              { value: TaxFilingOption.Yes, children: t('adult-apply:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === TaxFilingOption.Yes },
+              { value: TaxFilingOption.No, children: t('adult-apply:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === TaxFilingOption.No },
             ]}
             errorMessage={errorMessages['input-radio-tax-filing-2023-option-0']}
             required
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Tax filing click">
-              {t('apply:eligibility.tax-filing.continue-btn')}
+              {t('adult-apply:eligibility.tax-filing.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
             <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Tax filing click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-              {t('apply:eligibility.tax-filing.back-btn')}
+              {t('adult-apply:eligibility.tax-filing.back-btn')}
             </ButtonLink>
           </div>
         </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -36,7 +36,7 @@ export type TypeOfApplicationState = `${ApplicantType}`;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.typeOfApplication,
-  pageTitleI18nKey: 'apply:eligibility.type-of-application.page-title',
+  pageTitleI18nKey: 'apply:type-of-application.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:eligibility.type-of-application.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:type-of-application.page-title') }) };
 
   return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfApplication });
 }
@@ -64,7 +64,7 @@ export async function action({ context: { session }, params, request }: ActionFu
    * Schema for application delegate.
    */
   const typeOfApplicationSchema: z.ZodType<TypeOfApplicationState> = z.nativeEnum(ApplicantType, {
-    errorMap: () => ({ message: t('apply:eligibility.type-of-application.error-message.type-of-application-required') }),
+    errorMap: () => ({ message: t('apply:type-of-application.error-message.type-of-application-required') }),
   });
 
   const formData = await request.formData();
@@ -131,25 +131,25 @@ export default function ApplyFlowTypeOfApplication() {
       </div>
       <div className="max-w-prose">
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6">{t('apply:eligibility.type-of-application.page-description')}</p>
+        <p className="mb-6">{t('apply:type-of-application.page-description')}</p>
         <div className="mb-6 space-y-4">
-          <h2 className="font-bold">{t('apply:eligibility.type-of-application.apply-self')}</h2>
-          <p>{t('apply:eligibility.type-of-application.apply-self-eligibility')}</p>
+          <h2 className="font-bold">{t('apply:type-of-application.apply-self')}</h2>
+          <p>{t('apply:type-of-application.apply-self-eligibility')}</p>
           <ul className="list-disc space-y-1 pl-7">
-            <li>{t('apply:eligibility.type-of-application.senior')}</li>
-            <li>{t('apply:eligibility.type-of-application.valid-disability-tax-credit')}</li>
-            <li>{t('apply:eligibility.type-of-application.live-independently')}</li>
+            <li>{t('apply:type-of-application.senior')}</li>
+            <li>{t('apply:type-of-application.valid-disability-tax-credit')}</li>
+            <li>{t('apply:type-of-application.live-independently')}</li>
           </ul>
-          <h2 className="font-bold">{t('apply:eligibility.type-of-application.apply-child')}</h2>
-          <p>{t('apply:eligibility.type-of-application.apply-child-eligibility')}</p>
+          <h2 className="font-bold">{t('apply:type-of-application.apply-child')}</h2>
+          <p>{t('apply:type-of-application.apply-child-eligibility')}</p>
           <ul className="list-disc space-y-1 pl-7">
-            <li>{t('apply:eligibility.type-of-application.sixteen-or-older')}</li>
-            <li>{t('apply:eligibility.type-of-application.under-eighteen')}</li>
+            <li>{t('apply:type-of-application.sixteen-or-older')}</li>
+            <li>{t('apply:type-of-application.under-eighteen')}</li>
           </ul>
-          <p>{t('apply:eligibility.type-of-application.note')}</p>
+          <p>{t('apply:type-of-application.note')}</p>
         </div>
-        <Collapsible summary={t('apply:eligibility.type-of-application.split-custody-summary')}>
-          <p>{t('apply:eligibility.type-of-application.split-custody-detail')}</p>
+        <Collapsible summary={t('apply:type-of-application.split-custody-summary')}>
+          <p>{t('apply:type-of-application.split-custody-detail')}</p>
         </Collapsible>
         <p className="mb-4 mt-8 italic" id="form-instructions">
           {t('apply:required-label')}
@@ -159,26 +159,26 @@ export default function ApplyFlowTypeOfApplication() {
           <InputRadios
             id="type-of-application"
             name="typeOfApplication"
-            legend={t('apply:eligibility.type-of-application.form-instructions')}
+            legend={t('apply:type-of-application.form-instructions')}
             options={[
               {
                 value: ApplicantType.Personal,
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.type-of-application.radio-options.personal" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.personal" />,
                 defaultChecked: defaultState === ApplicantType.Personal,
               },
               {
                 value: ApplicantType.Child,
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.type-of-application.radio-options.child" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.child" />,
                 defaultChecked: defaultState === ApplicantType.Child,
               },
               {
                 value: ApplicantType.Both,
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.type-of-application.radio-options.personal-and-child" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.personal-and-child" />,
                 defaultChecked: defaultState === ApplicantType.Both,
               },
               {
                 value: ApplicantType.Delegate,
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:eligibility.type-of-application.radio-options.delegate" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.delegate" />,
                 defaultChecked: defaultState === ApplicantType.Delegate,
               },
             ]}
@@ -187,12 +187,12 @@ export default function ApplyFlowTypeOfApplication() {
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Type of application click">
-              {t('apply:eligibility.type-of-application.continue-btn')}
+              {t('apply:type-of-application.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
             <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/terms-and-conditions" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Type of application click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-              {t('apply:eligibility.type-of-application.back-btn')}
+              {t('apply:type-of-application.back-btn')}
             </ButtonLink>
           </div>
         </fetcher.Form>

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -1,6 +1,7 @@
 import { AppLoadContext, Session } from '@remix-run/node';
 import type { ActionFunctionArgs as RRActionFunctionArgs, LoaderFunctionArgs as RRLoaderFunctionArgs } from '@remix-run/router';
 
+import type adultApply from '../public/locales/en/adult-apply.json';
 import type alerts from '../public/locales/en/alerts.json';
 import type apply from '../public/locales/en/apply.json';
 import type dataUnavailable from '../public/locales/en/data-unavailable.json';
@@ -33,6 +34,7 @@ declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: false;
     resources: {
+      'adult-apply': typeof adultApply;
       apply: typeof apply;
       'data-unavailable': typeof dataUnavailable;
       gcweb: typeof gcweb;

--- a/frontend/public/locales/en/adult-apply.json
+++ b/frontend/public/locales/en/adult-apply.json
@@ -1,0 +1,380 @@
+{
+  "applicant-information": {
+    "page-title": "Applicant Information",
+    "form-instructions-sin": "Please provide your legal name as indicated on your Social Insurance Number (SIN) card or letter.",
+    "form-instructions-info": "We'll use the information you provide to verify your identity. Any information that does not match the information on your SIN application may cause a delay in the processing of your application.",
+    "sin": "Social Insurance Number (SIN)",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "single-legal-name": "If you have a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "marital-status": "Marital status",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "marital-status-required": "Select marital status",
+      "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
+      "sin-required": "Enter 9-digit SIN",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
+  },
+  "communication-preference": {
+    "page-title": "Communication",
+    "note": "If you're eligible, we will share your information with Sun Life Assurance Company of Canada (Sun Life). Sun Life will be responsible for handling member enrolment and administering claims processing and benefits for the Canadian Dental Care Plan.",
+    "preferred-method": "What is your preferred method of communication for Sun Life?",
+    "preferred-language": "What is your preferred official language of communication?",
+    "email": "Email address",
+    "email-note": "Service Canada and Health Canada may use this email for future communication about the Canadian Dental Care Plan.",
+    "confirm-email": "Confirm email address",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com",
+      "preferred-language-required": "Select preferred language of communication",
+      "preferred-method-required": "Select preferred method of communication"
+    }
+  },
+  "confirm": {
+    "page-title": "Application submitted",
+    "alert-heading": "You have successfully applied for the Canadian Dental Care Plan!",
+    "app-code-is": "Your application code is:",
+    "make-note": "Save this code, you'll need it to check the status of your application.",
+    "keep-copy": "Keep a copy of your application",
+    "print-copy-text": "You will <strong>not</strong> receive a <strong>confirmation email</strong>. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
+    "print-btn": "Print",
+    "whats-next": "What happens next",
+    "begin-process": "We will begin processing your application immediately.",
+    "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application or to recieve more information.",
+    "use-code": "You can use your application code to begin tracking the progress within 48 hours of applying.",
+    "register-msca-title": "Register for a My Service Canada Account",
+    "register-msca-text": "Once your application is processed, you will be able to sign into <mscaLink>My Service Canada Account (MSCA)</mscaLink>. You will also be able to view letters sent to you from the Government of Canada regarding the Canadian Dental Care Plan.",
+    "msca-notify": "You will be notified whether your application has been accepted or rejected in your My Service Canada Account.",
+    "msca-link": "https://www.canada.ca/en/employment-social-development/services/my-account.html",
+    "how-insurance": "How do I use my Canadian Dental Care Plan",
+    "eligible-text": "If you are deemed eligible, Sun Life will send you a welcome package by mail. Your welcome package will include your member card and details about the Canadian Dental Care Plan, including your coverage start date. The Canadian Dental Care Plan will not cover you for dental services received before that date.",
+    "more-info-cdcp": "For more information on what services and how much will be covered, visit <moreInfoLink>Canadian Dental Care Plan - What is covered</moreInfoLink>.",
+    "more-info-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/coverage.html",
+    "more-info-service": "For more information, please contact <dentalContactUsLink>Service Canada</dentalContactUsLink>.",
+    "dental-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
+    "application-summ": "Application summary",
+    "applicant-title": "Applicant information",
+    "spouse-info": "Spouse / Common-law information",
+    "contact-info": "Contact information",
+    "comm-prefs": "Communication",
+    "added-email": "Added email: {{email}}",
+    "dental-insurance": "Access to dental insurance",
+    "dob": "Date of birth",
+    "sin": "Social Insurance Number (SIN)",
+    "full-name": "Full name",
+    "marital-status": "Marital status",
+    "consent": "Consent",
+    "consent-answer": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
+    "phone-number": "Phone number",
+    "alt-phone-number": "Alternate phone number",
+    "mailing": "Mailing address",
+    "home": "Home address",
+    "comm-pref": "Communication preference",
+    "lang-pref": "Language preference",
+    "dental-private": "Access to dental insurance or coverage",
+    "dental-public": "Access to government dental benefit",
+    "application-code": "Application code",
+    "yes": "Yes",
+    "no": "No",
+    "exit": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html",
+    "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html"
+  },
+  "dental-benefits": {
+    "title": "Access to other federal, provincial or territorial dental benefits",
+    "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
+    "select-one": "Select one",
+    "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
+    "federal-benefits": {
+      "title": "Federal benefits",
+      "legend": "Do you have dental benefits through a social program offered by a federal program?",
+      "option-yes": "<strong>Yes</strong>, I have <strong>federal</strong> benefits",
+      "option-no": "<strong>No</strong>, I do not have <strong>federal</strong> benefits",
+      "social-programs": {
+        "legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "provincial-territorial-benefits": {
+      "title": "Provincial or territorial benefits",
+      "legend": "Do you have dental benefits through a social program offered by your province or territory?",
+      "option-yes": "<strong>Yes</strong>, I have <strong>provincial or territorial</strong> benefits",
+      "option-no": "<strong>No</strong>, I do not have <strong>provincial or territorial</strong> benefits",
+      "social-programs": {
+        "input-legend": "If yes, through which province or territory?",
+        "radio-legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "error-message": {
+      "federal-benefit-required": "Select whether you have federal dental benefits",
+      "program-required": "Select a program",
+      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
+      "provincial-territorial-required": "Select a province or territory"
+    }
+  },
+  "dental-insurance": {
+    "title": "Access to other dental insurance",
+    "legend": "Do you have access to dental insurance or coverage through one of the following four situations?",
+    "list": {
+      "employment": "Your employment benefits or a family member's employment benefits, including health and wellness accounts",
+      "pension": "Your pension benefits or a family member's pension benefits",
+      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "professional": "Through a professional or student organization"
+    },
+    "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
+    "option-no": "<strong>No</strong>, I do not have access to dental insurance or coverage",
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "detail": {
+      "additional-info": {
+        "title": "Additional information",
+        "eligible": "Exception: You may still be eligible if you are retired and:",
+        "list": {
+          "opted": "you opted out of pension benefits before December 11, 2023, and",
+          "cannot-opt": "you can't opt back in under the pension rules"
+        },
+        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your employer/pension (see exception) benefits or through a professional or student organization. As such, you are not eligible for the Canadian Dental Care Plan.",
+        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own (and not part of any of the coverage described above), you are not eligible for the CDCP while that coverage is in effect."
+      }
+    },
+    "error-message": {
+      "dental-insurance-required": "Select whether you have access to dental insurance"
+    }
+  },
+  "eligibility": {
+    "tax-filing": {
+      "page-title": "Tax filing",
+      "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2023 and received your Notice of Assessment?",
+      "radio-options": {
+        "yes": "Yes",
+        "no": "No"
+      },
+      "error-message": {
+        "tax-filing-required": "Select whether or not you have filed your taxes"
+      },
+      "back-btn": "Back",
+      "continue-btn": "Continue"
+    },
+    "date-of-birth": {
+      "page-title": "Age",
+      "description": "Applications for the Canadian Dental Care Plan will open in phases. Your date of birth determines when you can apply.",
+      "age-heading": "Your age",
+      "child-age-heading": "Your child(ren)'s age",
+      "form-instructions": "Please select your date of birth",
+      "child-age-instruction": "Are all the children you are applying for under 18?",
+      "yes": "Yes",
+      "no": "No",
+      "collapsible-content-summary": "If your child is over 18 and has a Disability Tax Credit",
+      "collapsible-content-detail": "You must speak to a Service Canada representative to apply on behalf of your child. Please contact Service Canada by calling 1-833-537-4342.",
+      "error-message": {
+        "date-of-birth-day-number": "Day must be a number",
+        "date-of-birth-day-required": "Date of birth must include a day",
+        "date-of-birth-is-past": "Date of birth must be in the past",
+        "date-of-birth-is-past-valid": "Date of birth too far in the past",
+        "date-of-birth-month-required": "Date of birth must include a month",
+        "date-of-birth-valid": "Day must be valid for the given month and year",
+        "date-of-birth-year-number": "Year must be a number, for example 1950",
+        "date-of-birth-year-required": "Date of birth must include a year",
+        "child-age-required": "Please indicate if all children are under 18"
+      },
+      "back-btn": "Back",
+      "continue-btn": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "application-delegate": {
+      "page-title": "Applying on behalf of someone cannot be completed online at this time",
+      "contact-representative": "You must <contactServiceCanada>speak to a Service Canada representative</contactServiceCanada> to apply on behalf of someone. Please contact Service Canada at <span>1-833-537-4342</span> or visit a Service Canada office.",
+      "prepare-to-apply": "<preparingToApply>Preparing to apply on behalf of someone</preparingToApply>",
+      "contact-service-canada-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
+      "preparing-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#helping",
+      "back-btn": "Back",
+      "return-btn": "Return to main page",
+      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    },
+    "file-your-taxes": {
+      "page-title": "File your taxes",
+      "ineligible-to-apply": "You are not eligible to apply for the Canadian Dental Care Plan at this time.",
+      "tax-not-filed": "You, your spouse or common-law partner have not filed a tax return for 2023 with the Canada Revenue Agency.",
+      "unable-to-assess": "We use the information from your tax file to verify that you meet the income eligibility for the CDCP. Until you file your 2023 taxes, we will not be able to assess your eligibility.",
+      "tax-info": "For more information on how to file your taxes, visit <taxInfo>Get ready to do your taxes.</taxInfo>",
+      "apply-after": "You can apply for the plan after you have filed your taxes and received your Notice of Assessment.",
+      "tax-info-href": "https://www.canada.ca/en/services/taxes/income-tax/personal-income-tax/get-ready-taxes.html",
+      "back-btn": "Back",
+      "return-btn": "Return to main page",
+      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    },
+    "dob-eligibility": {
+      "page-title": "Find out when you can apply",
+      "ineligible-to-apply": "You are not currently eligible to apply for the Canadian Dental Care Plan.",
+      "currently-accepting": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults who receive the Disability Tax Credit.",
+      "later-date": "Adults 18 to 64 who do not have a disability tax credit will be invited to apply for the Canadian Dental Care Plan in 2025.",
+      "eligibility-info": "<eligibilityInfo>Find out when you can apply for the Canadian Dental Care Plan</eligibilityInfo>",
+      "eligibility-info-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "back-btn": "Back",
+      "return-btn": "Return to main page",
+      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    }
+  },
+  "exit-application": {
+    "page-title": "Exit Application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and your information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "partner-information": {
+    "page-title": "Spouse or Common-law partner information",
+    "provide-sin": "Provide information on your current spouse or common-law partner as indicated on their Social Insurance Number (SIN) card or letter.",
+    "required-information": "This information is required to calculate the adjusted family net income. Your spouse or common-law partner must submit their own application for the Canadian Dental Care Plan.",
+    "sin": "Social Insurance Number (SIN)",
+    "date-of-birth": "Date of birth",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "single-legal-name": "If your spouse or common-law partner has a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-day-number": "Day must be a number",
+      "date-of-birth-day-required": "Date of birth must include a day",
+      "date-of-birth-is-past": "Date of birth must be in the past",
+      "date-of-birth-is-past-valid": "Date of birth too far in the past",
+      "date-of-birth-month-required": "Date of birth must include a month",
+      "date-of-birth-valid": "Day must be valid for the given month and year",
+      "date-of-birth-year-number": "Year must be a number, for example 1950",
+      "date-of-birth-year-required": "Date of birth must include a year",
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "sin-required": "Enter 9-digit SIN",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
+  },
+  "personal-information": {
+    "page-title": "Personal information",
+    "form-instructions": "Adding a phone number helps Service Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
+    "add-phone": "Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
+    "phone-number": "Phone number (optional)",
+    "phone-number-alt": "Alternate phone number (optional)",
+    "add-email": "Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
+    "email": "Email address (optional)",
+    "confirm-email": "Confirm email address (optional)",
+    "mailing-address": {
+      "header": "Mailing address"
+    },
+    "home-address": {
+      "header": "Home address",
+      "use-mailing-address": "My mailing address is the same as my home address"
+    },
+    "address-field": {
+      "address": "Address",
+      "address-note": "Include street number and name",
+      "apartment": "Apartment, suite, etc. (optional)",
+      "country": "Country",
+      "province": "Province, territory, state, or region",
+      "city": "City or town",
+      "postal-code": "Postal code or ZIP code",
+      "postal-code-optional": "Postal code or ZIP code (optional)",
+      "select-one": "Select one"
+    },
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "address-required": "Enter address, typically number and street",
+      "city-required": "Enter a city or town",
+      "country-required": "Select a country",
+      "postal-code-required": "Enter postal code or zip code",
+      "postal-code-valid": "Enter postal code in the correct format, such as A1A 1A1",
+      "province-required": "Select a province, territory, state or region",
+      "zip-code-valid": "Enter zip code in the correct format, such as 12345 or 12345-6789",
+      "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
+      "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com"
+    }
+  },
+  "review-information": {
+    "read-carefully": "Please review this information carefully. The information provided will be used by Sun Life to create your member account and will be reflected on your member card.",
+    "page-title": "Review Information",
+    "page-sub-title": "Applicant Information",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "sin-title": "Social Insurance Number (SIN)",
+    "sin-change": "Change SIN",
+    "full-name-title": "Full name",
+    "full-name-change": "Change full name",
+    "marital-title": "Marital status",
+    "marital-change": "Change marital status",
+    "spouse-title": "Spouse / Commom-law information",
+    "spouse-consent": {
+      "label": "Consent",
+      "yes": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
+      "no": "My spouse or common-law partner is aware and has not consented to sharing of their personal information."
+    },
+    "personal-info-title": "Personal Information",
+    "phone-title": "Phone number",
+    "phone-change": "Change phone number",
+    "alt-phone-title": "Alternate phone number",
+    "alt-phone-change": "Change alternate phone number",
+    "mailing-title": "Mailing address",
+    "mailing-change": "Change mailing address",
+    "home-title": "Home address",
+    "home-change": "Change home address",
+    "comm-title": "Communication",
+    "comm-electronic": "Email",
+    "comm-mail": "By mail",
+    "comm-pref-title": "Communication preference",
+    "comm-pref-change": "Change communication preference",
+    "added-email": "Added email: {{email}}",
+    "lang-pref-title": "Language preference",
+    "lang-pref-change": "Change language preference",
+    "dental-title": "Access to dental insurance",
+    "dental-insurance-title": "Access to dental insurance",
+    "dental-insurance-change": "Change answer to dental insurance",
+    "dental-benefit-title": "Access to governmental dental benefit",
+    "dental-benefit-change": "Change answer to public dental benefits",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "dental-benefit-has-no-access": "Has access to the following benefits:",
+    "submit-app-title": "Submit your application",
+    "submit-p-proceed": "By proceeding with this application, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "If you provide false information on your application, you and others you applied for may be removed from the plan.",
+    "submit-p-repayment": "If you or your family members were not eligible to apply, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "submit-button": "Submit Application",
+    "exit-button": "Exit application",
+    "yes": "Yes",
+    "no": "No"
+  }
+}

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -1,169 +1,4 @@
 {
-  "applicant-information": {
-    "page-title": "Applicant Information",
-    "form-instructions-sin": "Please provide your legal name as indicated on your Social Insurance Number (SIN) card or letter.",
-    "form-instructions-info": "We'll use the information you provide to verify your identity. Any information that does not match the information on your SIN application may cause a delay in the processing of your application.",
-    "sin": "Social Insurance Number (SIN)",
-    "last-name": "Last name",
-    "first-name": "First name",
-    "single-legal-name": "If you have a single legal name",
-    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
-    "marital-status": "Marital status",
-    "back-btn": "Back",
-    "continue-btn": "Continue",
-    "cancel-btn": "Cancel",
-    "save-btn": "Save",
-    "error-message": {
-      "first-name-required": "Enter first name",
-      "last-name-required": "Enter last name",
-      "marital-status-required": "Select marital status",
-      "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
-      "sin-required": "Enter 9-digit SIN",
-      "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
-    }
-  },
-  "communication-preference": {
-    "page-title": "Communication",
-    "note": "If you're eligible, we will share your information with Sun Life Assurance Company of Canada (Sun Life). Sun Life will be responsible for handling member enrolment and administering claims processing and benefits for the Canadian Dental Care Plan.",
-    "preferred-method": "What is your preferred method of communication for Sun Life?",
-    "preferred-language": "What is your preferred official language of communication?",
-    "email": "Email address",
-    "email-note": "Service Canada and Health Canada may use this email for future communication about the Canadian Dental Care Plan.",
-    "confirm-email": "Confirm email address",
-    "back": "Back",
-    "continue": "Continue",
-    "cancel-btn": "Cancel",
-    "save-btn": "Save",
-    "error-message": {
-      "email-match": "The email addresses entered do not match",
-      "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
-      "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "preferred-language-required": "Select preferred language of communication",
-      "preferred-method-required": "Select preferred method of communication"
-    }
-  },
-  "confirm": {
-    "page-title": "Application submitted",
-    "alert-heading": "You have successfully applied for the Canadian Dental Care Plan!",
-    "app-code-is": "Your application code is:",
-    "make-note": "Save this code, you'll need it to check the status of your application.",
-    "keep-copy": "Keep a copy of your application",
-    "print-copy-text": "You will <strong>not</strong> receive a <strong>confirmation email</strong>. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
-    "print-btn": "Print",
-    "whats-next": "What happens next",
-    "begin-process": "We will begin processing your application immediately.",
-    "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application or to recieve more information.",
-    "use-code": "You can use your application code to begin tracking the progress within 48 hours of applying.",
-    "register-msca-title": "Register for a My Service Canada Account",
-    "register-msca-text": "Once your application is processed, you will be able to sign into <mscaLink>My Service Canada Account (MSCA)</mscaLink>. You will also be able to view letters sent to you from the Government of Canada regarding the Canadian Dental Care Plan.",
-    "msca-notify": "You will be notified whether your application has been accepted or rejected in your My Service Canada Account.",
-    "msca-link": "https://www.canada.ca/en/employment-social-development/services/my-account.html",
-    "how-insurance": "How do I use my Canadian Dental Care Plan",
-    "eligible-text": "If you are deemed eligible, Sun Life will send you a welcome package by mail. Your welcome package will include your member card and details about the Canadian Dental Care Plan, including your coverage start date. The Canadian Dental Care Plan will not cover you for dental services received before that date.",
-    "more-info-cdcp": "For more information on what services and how much will be covered, visit <moreInfoLink>Canadian Dental Care Plan - What is covered</moreInfoLink>.",
-    "more-info-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/coverage.html",
-    "more-info-service": "For more information, please contact <dentalContactUsLink>Service Canada</dentalContactUsLink>.",
-    "dental-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
-    "application-summ": "Application summary",
-    "applicant-title": "Applicant information",
-    "spouse-info": "Spouse / Common-law information",
-    "contact-info": "Contact information",
-    "comm-prefs": "Communication",
-    "added-email": "Added email: {{email}}",
-    "dental-insurance": "Access to dental insurance",
-    "dob": "Date of birth",
-    "sin": "Social Insurance Number (SIN)",
-    "full-name": "Full name",
-    "marital-status": "Marital status",
-    "consent": "Consent",
-    "consent-answer": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
-    "phone-number": "Phone number",
-    "alt-phone-number": "Alternate phone number",
-    "mailing": "Mailing address",
-    "home": "Home address",
-    "comm-pref": "Communication preference",
-    "lang-pref": "Language preference",
-    "dental-private": "Access to dental insurance or coverage",
-    "dental-public": "Access to government dental benefit",
-    "application-code": "Application code",
-    "yes": "Yes",
-    "no": "No",
-    "exit": "Exit",
-    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html",
-    "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html"
-  },
-  "dental-benefits": {
-    "title": "Access to other federal, provincial or territorial dental benefits",
-    "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
-    "select-one": "Select one",
-    "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
-    "federal-benefits": {
-      "title": "Federal benefits",
-      "legend": "Do you have dental benefits through a social program offered by a federal program?",
-      "option-yes": "<strong>Yes</strong>, I have <strong>federal</strong> benefits",
-      "option-no": "<strong>No</strong>, I do not have <strong>federal</strong> benefits",
-      "social-programs": {
-        "legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
-      }
-    },
-    "provincial-territorial-benefits": {
-      "title": "Provincial or territorial benefits",
-      "legend": "Do you have dental benefits through a social program offered by your province or territory?",
-      "option-yes": "<strong>Yes</strong>, I have <strong>provincial or territorial</strong> benefits",
-      "option-no": "<strong>No</strong>, I do not have <strong>provincial or territorial</strong> benefits",
-      "social-programs": {
-        "input-legend": "If yes, through which province or territory?",
-        "radio-legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
-      }
-    },
-    "button": {
-      "back": "Back",
-      "continue": "Continue",
-      "cancel-btn": "Cancel",
-      "save-btn": "Save"
-    },
-    "error-message": {
-      "federal-benefit-required": "Select whether you have federal dental benefits",
-      "program-required": "Select a program",
-      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
-      "provincial-territorial-required": "Select a province or territory"
-    }
-  },
-  "dental-insurance": {
-    "title": "Access to other dental insurance",
-    "legend": "Do you have access to dental insurance or coverage through one of the following four situations?",
-    "list": {
-      "employment": "Your employment benefits or a family member's employment benefits, including health and wellness accounts",
-      "pension": "Your pension benefits or a family member's pension benefits",
-      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
-      "professional": "Through a professional or student organization"
-    },
-    "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
-    "option-no": "<strong>No</strong>, I do not have access to dental insurance or coverage",
-    "button": {
-      "back": "Back",
-      "continue": "Continue",
-      "cancel-btn": "Cancel",
-      "save-btn": "Save"
-    },
-    "detail": {
-      "additional-info": {
-        "title": "Additional information",
-        "eligible": "Exception: You may still be eligible if you are retired and:",
-        "list": {
-          "opted": "you opted out of pension benefits before December 11, 2023, and",
-          "cannot-opt": "you can't opt back in under the pension rules"
-        },
-        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your employer/pension (see exception) benefits or through a professional or student organization. As such, you are not eligible for the Canadian Dental Care Plan.",
-        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own (and not part of any of the coverage described above), you are not eligible for the CDCP while that coverage is in effect."
-      }
-    },
-    "error-message": {
-      "dental-insurance-required": "Select whether you have access to dental insurance"
-    }
-  },
   "disability-tax-credit": {
     "page-title": "Disability tax credit",
     "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
@@ -179,117 +14,6 @@
     "error-message": {
       "disability-tax-credit-required": "Select whether or not you have a valid disability tax credit"
     }
-  },
-  "eligibility": {
-    "type-of-application": {
-      "page-title": "Type of application",
-      "page-description": "Applications for the Canadian Dental Care Plan is opening in phases.",
-      "apply-self": "Applying for yourself",
-      "apply-self-eligibility": "You can currently apply for yourself if you are:",
-      "senior": "65 or older",
-      "valid-disability-tax-credit": "18 to 64 and have a valid Disability Tax Credit certificate",
-      "live-independently": "16 and 17 and live independently from your parents",
-      "apply-child": "Applying on behalf of your child",
-      "apply-child-eligibility": "You can apply on behalf of your child if:",
-      "sixteen-or-older": "You are 16 or older and the parent or legal guardian of the child; and",
-      "under-eighteen": "The child is under 18 years old",
-      "form-instructions": "Who are you applying for?",
-      "note": "please note, only one application can be processed for each child.",
-      "split-custody-summary": "If you split custody of a child",
-      "split-custody-detail": "If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
-      "radio-options": {
-        "personal": "I am applying for <strong>myself</strong>",
-        "delegate": "I am applying on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>",
-        "child": "I am applying for <strong>my child(ren)</strong>",
-        "personal-and-child": "I am applying for <strong>myself and my child(ren)</strong>"
-      },
-      "error-message": {
-        "type-of-application-required": "Select who this application is for"
-      },
-      "back-btn": "Back",
-      "continue-btn": "Continue"
-    },
-    "tax-filing": {
-      "page-title": "Tax filing",
-      "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2023 and received your Notice of Assessment?",
-      "radio-options": {
-        "yes": "Yes",
-        "no": "No"
-      },
-      "error-message": {
-        "tax-filing-required": "Select whether or not you have filed your taxes"
-      },
-      "back-btn": "Back",
-      "continue-btn": "Continue"
-    },
-    "date-of-birth": {
-      "page-title": "Age",
-      "description": "Applications for the Canadian Dental Care Plan will open in phases. Your date of birth determines when you can apply.",
-      "age-heading": "Your age",
-      "child-age-heading": "Your child(ren)'s age",
-      "form-instructions": "Please select your date of birth",
-      "child-age-instruction": "Are all the children you are applying for under 18?",
-      "yes": "Yes",
-      "no": "No",
-      "collapsible-content-summary": "If your child is over 18 and has a Disability Tax Credit",
-      "collapsible-content-detail": "You must speak to a Service Canada representative to apply on behalf of your child. Please contact Service Canada by calling 1-833-537-4342.",
-      "error-message": {
-        "date-of-birth-day-number": "Day must be a number",
-        "date-of-birth-day-required": "Date of birth must include a day",
-        "date-of-birth-is-past": "Date of birth must be in the past",
-        "date-of-birth-is-past-valid": "Date of birth too far in the past",
-        "date-of-birth-month-required": "Date of birth must include a month",
-        "date-of-birth-valid": "Day must be valid for the given month and year",
-        "date-of-birth-year-number": "Year must be a number, for example 1950",
-        "date-of-birth-year-required": "Date of birth must include a year",
-        "child-age-required": "Please indicate if all children are under 18"
-      },
-      "back-btn": "Back",
-      "continue-btn": "Continue",
-      "cancel-btn": "Cancel",
-      "save-btn": "Save"
-    },
-    "application-delegate": {
-      "page-title": "Applying on behalf of someone cannot be completed online at this time",
-      "contact-representative": "You must <contactServiceCanada>speak to a Service Canada representative</contactServiceCanada> to apply on behalf of someone. Please contact Service Canada at <span>1-833-537-4342</span> or visit a Service Canada office.",
-      "prepare-to-apply": "<preparingToApply>Preparing to apply on behalf of someone</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
-      "preparing-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#helping",
-      "back-btn": "Back",
-      "return-btn": "Return to main page",
-      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-    },
-    "file-your-taxes": {
-      "page-title": "File your taxes",
-      "ineligible-to-apply": "You are not eligible to apply for the Canadian Dental Care Plan at this time.",
-      "tax-not-filed": "You, your spouse or common-law partner have not filed a tax return for 2023 with the Canada Revenue Agency.",
-      "unable-to-assess": "We use the information from your tax file to verify that you meet the income eligibility for the CDCP. Until you file your 2023 taxes, we will not be able to assess your eligibility.",
-      "tax-info": "For more information on how to file your taxes, visit <taxInfo>Get ready to do your taxes.</taxInfo>",
-      "apply-after": "You can apply for the plan after you have filed your taxes and received your Notice of Assessment.",
-      "tax-info-href": "https://www.canada.ca/en/services/taxes/income-tax/personal-income-tax/get-ready-taxes.html",
-      "back-btn": "Back",
-      "return-btn": "Return to main page",
-      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-    },
-    "dob-eligibility": {
-      "page-title": "Find out when you can apply",
-      "ineligible-to-apply": "You are not currently eligible to apply for the Canadian Dental Care Plan.",
-      "currently-accepting": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults who receive the Disability Tax Credit.",
-      "later-date": "Adults 18 to 64 who do not have a disability tax credit will be invited to apply for the Canadian Dental Care Plan in 2025.",
-      "eligibility-info": "<eligibilityInfo>Find out when you can apply for the Canadian Dental Care Plan</eligibilityInfo>",
-      "eligibility-info-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
-      "back-btn": "Back",
-      "return-btn": "Return to main page",
-      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-    }
-  },
-  "exit-application": {
-    "page-title": "Exit Application",
-    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and your information will be lost.",
-    "click-back": "Click \"Back\" to return to the form.",
-    "back-btn": "Back",
-    "exit-btn": "Exit",
-    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
   "index": {
     "page-title": "Applying for the Canadian Dental Care Plan"
@@ -315,140 +39,10 @@
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
-  "partner-information": {
-    "page-title": "Spouse or Common-law partner information",
-    "provide-sin": "Provide information on your current spouse or common-law partner as indicated on their Social Insurance Number (SIN) card or letter.",
-    "required-information": "This information is required to calculate the adjusted family net income. Your spouse or common-law partner must submit their own application for the Canadian Dental Care Plan.",
-    "sin": "Social Insurance Number (SIN)",
-    "date-of-birth": "Date of birth",
-    "last-name": "Last name",
-    "first-name": "First name",
-    "single-legal-name": "If your spouse or common-law partner has a single legal name",
-    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
-    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
-    "back-btn": "Back",
-    "continue-btn": "Continue",
-    "cancel-btn": "Cancel",
-    "save-btn": "Save",
-    "error-message": {
-      "confirm-required": "Checkbox must be selected",
-      "date-of-birth-day-number": "Day must be a number",
-      "date-of-birth-day-required": "Date of birth must include a day",
-      "date-of-birth-is-past": "Date of birth must be in the past",
-      "date-of-birth-is-past-valid": "Date of birth too far in the past",
-      "date-of-birth-month-required": "Date of birth must include a month",
-      "date-of-birth-valid": "Day must be valid for the given month and year",
-      "date-of-birth-year-number": "Year must be a number, for example 1950",
-      "date-of-birth-year-required": "Date of birth must include a year",
-      "first-name-required": "Enter first name",
-      "last-name-required": "Enter last name",
-      "sin-required": "Enter 9-digit SIN",
-      "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
-    }
-  },
-  "personal-information": {
-    "page-title": "Personal information",
-    "form-instructions": "Adding a phone number helps Service Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
-    "add-phone": "Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
-    "phone-number": "Phone number (optional)",
-    "phone-number-alt": "Alternate phone number (optional)",
-    "add-email": "Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
-    "email": "Email address (optional)",
-    "confirm-email": "Confirm email address (optional)",
-    "mailing-address": {
-      "header": "Mailing address"
-    },
-    "home-address": {
-      "header": "Home address",
-      "use-mailing-address": "My mailing address is the same as my home address"
-    },
-    "address-field": {
-      "address": "Address",
-      "address-note": "Include street number and name",
-      "apartment": "Apartment, suite, etc. (optional)",
-      "country": "Country",
-      "province": "Province, territory, state, or region",
-      "city": "City or town",
-      "postal-code": "Postal code or ZIP code",
-      "postal-code-optional": "Postal code or ZIP code (optional)",
-      "select-one": "Select one"
-    },
-    "back": "Back",
-    "continue": "Continue",
-    "cancel-btn": "Cancel",
-    "save-btn": "Save",
-    "error-message": {
-      "address-required": "Enter address, typically number and street",
-      "city-required": "Enter a city or town",
-      "country-required": "Select a country",
-      "postal-code-required": "Enter postal code or zip code",
-      "postal-code-valid": "Enter postal code in the correct format, such as A1A 1A1",
-      "province-required": "Select a province, territory, state or region",
-      "zip-code-valid": "Enter zip code in the correct format, such as 12345 or 12345-6789",
-      "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
-      "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
-      "email-match": "The email addresses entered do not match",
-      "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
-      "email-valid": "Enter an email address in the correct format, such as name@example.com"
-    }
-  },
   "progress": {
     "label": "Application Progress Tracking"
   },
   "required-label": "Complete all fields unless marked as optional",
-  "review-information": {
-    "read-carefully": "Please review this information carefully. The information provided will be used by Sun Life to create your member account and will be reflected on your member card.",
-    "page-title": "Review Information",
-    "page-sub-title": "Applicant Information",
-    "dob-title": "Date of birth",
-    "dob-change": "Change date of birth",
-    "sin-title": "Social Insurance Number (SIN)",
-    "sin-change": "Change SIN",
-    "full-name-title": "Full name",
-    "full-name-change": "Change full name",
-    "marital-title": "Marital status",
-    "marital-change": "Change marital status",
-    "spouse-title": "Spouse / Commom-law information",
-    "spouse-consent": {
-      "label": "Consent",
-      "yes": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
-      "no": "My spouse or common-law partner is aware and has not consented to sharing of their personal information."
-    },
-    "personal-info-title": "Personal Information",
-    "phone-title": "Phone number",
-    "phone-change": "Change phone number",
-    "alt-phone-title": "Alternate phone number",
-    "alt-phone-change": "Change alternate phone number",
-    "mailing-title": "Mailing address",
-    "mailing-change": "Change mailing address",
-    "home-title": "Home address",
-    "home-change": "Change home address",
-    "comm-title": "Communication",
-    "comm-electronic": "Email",
-    "comm-mail": "By mail",
-    "comm-pref-title": "Communication preference",
-    "comm-pref-change": "Change communication preference",
-    "added-email": "Added email: {{email}}",
-    "lang-pref-title": "Language preference",
-    "lang-pref-change": "Change language preference",
-    "dental-title": "Access to dental insurance",
-    "dental-insurance-title": "Access to dental insurance",
-    "dental-insurance-change": "Change answer to dental insurance",
-    "dental-benefit-title": "Access to governmental dental benefit",
-    "dental-benefit-change": "Change answer to public dental benefits",
-    "dental-benefit-has-access": "Has access to the following benefits:",
-    "dental-benefit-has-no-access": "Has access to the following benefits:",
-    "submit-app-title": "Submit your application",
-    "submit-p-proceed": "By proceeding with this application, you are agreeing to attest truthfully to the information provided.",
-    "submit-p-false-info": "If you provide false information on your application, you and others you applied for may be removed from the plan.",
-    "submit-p-repayment": "If you or your family members were not eligible to apply, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
-    "submit-button": "Submit Application",
-    "exit-button": "Exit application",
-    "yes": "Yes",
-    "no": "No"
-  },
   "terms-and-conditions": {
     "page-title": "Terms and conditions",
     "page-heading": "Terms and conditions of use and privacy notice statement",
@@ -517,5 +111,33 @@
       "info-source": "https://www.canada.ca/en/employment-social-development/corporate/transparency/access-information/reports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/en-ca/trust-center/privacy"
     }
+  },
+  "type-of-application": {
+    "page-title": "Type of application",
+    "page-description": "Applications for the Canadian Dental Care Plan is opening in phases.",
+    "apply-self": "Applying for yourself",
+    "apply-self-eligibility": "You can currently apply for yourself if you are:",
+    "senior": "65 or older",
+    "valid-disability-tax-credit": "18 to 64 and have a valid Disability Tax Credit certificate",
+    "live-independently": "16 and 17 and live independently from your parents",
+    "apply-child": "Applying on behalf of your child",
+    "apply-child-eligibility": "You can apply on behalf of your child if:",
+    "sixteen-or-older": "You are 16 or older and the parent or legal guardian of the child; and",
+    "under-eighteen": "The child is under 18 years old",
+    "form-instructions": "Who are you applying for?",
+    "note": "please note, only one application can be processed for each child.",
+    "split-custody-summary": "If you split custody of a child",
+    "split-custody-detail": "If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
+    "radio-options": {
+      "personal": "I am applying for <strong>myself</strong>",
+      "delegate": "I am applying on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>",
+      "child": "I am applying for <strong>my child(ren)</strong>",
+      "personal-and-child": "I am applying for <strong>myself and my child(ren)</strong>"
+    },
+    "error-message": {
+      "type-of-application-required": "Select who this application is for"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
   }
 }

--- a/frontend/public/locales/fr/adult-apply.json
+++ b/frontend/public/locales/fr/adult-apply.json
@@ -1,0 +1,381 @@
+{
+  "applicant-information": {
+    "page-title": "Renseignements sur le demandeur",
+    "form-instructions-sin": "Veuillez indiquer votre nom légal tel qu'indiqué sur votre carte ou votre lettre de numéro d'assurance sociale (NAS).",
+    "form-instructions-info": "Nous utiliserons les renseignements que vous avez fournis pour vérifier votre identité. Tout renseignement qui ne correspond pas à ceux associés à votre numéro d'assurance sociale pourrait retarder le traitement de votre demande.",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "last-name": "Nom de famille",
+    "first-name": "Prénom",
+    "single-legal-name": "(FR) If you have a single legal name",
+    "name-instructions": "Si vous utilisez un seul nom légal, veuillez indiquer ce nom dans les DEUX champs «\u00a0Prénom\u00a0» et «\u00a0Nom de famille\u00a0».",
+    "marital-status": "État civil",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "first-name-required": "Entrez le prénom",
+      "last-name-required": "Entrez le nom de famille",
+      "marital-status-required": "Sélectionnez l'état civil",
+      "marital-status-no-partner-information": "Si vous êtes marié ou vivez en conjoint de fait, vous devez saisir leurs informations sur la page suivante. Sélectionnez votre état civil et appuyez sur «\u00a0Enregistrer\u00a0».",
+      "sin-required": "Entrez un NAS de 9 chiffres",
+      "sin-valid": "Le NAS doit être valide",
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+    }
+  },
+  "communication-preference": {
+    "page-title": "Communication",
+    "note": "Si vous êtes admissible, nous communiquerons vos renseignements à la Sun Life du Canada, compagnie d'assurance-vie (Sun Life). La Sun Life sera responsable du traitement de l'adhésion des membres et de l'administration des demandes de réclamations et des prestations du Régime canadien de soins dentaires.",
+    "preferred-method": "Quel est votre mode de communication préféré pour la Sun Life?",
+    "preferred-language": "Quelle langue officielle de communication préférez-vous",
+    "email": "Adresse courriel",
+    "email-note": "Service Canada et Santé Canada peuvent utiliser ce courriel pour des communications futures au sujet du Régime canadien de soins dentaires.",
+    "confirm-email": "Confirmer l'adresse courriel",
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "email-match": "Les adresses courriel entrées ne concordent pas",
+      "confirm-email-required": "Confirmez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
+      "preferred-language-required": "Sélectionnez la langue de communication préférée",
+      "preferred-method-required": "Sélectionnez le moyen de communication préféré"
+    }
+  },
+  "confirm": {
+    "page-title": "Demande transmise",
+    "alert-heading": "Vous avez présenté avec succès une demande au Régime canadien de soins dentaires!",
+    "app-code-is": "Votre code de demande est\u00a0:",
+    "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
+    "keep-copy": "Conservez une copie de votre demande",
+    "print-copy-text": "Vous <strong>ne recevrez pas</strong> de <strong>courriel de confirmation</strong>. Il est important de conserver une copie de votre demande. <noPrint>Vous pouvez utiliser ce bouton pour imprimer.<noPrint>",
+    "print-btn": "Imprimer",
+    "whats-next": "Prochaines étapes",
+    "begin-process": "Nous commencerons à traiter votre demande immédiatement.",
+    "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
+    "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
+    "register-msca-title": "Inscrivez-vous à Mon dossier Service Canada dès maintenant",
+    "register-msca-text": "Une fois votre demande traitée, vous pourrez ouvrir une session dans <mscaLink>Mon dossier Service Canada (MDSC)</mscaLink>. Vous pourrez consulter les lettres qui vous ont été envoyées par le gouvernement du Canada au sujet du Régime canadien de soins dentaires.",
+    "msca-notify": "Vous serez avisé si votre demande a été acceptée ou rejetée dans Mon dossier Service Canada.",
+    "msca-link": "https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier.html",
+    "how-insurance": "Comment utiliser le Régime canadien de soins dentaires",
+    "eligible-text": "Si vous êtes jugé admissible, la Sun Life vous enverra par la poste une trousse de bienvenue. Votre trousse de bienvenue comprendra votre carte de membre et des renseignements sur le Régime canadien de soins dentaires, y compris la date de début de votre couverture. Le Régime canadien de soins dentaires ne vous couvrira pas les services de soins dentaires reçus avant cette date.",
+    "more-info-cdcp": "Pour en savoir plus sur les services et le montant de la couverture, consultez le site Web du Régime canadien de soins dentaires. <moreInfoLink>Quels sont les services couverts.</moreInfoLink>",
+    "more-info-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/couverture.html",
+    "more-info-service": "Pour plus d'informations, <dentalContactUsLink>contactez Service Canada</dentalContactUsLink>.",
+    "dental-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
+    "application-summ": "Sommaire de la demande",
+    "applicant-title": "Renseignements sur le demandeur",
+    "spouse-info": "Renseignements sur l'époux/épouse ou le conjoint(e) de fait",
+    "contact-info": "Coordonnées",
+    "comm-prefs": "Communication",
+    "added-email": "Courriel ajouté\u00a0: {{email}}",
+    "dental-insurance": "Accès à une assurance ou une couverture dentaire",
+    "dob": "Date de naissance",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "full-name": "Nom complet",
+    "marital-status": "État civil",
+    "consent": "Consentement",
+    "consent-answer": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et a consenti à la communication de ses renseignements personnels.",
+    "phone-number": "Numéro de téléphone",
+    "alt-phone-number": "Autre numéro de téléphone",
+    "mailing": "Adresse postale",
+    "home": "Adresse domiciliaire",
+    "comm-pref": "Préférence en matière de communication",
+    "lang-pref": "Langue de préférence",
+    "dental-private": "Accès à une assurance dentaire",
+    "dental-public": "Accès à des prestations dentaires gouvernementales",
+    "application-code": "Code de demande",
+    "yes": "Oui",
+    "no": "Non",
+    "exit": "Sortie",
+    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
+    "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
+  },
+  "dental-benefits": {
+    "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+    "access-to-dental": "L'accès à une assurance dentaire dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur votre admissibilité au Régime canadien de soins dentaires.",
+    "eligibility-criteria": "Si vous répondez à tous les critères d'admissibilité, votre couverture sera coordonnée entre les régimes afin qu'il n'y ait pas de lacunes ou de dédoublement dans la couverture.",
+    "select-one": "Choisissez une option",
+    "federal-benefits": {
+      "title": "Prestations fédérales",
+      "legend": "Bénéficiez-vous d'une assurance dentaire dans le cadre d'un programme social offert par un programme fédéral?",
+      "option-yes": "<strong>Oui</strong>, je bénéficie d'une assurance <strong>fédérale</strong>",
+      "option-no": "<strong>Non</strong>, je ne bénéficie pas d'une assurance <strong>fédérale</strong>",
+      "social-programs": {
+        "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
+      }
+    },
+    "provincial-territorial-benefits": {
+      "title": "Assurances provinciales ou territoriales",
+      "legend": "Bénéficiez-vous d'une assurance dentaire dans le cadre d'un programme social offert par votre province ou territoire?",
+      "option-yes": "<strong>Oui</strong>, j'ai une assurance <strong>provinciale ou territoriale</strong>",
+      "option-no": "<strong>Non</strong>, je n'ai pas d'assurance <strong>provinciale ou territoriale</strong>",
+      "social-programs": {
+        "input-legend": "Si oui, par l'entremise de quelle province ou de quel territoire?",
+        "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
+      }
+    },
+    "button": {
+      "back": "Retour",
+      "continue": "Continuer",
+      "cancel-btn": "Annuler",
+      "save-btn": "Enregistrer"
+    },
+    "error-message": {
+      "federal-benefit-required": "Sélectionnez si vous avez la prestation dentaire fédérale",
+      "program-required": "Sélectionnez un programme",
+      "provincial-benefit-required": "Sélectionnez si vous avez la prestation dentaire provinciale ou territoriale",
+      "provincial-territorial-required": "Sélectionnez une province ou territoire"
+    }
+  },
+  "dental-insurance": {
+    "title": "Accès à d'autres assurances dentaires",
+    "legend": "Avez-vous accès à une assurance dentaire ou à une couverture dans l'une des quatre situations suivantes?",
+    "list": {
+      "employment": "Vos avantages en matière d'emploi ou les avantages en matière d'emploi d'un membre de votre famille, y compris vos comptes de santé et de bien-être",
+      "pension": "Vos prestations de retraite ou celles d'un membre de votre famille",
+      "purchased": "Assurance ou couverture achetée individuellement par vous, par un membre de votre famille ou par l'entremise d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+      "professional": "Assurance ou couverture par une organisation professionnelle ou étudiante"
+    },
+    "option-yes": "<strong>Oui</strong>, j'ai accès à une assurance dentaire",
+    "option-no": "<strong>Non</strong>, je n'ai pas accès à une assurance dentaire",
+    "button": {
+      "back": "Retour",
+      "continue": "Continuer",
+      "cancel-btn": "Annuler",
+      "save-btn": "Enregistrer"
+    },
+    "detail": {
+      "additional-info": {
+        "title": "Renseignements supplémentaires",
+        "eligible": "Exception\u00a0: vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
+        "list": {
+          "opted": "Vous avez choisi de ne pas recevoir de prestations de retraite avant le 11 décembre 2023;",
+          "cannot-opt": "Vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite;"
+        },
+        "not-eligible": "Vous êtes toujours considéré comme ayant accès à une assurance ou à une couverture dentaire si vous choisissez de vous retirer des avantages offerts par votre employeur ou votre régime de retraite (voir l'exception) ou par l'entremise d'une organisation professionnelle ou étudiante. Par conséquent, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
+        "not-eligible-purchased": "Si vous avez souscrit votre police d'assurance dentaire actuelle de votre propre chef (et non dans le cadre de l'une des couvertures décrites ci-dessus), vous n'êtes pas admissible au RCSD pendant que cette protection est en vigueur."
+      }
+    },
+    "error-message": {
+      "dental-insurance-required": "Sélectionnez si vous avez une assurance dentaire"
+    }
+  },
+  "eligibility": {
+    "tax-filing": {
+      "page-title": "Déclaration de revenus",
+      "form-instructions": "Est-ce que vous et votre époux/épouse ou conjoint/conjointe de fait (s'il y a lieu) avez produit votre déclaration de revenus pour 2023 et avez reçu votre avis de cotisation?",
+      "radio-options": {
+        "yes": "Oui",
+        "no": "Non"
+      },
+      "error-message": {
+        "tax-filing-required": "Sélectionnez si vous avez fait votre déclaration de revenus ou non"
+      },
+      "back-btn": "Retour",
+      "continue-btn": "Continuer"
+    },
+    "date-of-birth": {
+      "page-title": "Âge",
+      "description": "Les demandes au titre du Régime canadien de soins dentaires seront acceptées progressivement. Votre date de naissance détermine le moment où vous pouvez présenter une demande.",
+      "age-heading": "(FR) Your age",
+      "child-age-heading": "(FR) Your child(ren)'s age",
+      "form-instructions": "Veuillez sélectionner votre date de naissance",
+      "child-age-instruction": "(FR) Are all the children you are applying for under 18?",
+      "yes": "Oui",
+      "no": "Non",
+      "collapsible-content-summary": "(FR) If your child is over 18 and has a Disability Tax Credit",
+      "collapsible-content-detail": "(FR) You must speak to a Service Canada representative to apply on behalf of your child. Please contact Service Canada by calling 1-833-537-4342.",
+      "error-message": {
+        "date-of-birth-day-number": "Le jour doit être un nombre",
+        "date-of-birth-day-required": "La date de naissance doit inclure un jour",
+        "date-of-birth-is-past": "La date de naissance doit être dans le passé",
+        "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
+        "date-of-birth-month-required": "La date de naissance doit inclure un mois",
+        "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
+        "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
+        "date-of-birth-year-required": "La date de naissance doit inclure une année",
+        "child-age-required": "(FR) Please indicate if all children are under 18"
+      },
+      "back-btn": "Retour",
+      "continue-btn": "Continuer",
+      "cancel-btn": "Annuler",
+      "save-btn": "Enregistrer"
+    },
+    "application-delegate": {
+      "page-title": "La demande au nom d'une autre personne ne peut pas être effectuée en ligne pour le moment.",
+      "contact-representative": "Vous devez <contactServiceCanada>parler à un représentant de Service Canada</contactServiceCanada> pour présenter une demande au nom de quelqu'un. Veuillez communiquer avec Service Canada au <span>1-833-537-4342</span> ou vous rendre dans un bureau de Service Canada.",
+      "prepare-to-apply": "<preparingToApply>Se préparer à présenter une demande au nom de quelqu'un</preparingToApply>",
+      "contact-service-canada-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
+      "preparing-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#aide",
+      "back-btn": "Retour",
+      "return-btn": "Revenir à la page principale",
+      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+    },
+    "file-your-taxes": {
+      "page-title": "Produire votre déclaration de revenus",
+      "ineligible-to-apply": "Vous n'êtes pas admissible au Régime canadien de soins dentaires pour le moment.",
+      "tax-not-filed": "Vous, votre épouse/époux ou conjoint(e) de fait n'avez pas produit de déclaration de revenus pour l'année 2023 auprès de l'Agence du revenu du Canada.",
+      "unable-to-assess": "Nous utilisons les renseignements de votre déclaration de revenus pour nous assurer que vous répondez aux critères d'admissibilité au RCSD. Tant que vous n'aurez pas produit votre déclaration de revenus de 2023, nous ne pourrons pas évaluer votre admissibilité.",
+      "tax-info": "Pour en savoir plus sur la façon de produire votre déclaration de revenus, consultez la page <taxInfo>Préparez-vous à faire vos impôts.</taxInfo>",
+      "apply-after": "Vous pouvez demander le plan après avoir produit vos déclarations de revenus et reçu votre avis de cotisation.",
+      "tax-info-href": "https://www.canada.ca/fr/services/impots/impot-sur-le-revenu/impot-sur-le-revenu-des-particuliers/preparez-vous-impots.html",
+      "back-btn": "Retour",
+      "return-btn": "Revenir à la page principale",
+      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+    },
+    "dob-eligibility": {
+      "page-title": "Découvrez quand vous pouvez présenter une demande",
+      "ineligible-to-apply": "Vous n'êtes actuellement pas admissible au Régime canadien de soins dentaires.",
+      "currently-accepting": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults who receive the Disability Tax Credit.",
+      "later-date": "(FR) Adults 18 to 64 who do not have a disability tax credit will be invited to apply for the Canadian Dental Care Plan in 2025.",
+      "eligibility-info": "<eligibilityInfo>Découvrez quand vous pouvez faire une demande au Régime canadien de soins dentaires.</eligibilityInfo>",
+      "eligibility-info-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
+      "back-btn": "Retour",
+      "return-btn": "Revenir à la page principale",
+      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+    }
+  },
+  "exit-application": {
+    "page-title": "Quitter la demande",
+    "are-you-sure": "Êtes-vous sûr de vouloir quitter cette demande? Si vous cliquez sur «\u00a0Quitter\u00a0», le formulaire sera réinitialisé et vous perdrez vos informations.",
+    "click-back": "Cliquez sur «\u00a0Retour\u00a0» pour revenir au formulaire.",
+    "back-btn": "Retour",
+    "exit-btn": "Quitter",
+    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
+  "partner-information": {
+    "page-title": "Renseignements sur l'époux/épouse ou le conjoint/conjointe de fait",
+    "provide-sin": "Fournissez les renseignements sur votre époux/épouse ou conjoint/conjointe de fait actuel tels qu'ils figurent sur sa carte ou lettre d'assurance sociale (NAS).",
+    "required-information": "Ces renseignements sont nécessaires pour calculer le revenu familial net rajusté. Votre époux/épouse ou conjoint/conjointe de fait doit présenter sa propre demande au Régime canadien de soins dentaires.",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "date-of-birth": "Date de naissance",
+    "last-name": "Nom de famille",
+    "first-name": "Prénom",
+    "single-legal-name": "(FR) If your spouse or common-law partner has a single legal name",
+    "name-instructions": "Si vous utilisez un seul nom légal, veuillez indiquer ce nom dans les DEUX champs «\u00a0Prénom\u00a0» et «\u00a0Nom de famille\u00a0».",
+    "confirm-checkbox": "Je confirme que mon époux/épouse ou mon conjoint/conjointe de fait est au courant et d'accord que ses renseignements personnels soient communiqués.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "confirm-required": "La case à cocher doit être sélectionnée",
+      "date-of-birth-day-number": "Le jour doit être un nombre",
+      "date-of-birth-day-required": "La date de naissance doit inclure un jour",
+      "date-of-birth-is-past": "La date de naissance doit être dans le passé",
+      "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
+      "date-of-birth-month-required": "La date de naissance doit inclure un mois",
+      "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
+      "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
+      "date-of-birth-year-required": "La date de naissance doit inclure une année",
+      "first-name-required": "Entrez le prénom",
+      "last-name-required": "Entrez le nom de famille",
+      "sin-required": "Entrez un NAS de 9 chiffres",
+      "sin-valid": "Le NAS doit être valide",
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+    }
+  },
+  "personal-information": {
+    "page-title": "Renseignements personnels",
+    "form-instructions": "L'ajout d'un numéro de téléphone permet à Service Canada de vous contacter en cas de problème avec votre demande. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
+    "add-phone": "(FR) Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
+    "phone-number": "Numéro de téléphone (facultatif)",
+    "phone-number-alt": "Autre numéro de téléphone (facultatif)",
+    "add-email": "(FR) Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
+    "email": "Adresse courriel (facultatif)",
+    "confirm-email": "Confirmer l'adresse courriel (facultatif)",
+    "mailing-address": {
+      "header": "Adresse postale"
+    },
+    "home-address": {
+      "header": "Adresse du domicile",
+      "use-mailing-address": "Mon adresse postale et mon adresse domiciliaire sont les mêmes."
+    },
+    "address-field": {
+      "address": "Adresse",
+      "address-note": "Inclure le numéro municipal et le nom de rue",
+      "apartment": "Appartement, suite, etc. (facultatif)",
+      "country": "Pays",
+      "province": "Province, territoire, état ou région",
+      "city": "Ville ou municipalité",
+      "postal-code": "Code postal/code ZIP",
+      "postal-code-optional": "Code postal/code ZIP (facultatif)",
+      "select-one": "Choisissez une option"
+    },
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "address-required": "Entrez l'adresse, normalement le numéro et le nom de la rue",
+      "city-required": "Entrez une ville ou une municipalité",
+      "country-required": "Sélectionnez un pays",
+      "postal-code-required": "Entrez un code postal ou un code postal américain",
+      "postal-code-valid": "Entrez un code postal dans le bon format, par exemple A1A 1A1",
+      "province-required": "Sélectionnez une province, un territoire, un état ou une région",
+      "zip-code-valid": "Entrez un code postal américain dans le bon format, par exemple 12345 ou 12345-6789",
+      "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
+      "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
+      "email-match": "Les adresses courriel entrées ne concordent pas",
+      "confirm-email-required": "Confirmez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
+      "preferred-language-required": "Sélectionnez la langue de communication préférée"
+    }
+  },
+  "review-information": {
+    "read-carefully": "Veuillez examiner attentivement les renseignements suivants. Les renseignements fournis seront utilisés par la Sun Life pour créer votre compte de membre et figureront sur votre carte de membre.",
+    "page-title": "Vérifiez vos renseignements",
+    "page-sub-title": "Renseignements sur le demandeur",
+    "dob-title": "Date de naissance",
+    "dob-change": "Modifier la date de naissance",
+    "sin-title": "Numéro d'assurance sociale (NAS)",
+    "sin-change": "Modifier le NAS",
+    "full-name-title": "Nom complet",
+    "full-name-change": "Modifier le nom complet",
+    "marital-title": "État civil",
+    "marital-change": "Modifier l'état civil",
+    "spouse-title": "Renseignements sur l'époux/épouse ou le conjoint(e) de fait",
+    "spouse-consent": {
+      "label": "Consentement",
+      "yes": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et a consenti à la communication de ses renseignements personnels.",
+      "no": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et n'a pas consenti à la communication de ses renseignements personnels."
+    },
+    "personal-info-title": "Renseignements personnels",
+    "phone-title": "Téléphone",
+    "phone-change": "Modifier le numéro de téléphone",
+    "alt-phone-title": "Autre numéro de téléphone",
+    "alt-phone-change": "Modifier l'autre numéro de téléphone",
+    "mailing-title": "Adresse postale",
+    "mailing-change": "Modifier l'adresse postale",
+    "home-title": "Adresse domiciliaire",
+    "home-change": "Modifier l'adresse domiciliaire",
+    "comm-title": "Communication",
+    "comm-electronic": "Courriel",
+    "comm-mail": "Par la poste",
+    "comm-pref-title": "Préférence en matière de communication",
+    "comm-pref-change": "Modifier la préférence de communication",
+    "added-email": "Courriel ajouté\u00a0: {{email}}",
+    "lang-pref-title": "Langue de préférence",
+    "lang-pref-change": "Modifier la langue de préférence",
+    "dental-title": "Accès à l'assurance dentaire",
+    "dental-insurance-title": "Accès à une assurance ou une couverture dentaire",
+    "dental-insurance-change": "Modifier la réponse à «\u00a0accès à l'assurance dentaire\u00a0»",
+    "dental-benefit-title": "Accès à des prestations dentaires gouvernementales",
+    "dental-benefit-change": "Modifier la réponse à «\u00a0soins dentaires gouvernementaux\u00a0»",
+    "dental-benefit-has-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
+    "dental-benefit-has-no-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
+    "submit-app-title": "Soumettre votre demande",
+    "submit-p-proceed": "En transmettant votre demande, vous consentez à attester de la véracité des informations fournies.",
+    "submit-p-false-info": "Si vous fournissez de fausses informations sur votre demande, vous et les autres personnes pour lesquelles vous avez postulé pourriez être exclus du régime.",
+    "submit-p-repayment": "Si vous ou les membres de votre famille n'étiez pas admissibles, vous ou les membres de votre famille pourriez devoir rembourser le coût total des soins reçus dans le cadre du régime canadien de soins dentaires.",
+    "submit-button": "Soumettre la demande",
+    "exit-button": "Quitter la demande",
+    "yes": "Oui",
+    "no": "Non"
+  }
+}

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -1,169 +1,4 @@
 {
-  "applicant-information": {
-    "page-title": "Renseignements sur le demandeur",
-    "form-instructions-sin": "Veuillez indiquer votre nom légal tel qu'indiqué sur votre carte ou votre lettre de numéro d'assurance sociale (NAS).",
-    "form-instructions-info": "Nous utiliserons les renseignements que vous avez fournis pour vérifier votre identité. Tout renseignement qui ne correspond pas à ceux associés à votre numéro d'assurance sociale pourrait retarder le traitement de votre demande.",
-    "sin": "Numéro d'assurance sociale (NAS)",
-    "last-name": "Nom de famille",
-    "first-name": "Prénom",
-    "single-legal-name": "(FR) If you have a single legal name",
-    "name-instructions": "Si vous utilisez un seul nom légal, veuillez indiquer ce nom dans les DEUX champs «\u00a0Prénom\u00a0» et «\u00a0Nom de famille\u00a0».",
-    "marital-status": "État civil",
-    "back-btn": "Retour",
-    "continue-btn": "Continuer",
-    "cancel-btn": "Annuler",
-    "save-btn": "Enregistrer",
-    "error-message": {
-      "first-name-required": "Entrez le prénom",
-      "last-name-required": "Entrez le nom de famille",
-      "marital-status-required": "Sélectionnez l'état civil",
-      "marital-status-no-partner-information": "Si vous êtes marié ou vivez en conjoint de fait, vous devez saisir leurs informations sur la page suivante. Sélectionnez votre état civil et appuyez sur «\u00a0Enregistrer\u00a0».",
-      "sin-required": "Entrez un NAS de 9 chiffres",
-      "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
-    }
-  },
-  "communication-preference": {
-    "page-title": "Communication",
-    "note": "Si vous êtes admissible, nous communiquerons vos renseignements à la Sun Life du Canada, compagnie d'assurance-vie (Sun Life). La Sun Life sera responsable du traitement de l'adhésion des membres et de l'administration des demandes de réclamations et des prestations du Régime canadien de soins dentaires.",
-    "preferred-method": "Quel est votre mode de communication préféré pour la Sun Life?",
-    "preferred-language": "Quelle langue officielle de communication préférez-vous",
-    "email": "Adresse courriel",
-    "email-note": "Service Canada et Santé Canada peuvent utiliser ce courriel pour des communications futures au sujet du Régime canadien de soins dentaires.",
-    "confirm-email": "Confirmer l'adresse courriel",
-    "back": "Retour",
-    "continue": "Continuer",
-    "cancel-btn": "Annuler",
-    "save-btn": "Enregistrer",
-    "error-message": {
-      "email-match": "Les adresses courriel entrées ne concordent pas",
-      "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
-      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
-      "preferred-language-required": "Sélectionnez la langue de communication préférée",
-      "preferred-method-required": "Sélectionnez le moyen de communication préféré"
-    }
-  },
-  "confirm": {
-    "page-title": "Demande transmise",
-    "alert-heading": "Vous avez présenté avec succès une demande au Régime canadien de soins dentaires!",
-    "app-code-is": "Votre code de demande est\u00a0:",
-    "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
-    "keep-copy": "Conservez une copie de votre demande",
-    "print-copy-text": "Vous <strong>ne recevrez pas</strong> de <strong>courriel de confirmation</strong>. Il est important de conserver une copie de votre demande. <noPrint>Vous pouvez utiliser ce bouton pour imprimer.<noPrint>",
-    "print-btn": "Imprimer",
-    "whats-next": "Prochaines étapes",
-    "begin-process": "Nous commencerons à traiter votre demande immédiatement.",
-    "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
-    "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
-    "register-msca-title": "Inscrivez-vous à Mon dossier Service Canada dès maintenant",
-    "register-msca-text": "Une fois votre demande traitée, vous pourrez ouvrir une session dans <mscaLink>Mon dossier Service Canada (MDSC)</mscaLink>. Vous pourrez consulter les lettres qui vous ont été envoyées par le gouvernement du Canada au sujet du Régime canadien de soins dentaires.",
-    "msca-notify": "Vous serez avisé si votre demande a été acceptée ou rejetée dans Mon dossier Service Canada.",
-    "msca-link": "https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier.html",
-    "how-insurance": "Comment utiliser le Régime canadien de soins dentaires",
-    "eligible-text": "Si vous êtes jugé admissible, la Sun Life vous enverra par la poste une trousse de bienvenue. Votre trousse de bienvenue comprendra votre carte de membre et des renseignements sur le Régime canadien de soins dentaires, y compris la date de début de votre couverture. Le Régime canadien de soins dentaires ne vous couvrira pas les services de soins dentaires reçus avant cette date.",
-    "more-info-cdcp": "Pour en savoir plus sur les services et le montant de la couverture, consultez le site Web du Régime canadien de soins dentaires. <moreInfoLink>Quels sont les services couverts.</moreInfoLink>",
-    "more-info-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/couverture.html",
-    "more-info-service": "Pour plus d'informations, <dentalContactUsLink>contactez Service Canada</dentalContactUsLink>.",
-    "dental-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
-    "application-summ": "Sommaire de la demande",
-    "applicant-title": "Renseignements sur le demandeur",
-    "spouse-info": "Renseignements sur l'époux/épouse ou le conjoint(e) de fait",
-    "contact-info": "Coordonnées",
-    "comm-prefs": "Communication",
-    "added-email": "Courriel ajouté\u00a0: {{email}}",
-    "dental-insurance": "Accès à une assurance ou une couverture dentaire",
-    "dob": "Date de naissance",
-    "sin": "Numéro d'assurance sociale (NAS)",
-    "full-name": "Nom complet",
-    "marital-status": "État civil",
-    "consent": "Consentement",
-    "consent-answer": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et a consenti à la communication de ses renseignements personnels.",
-    "phone-number": "Numéro de téléphone",
-    "alt-phone-number": "Autre numéro de téléphone",
-    "mailing": "Adresse postale",
-    "home": "Adresse domiciliaire",
-    "comm-pref": "Préférence en matière de communication",
-    "lang-pref": "Langue de préférence",
-    "dental-private": "Accès à une assurance dentaire",
-    "dental-public": "Accès à des prestations dentaires gouvernementales",
-    "application-code": "Code de demande",
-    "yes": "Oui",
-    "no": "Non",
-    "exit": "Sortie",
-    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
-    "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
-  },
-  "dental-benefits": {
-    "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
-    "access-to-dental": "L'accès à une assurance dentaire dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur votre admissibilité au Régime canadien de soins dentaires.",
-    "eligibility-criteria": "Si vous répondez à tous les critères d'admissibilité, votre couverture sera coordonnée entre les régimes afin qu'il n'y ait pas de lacunes ou de dédoublement dans la couverture.",
-    "select-one": "Choisissez une option",
-    "federal-benefits": {
-      "title": "Prestations fédérales",
-      "legend": "Bénéficiez-vous d'une assurance dentaire dans le cadre d'un programme social offert par un programme fédéral?",
-      "option-yes": "<strong>Oui</strong>, je bénéficie d'une assurance <strong>fédérale</strong>",
-      "option-no": "<strong>Non</strong>, je ne bénéficie pas d'une assurance <strong>fédérale</strong>",
-      "social-programs": {
-        "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
-      }
-    },
-    "provincial-territorial-benefits": {
-      "title": "Assurances provinciales ou territoriales",
-      "legend": "Bénéficiez-vous d'une assurance dentaire dans le cadre d'un programme social offert par votre province ou territoire?",
-      "option-yes": "<strong>Oui</strong>, j'ai une assurance <strong>provinciale ou territoriale</strong>",
-      "option-no": "<strong>Non</strong>, je n'ai pas d'assurance <strong>provinciale ou territoriale</strong>",
-      "social-programs": {
-        "input-legend": "Si oui, par l'entremise de quelle province ou de quel territoire?",
-        "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
-      }
-    },
-    "button": {
-      "back": "Retour",
-      "continue": "Continuer",
-      "cancel-btn": "Annuler",
-      "save-btn": "Enregistrer"
-    },
-    "error-message": {
-      "federal-benefit-required": "Sélectionnez si vous avez la prestation dentaire fédérale",
-      "program-required": "Sélectionnez un programme",
-      "provincial-benefit-required": "Sélectionnez si vous avez la prestation dentaire provinciale ou territoriale",
-      "provincial-territorial-required": "Sélectionnez une province ou territoire"
-    }
-  },
-  "dental-insurance": {
-    "title": "Accès à d'autres assurances dentaires",
-    "legend": "Avez-vous accès à une assurance dentaire ou à une couverture dans l'une des quatre situations suivantes?",
-    "list": {
-      "employment": "Vos avantages en matière d'emploi ou les avantages en matière d'emploi d'un membre de votre famille, y compris vos comptes de santé et de bien-être",
-      "pension": "Vos prestations de retraite ou celles d'un membre de votre famille",
-      "purchased": "Assurance ou couverture achetée individuellement par vous, par un membre de votre famille ou par l'entremise d'un plan de groupe d'une compagnie d'assurance ou de prestations",
-      "professional": "Assurance ou couverture par une organisation professionnelle ou étudiante"
-    },
-    "option-yes": "<strong>Oui</strong>, j'ai accès à une assurance dentaire",
-    "option-no": "<strong>Non</strong>, je n'ai pas accès à une assurance dentaire",
-    "button": {
-      "back": "Retour",
-      "continue": "Continuer",
-      "cancel-btn": "Annuler",
-      "save-btn": "Enregistrer"
-    },
-    "detail": {
-      "additional-info": {
-        "title": "Renseignements supplémentaires",
-        "eligible": "Exception\u00a0: vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
-        "list": {
-          "opted": "Vous avez choisi de ne pas recevoir de prestations de retraite avant le 11 décembre 2023;",
-          "cannot-opt": "Vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite;"
-        },
-        "not-eligible": "Vous êtes toujours considéré comme ayant accès à une assurance ou à une couverture dentaire si vous choisissez de vous retirer des avantages offerts par votre employeur ou votre régime de retraite (voir l'exception) ou par l'entremise d'une organisation professionnelle ou étudiante. Par conséquent, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
-        "not-eligible-purchased": "Si vous avez souscrit votre police d'assurance dentaire actuelle de votre propre chef (et non dans le cadre de l'une des couvertures décrites ci-dessus), vous n'êtes pas admissible au RCSD pendant que cette protection est en vigueur."
-      }
-    },
-    "error-message": {
-      "dental-insurance-required": "Sélectionnez si vous avez une assurance dentaire"
-    }
-  },
   "disability-tax-credit": {
     "page-title": "(FR) Disability tax credit",
     "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
@@ -179,120 +14,6 @@
     "error-message": {
       "disability-tax-credit-required": "(FR) Select whether or not you have a valid disability tax credit"
     }
-  },
-  "eligibility": {
-    "type-of-application": {
-      "page-title": "Type de demande",
-      "page-description": "(FR) Applications for the Canadian Dental Care Plan is opening in phases.",
-      "apply-self": "(FR) Applying for yourself",
-      "apply-self-eligibility": "(FR) You can currently apply for yourself if you are:",
-      "senior": "(FR) 65 or older",
-      "valid-disability-tax-credit": "(FR) 18 to 64 and have a valid Disability Tax Credit certificate",
-      "live-independently": "(FR) 16 and 17 and live independently from your parents",
-      "apply-child": "(FR) Applying on behalf of your child",
-      "apply-child-eligibility": "(FR) You can apply on behalf of your child if:",
-      "sixteen-or-older": "(FR) You are 16 or older and the parent or legal guardian of the child; and",
-      "under-eighteen": "(FR) The child is under 18 years old",
-      "form-instructions": "Qui présente la demande?",
-      "note": "(FR) please note, only one application can be processed for each child.",
-      "split-custody-summary": "(FR) If you split custody of a child",
-      "split-custody-detail": "(FR) If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
-      "radio-options": {
-        "personal": "Je présente une demande pour <strong>moi</strong>",
-        "delegate": "(FR) I am applying on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>",
-        "child": "(FR) I am applying for <strong>my child(ren)</strong>",
-        "personal-and-child": "(FR) I am applying for <strong>myself and my child(ren)</strong>"
-      },
-      "error-message": {
-        "type-of-application-required": "Sélectionnez à qui s'adresse cette demande"
-      },
-      "back-btn": "Retour",
-      "continue-btn": "Continuer"
-    },
-    "tax-filing": {
-      "page-title": "Déclaration de revenus",
-      "form-instructions": "Est-ce que vous et votre époux/épouse ou conjoint/conjointe de fait (s'il y a lieu) avez produit votre déclaration de revenus pour 2023 et avez reçu votre avis de cotisation?",
-      "radio-options": {
-        "yes": "Oui",
-        "no": "Non"
-      },
-      "error-message": {
-        "tax-filing-required": "Sélectionnez si vous avez fait votre déclaration de revenus ou non"
-      },
-      "back-btn": "Retour",
-      "continue-btn": "Continuer"
-    },
-    "date-of-birth": {
-      "page-title": "Âge",
-      "description": "Les demandes au titre du Régime canadien de soins dentaires seront acceptées progressivement. Votre date de naissance détermine le moment où vous pouvez présenter une demande.",
-      "age-heading": "(FR) Your age",
-      "child-age-heading": "(FR) Your child(ren)'s age",
-      "form-instructions": "Veuillez sélectionner votre date de naissance",
-      "child-age-instruction": "(FR) Are all the children you are applying for under 18?",
-      "yes": "Oui",
-      "no": "Non",
-      "collapsible-content-summary": "(FR) If your child is over 18 and has a Disability Tax Credit",
-      "collapsible-content-detail": "(FR) You must speak to a Service Canada representative to apply on behalf of your child. Please contact Service Canada by calling 1-833-537-4342.",
-      "error-message": {
-        "date-of-birth-day-number": "Le jour doit être un nombre",
-        "date-of-birth-day-required": "La date de naissance doit inclure un jour",
-        "date-of-birth-is-past": "La date de naissance doit être dans le passé",
-        "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
-        "date-of-birth-month-required": "La date de naissance doit inclure un mois",
-        "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
-        "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
-        "date-of-birth-year-required": "La date de naissance doit inclure une année",
-        "child-age-required": "(FR) Please indicate if all children are under 18"
-      },
-      "back-btn": "Retour",
-      "continue-btn": "Continuer",
-      "cancel-btn": "Annuler",
-      "save-btn": "Enregistrer"
-    },
-    "application-delegate": {
-      "page-title": "La demande au nom d'une autre personne ne peut pas être effectuée en ligne pour le moment.",
-      "contact-representative": "Vous devez <contactServiceCanada>parler à un représentant de Service Canada</contactServiceCanada> pour présenter une demande au nom de quelqu'un. Veuillez communiquer avec Service Canada au <span>1-833-537-4342</span> ou vous rendre dans un bureau de Service Canada.",
-      "prepare-to-apply": "<preparingToApply>Se préparer à présenter une demande au nom de quelqu'un</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
-      "preparing-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#aide",
-      "back-btn": "Retour",
-      "return-btn": "Revenir à la page principale",
-      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-    },
-    "file-your-taxes": {
-      "page-title": "Produire votre déclaration de revenus",
-      "ineligible-to-apply": "Vous n'êtes pas admissible au Régime canadien de soins dentaires pour le moment.",
-      "tax-not-filed": "Vous, votre épouse/époux ou conjoint(e) de fait n'avez pas produit de déclaration de revenus pour l'année 2023 auprès de l'Agence du revenu du Canada.",
-      "unable-to-assess": "Nous utilisons les renseignements de votre déclaration de revenus pour nous assurer que vous répondez aux critères d'admissibilité au RCSD. Tant que vous n'aurez pas produit votre déclaration de revenus de 2023, nous ne pourrons pas évaluer votre admissibilité.",
-      "tax-info": "Pour en savoir plus sur la façon de produire votre déclaration de revenus, consultez la page <taxInfo>Préparez-vous à faire vos impôts.</taxInfo>",
-      "apply-after": "Vous pouvez demander le plan après avoir produit vos déclarations de revenus et reçu votre avis de cotisation.",
-      "tax-info-href": "https://www.canada.ca/fr/services/impots/impot-sur-le-revenu/impot-sur-le-revenu-des-particuliers/preparez-vous-impots.html",
-      "back-btn": "Retour",
-      "return-btn": "Revenir à la page principale",
-      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-    },
-    "dob-eligibility": {
-      "page-title": "Découvrez quand vous pouvez présenter une demande",
-      "ineligible-to-apply": "Vous n'êtes actuellement pas admissible au Régime canadien de soins dentaires.",
-      "currently-accepting": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults who receive the Disability Tax Credit.",
-      "later-date": "(FR) Adults 18 to 64 who do not have a disability tax credit will be invited to apply for the Canadian Dental Care Plan in 2025.",
-      "eligibility-info": "<eligibilityInfo>Découvrez quand vous pouvez faire une demande au Régime canadien de soins dentaires.</eligibilityInfo>",
-      "eligibility-info-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
-      "back-btn": "Retour",
-      "return-btn": "Revenir à la page principale",
-      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-    }
-  },
-  "exit-application": {
-    "page-title": "Quitter la demande",
-    "are-you-sure": "Êtes-vous sûr de vouloir quitter cette demande? Si vous cliquez sur «\u00a0Quitter\u00a0», le formulaire sera réinitialisé et vous perdrez vos informations.",
-    "click-back": "Cliquez sur «\u00a0Retour\u00a0» pour revenir au formulaire.",
-    "back-btn": "Retour",
-    "exit-btn": "Quitter",
-    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-  },
-  "index": {
-    "page-title": "Présentation d'une demande d'adhésion au Régime canadien de soins dentaires"
   },
   "living-independently": {
     "page-title": "Vivre de manière indépendante",
@@ -315,141 +36,10 @@
     "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
-  "partner-information": {
-    "page-title": "Renseignements sur l'époux/épouse ou le conjoint/conjointe de fait",
-    "provide-sin": "Fournissez les renseignements sur votre époux/épouse ou conjoint/conjointe de fait actuel tels qu'ils figurent sur sa carte ou lettre d'assurance sociale (NAS).",
-    "required-information": "Ces renseignements sont nécessaires pour calculer le revenu familial net rajusté. Votre époux/épouse ou conjoint/conjointe de fait doit présenter sa propre demande au Régime canadien de soins dentaires.",
-    "sin": "Numéro d'assurance sociale (NAS)",
-    "date-of-birth": "Date de naissance",
-    "last-name": "Nom de famille",
-    "first-name": "Prénom",
-    "single-legal-name": "(FR) If your spouse or common-law partner has a single legal name",
-    "name-instructions": "Si vous utilisez un seul nom légal, veuillez indiquer ce nom dans les DEUX champs «\u00a0Prénom\u00a0» et «\u00a0Nom de famille\u00a0».",
-    "confirm-checkbox": "Je confirme que mon époux/épouse ou mon conjoint/conjointe de fait est au courant et d'accord que ses renseignements personnels soient communiqués.",
-    "back-btn": "Retour",
-    "continue-btn": "Continuer",
-    "cancel-btn": "Annuler",
-    "save-btn": "Enregistrer",
-    "error-message": {
-      "confirm-required": "La case à cocher doit être sélectionnée",
-      "date-of-birth-day-number": "Le jour doit être un nombre",
-      "date-of-birth-day-required": "La date de naissance doit inclure un jour",
-      "date-of-birth-is-past": "La date de naissance doit être dans le passé",
-      "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
-      "date-of-birth-month-required": "La date de naissance doit inclure un mois",
-      "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
-      "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
-      "date-of-birth-year-required": "La date de naissance doit inclure une année",
-      "first-name-required": "Entrez le prénom",
-      "last-name-required": "Entrez le nom de famille",
-      "sin-required": "Entrez un NAS de 9 chiffres",
-      "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
-    }
-  },
-  "personal-information": {
-    "page-title": "Renseignements personnels",
-    "form-instructions": "L'ajout d'un numéro de téléphone permet à Service Canada de vous contacter en cas de problème avec votre demande. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
-    "add-phone": "(FR) Adding a phone number helps Government of Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",
-    "phone-number": "Numéro de téléphone (facultatif)",
-    "phone-number-alt": "Autre numéro de téléphone (facultatif)",
-    "add-email": "(FR) Adding an email will help the Government of Canada contact you regarding your Canadian Dental Care Plan membership.",
-    "email": "Adresse courriel (facultatif)",
-    "confirm-email": "Confirmer l'adresse courriel (facultatif)",
-    "mailing-address": {
-      "header": "Adresse postale"
-    },
-    "home-address": {
-      "header": "Adresse du domicile",
-      "use-mailing-address": "Mon adresse postale et mon adresse domiciliaire sont les mêmes."
-    },
-    "address-field": {
-      "address": "Adresse",
-      "address-note": "Inclure le numéro municipal et le nom de rue",
-      "apartment": "Appartement, suite, etc. (facultatif)",
-      "country": "Pays",
-      "province": "Province, territoire, état ou région",
-      "city": "Ville ou municipalité",
-      "postal-code": "Code postal/code ZIP",
-      "postal-code-optional": "Code postal/code ZIP (facultatif)",
-      "select-one": "Choisissez une option"
-    },
-    "back": "Retour",
-    "continue": "Continuer",
-    "cancel-btn": "Annuler",
-    "save-btn": "Enregistrer",
-    "error-message": {
-      "address-required": "Entrez l'adresse, normalement le numéro et le nom de la rue",
-      "city-required": "Entrez une ville ou une municipalité",
-      "country-required": "Sélectionnez un pays",
-      "postal-code-required": "Entrez un code postal ou un code postal américain",
-      "postal-code-valid": "Entrez un code postal dans le bon format, par exemple A1A 1A1",
-      "province-required": "Sélectionnez une province, un territoire, un état ou une région",
-      "zip-code-valid": "Entrez un code postal américain dans le bon format, par exemple 12345 ou 12345-6789",
-      "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
-      "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
-      "email-match": "Les adresses courriel entrées ne concordent pas",
-      "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
-      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
-      "preferred-language-required": "Sélectionnez la langue de communication préférée"
-    }
-  },
   "progress": {
     "label": "Suivi de la progression de l'application"
   },
   "required-label": "Remplir tous les champs sauf s'ils sont indiqués facultatifs",
-  "review-information": {
-    "read-carefully": "Veuillez examiner attentivement les renseignements suivants. Les renseignements fournis seront utilisés par la Sun Life pour créer votre compte de membre et figureront sur votre carte de membre.",
-    "page-title": "Vérifiez vos renseignements",
-    "page-sub-title": "Renseignements sur le demandeur",
-    "dob-title": "Date de naissance",
-    "dob-change": "Modifier la date de naissance",
-    "sin-title": "Numéro d'assurance sociale (NAS)",
-    "sin-change": "Modifier le NAS",
-    "full-name-title": "Nom complet",
-    "full-name-change": "Modifier le nom complet",
-    "marital-title": "État civil",
-    "marital-change": "Modifier l'état civil",
-    "spouse-title": "Renseignements sur l'époux/épouse ou le conjoint(e) de fait",
-    "spouse-consent": {
-      "label": "Consentement",
-      "yes": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et a consenti à la communication de ses renseignements personnels.",
-      "no": "Mon époux/épouse ou mon conjoint/conjointe de fait est au courant et n'a pas consenti à la communication de ses renseignements personnels."
-    },
-    "personal-info-title": "Renseignements personnels",
-    "phone-title": "Téléphone",
-    "phone-change": "Modifier le numéro de téléphone",
-    "alt-phone-title": "Autre numéro de téléphone",
-    "alt-phone-change": "Modifier l'autre numéro de téléphone",
-    "mailing-title": "Adresse postale",
-    "mailing-change": "Modifier l'adresse postale",
-    "home-title": "Adresse domiciliaire",
-    "home-change": "Modifier l'adresse domiciliaire",
-    "comm-title": "Communication",
-    "comm-electronic": "Courriel",
-    "comm-mail": "Par la poste",
-    "comm-pref-title": "Préférence en matière de communication",
-    "comm-pref-change": "Modifier la préférence de communication",
-    "added-email": "Courriel ajouté\u00a0: {{email}}",
-    "lang-pref-title": "Langue de préférence",
-    "lang-pref-change": "Modifier la langue de préférence",
-    "dental-title": "Accès à l'assurance dentaire",
-    "dental-insurance-title": "Accès à une assurance ou une couverture dentaire",
-    "dental-insurance-change": "Modifier la réponse à «\u00a0accès à l'assurance dentaire\u00a0»",
-    "dental-benefit-title": "Accès à des prestations dentaires gouvernementales",
-    "dental-benefit-change": "Modifier la réponse à «\u00a0soins dentaires gouvernementaux\u00a0»",
-    "dental-benefit-has-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
-    "dental-benefit-has-no-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
-    "submit-app-title": "Soumettre votre demande",
-    "submit-p-proceed": "En transmettant votre demande, vous consentez à attester de la véracité des informations fournies.",
-    "submit-p-false-info": "Si vous fournissez de fausses informations sur votre demande, vous et les autres personnes pour lesquelles vous avez postulé pourriez être exclus du régime.",
-    "submit-p-repayment": "Si vous ou les membres de votre famille n'étiez pas admissibles, vous ou les membres de votre famille pourriez devoir rembourser le coût total des soins reçus dans le cadre du régime canadien de soins dentaires.",
-    "submit-button": "Soumettre la demande",
-    "exit-button": "Quitter la demande",
-    "yes": "Oui",
-    "no": "Non"
-  },
   "terms-and-conditions": {
     "page-title": "Présentation d'une demande d'adhésion au Régime canadien de soins dentaires",
     "page-heading": "Conditions générales d'utilisation et énoncé de confidentialité",
@@ -518,5 +108,33 @@
       "info-source": "https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/fr-ca/trust-center/privacy"
     }
+  },
+  "type-of-application": {
+    "page-title": "Type de demande",
+    "page-description": "(FR) Applications for the Canadian Dental Care Plan is opening in phases.",
+    "apply-self": "(FR) Applying for yourself",
+    "apply-self-eligibility": "(FR) You can currently apply for yourself if you are:",
+    "senior": "(FR) 65 or older",
+    "valid-disability-tax-credit": "(FR) 18 to 64 and have a valid Disability Tax Credit certificate",
+    "live-independently": "(FR) 16 and 17 and live independently from your parents",
+    "apply-child": "(FR) Applying on behalf of your child",
+    "apply-child-eligibility": "(FR) You can apply on behalf of your child if:",
+    "sixteen-or-older": "(FR) You are 16 or older and the parent or legal guardian of the child; and",
+    "under-eighteen": "(FR) The child is under 18 years old",
+    "form-instructions": "Qui présente la demande?",
+    "note": "(FR) please note, only one application can be processed for each child.",
+    "split-custody-summary": "(FR) If you split custody of a child",
+    "split-custody-detail": "(FR) If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
+    "radio-options": {
+      "personal": "Je présente une demande pour <strong>moi</strong>",
+      "delegate": "(FR) I am applying on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>",
+      "child": "(FR) I am applying for <strong>my child(ren)</strong>",
+      "personal-and-child": "(FR) I am applying for <strong>myself and my child(ren)</strong>"
+    },
+    "error-message": {
+      "type-of-application-required": "Sélectionnez à qui s'adresse cette demande"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer"
   }
 }


### PR DESCRIPTION
### Description
Split locales for the adult apply flow and clean up the top level apply flow locales per the following [comment](https://github.com/DTS-STN/canadian-dental-care-plan/pull/1200#issuecomment-2079741150)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`