### PR TITLE
Fix RAOIDC token validation

### DIFF
--- a/frontend/app/routes/[.]well-known.jwks[.]json.tsx
+++ b/frontend/app/routes/[.]well-known.jwks[.]json.tsx
@@ -2,7 +2,7 @@ import { json } from '@remix-run/node';
 
 import { subtle } from 'node:crypto';
 
-import { generateJwkId, publicKeyPemToCryptoKey } from '~/utils/crypto-utils.server';
+import { generateCryptoKey, generateJwkId } from '~/utils/crypto-utils.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 
@@ -27,8 +27,7 @@ async function getJwks() {
     return [];
   }
 
-  const cryptoKey = await publicKeyPemToCryptoKey(AUTH_JWT_PUBLIC_KEY);
-  const jwk = await subtle.exportKey('jwk', cryptoKey);
+  const jwk = await subtle.exportKey('jwk', await generateCryptoKey(AUTH_JWT_PUBLIC_KEY, 'encrypt'));
   const keyId = generateJwkId(jwk);
 
   return [{ ...jwk, kid: keyId } as JWK];

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -2,7 +2,7 @@ import { DiagLogLevel } from '@opentelemetry/api';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
-import { privateKeyPemToCryptoKey, publicKeyPemToCryptoKey } from './crypto-utils.server';
+import { generateCryptoKey } from './crypto-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('env.server');
@@ -28,8 +28,8 @@ export type FeatureName = (typeof validFeatureNames)[number];
 // refiners
 const areValidFeatureNames = (arr: Array<string>) => arr.every((featureName) => validFeatureNames.includes(featureName as FeatureName));
 const areValidMockNames = (arr: Array<string>) => arr.every((mockName) => validMockNames.includes(mockName as MockName));
-const isValidPublicKey = (val: string) => tryOrElseFalse(() => publicKeyPemToCryptoKey(val));
-const isValidPrivateKey = (val: string) => tryOrElseFalse(() => privateKeyPemToCryptoKey(val));
+const isValidPublicKey = (val: string) => tryOrElseFalse(() => generateCryptoKey(val, 'verify'));
+const isValidPrivateKey = (val: string) => tryOrElseFalse(() => generateCryptoKey(val, 'sign'));
 
 // transformers
 const csvToArray = (csv?: string) => csv?.split(',').map((str) => str.trim()) ?? [];


### PR DESCRIPTION
### Fix RAOIDC token validation

During a code review, it was discovered that the ID and userinfo tokens coming from RAOIDC are not adequately verified using RAOIDC's public JWKs.

This PR fixes that by adding additional checks when handling these tokens.

To facilitate this change, some of the existing code was refactored:

- `crypto-utils.server.ts` -- the existing pem-to-cryptokey functions were removed and replaced with a more generic `generateCryptoKey()` function that accepts a PEM-encoded string and a target crypto algorithm.
- `raoidc-utils.server.ts` -- a new generic `verifyJwt()` function was added that will attempt to validate a JWT against a collection of JWKs.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

I could not test the code locally because of proxy issues. Because of this, there is a small possibility that this code will not work as expected when integrated with the actual RAOIDC service. If there are issues, I will submit a new PR to fix them.