### PR TITLE
AB#3334 - adult-child flow apply for yourself

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -258,6 +258,14 @@
                           "en": "/:lang/apply/:id/adult-child/confirmation",
                           "fr": "/:lang/demander/:id/adulte-enfant/confirmation"
                         }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/apply-for-yourself",
+                          "fr": "/:lang/demander/:id/adulte-enfant/postulez-pour-vous-meme"
+                        }
                       }
                     ]
                   },

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -260,11 +260,11 @@
                         }
                       },
                       {
-                        "id": "$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself",
-                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx",
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/apply-yourself",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx",
                         "paths": {
-                          "en": "/:lang/apply/:id/adult-child/apply-for-yourself",
-                          "fr": "/:lang/demander/:id/adulte-enfant/postulez-pour-vous-meme"
+                          "en": "/:lang/apply/:id/adult-child/apply-yourself",
+                          "fr": "/:lang/demander/:id/adulte-enfant/postulez-vous-meme"
                         }
                       }
                     ]

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
@@ -1,0 +1,84 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { InlineLink } from '~/components/inline-link';
+import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.applySelf,
+  pageTitleI18nKey: 'apply-adult-child:eligibility.apply-for-yourself.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.apply-for-yourself.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/apply-for-yourself');
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
+}
+
+export default function ApplyForYourself() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <div className="max-w-prose">
+      <div className="mb-6 space-y-4">
+        <p>
+          {t('apply-adult-child:eligibility.apply-for-yourself.ineligible-to-apply')}&nbsp;
+          <InlineLink to={t('apply-adult-child:eligibility.apply-for-yourself.eligibility-info-href')}>{t('apply-adult-child:eligibility.apply-for-yourself.eligibility-info')}</InlineLink>
+        </p>
+        <p>{t('apply-adult-child:eligibility.apply-for-yourself.submit-application')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Apply for yourself">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply-adult-child:eligibility.apply-for-yourself.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" id="proceed-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Proceed - Apply for yourself click">
+          {t('apply-adult-child:eligibility.apply-for-yourself.proceed-btn')}
+          <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+        </Button>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
@@ -49,7 +49,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     throw new Response('Invalid CSRF token', { status: 400 });
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
 }
 
 export default function ApplyForYourself() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself.tsx
@@ -51,14 +51,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     throw new Response('Invalid CSRF token', { status: 400 });
   }
 
-  saveApplyState({
-    params,
-    session,
-    state: {
-      ...state,
-      typeOfApplication: 'adult',
-    },
-  });
+  saveApplyState({ params, session, state: { typeOfApplication: 'adult' } });
 
   const { taxFiling2023, dateOfBirth } = state.adultChildState;
   saveApplyAdultState({ params, request, session, state: { taxFiling2023, dateOfBirth } });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
@@ -22,7 +22,7 @@ import { cn } from '~/utils/tw-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'gcweb'),
   pageIdentifier: pageIds.public.apply.adultChild.applySelf,
-  pageTitleI18nKey: 'apply-adult-child:eligibility.apply-for-yourself.page-title',
+  pageTitleI18nKey: 'apply-adult-child:eligibility.apply-yourself.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -34,13 +34,13 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.apply-for-yourself.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.apply-yourself.page-title') }) };
 
   return json({ id: state.id, csrfToken, meta });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/adult-child/apply-for-yourself');
+  const log = getLogger('apply/adult-child/apply-yourself');
   const state = loadApplyAdultChildState({ params, request, session });
   const formData = await request.formData();
   const expectedCsrfToken = String(session.get('csrfToken'));
@@ -70,19 +70,19 @@ export default function ApplyForYourself() {
     <div className="max-w-prose">
       <div className="mb-6 space-y-4">
         <p>
-          {t('apply-adult-child:eligibility.apply-for-yourself.ineligible-to-apply')}&nbsp;
-          <InlineLink to={t('apply-adult-child:eligibility.apply-for-yourself.eligibility-info-href')}>{t('apply-adult-child:eligibility.apply-for-yourself.eligibility-info')}</InlineLink>
+          {t('apply-adult-child:eligibility.apply-yourself.ineligible-to-apply')}&nbsp;
+          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.eligibility-info-href')}>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</InlineLink>
         </p>
-        <p>{t('apply-adult-child:eligibility.apply-for-yourself.submit-application')}</p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.submit-application')}</p>
       </div>
       <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Apply for yourself">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply-adult-child:eligibility.apply-for-yourself.back-btn')}
+          {t('apply-adult-child:eligibility.apply-yourself.back-btn')}
         </ButtonLink>
         <Button type="submit" variant="primary" id="proceed-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Proceed - Apply for yourself click">
-          {t('apply-adult-child:eligibility.apply-for-yourself.proceed-btn')}
+          {t('apply-adult-child:eligibility.apply-yourself.proceed-btn')}
           <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/date-of-birth.tsx
@@ -165,7 +165,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   if (age >= 65 && allChildrenUnder18 === 'no') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-for-yourself', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-yourself', params));
   }
 
   if (state.adultChildState.editMode) {

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -72,7 +72,8 @@
         "exitApplication": "CDCP-APPL-ADCH-0013",
         "confirmation": "CDCP-APPL-ADCH-0014",
         "childInformation": "CDCP-APPL-ADCH-0015",
-        "applyChildren": "CDCP-APPL-ADCH-0016"
+        "applyChildren": "CDCP-APPL-ADCH-0016",
+        "applySelf": "CDCP-APPL-ADCH-0017"
       },
       "child": {
         "taxFiling": "CDCP-APPL-CH-0002",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -186,8 +186,7 @@
       "eligibility-info-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
       "submit-application": "You can still submit an application for yourself.",
       "back-btn": "Back",
-      "proceed-btn": "Proceed to apply for yourself",
-      "procees-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+      "proceed-btn": "Proceed to apply for yourself"
     }
   },
   "exit-application": {

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -178,6 +178,16 @@
         "has-social-insurance-number": "Select whether or not this child has a social insurance number",
         "is-parent": "Select whether or not you are this child's parent or legal guardian"
       }
+    },
+    "apply-for-yourself": {
+      "page-title": "Apply for yourself",
+      "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
+      "eligibility-info": "Find out when they can apply.",
+      "eligibility-info-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "submit-application": "You can still submit an application for yourself.",
+      "back-btn": "Back",
+      "proceed-btn": "Proceed to apply for yourself",
+      "procees-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
     }
   },
   "exit-application": {

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -179,7 +179,7 @@
         "is-parent": "Select whether or not you are this child's parent or legal guardian"
       }
     },
-    "apply-for-yourself": {
+    "apply-yourself": {
       "page-title": "Apply for yourself",
       "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
       "eligibility-info": "Find out when they can apply.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -273,7 +273,7 @@
         "is-parent": "(FR) Select whether or not you are this child's parent or legal guardian"
       }
     },
-    "apply-for-yourself": {
+    "apply-yourself": {
       "page-title": "(FR) Apply for yourself",
       "ineligible-to-apply": "(FR) Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
       "eligibility-info": "(FR) Find out when they can apply.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -277,11 +277,11 @@
       "page-title": "(FR) Apply for yourself",
       "ineligible-to-apply": "(FR) Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
       "eligibility-info": "(FR) Find out when they can apply.",
-      "eligibility-info-href": "(FR) https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "eligibility-info-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
       "submit-application": "(FR) You can still submit an application for yourself.",
       "back-btn": "Retour",
       "proceed-btn": "(FR) Proceed to apply for yourself",
-      "procees-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+      "procees-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
     }
   },
   "exit-application": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -280,8 +280,7 @@
       "eligibility-info-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
       "submit-application": "(FR) You can still submit an application for yourself.",
       "back-btn": "Retour",
-      "proceed-btn": "(FR) Proceed to apply for yourself",
-      "procees-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+      "proceed-btn": "(FR) Proceed to apply for yourself"
     }
   },
   "exit-application": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -272,6 +272,16 @@
         "has-social-insurance-number": "(FR) Select whether or not this child has a social insurance number",
         "is-parent": "(FR) Select whether or not you are this child's parent or legal guardian"
       }
+    },
+    "apply-for-yourself": {
+      "page-title": "(FR) Apply for yourself",
+      "ineligible-to-apply": "(FR) Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
+      "eligibility-info": "(FR) Find out when they can apply.",
+      "eligibility-info-href": "(FR) https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "submit-application": "(FR) You can still submit an application for yourself.",
+      "back-btn": "Retour",
+      "proceed-btn": "(FR) Proceed to apply for yourself",
+      "procees-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
     }
   },
   "exit-application": {


### PR DESCRIPTION
### Description
Added `apply-for-yourself` route for adult-child flow

Update: When click on the proceed button, the apply flow should change to 'adult'. The action should update typeOfApplication state to `adult`, and copy the `adultChild` state to `adult` state

### Related Azure Boards Work Items
[AB#3334](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3334)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`