### PR TITLE
fix incorrect state reference in review-information

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/review-information.tsx
@@ -142,7 +142,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     province: provinceHome,
     postalCode: state.personalInformation.homePostalCode,
     country: countryHome,
-    apartment: state.personalInformation.mailingApartment,
+    apartment: state.personalInformation.homeApartment,
   };
 
   const dentalInsurance = state.dentalInsurance;


### PR DESCRIPTION
### Description
Incorrect reference to the suite/apartment number in state

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/9836881e-4384-4f68-9a0f-b05ffa83dde4)