### PR TITLE
3336 Apply for your children screen

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -254,6 +254,14 @@
                       "en": "/:lang/apply/:id/living-independently",
                       "fr": "/:lang/demander/:id/living-independently"
                     }
+                  },
+                  {
+                    "id": "$lang+/_public+/apply+/$id+/apply-children",
+                    "file": "routes/$lang+/_public+/apply+/$id+/apply-children.tsx",
+                    "paths": {
+                      "en": "/:lang/apply/:id/apply-children",
+                      "fr": "/:lang/demander/:id/apply-children"
+                    }
                   }
                 ]
               }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/apply-children.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/apply-children.tsx
@@ -1,0 +1,80 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.applyChildren,
+  pageTitleI18nKey: 'apply:apply-children.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:apply-children.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/apply-children');
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  // todo: build out route
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/child-information', params));
+}
+
+export default function ApplyFlowApplyChildren() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <>
+      <div className="mb-8 space-y-4">
+        <p>{t('apply:apply-children.not-eligible')}</p>
+        <p>{t('apply:apply-children.still-apply')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/disability-tax-credit" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply:apply-children.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Parent or guardian needs to apply click">
+          {t('apply:apply-children.continue-btn')}
+          {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
+        </Button>
+      </fetcher.Form>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -55,7 +55,8 @@
       },
       "disabilityTaxCredit": "CDCP-APPL-0018",
       "parentOrGuardian": "CDCP-APPL-0019",
-      "livingIndependently": "CDCP-APPL-0020"
+      "livingIndependently": "CDCP-APPL-0020",
+      "applyChildren": "CDCP-APPL-0021"
     },
     "status": "CDCP-STAT-0001",
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -1,4 +1,12 @@
 {
+  "apply-children": {
+    "page-title": "Apply for your child(ren)",
+    "not-eligible": "You are not currently eligible to apply for the Canadian Dental Care Plan.",
+    "still-apply": "However, you can still submit an application for you child(ren).",
+    "back-btn": "Back",
+    "continue-btn": "Proceed to apply for your child(ren)"
+  },
+
   "disability-tax-credit": {
     "page-title": "Disability tax credit",
     "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -1,4 +1,11 @@
 {
+  "apply-children": {
+    "page-title": "(FR) Apply for your child(ren)",
+    "not-eligible": "(FR) You are not currently eligible to apply for the Canadian Dental Care Plan.",
+    "still-apply": "(FR) However, you can still submit an application for you child(ren).",
+    "back-btn": "Retour",
+    "continue-btn": "(FR) Proceed to apply for your child(ren)"
+  },
   "disability-tax-credit": {
     "page-title": "(FR) Disability tax credit",
     "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",


### PR DESCRIPTION
### Description
Add screen B-3.6

NOTE: 
- translations are NOT in. 
- the adult-child apply flow hasn't been implemented in main (yet), therefore logic in this PR will have to change in a future PR

### Related Azure Boards Work Items
[AB#3336](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3336)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
