### PR TITLE
Adding unsubscription success page.

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -664,7 +664,15 @@
                     "file": "routes/$lang+/_protected+/alerts+/unsubscribe+/index.tsx",
                     "paths": {
                       "en": "/:lang/alerts/unsubscribe",
-                      "fr": "/:lang/alertes/désabonner"
+                      "fr": "/:lang/alertes/desabonner"
+                    }
+                  },
+                  {
+                    "id": "$lang+/_protected+/alerts+/unsubscribe+/success",
+                    "file": "routes/$lang+/_protected+/alerts+/unsubscribe+/success.tsx",
+                    "paths": {
+                      "en": "/:lang/alerts/unsubscribe/success",
+                      "fr": "/:lang/alertes/desabonner/succes"
                     }
                   }
                 ]

--- a/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/success.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/success.tsx
@@ -1,0 +1,72 @@
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useParams } from '@remix-run/react';
+
+import { Trans, useTranslation } from 'react-i18next';
+
+import pageIds from '../../../page-ids.json';
+import { InlineLink } from '~/components/inline-link';
+import { getRaoidcService } from '~/services/raoidc-service.server';
+import { getSubscriptionService } from '~/services/subscription-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { UserinfoToken } from '~/utils/raoidc-utils.server';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  breadcrumbs: [{ labelI18nKey: 'alerts:success.page-title' }],
+  i18nNamespaces: getTypedI18nNamespaces('alerts', 'gcweb'),
+  pageIdentifier: pageIds.protected.alerts.success,
+  pageTitleI18nKey: 'alerts:success.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const raoidcService = await getRaoidcService();
+
+  await raoidcService.handleSessionValidation(request, session);
+
+  const log = getLogger('alerts.success');
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('alerts:success.page-title') }) };
+
+  const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  if (!userInfoToken.sin) {
+    log.warn('SIN was not found in session, returning a 500 status');
+    throw new Response(null, { status: 500 });
+  }
+  const alertSubscription = await getSubscriptionService().getSubscription(userInfoToken.sin);
+
+  if (alertSubscription?.subscribed) {
+    log.warn('User is already subscribed, returning a 400 status');
+    throw new Response(null, { status: 400 });
+  }
+
+  return json({ meta });
+}
+
+export default function SuccessSubscription() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const params = useParams();
+
+  const subscribelink = <InlineLink routeId="$lang+/_protected+/alerts+/subscribe+/index" params={params} />;
+  const homeLink = <InlineLink routeId="$lang+/_protected+/home" params={params} />;
+  return (
+    <>
+      <p className="mb-4">{t('alerts:success.unsubscribe-successful')}</p>
+      <p className="mb-4">
+        <Trans ns={handle.i18nNamespaces} i18nKey="alerts:success.subscribe-again" components={{ subscribelink }} />
+      </p>
+      <p className="mb-4">
+        <Trans ns={handle.i18nNamespaces} i18nKey="alerts:success.return-home" components={{ homeLink }} />
+      </p>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -26,7 +26,8 @@
       "unsubscribe": "CDCP-PROT-0017",
       "manage": "CDCP-PROT-0018",
       "confirm": "CDCP-PROT-0019",
-      "expired": "CDCP-PROT-0020"
+      "expired": "CDCP-PROT-0020",
+      "success": "CDCP-PROT-0021"
     },
     "status-check": {
       "index": "CDCP-PROT-0021"

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -78,5 +78,11 @@
     "confirm-code-expired": "The confirmation code sent to you has expired. Select the \"Request New Confirmation Code\" button below to have a new confirmation code sent to you at <strong>{{userEmailAddress}}</strong>.",
     "request-new-code": "Request New Confirmation Code",
     "back": "Back"
+  },
+  "success": {
+    "page-title": "Unscubscribe Confirmation",
+    "unsubscribe-successful": "You have successfully unsubscribed from Canada Dental Care Plan. You will no longer receive emails when important new Canada Dental Care Plan information is available in your My Service Canada Account.",
+    "subscribe-again": "You may subscribe again to Canada Dental Care Plan alerts by <subscribelink>completing the subscription process</subscribelink>.",
+    "return-home": "Return <homeLink>Home</homeLink>"
   }
 }

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -76,5 +76,11 @@
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
     "confirm-code-expired": "(FR) The confirmation code sent to you has expired. Select the \"Request New Confirmation Code\" button below to have a new confirmation code sent to you at <strong>{{userEmailAddress}}</strong>."
+  },
+  "success": {
+    "page-title": "(FR) Unscubscribe Confirmation",
+    "unsubscribe-successful": "(FR) You have successfully unsubscribed from Canada Dental Care Plan. You will no longer receive emails when important new Canada Dental Care Plan information is available in your My Service Canada Account.",
+    "subscribe-again": "(FR) You may subscribe again to Canada Dental Care Plan alerts by <subscribelink>completing the subscription process</subscribelink>.",
+    "return-home": "(FR) Return <homeLink>Home</homeLink>"
   }
 }


### PR DESCRIPTION
### Description
Adding unsubscription success page.

### Related Azure Boards Work Items
[AB#3345](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3345)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `http://localhost:3000/en/alerts/unsubscribe` and unsubscribe -> success page should be displayed.

If you navigate directly to `http://localhost:3000/en/alerts/unsubscribe/success`, 404 should be thrown. (Is this what we want?)

### Additional Notes
- Open to feedback. I left it really simple.
- Do we want tests?