### PR TITLE
Move radio label outside of input element; fix hitboxes

### DIFF
--- a/frontend/app/components/input-checkbox.tsx
+++ b/frontend/app/components/input-checkbox.tsx
@@ -40,7 +40,7 @@ export function InputCheckbox({ errorMessage, append, appendClassName, children,
           data-testid="input-checkbox"
           {...restProps}
         />
-        <label id={inputLabelId} htmlFor={inputCheckboxId} className={cn('ml-3 block leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
+        <label id={inputLabelId} htmlFor={inputCheckboxId} className={cn('block pl-3 leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
           {children}
         </label>
       </div>

--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -23,9 +23,9 @@ export function InputRadio({ append, appendClassName, children, className, hasEr
   return (
     <div className={className}>
       <div className="flex items-center">
-        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
-          <input type="radio" id={inputRadioId} aria-labelledby={inputLabelId} className={cn(inputBaseClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)} data-testid="input-radio" {...restProps} />
-          <span className="ml-3">{children}</span>
+        <input type="radio" id={inputRadioId} aria-labelledby={inputLabelId} className={cn(inputBaseClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)} data-testid="input-radio" {...restProps} />
+        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block pl-3 leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
+          {children}
         </label>
       </div>
       {append && <div className={cn('ml-7 mt-4', appendClassName)}>{append}</div>}


### PR DESCRIPTION
### Fix radio labels

In PR #3266, radio inputs were moved inside of their associated labels to match canada.ca. This led to some ugly wrapping of the labels when the text inside was long.

This PR undoes the aforementioned PR, and fixes the radio and checkbox label hitboxes.

### Screenshots

**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/417331ef-5cad-4f83-8b7f-9a21982b25d2)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/66d34384-c194-4a61-8a29-d4d09d7f62b0)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
