### PR TITLE
Fixed typos and button on the data unavailable page

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
+++ b/frontend/app/routes/$lang+/_protected+/data-unavailable.tsx
@@ -15,7 +15,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { useUserOrigin } from '~/utils/user-origin-utils';
 
 export const handle = {
-  breadcrumbs: [{ labelI18nKey: 'data-unavailable:page-title' }],
+  breadcrumbs: [{ labelI18nKey: 'data-unavailable:breadcrumbs.cdcp' }],
   i18nNamespaces: getTypedI18nNamespaces('data-unavailable', 'gcweb'),
   pageIdentifier: pageIds.protected.dataUnavailable,
   pageTitleI18nKey: 'data-unavailable:page-title',

--- a/frontend/public/locales/en/data-unavailable.json
+++ b/frontend/public/locales/en/data-unavailable.json
@@ -1,14 +1,14 @@
 {
   "page-title": "You have not applied for CDCP",
   "breadcrumbs": {
-    "unable-to-continue": "You have not applied for CDCP"
+    "cdcp": "Canadian Dental Care Plan"
   },
   "service-eligible": "<strong>You are currently not a participant in the Canadian Dental Care Plan.</strong> To find out if you are eligible please visit <doyouqualify>Do you qualify</doyouqualify> on Canada.ca. For more information on how to apply, please visit <howtoapply>How to apply</howtoapply>.",
   "do-you-qualify.href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/qualify.html",
   "how-to-apply.href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",
-  "other-enquiry": "For other enquiries, please visit the <contactus>Contact us</contactus> page to find out how to reach us",
+  "other-enquiry": "For other enquiries, please visit the <contactus>Contact us</contactus> page to find out how to reach us.",
   "contact-us.href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
   "service-delay": "If you have recently applied, please note that there could be a delay in your application appearing within the My Service Canada Account.  For any enquiries on the status of your application please visit <statuschecker>Verify the Status of your application</statuschecker>.",
   "status-checker.href": "https://canadadental-uat.powerappsportals.com/en/status-etat/",
-  "back-button": "Back"
+  "back-button": "Return to Dashboard"
 }

--- a/frontend/public/locales/fr/data-unavailable.json
+++ b/frontend/public/locales/fr/data-unavailable.json
@@ -1,7 +1,7 @@
 {
   "page-title": "Vous n'avez pas fait de demande pour le RCSD",
   "breadcrumbs": {
-    "unable-to-continue": "Vous n'avez pas fait de demande pour le RCSD"
+    "cdcp": "Régime canadien de soins dentaires"
   },
   "service-eligible": "<strong>Vous n'êtes pas un participant du Régime canadien de soins dentaires actuellement.</strong> Pour savoir si vous êtes admissible, consultez le site <doyouqualify>Êtes-vous admissible</doyouqualify>, sur Canada.ca. Pour obtenir de plus amples renseignements sur le processus de demande, veuillez visiter <howtoapply>Présentation d'une demande</howtoapply>.",
   "do-you-qualify.href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/admissibilite.html",
@@ -10,5 +10,5 @@
   "contact-us.href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
   "service-delay": "Si vous avez récemment présenté votre demande, veuillez noter qu'un délai peut s'écouler avant que votre demande n'apparaisse dans votre compte Mon dossier Service Canada (MDSC). Pour toute question sur l'état d'avancement de votre demande, visiter <statuschecker>Vérifier l'état de ma demande</statuschecker>.",
   "status-checker.href": "https://canadadental-uat.powerappsportals.com/fr/status-etat/",
-  "back-button": "Retour"
+  "back-button": "Retour au tableau de bord"
 }


### PR DESCRIPTION
### Description
Fixed identified typos and the back button text on the data unavailable page from ticket ESDCCM-CDCP-AB#7527

Changes:
-changed breadcrumbs to CDCP
-added punctuation for English i18n 
-changed back button

### Related Azure Boards Work Items
ESDCCM-CDCP-AB#7527

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/13133d8c-8640-4282-8bcd-445830c79ffe)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/4bc99bcb-af2d-417c-882a-65ac8a134eb9)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Visit `/en/data-unavailable` to confirm changes

### Additional Notes
n/a