### PR TITLE
AB-3255: Updated personal info data and mapping to include federal, private, and provincial and terroritorial dental plan fields

### DIFF
--- a/frontend/__tests__/services/personal-information-service.server.test.ts
+++ b/frontend/__tests__/services/personal-information-service.server.test.ts
@@ -1,0 +1,76 @@
+import { HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getPersonalInformationService } from '~/services/personal-information-service.server';
+
+global.fetch = vi.fn();
+
+vi.mock('~/utils/logging.server', () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    audit: vi.fn(),
+    trace: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/env.server', () => ({
+  getEnv: vi.fn().mockReturnValue({}),
+}));
+
+describe('personal-information-service.server tests', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('getPersonalInformation()', () => {
+    it('should return personal information of the user (federal, provincial and territorial, private insurance info)', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        HttpResponse.json({
+          BenefitApplication: {
+            InsurancePlan: [
+              { InsurancePlanIdentification: { IdentificationID: '000000', IdentificationCategoryText: 'Federal' } },
+              { InsurancePlanIdentification: { IdentificationID: '1111111', IdentificationCategoryText: 'Provincial and Territorial' } },
+              { InsurancePlanIdentification: { IdentificationID: '222222222', IdentificationCategoryText: 'Private' } },
+            ],
+            PrivateDentalInsuranceIndicator: true,
+            FederalDentalCoverageIndicator: { ReferenceDataID: '000000', ReferenceDataName: 'true' },
+            ProvicialDentalCoverageIndicator: true,
+          },
+        }),
+      );
+
+      const personalInformationService = getPersonalInformationService();
+      const personalInfo = await personalInformationService.getPersonalInformation('sin', 'userId');
+
+      expect(personalInfo).toEqual({
+        alternateTelephoneNumber: undefined,
+        applicantCategoryCode: undefined,
+        applictantId: undefined,
+        birthDate: undefined,
+        clientId: undefined,
+        clientNumber: undefined,
+        emailAddress: undefined,
+        federalDentalPlanId: '000000',
+        firstName: undefined,
+        homeAddress: undefined,
+        lastName: undefined,
+        mailingAddress: undefined,
+        maritalStatusId: undefined,
+        preferredLanguageId: undefined,
+        primaryTelephoneNumber: undefined,
+        privateDentalPlanId: '222222222',
+        provincialTerritorialDentalPlanId: '1111111',
+      });
+    });
+
+    it('should throw error if response is not ok', async () => {
+      vi.mocked(fetch).mockResolvedValue(new HttpResponse(null, { status: 500 }));
+
+      const personalInformationService = getPersonalInformationService();
+      await expect(() => personalInformationService.getPersonalInformation('sin', 'userId')).rejects.toThrowError();
+    });
+  });
+});

--- a/frontend/app/mappers/personal-information-service-mappers.server.ts
+++ b/frontend/app/mappers/personal-information-service-mappers.server.ts
@@ -71,6 +71,10 @@ export function toPersonalInformationApi(personalInformation: PersonalInfo): Per
           ReferenceDataID: personalInformation.preferredLanguageId,
         },
       },
+      InsurancePlan: toInsurancePlanApi(personalInformation.privateDentalPlanId, personalInformation.federalDentalPlanId, personalInformation.provincialTerritorialDentalPlanId),
+      PrivateDentalInsuranceIndicator: personalInformation.privateDentalPlanId ? true : false,
+      FederalDentalCoverageIndicator: toFederalDentalCoverageIndicator(personalInformation.federalDentalPlanId),
+      ProvicialDentalCoverageIndicator: personalInformation.provincialTerritorialDentalPlanId ? true : false,
     },
   };
 }
@@ -116,6 +120,10 @@ export function toPersonalInformation(personalInformationApi: PersonalInformatio
     alternateTelephoneNumber: personalInformationApi.BenefitApplication.Applicant?.PersonContactInformation.at(0)?.TelephoneNumber.find((phoneNumber) => phoneNumber.TelephoneNumberCategoryCode.ReferenceDataName === 'Alternate')?.FullTelephoneNumber
       .TelephoneNumberFullID,
     preferredLanguageId: personalInformationApi.BenefitApplication.Applicant?.PreferredMethodCommunicationCode?.ReferenceDataID,
+    federalDentalPlanId: personalInformationApi.BenefitApplication.InsurancePlan?.find((insurancePlan) => insurancePlan.InsurancePlanIdentification?.IdentificationCategoryText === 'Federal')?.InsurancePlanIdentification?.IdentificationID,
+    provincialTerritorialDentalPlanId: personalInformationApi.BenefitApplication.InsurancePlan?.find((insurancePlan) => insurancePlan.InsurancePlanIdentification?.IdentificationCategoryText === 'Provincial and Territorial')?.InsurancePlanIdentification
+      ?.IdentificationID,
+    privateDentalPlanId: personalInformationApi.BenefitApplication.InsurancePlan?.find((insurancePlan) => insurancePlan.InsurancePlanIdentification?.IdentificationCategoryText === 'Private')?.InsurancePlanIdentification?.IdentificationID,
   };
 }
 
@@ -172,4 +180,33 @@ function toAddress(addressDto: AddressDto | undefined, category: string) {
     province: addressDto?.provinceTerritoryStateId,
     street: addressDto?.streetName,
   });
+}
+
+function toInsurancePlanApi(
+  federalDentalPlanId: string | undefined,
+  provincialTerritorialDentalPlanId: string | undefined,
+  privateDentalPlanId: string | undefined,
+): {
+  InsurancePlanIdentification?: {
+    IdentificationID: string;
+    IdentificationCategoryText?: string;
+  };
+}[] {
+  const listOfInsurancePlans = [];
+
+  if (federalDentalPlanId) {
+    listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: federalDentalPlanId, IdentificationCategoryText: 'Federal' } });
+  }
+  if (provincialTerritorialDentalPlanId) {
+    listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: provincialTerritorialDentalPlanId, IdentificationCategoryText: 'Provincial and Territorial' } });
+  }
+  if (privateDentalPlanId) {
+    listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: privateDentalPlanId, IdentificationCategoryText: 'Private' } });
+  }
+
+  return listOfInsurancePlans;
+}
+
+function toFederalDentalCoverageIndicator(federalDentalPlanId: string | undefined): { ReferenceDataID: string | undefined; ReferenceDataName: string | undefined } | undefined {
+  return federalDentalPlanId ? { ReferenceDataID: federalDentalPlanId, ReferenceDataName: 'true' } : undefined; //TODO: Revisit once sample FederalDentalCoverageIndicator response gets sent
 }

--- a/frontend/app/mocks/db.ts
+++ b/frontend/app/mocks/db.ts
@@ -33,6 +33,9 @@ const db = factory({
     maritialStatus: String,
     dentalApplicationID: String,
     preferredMethodCommunicationCode: String,
+    federalDentalPlanId: String,
+    provincialTerritorialDentalPlanId: String,
+    privateDentalPlanId: String,
     sinIdentification: primaryKey(String),
   },
   subscription: {
@@ -79,6 +82,9 @@ db.personalInformation.create({
   primaryTelephoneNumber: '807-555-5555',
   alternateTelephoneNumber: '416-555-6666',
   preferredMethodCommunicationCode: '1033',
+  federalDentalPlanId: 'e174250d-26c5-ee11-9079-000d3a09d640',
+  provincialTerritorialDentalPlanId: 'b5f25fea-a7a9-ee11-a569-000d3af4f898',
+  privateDentalPlanId: '333333',
   sinIdentification: '800011819',
 });
 
@@ -107,6 +113,9 @@ db.personalInformation.create({
   primaryTelephoneNumber: '555-555-5555',
   alternateTelephoneNumber: '789-555-6666',
   preferredMethodCommunicationCode: '775170002',
+  federalDentalPlanId: '5a5c5294-26c5-ee11-9079-000d3a09d640',
+  provincialTerritorialDentalPlanId: '39449f70-37b3-eb11-8236-0022486d8d5f',
+  privateDentalPlanId: '1111111',
   sinIdentification: '800000002',
 });
 

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -123,6 +123,18 @@ export function getPowerPlatformApiMockHandlers() {
 
       const nameInfoList = [{ PersonSurName: peronalInformationEntity.lastName, PersonGivenName: [peronalInformationEntity.firstName] }];
 
+      const listOfInsurancePlans = [];
+
+      if (peronalInformationEntity.federalDentalPlanId) {
+        listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: peronalInformationEntity.federalDentalPlanId, IdentificationCategoryText: 'Federal' } });
+      }
+      if (peronalInformationEntity.provincialTerritorialDentalPlanId) {
+        listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: peronalInformationEntity.provincialTerritorialDentalPlanId, IdentificationCategoryText: 'Provincial and Territorial' } });
+      }
+      if (peronalInformationEntity.privateDentalPlanId) {
+        listOfInsurancePlans.push({ InsurancePlanIdentification: { IdentificationID: peronalInformationEntity.federalDentalPlanId, IdentificationCategoryText: 'Private' } });
+      }
+
       return HttpResponse.json({
         BenefitApplication: {
           Applicant: {
@@ -164,6 +176,10 @@ export function getPowerPlatformApiMockHandlers() {
               IdentificationCategoryText: 'Dental Application ID',
             },
           ],
+          InsurancePlan: listOfInsurancePlans,
+          FederalDentalCoverageIndicator: peronalInformationEntity.federalDentalPlanId ? { ReferenceDataID: peronalInformationEntity.federalDentalPlanId, ReferenceDataName: 'true' } : null, //TODO: Update once sample response with these fields is avaliable
+          ProvicialDentalCoverageIndicator: peronalInformationEntity.provincialTerritorialDentalPlanId ? true : false,
+          PrivateDentalInsuranceIndicator: peronalInformationEntity.privateDentalPlanId ? true : false,
         },
       });
     }),

--- a/frontend/app/schemas/personal-informaton-service-schemas.server.ts
+++ b/frontend/app/schemas/personal-informaton-service-schemas.server.ts
@@ -138,14 +138,22 @@ export const personalInformationApiSchema = z.object({
       .optional(),
     InsurancePlan: z
       .object({
-        InsurancePlanIdentification: z.object({
-          IdentificationID: z.string(),
-          IdentificationCategoryText: z.string().optional(),
-        }),
+        InsurancePlanIdentification: z
+          .object({
+            IdentificationID: z.string(),
+            IdentificationCategoryText: z.string().optional(),
+          })
+          .optional(),
       })
+      .array()
       .optional(),
     PrivateDentalInsuranceIndicator: z.boolean().optional(),
-    FederalDentalCoverageIndicator: z.boolean().optional(),
+    FederalDentalCoverageIndicator: z
+      .object({
+        ReferenceDataID: z.string().optional(),
+        ReferenceDataName: z.string().optional(),
+      })
+      .optional(),
     ProvicialDentalCoverageIndicator: z.boolean().optional(),
   }),
 });
@@ -186,6 +194,9 @@ export const personalInfoDtoSchema = z.object({
   primaryTelephoneNumber: z.string().optional(),
   alternateTelephoneNumber: z.string().optional(),
   preferredLanguageId: z.string().optional(),
+  privateDentalPlanId: z.string().optional(),
+  federalDentalPlanId: z.string().optional(),
+  provincialTerritorialDentalPlanId: z.string().optional(),
 });
 
 export type PersonalInfo = z.infer<typeof personalInfoDtoSchema>;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

- Updated personal information to include federal insurance dental plans,  provincial and territorial dental plans, and private dental plan fields
- Updated corresponding mappings

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->
[AB#3255](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3255)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

- Call `getPersonalInformation` from `personalInformationService`. Response should include newly added fields, if available for the user

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->