### PR TITLE
Fixed a11y not screen reading progress bar component

### DIFF
--- a/frontend/app/components/progress.tsx
+++ b/frontend/app/components/progress.tsx
@@ -30,7 +30,7 @@ export interface ProgressProps extends React.ComponentPropsWithoutRef<typeof Pro
 
 const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(({ className, size = 'base', variant = 'default', value, ...props }, ref) => {
   return (
-    <ProgressPrimitive.Root ref={ref} className={cn(rootBaseClassName, sizes[size], className)} data-testid="progress-root" {...props}>
+    <ProgressPrimitive.Root ref={ref} className={cn(rootBaseClassName, sizes[size], className)} data-testid="progress-root" value={value} {...props}>
       <ProgressPrimitive.Indicator className={cn(indicatorBaseClassName, variants[variant])} style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }} data-testid="progress-indicator" />
     </ProgressPrimitive.Root>
   );


### PR DESCRIPTION
### Description
Fixed a11y not screen reading progress bar component

### Related Azure Boards Work Items
[AB#3390](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3390)

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
View apply page with a progress bar, tab to title section, use arrow key down to navigate to progress bar to screen read.

### Additional Notes
n/a