### PR TITLE
AB#3381 - add view applications page and mock api

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -189,7 +189,7 @@ REDIS_PASSWORD=password
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress,subscription
+ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress,subscription,application-history
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/mocks/application-history-api.server.ts
+++ b/frontend/app/mocks/application-history-api.server.ts
@@ -1,0 +1,45 @@
+import { HttpResponse, http } from 'msw';
+import { z } from 'zod';
+
+import { getLogger } from '~/utils/logging.server';
+
+const log = getLogger('application-history-api.server');
+
+/**
+ * Server-side MSW mocks for the Application History API.
+ */
+export function getApplicationHistoryApiMockHandlers() {
+  log.info('Initializing Application History API mock handlers');
+
+  return [
+    /**
+     * Handler for GET requests to retrieve application history.
+     */
+    http.get('https://api.example.com/v1/users/:userId/applications', ({ params, request }) => {
+      log.debug('Handling request for [%s]', request.url);
+
+      const parsedUserId = z.string().safeParse(params.userId);
+
+      if (!parsedUserId.success) {
+        throw new HttpResponse(null, { status: 400 });
+      }
+
+      return HttpResponse.json([
+        {
+          AppicationId: '038d9d0f-fb35-4d98-8f31-a4b2171e521a',
+          SubmittedDate: '2024/04/05',
+          ApplicationStatus: 'Submitted',
+          ConfirmationCode: '202403051212',
+          Data: [],
+        },
+        {
+          AppicationId: '038d9d0f-fb35-4d98-9d34-a4b2171e789b',
+          SubmittedDate: '2024/03/05',
+          ApplicationStatus: 'Approved',
+          ConfirmationCode: '202403054231',
+          Data: [],
+        },
+      ]);
+    }),
+  ];
+}

--- a/frontend/app/mocks/node.ts
+++ b/frontend/app/mocks/node.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 
+import { getApplicationHistoryApiMockHandlers } from './application-history-api.server';
 import { getSubscriptionApiMockHandlers } from './subscription-api.server';
 import { getCCTApiMockHandlers } from '~/mocks/cct-api.server';
 import { getLookupApiMockHandlers } from '~/mocks/lookup-api.server';
@@ -10,6 +11,7 @@ import { getWSAddressApiMockHandlers } from '~/mocks/wsaddress-api.server';
 import { mockEnabled } from '~/utils/env.server';
 
 export const server = setupServer(
+  ...(mockEnabled('application-history') ? getApplicationHistoryApiMockHandlers() : []),
   ...(mockEnabled('subscription') ? getSubscriptionApiMockHandlers() : []),
   ...(mockEnabled('cct') ? getCCTApiMockHandlers() : []),
   ...(mockEnabled('lookup') ? getLookupApiMockHandlers() : []),

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -670,6 +670,21 @@
             ]
           },
           {
+            "id": "$lang+/_protected+/applications+/_route",
+            "file": "routes/$lang+/_protected+/applications+/_route.tsx",
+            "children": [
+              {
+                "id": "$lang+/_protected+/applications+/index",
+                "file": "routes/$lang+/_protected+/applications+/index.tsx",
+                "paths": {
+                  "en": "/:lang/applications",
+                  "fr": "/:lang/applications"
+                },
+                "index": true
+              }
+            ]
+          },
+          {
             "id": "$lang+/_protected+/stub-sin-editor",
             "file": "routes/$lang+/_protected+/stub-sin-editor.tsx",
             "paths": {

--- a/frontend/app/routes/$lang+/_protected+/applications+/_route.tsx
+++ b/frontend/app/routes/$lang+/_protected+/applications+/_route.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from '@remix-run/react';
+
+/**
+ * Do-nothing parent route.
+ * (placeholder for future code)
+ */
+export default function Route() {
+  return <Outlet />;
+}

--- a/frontend/app/routes/$lang+/_protected+/applications+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/applications+/index.tsx
@@ -1,0 +1,99 @@
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useLoaderData, useParams } from '@remix-run/react';
+
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { ContextualAlert } from '~/components/contextual-alert';
+import { InlineLink } from '~/components/inline-link';
+import { getAuditService } from '~/services/audit-service.server';
+import { getBenefitApplicationService } from '~/services/benefit-application-service.server';
+import { getInstrumentationService } from '~/services/instrumentation-service.server';
+import { getRaoidcService } from '~/services/raoidc-service.server';
+import { featureEnabled } from '~/utils/env.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { useUserOrigin } from '~/utils/user-origin-utils';
+
+export const handle = {
+  breadcrumbs: [{ labelI18nKey: 'applications:index.page-title' }],
+  i18nNamespaces: getTypedI18nNamespaces('applications', 'gcweb'),
+  pageIdentifier: pageIds.protected.applications.index,
+  pageTitleI18nKey: 'applications:index.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  if (!data) return [];
+  return getTitleMetaTags(data.meta.title);
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  featureEnabled('view-applications');
+
+  const auditService = getAuditService();
+  const instrumentationService = getInstrumentationService();
+  const raoidcService = await getRaoidcService();
+  const benefitApplicationService = getBenefitApplicationService();
+
+  await raoidcService.handleSessionValidation(request, session);
+
+  const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  const applications = await benefitApplicationService.getApplications(userInfoToken.sub);
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('applications:index.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  auditService.audit('page-view.applications', { userId: idToken.sub });
+  instrumentationService.countHttpStatus('applications.view', 200);
+
+  return json({ applications, meta });
+}
+
+export default function ApplicationsIndex() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { applications } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const userOrigin = useUserOrigin();
+
+  //TODO: will update <InlineLink rounteId> when view details page is ready
+  return (
+    <>
+      {applications.length === 0 ? (
+        <ContextualAlert type="info">
+          <p>{t('applications:index.no-application')}</p>
+        </ContextualAlert>
+      ) : (
+        <>
+          <ul className="divide-y border-y">
+            {applications.map((application) => {
+              return (
+                <li key={application.id} className="py-4 sm:py-6">
+                  <InlineLink routeId="$lang+/_protected+/letters+/$id.download" params={{ ...params, id: application.id }} className="external-link font-lato font-semibold" newTabIndicator target="_blank">
+                    {t('applications:index.date', { date: application.submittedOn })}
+                  </InlineLink>
+                  <p className="mt-1 text-sm text-gray-500">{application.status}</p>
+                  <p className="mt-1 text-sm text-gray-500">{application.confirmationCode}</p>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {userOrigin && (
+        <div className="my-6 flex flex-wrap items-center gap-3">
+          <ButtonLink id="back-button" to={userOrigin.to}>
+            {t('applications:index.button.back')}
+          </ButtonLink>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/_protected+/home.tsx
+++ b/frontend/app/routes/$lang+/_protected+/home.tsx
@@ -64,7 +64,7 @@ export default function Index() {
           </CardLink>
         )}
         {useFeature('view-applications') && (
-          <CardLink title={t('index:view-my-application')} routeId="$lang+/_protected+/home" params={params}>
+          <CardLink title={t('index:view-my-application')} routeId="$lang+/_protected+/applications+/index" params={params}>
             {t('index:view-my-application-desc')}
           </CardLink>
         )}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -30,6 +30,9 @@
     "status-check": {
       "index": "CDCP-PROT-0020"
     },
+    "applications": {
+      "index": "CDCP-PROT-0021"
+    },
     "dataUnavailable": "CDCP-PROT-0099"
   },
   "public": {

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -3,6 +3,7 @@ import type { ActionFunctionArgs as RRActionFunctionArgs, LoaderFunctionArgs as 
 
 import type accessToGovernmentalBenefits from '../public/locales/en/access-to-governmental-benefits.json';
 import type alerts from '../public/locales/en/alerts.json';
+import type applications from '../public/locales/en/applications.json';
 import type applyAdultChild from '../public/locales/en/apply-adult-child.json';
 import type applyAdult from '../public/locales/en/apply-adult.json';
 import type applyChild from '../public/locales/en/apply-child.json';
@@ -48,6 +49,7 @@ declare module 'i18next' {
       'access-to-governmental-benefits': typeof accessToGovernmentalBenefits;
       'personal-information': typeof personalInformation;
       alerts: typeof alerts;
+      applications: typeof applications;
       status: typeof status;
       'status-check': typeof statusCheck;
       'stub-sin-editor': typeof stubSinEditor;

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -19,7 +19,7 @@ function tryOrElseFalse(fn: () => unknown) {
   catch { return false; }
 }
 
-const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'subscription'] as const;
+const validMockNames = ['cct', 'lookup', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'subscription', 'application-history'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 const validFeatureNames = [

--- a/frontend/public/locales/en/applications.json
+++ b/frontend/public/locales/en/applications.json
@@ -1,0 +1,13 @@
+{
+  "index": {
+    "page-title": "Applications",
+    "breadcrumbs": {
+      "application": "Applications"
+    },
+    "no-application": "There are no application submitted on file.",
+    "date": "Submitted Date: {{date}}",
+    "button": {
+      "back": "Back"
+    }
+  }
+}

--- a/frontend/public/locales/fr/applications.json
+++ b/frontend/public/locales/fr/applications.json
@@ -1,0 +1,13 @@
+{
+  "index": {
+    "page-title": "(FR) Applications",
+    "breadcrumbs": {
+      "application": "(FR) Applications"
+    },
+    "no-application": "(FR) There are no application submitted on file.",
+    "date": "(FR) Submitted Date: {{date}}",
+    "button": {
+      "back": "Retour"
+    }
+  }
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

1. add new view application page
2. add mock api and service to retrieve all applications

### Related Azure Boards Work Items
[AB#3381](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3381)
[AB#3383](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3383)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/132592996/17960890-f150-4d63-92cb-9db968903524)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`