### PR TITLE
[gitops] Deploy v1.0.0 to production

### DIFF
--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,view-letters
+ENABLED_FEATURES=hcaptcha
 
 #
 # Session/redis configuration

--- a/gitops/overlays/prod/patches/deployments.yaml
+++ b/gitops/overlays/prod/patches/deployments.yaml
@@ -10,8 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0
-          imagePullPolicy: Always # TODO :: GjB :: remove this when switching to an actual release
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:1.0.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Deploy v1.0.0 to production! 🥳

This PR deploys v1.0.0 (initial release) of CDCP to production.
Note that the auth proxy will remain enabled until golive on May 01.
