### PR TITLE
3347 Create child information screen

### DIFF
--- a/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
@@ -11,6 +11,7 @@ import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/ad
 import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
 import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/adult/review-information';
 import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/adult/tax-filing';
+import { ChildInformationState } from '~/routes/$lang+/_public+/apply+/$id+/child-information';
 import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/disability-tax-credit';
 import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/living-independently';
 import { getEnv } from '~/utils/env.server';
@@ -33,6 +34,7 @@ export interface ApplyAdultState {
   readonly disabilityTaxCredit?: DisabilityTaxCreditState;
   readonly livingIndependently?: LivingIndependentlyState;
   readonly allChildrenUnder18?: AllChildrenUnder18State;
+  readonly childInformation?: ChildInformationState;
 }
 
 interface LoadApplyAdultStateArgs {

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -262,6 +262,14 @@
                       "en": "/:lang/apply/:id/apply-children",
                       "fr": "/:lang/demander/:id/apply-children"
                     }
+                  },
+                  {
+                    "id": "$lang+/_public+/apply+/$id+/child-information",
+                    "file": "routes/$lang+/_public+/apply+/$id+/child-information.tsx",
+                    "paths": {
+                      "en": "/:lang/apply/:id/child-information",
+                      "fr": "/:lang/demander/:id/child-information"
+                    }
                   }
                 ]
               }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child-information.tsx
@@ -1,0 +1,376 @@
+import { ChangeEventHandler, useEffect, useMemo, useState } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { differenceInYears, isPast, isValid, parse } from 'date-fns';
+import { Trans, useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+
+import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { Collapsible } from '~/components/collapsible';
+import { DatePickerField } from '~/components/date-picker-field';
+import { ErrorSummary, ErrorSummaryItem, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { InputRadios, InputRadiosProps } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultState, saveApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
+import '~/route-helpers/apply-route-helpers.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { parseDateString } from '~/utils/date-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isValidSin } from '~/utils/sin-utils';
+import { cn } from '~/utils/tw-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+  Yes = 'yes',
+  No = 'no',
+}
+
+export type ChildInformationState = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  hasSocialInsuranceNumber: string;
+  socialInsuranceNumber?: string;
+  isParent: string;
+};
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.childInformation,
+  pageTitleI18nKey: 'apply:child-information.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:child-information.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultState.childInformation, editMode: state.adultState.editMode });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/child-information');
+
+  const state = loadApplyAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+
+  if (formAction === FormAction.Cancel) {
+    invariant(state.adultState.childInformation, 'Expected state.childInformation to be defined');
+
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
+  }
+
+  // Form action Continue & Save
+  // state validation schema
+  const childInformationSchema = z
+    .object({
+      firstName: z.string().trim().min(1, t('apply:child-information.error-message.first-name-required')).max(100),
+      lastName: z.string().trim().min(1, t('apply:child-information.error-message.last-name-required')).max(100),
+      dateOfBirthYear: z
+        .number({
+          required_error: t('apply:child-information.error-message.date-of-birth-year-required'),
+          invalid_type_error: t('apply:child-information.error-message.date-of-birth-year-number'),
+        })
+        .int()
+        .positive(),
+      dateOfBirthMonth: z
+        .number({
+          required_error: t('apply:child-information.error-message.date-of-birth-month-required'),
+        })
+        .int()
+        .positive(),
+      dateOfBirthDay: z
+        .number({
+          required_error: t('apply:child-information.error-message.date-of-birth-day-required'),
+          invalid_type_error: t('apply:child-information.error-message.date-of-birth-day-number'),
+        })
+        .int()
+        .positive(),
+      dateOfBirth: z.string(),
+      hasSocialInsuranceNumber: z.string().trim().min(1, t('apply:child-information.error-message.has-social-insurance-number')),
+      socialInsuranceNumber: z.string().trim().optional(),
+      isParent: z.string().trim().min(1, t('apply:child-information.error-message.is-parent')),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasSocialInsuranceNumber === FormAction.Yes) {
+        if (!val.socialInsuranceNumber) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:child-information.error-message.sin-required'), path: ['socialInsuranceNumber'] });
+        } else if (!isValidSin(val.socialInsuranceNumber)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:child-information.error-message.sin-valid'), path: ['socialInsuranceNumber'] });
+        }
+      }
+
+      // At this point the year, month and day should have been validated as positive integer
+      const parseDateOfBirthString = parseDateString(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
+      const dateOfBirth = `${parseDateOfBirthString.year}-${parseDateOfBirthString.month}-${parseDateOfBirthString.day}`;
+      const parsedDateOfBirth = parse(dateOfBirth, 'yyyy-MM-dd', new Date());
+
+      if (!isValid(parsedDateOfBirth)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('apply:child-information.error-message.date-of-birth-valid'),
+          path: ['dateOfBirth'],
+        });
+      } else if (!isPast(parsedDateOfBirth)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('apply:child-information.error-message.date-of-birth-is-past'),
+          path: ['dateOfBirth'],
+        });
+      } else if (differenceInYears(new Date(), parsedDateOfBirth) > 150) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('apply:child-information.error-message.date-of-birth-is-past-valid'),
+          path: ['dateOfBirth'],
+        });
+      }
+    })
+    .transform((val) => {
+      // At this point the year, month and day should have been validated as positive integer
+      const parseDateOfBirthString = parseDateString(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
+      return {
+        ...val,
+        dateOfBirth: `${parseDateOfBirthString.year}-${parseDateOfBirthString.month}-${parseDateOfBirthString.day}`,
+      };
+    }) satisfies z.ZodType<ChildInformationState>;
+
+  const data = {
+    firstName: String(formData.get('firstName') ?? ''),
+    lastName: String(formData.get('lastName') ?? ''),
+    dateOfBirthYear: formData.get('dateOfBirthYear') ? Number(formData.get('dateOfBirthYear')) : undefined,
+    dateOfBirthMonth: formData.get('dateOfBirthMonth') ? Number(formData.get('dateOfBirthMonth')) : undefined,
+    dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
+    dateOfBirth: '',
+    hasSocialInsuranceNumber: String(formData.get('hasSocialInsuranceNumber') ?? ''),
+    socialInsuranceNumber: formData.get('socialInsuranceNumber') ? String(formData.get('socialInsuranceNumber') ?? '') : undefined,
+    isParent: String(formData.get('isParent') ?? ''),
+  };
+
+  const parsedDataResult = childInformationSchema.safeParse(data);
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format() });
+  }
+
+  await saveApplyAdultState({ params, request, session, state: { childInformation: parsedDataResult.data } });
+
+  if (state.adultState.editMode) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/personal-information', params));
+}
+
+export default function ApplyFlowChildInformation() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errorSummaryId = 'error-summary';
+  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber ?? '');
+
+  const handleSocialInsuranceNumberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setHasSocialInsuranceNumberValue(e.target.value);
+  };
+
+  // Keys order should match the input IDs order.
+  const errorSummaryItems = useMemo(() => {
+    const items: ErrorSummaryItem[] = [];
+    if (fetcher.data?.errors.firstName?._errors[0]) items.push(createErrorSummaryItem('first-name', fetcher.data.errors.firstName._errors[0]));
+    if (fetcher.data?.errors.lastName?._errors[0]) items.push(createErrorSummaryItem('last-name', fetcher.data.errors.lastName._errors[0]));
+    if (fetcher.data?.errors.dateOfBirth?._errors[0]) items.push(createErrorSummaryItem('date-picker-date-of-birth-month', fetcher.data.errors.dateOfBirth._errors[0]));
+    if (fetcher.data?.errors.dateOfBirthMonth?._errors[0]) items.push(createErrorSummaryItem('date-picker-date-of-birth-month', fetcher.data.errors.dateOfBirthMonth._errors[0]));
+    if (fetcher.data?.errors.dateOfBirthDay?._errors[0]) items.push(createErrorSummaryItem('date-picker-date-of-birth-day', fetcher.data.errors.dateOfBirthDay._errors[0]));
+    if (fetcher.data?.errors.dateOfBirthYear?._errors[0]) items.push(createErrorSummaryItem('date-picker-date-of-birth-year', fetcher.data.errors.dateOfBirthYear._errors[0]));
+    if (fetcher.data?.errors.socialInsuranceNumber?._errors[0]) items.push(createErrorSummaryItem('social-insurance-number', fetcher.data.errors.socialInsuranceNumber._errors[0]));
+    if (fetcher.data?.errors.hasSocialInsuranceNumber?._errors[0]) items.push(createErrorSummaryItem('input-radios-has-social-insurance-number', fetcher.data.errors.hasSocialInsuranceNumber._errors[0]));
+    if (fetcher.data?.errors.isParent?._errors[0]) items.push(createErrorSummaryItem('input-radios-is-parent-radios', fetcher.data.errors.isParent._errors[0]));
+    return items;
+  }, [
+    fetcher.data?.errors.firstName?._errors,
+    fetcher.data?.errors.lastName?._errors,
+    fetcher.data?.errors.dateOfBirth?._errors,
+    fetcher.data?.errors.dateOfBirthDay?._errors,
+    fetcher.data?.errors.dateOfBirthMonth?._errors,
+    fetcher.data?.errors.dateOfBirthYear?._errors,
+    fetcher.data?.errors.socialInsuranceNumber?._errors,
+    fetcher.data?.errors.hasSocialInsuranceNumber?._errors,
+    fetcher.data?.errors.isParent?._errors,
+  ]);
+
+  useEffect(() => {
+    if (errorSummaryItems.length > 0) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        const fieldIds = errorSummaryItems.map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorSummaryItems]);
+
+  const options: InputRadiosProps['options'] = [
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:child-information.sin-yes" components={{ bold: <strong /> }} />,
+      value: FormAction.Yes,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber === FormAction.Yes,
+      append: hasSocialInsuranceNumberValue === FormAction.Yes && (
+        <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+          <InputField
+            id="social-insurance-number"
+            name="socialInsuranceNumber"
+            label={t('apply:child-information.sin')}
+            placeholder="000-000-000"
+            defaultValue={defaultState?.socialInsuranceNumber ?? ''}
+            errorMessage={fetcher.data?.errors.socialInsuranceNumber?._errors[0]}
+            required
+          />
+        </div>
+      ),
+      onChange: handleSocialInsuranceNumberSelection,
+    },
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:child-information.sin-no" components={{ bold: <strong /> }} />,
+      value: FormAction.No,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber === FormAction.No,
+      onChange: handleSocialInsuranceNumberSelection,
+    },
+  ];
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={40} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p id="form-instructions-sin" className="mb-4">
+          {t('apply:child-information.form-instructions-sin')}
+        </p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" aria-describedby="form-instructions-sin form-instructions" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="mb-8 space-y-6">
+            <p className="italic" id="form-instructions">
+              {t('apply:required-label')}
+            </p>
+            <Collapsible id="name-instructions" summary={t('apply:child-information.single-legal-name')}>
+              <p>{t('apply:child-information.name-instructions')}</p>
+            </Collapsible>
+            <div className="grid items-end gap-6 md:grid-cols-2">
+              <InputField
+                id="first-name"
+                name="firstName"
+                label={t('apply:child-information.first-name')}
+                className="w-full"
+                maxLength={100}
+                aria-describedby="name-instructions"
+                autoComplete="given-name"
+                errorMessage={fetcher.data?.errors.firstName?._errors[0]}
+                defaultValue={defaultState?.firstName ?? ''}
+                required
+              />
+              <InputField
+                id="last-name"
+                name="lastName"
+                label={t('apply:child-information.last-name')}
+                className="w-full"
+                maxLength={100}
+                autoComplete="family-name"
+                defaultValue={defaultState?.lastName ?? ''}
+                errorMessage={fetcher.data?.errors.lastName?._errors[0]}
+                aria-describedby="name-instructions"
+                required
+              />
+            </div>
+            <DatePickerField
+              id="date-of-birth"
+              names={{
+                day: 'dateOfBirthDay',
+                month: 'dateOfBirthMonth',
+                year: 'dateOfBirthYear',
+              }}
+              defaultValue={defaultState?.dateOfBirth ?? ''}
+              legend={t('apply:child-information.date-of-birth')}
+              errorMessages={{
+                all: fetcher.data?.errors.dateOfBirth?._errors[0],
+                year: fetcher.data?.errors.dateOfBirthYear?._errors[0],
+                month: fetcher.data?.errors.dateOfBirthMonth?._errors[0],
+                day: fetcher.data?.errors.dateOfBirthDay?._errors[0],
+              }}
+              required
+            />
+
+            <InputRadios id="has-social-insurance-number" legend={t('apply:child-information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={fetcher.data?.errors.hasSocialInsuranceNumber?._errors[0]} required />
+
+            <InputRadios
+              id="is-parent-radios"
+              name="isParent"
+              legend={t('apply:child-information.parent-legend')}
+              options={[
+                { value: FormAction.Yes, children: t('apply:child-information.radio-options.yes'), defaultChecked: defaultState?.isParent === FormAction.Yes },
+                { value: FormAction.No, children: t('apply:child-information.radio-options.no'), defaultChecked: defaultState?.isParent === FormAction.No },
+              ]}
+              errorMessage={fetcher.data?.errors.isParent?._errors[0]}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Applicant Information click">
+                {t('apply:child-information.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Applicant Information click">
+                {t('apply:child-information.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button id="continue-button" name="_action" value={FormAction.Continue} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Applicant Information click">
+                {t('apply:child-information.continue-btn')}
+                <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+              </Button>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+                <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+                {t('apply:child-information.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -56,7 +56,8 @@
       "disabilityTaxCredit": "CDCP-APPL-0018",
       "parentOrGuardian": "CDCP-APPL-0019",
       "livingIndependently": "CDCP-APPL-0020",
-      "applyChildren": "CDCP-APPL-0021"
+      "applyChildren": "CDCP-APPL-0021",
+      "childInformation": "CDCP-APPL-0021"
     },
     "status": "CDCP-STAT-0001",
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -6,7 +6,44 @@
     "back-btn": "Back",
     "continue-btn": "Proceed to apply for your child(ren)"
   },
-
+  "child-information": {
+    "page-title": "Child 1: information",
+    "form-instructions-sin": "Provide the child's legal name as indicated on their Social Insurance Number (SIN) card or letter (if available), or other government documentation.",
+    "single-legal-name": "If the child has a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "date-of-birth": "Date of birth",
+    "sin-legend": "Does this child have a Social Insurance Number (SIN)?",
+    "sin-yes": "<bold>Yes</bold>, this child has a SIN",
+    "sin-no": "<bold>No</bold>, this child does not have a SIN",
+    "sin": "Enter the 9-digit SIN",
+    "parent-legend": "Are you the parent or legal guardian of this child?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "sin-required": "Enter 9-digit SIN",
+      "sin-valid": "Must be a valid SIN",
+      "date-of-birth-day-number": "Day must be a number",
+      "date-of-birth-day-required": "Date of birth must include a day",
+      "date-of-birth-is-past": "Date of birth must be in the past",
+      "date-of-birth-is-past-valid": "Date of birth too far in the past",
+      "date-of-birth-month-required": "Date of birth must include a month",
+      "date-of-birth-valid": "Day must be valid for the given month and year",
+      "date-of-birth-year-number": "Year must be a number, for example 1950",
+      "date-of-birth-year-required": "Date of birth must include a year",
+      "has-social-insurance-number": "Select whether or not this child has a social insurance number",
+      "is-parent": "Select whether or not you are this child's parent or legal guardian"
+    }
+  },
   "disability-tax-credit": {
     "page-title": "Disability tax credit",
     "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -6,6 +6,43 @@
     "back-btn": "Retour",
     "continue-btn": "(FR) Proceed to apply for your child(ren)"
   },
+  "child-information": {
+    "page-title": "(FR) Child 1: information",
+    "form-instructions-sin": "(FR) Provide the child's legal name as indicated on their Social Insurance Number (SIN) card or letter (if available), or other government documentation.",
+    "single-legal-name": "(FR) If the child has a single legal name",
+    "name-instructions": "(FR) If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "last-name": "Nom de famille",
+    "first-name": "Prénom",
+    "date-of-birth": "(FR) Date of birth",
+    "sin-legend": "(FR) Does this child have a Social Insurance Number (SIN)?",
+    "sin-yes": "(FR) <bold>Yes</bold>, this child has a SIN",
+    "sin-no": "(FR) <bold>No</bold>, this child does not have a SIN",
+    "sin": "(FR) Enter the 9-digit SIN",
+    "parent-legend": "(FR) Are you the parent or legal guardian of this child?",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "first-name-required": "Entrez le prénom",
+      "sin-required": "Entrez un NAS de 9 chiffres",
+      "sin-valid": "Le NAS doit être valide",
+      "date-of-birth-day-number": "Le jour doit être un nombre",
+      "date-of-birth-day-required": "La date de naissance doit inclure un jour",
+      "date-of-birth-is-past": "La date de naissance doit être dans le passé",
+      "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
+      "date-of-birth-month-required": "La date de naissance doit inclure un mois",
+      "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
+      "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
+      "date-of-birth-year-required": "La date de naissance doit inclure une année",
+      "has-social-insurance-number": "(FR) Select whether or not this child has a social insurance number",
+      "is-parent": "(FR) Select whether or not you are this child's parent or legal guardian"
+    }
+  },
   "disability-tax-credit": {
     "page-title": "(FR) Disability tax credit",
     "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",


### PR DESCRIPTION
### Description
Add screen B-9

NOTE: 
- translations are NOT in. 
- the adult-child apply flow hasn't been implemented in main (yet), therefore logic in this PR will have to change in a future PR

### Related Azure Boards Work Items
[AB#3347](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3347)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`