### PR TITLE
- Move form instructions prior to form elements

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/applicant-information.tsx
@@ -187,19 +187,13 @@ export default function ApplyFlowApplicationInformation() {
         <Progress aria-labelledby="progress-label" value={40} size="lg" />
       </div>
       <div className="max-w-prose">
-        <p id="form-instructions-sin" className="mb-4">
-          {t('applicant-information.form-instructions-sin')}
-        </p>
-        <p id="form-instructions-info" className="mb-6">
-          {t('applicant-information.form-instructions-info')}
-        </p>
+        <p className="mb-4">{t('applicant-information.form-instructions-sin')}</p>
+        <p className="mb-6">{t('applicant-information.form-instructions-info')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <fetcher.Form method="post" aria-describedby="form-instructions-sin form-instructions-info form-instructions" noValidate>
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-8 space-y-6">
-            <p className="mb-6 italic" id="form-instructions">
-              {t('apply:required-label')}
-            </p>
             <div className="grid items-end gap-6 md:grid-cols-2">
               <InputField
                 id="first-name"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/communication-preference.tsx
@@ -277,14 +277,10 @@ export default function ApplyFlowCommunicationPreferencePage() {
         <Progress aria-labelledby="progress-label" value={70} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6">{t('apply:communication-preference.note')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6" id="form-instructions-note">
-          {t('apply:communication-preference.note')}
-        </p>
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" noValidate aria-describedby="form-instructions form-instructions-note">
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-8 space-y-6">
             {preferredLanguages.length > 0 && (

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/date-of-birth.tsx
@@ -190,14 +190,10 @@ export default function ApplyFlowDateOfBirth() {
         <Progress aria-labelledby="progress-label" value={30} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6">{t('apply:eligibility.date-of-birth.description')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6" id="dob-desc">
-          {t('apply:eligibility.date-of-birth.description')}
-        </p>
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" aria-describedby="dob-desc form-instructions" noValidate>
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <DatePickerField
             id="date-of-birth"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/dental-insurance.tsx
@@ -143,13 +143,10 @@ export default function AccessToDentalInsuranceQuestion() {
         <Progress aria-labelledby="progress-label" value={80} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" noValidate aria-describedby="form-instructions">
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
-
           <div className="my-6">
             <InputRadios
               id="dental-insurance"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/federal-provincial-territorial-benefits.tsx
@@ -266,19 +266,13 @@ export default function AccessToDentalInsuranceQuestion() {
         <Progress aria-labelledby="progress-label" value={90} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-4">{t('apply:dental-benefits.access-to-dental')}</p>
+        <p className="mb-4">{t('apply:dental-benefits.eligibility-criteria')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <fetcher.Form method="post" noValidate aria-describedby="access-to-benefits-note eligibility-note form-instructions">
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <section>
-            <p className="mb-4" id="access-to-benefits-note">
-              {t('apply:dental-benefits.access-to-dental')}
-            </p>
-            <p className="mb-4" id="eligibility-note">
-              {t('apply:dental-benefits.eligibility-criteria')}
-            </p>
-            <p className="mb-6 italic" id="form-instructions">
-              {t('apply:required-label')}
-            </p>
             <h2 className="my-6 font-lato text-2xl font-bold">{t('apply:dental-benefits.federal-benefits.title')}</h2>
             <InputRadios
               id="has-federal-benefits"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/partner-information.tsx
@@ -221,19 +221,13 @@ export default function ApplyFlowApplicationInformation() {
         <Progress aria-labelledby="progress-label" value={50} size="lg" />
       </div>
       <div className="max-w-prose">
-        <p id="form-instructions-provide-sin" className="mb-4">
-          {t('partner-information.provide-sin')}
-        </p>
-        <p id="form-instructions-required-information" className="mb-6">
-          {t('partner-information.required-information')}
-        </p>
+        <p className="mb-4">{t('partner-information.provide-sin')}</p>
+        <p className="mb-6">{t('partner-information.required-information')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <fetcher.Form method="post" aria-describedby="form-instructions-provide-sin form-instructions-required-information form-instructions" noValidate>
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="space-y-6">
-            <p className="mb-6 italic" id="form-instructions">
-              {t('apply:required-label')}
-            </p>
             <div className="grid items-end gap-6 md:grid-cols-2">
               <InputField
                 id="first-name"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/personal-information.tsx
@@ -354,14 +354,10 @@ export default function ApplyFlowPersonalInformation() {
         <Progress aria-labelledby="progress-label" value={60} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6">{t('apply:personal-information.form-instructions')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p id="form-instructions-info" className="mb-6">
-          {t('apply:personal-information.form-instructions')}
-        </p>
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" noValidate aria-describedby="form-instructions-info form-instructions">
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
             <InputField

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/tax-filing.tsx
@@ -124,11 +124,9 @@ export default function ApplyFlowTaxFiling() {
         <Progress aria-labelledby="progress-label" value={20} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" aria-describedby="form-instructions" noValidate>
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <InputRadios
             id="tax-filing-2023"

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -127,11 +127,9 @@ export default function ApplyFlowTypeOfApplication() {
         <Progress aria-labelledby="progress-label" value={10} size="lg" />
       </div>
       <div className="max-w-prose">
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <p className="mb-6 italic" id="form-instructions">
-          {t('apply:required-label')}
-        </p>
-        <fetcher.Form method="post" aria-describedby="form-instructions" noValidate>
+        <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <InputRadios
             id="type-of-application"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

- Move form instructions prior to form elements
- Remove aria-describedby attribute on form elements
- Move error summaries prior to form elements

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3387](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3387)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Provide such instructions before the `form` element to ensure that it is read aloud by screen readers before they switch to “Forms Mode”.
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/5cf092c5-5c79-4535-853a-df53d6aa45c4)

Remove aria-describedby attribute on form elements
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/b43c5602-7cbd-4708-83b7-9a31191314e1)

Error summary prior to form element
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/cb0d74cf-a865-42cc-a990-1d3c05ef9002)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

- https://bati-itao.github.io/learning/esdc-self-paced-web-accessibility-course/module6/form-instructions.html#form-instructions
- https://www.w3.org/WAI/tutorials/forms/instructions/