### PR TITLE
Seb/fix button outline

### DIFF
--- a/frontend/__tests__/components/buttons.test.tsx
+++ b/frontend/__tests__/components/buttons.test.tsx
@@ -12,7 +12,7 @@ describe('Button Component', () => {
     const button = getByText('Click me');
     expect(button).toBeInTheDocument();
     expect(button.tagName).toEqual('BUTTON');
-    expect(button).toHaveClass('inline-flex', 'items-center', 'justify-center', 'rounded', 'border', 'align-middle', 'font-lato', 'outline-offset-2');
+    expect(button).toHaveClass('inline-flex', 'items-center', 'justify-center', 'rounded', 'border', 'align-middle', 'font-lato', 'outline-offset-4');
   });
 
   it('renders button with custom size and variant', () => {
@@ -60,7 +60,7 @@ describe('ButtonLink Component', () => {
     const link = getByText('Click me');
     expect(link).toBeInTheDocument();
     expect(link.tagName).toEqual('A');
-    expect(link).toHaveClass('inline-flex', 'items-center', 'justify-center', 'rounded', 'border', 'align-middle', 'font-lato', 'outline-offset-2');
+    expect(link).toHaveClass('inline-flex', 'items-center', 'justify-center', 'rounded', 'border', 'align-middle', 'font-lato', 'outline-offset-4');
   });
 
   it('renders link with custom size and variant', () => {

--- a/frontend/app/components/buttons.tsx
+++ b/frontend/app/components/buttons.tsx
@@ -13,15 +13,15 @@ const sizes = {
 };
 
 const variants = {
-  alternative: 'border-gray-200 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700',
-  default: 'border-gray-300 bg-gray-200 text-slate-700 hover:bg-neutral-300',
-  dark: 'border-gray-800 bg-gray-800 text-white hover:bg-gray-900 hover:bg-gray-900',
-  green: 'border-green-700 bg-green-700 text-white hover:bg-green-800 hover:bg-green-800',
-  primary: 'border-slate-700 bg-slate-700 text-white hover:bg-sky-800 hover:bg-sky-800',
-  red: 'border-red-700 bg-red-700 text-white hover:bg-red-800 hover:bg-red-800',
+  alternative: 'border-gray-200 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
+  default: 'border-gray-300 bg-gray-200 text-slate-700 hover:bg-neutral-300 focus:bg-neutral-300',
+  dark: 'border-gray-800 bg-gray-800 text-white hover:bg-gray-900 focus:bg-gray-900',
+  green: 'border-green-700 bg-green-700 text-white hover:bg-green-800 focus:bg-green-800',
+  primary: 'border-slate-700 bg-slate-700 text-white hover:bg-sky-800 focus:bg-sky-800',
+  red: 'border-red-700 bg-red-700 text-white hover:bg-red-800 focus:bg-red-800',
 };
 
-const baseClassName = 'inline-flex items-center justify-center rounded border align-middle font-lato outline-offset-2';
+const baseClassName = 'inline-flex items-center justify-center rounded border align-middle font-lato outline-offset-4';
 
 export interface ButtonProps extends ComponentProps<'button'> {
   size?: keyof typeof sizes;

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -11,7 +11,7 @@ import { parseDateString, useMonths } from '~/utils/date-utils';
 import { padWithZero } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg focus:border-blue-300 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-20';
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
 const inputDisabledClassName = 'disable:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-checkbox.tsx
+++ b/frontend/app/components/input-checkbox.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { InputError } from './input-error';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500';
+const inputBaseClassName = 'h-4 w-4 rounded border-gray-500 bg-gray-50 text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500';
 const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
 const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -5,7 +5,7 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg focus:border-blue-300 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-20';
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
 const inputDisabledClassName = 'disable:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-phone-field.tsx
+++ b/frontend/app/components/input-phone-field.tsx
@@ -10,7 +10,7 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg focus:border-blue-300 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-20';
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
 const inputDisabledClassName = 'disable:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'h-4 w-4 border-gray-300 bg-gray-100 text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500';
+const inputBaseClassName = 'h-4 w-4 border-gray-500 bg-gray-50 text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500';
 const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
 const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -7,7 +7,7 @@ import { InputLabel } from './input-label';
 import { InputOption } from './input-option';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg focus:border-blue-300 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-20';
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
 const inputDisabledClassName = 'disable:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -5,7 +5,7 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg focus:border-blue-300 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-20';
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
 const inputDisabledClassName = 'disable:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fixes accessibiliity reported issues regarding the form components styling that doesn't pass color contrast.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3389](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3389)
[AB#3391](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3391)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Button focus outline now visible
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/44ee0bcf-cc41-48b1-bf97-539fcbb260ed)

Radio and checkbox border pass color contrast
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/fb81e416-d77d-4afb-8ca0-f65eff798bc5)

Inputs focuse outline now pass color contrast
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/548cd7d7-12aa-4d44-8bc1-7d3117155c4e)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/00f27a7b-4184-44aa-9768-b7958778ec1f)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->