### PR TITLE
3397 move application-delegate screen

### DIFF
--- a/frontend/__tests__/route-helpers/apply-adult-child-route-helpers.server.test.ts
+++ b/frontend/__tests__/route-helpers/apply-adult-child-route-helpers.server.test.ts
@@ -68,7 +68,7 @@ describe('apply-route-helpers.server', () => {
         typeOfApplication: 'delegate',
       } satisfies ApplyState;
 
-      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if typeOfApplication is not adult-child', () => {

--- a/frontend/__tests__/route-helpers/apply-adult-route-helpers.server.test.ts
+++ b/frontend/__tests__/route-helpers/apply-adult-route-helpers.server.test.ts
@@ -68,7 +68,7 @@ describe('apply-route-helpers.server', () => {
         typeOfApplication: 'delegate',
       } satisfies ApplyState;
 
-      expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/adult/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if typeOfApplication is not adult', () => {

--- a/frontend/__tests__/route-helpers/apply-child-route-helpers.server.test.ts
+++ b/frontend/__tests__/route-helpers/apply-child-route-helpers.server.test.ts
@@ -68,7 +68,7 @@ describe('apply-route-helpers.server', () => {
         typeOfApplication: 'delegate',
       } satisfies ApplyState;
 
-      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/child/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath($lang+/_public+/apply+/$id+/application-delegate, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if typeOfApplication is not child', () => {

--- a/frontend/__tests__/routes/_public+/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/_public+/application-delegate.test.tsx
@@ -2,7 +2,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { loader } from '~/routes/$lang+/_public+/apply+/$id+/adult/application-delegate';
+import { loader } from '~/routes/$lang+/_public+/apply+/$id+/application-delegate';
 
 vi.mock('~/route-helpers/apply-route-helpers.server', () => ({
   loadApplyState: vi.fn().mockReturnValue({

--- a/frontend/__tests__/routes/_public+/type-application.test.tsx
+++ b/frontend/__tests__/routes/_public+/type-application.test.tsx
@@ -22,7 +22,7 @@ vi.mock('~/utils/locale-utils.server', async (importOriginal) => {
   return {
     ...actual,
     getFixedT: vi.fn().mockResolvedValue(tMockFn),
-    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/adult/application-delegate')).mockResolvedValueOnce(redirect('/en/apply/123/tax-filing')),
+    redirectWithLocale: vi.fn().mockResolvedValueOnce(redirect('/en/apply/123/application-delegate')).mockResolvedValueOnce(redirect('/en/apply/123/tax-filing')),
   };
 });
 
@@ -86,7 +86,7 @@ describe('_public.apply.id.type-of-application', () => {
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/adult/application-delegate');
+      expect(response.headers.get('location')).toBe('/en/apply/123/application-delegate');
     });
 
     it('should redirect to tax filing page if personal is selected', async () => {

--- a/frontend/app/route-helpers/apply-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-adult-child-route-helpers.server.ts
@@ -116,7 +116,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
   }
 
   if (state.typeOfApplication === 'delegate') {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
   }
 
   if (state.typeOfApplication !== 'adult-child') {

--- a/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
@@ -126,7 +126,7 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateStat
   }
 
   if (state.typeOfApplication === 'delegate') {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
   }
 
   if (state.typeOfApplication !== 'adult') {

--- a/frontend/app/route-helpers/apply-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-child-route-helpers.server.ts
@@ -126,7 +126,7 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
   }
 
   if (state.typeOfApplication === 'delegate') {
-    throw redirect(getPathById('$lang+/_public+/apply+/$id+/child/application-delegate', params));
+    throw redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
   }
 
   if (state.typeOfApplication !== 'child') {

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -110,14 +110,6 @@
                         }
                       },
                       {
-                        "id": "$lang+/_public+/apply+/$id+/adult/application-delegate",
-                        "file": "routes/$lang+/_public+/apply+/$id+/adult/application-delegate.tsx",
-                        "paths": {
-                          "en": "/:lang/apply/:id/adult/application-delegate",
-                          "fr": "/:lang/demander/:id/adulte/delegue-demande"
-                        }
-                      },
-                      {
                         "id": "$lang+/_public+/apply+/$id+/adult/communication-preference",
                         "file": "routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx",
                         "paths": {
@@ -393,6 +385,14 @@
                     "paths": {
                       "en": "/:lang/apply/:id/type-application",
                       "fr": "/:lang/demander/:id/type-demande"
+                    }
+                  },
+                  {
+                    "id": "$lang+/_public+/apply+/$id+/application-delegate",
+                    "file": "routes/$lang+/_public+/apply+/$id+/application-delegate.tsx",
+                    "paths": {
+                      "en": "/:lang/apply/:id/application-delegate",
+                      "fr": "/:lang/demander/:id/delegue-demande"
                     }
                   },
                   {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/application-delegate.tsx
@@ -7,7 +7,7 @@ import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans, useTranslation } from 'react-i18next';
 
-import pageIds from '../../../../page-ids.json';
+import pageIds from '../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { clearApplyState, loadApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -19,9 +19,9 @@ import { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.adult.applicationDelegate,
-  pageTitleI18nKey: 'apply-adult:eligibility.application-delegate.page-title',
+  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.applicationDelegate,
+  pageTitleI18nKey: 'apply:application-delegate.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -34,7 +34,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:eligibility.application-delegate.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:application-delegate.page-title') }) };
 
   return json({ id, csrfToken, meta });
 }
@@ -55,7 +55,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   clearApplyState({ params, session });
 
-  return redirect(t('apply-adult:eligibility.application-delegate.return-btn-link'));
+  return redirect(t('apply:application-delegate.return-btn-link'));
 }
 
 export default function ApplyFlowApplicationDelegate() {
@@ -65,8 +65,8 @@ export default function ApplyFlowApplicationDelegate() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const contactServiceCanada = <InlineLink to={t('apply-adult:eligibility.application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank" />;
-  const preparingToApply = <InlineLink to={t('apply-adult:eligibility.application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank" />;
+  const contactServiceCanada = <InlineLink to={t('apply:application-delegate.contact-service-canada-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank" />;
+  const preparingToApply = <InlineLink to={t('apply:application-delegate.preparing-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank" />;
   const span = <span className="whitespace-nowrap" />;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -79,20 +79,20 @@ export default function ApplyFlowApplicationDelegate() {
     <>
       <div className="mb-8 space-y-4">
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:eligibility.application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="apply:application-delegate.contact-representative" components={{ contactServiceCanada, span }} />
         </p>
         <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:eligibility.application-delegate.prepare-to-apply" components={{ preparingToApply }} />
+          <Trans ns={handle.i18nNamespaces} i18nKey="apply:application-delegate.prepare-to-apply" components={{ preparingToApply }} />
         </p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink type="button" routeId="$lang+/_public+/apply+/$id+/type-application" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applying on behalf of someone click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply-adult:eligibility.application-delegate.back-btn')}
+          {t('apply:application-delegate.back-btn')}
         </ButtonLink>
         <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Applying on behalf of someone click">
-          {t('apply-adult:eligibility.application-delegate.return-btn')}
+          {t('apply:application-delegate.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/living-independently.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/living-independently.tsx
@@ -81,7 +81,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   saveApplyAdultState({ params, request, session, state: { livingIndependently: parsedDataResult.data } });
 
   if (parsedDataResult.data === LivingIndependentlyOption.Yes) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
   }
 
   return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -108,7 +108,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   // TODO: change this route to $lang+/_public+/apply+/$id+/application-delegate
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/application-delegate', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
 }
 
 export default function ApplyFlowTypeOfApplication() {

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -41,8 +41,8 @@
       "index": "CDCP-APPL-0001",
       "termsAndConditions": "CDCP-APPL-0002",
       "typeOfApplication": "CDCP-APPL-0003",
+      "applicationDelegate": "CDCP-APPL-AD-0004",
       "adult": {
-        "applicationDelegate": "CDCP-APPL-AD-0001",
         "taxFiling": "CDCP-APPL-AD-0002",
         "fileYourTaxes": "CDCP-APPL-AD-0003",
         "dateOfBirth": "CDCP-APPL-AD-0004",
@@ -58,7 +58,6 @@
         "confirmation": "CDCP-APPL-AD-0014"
       },
       "adultChild": {
-        "applicationDelegate": "CDCP-APPL-ADCH-0001",
         "taxFiling": "CDCP-APPL-ADCH-0002",
         "fileYourTaxes": "CDCP-APPL-ADCH-0003",
         "dateOfBirth": "CDCP-APPL-ADCH-0004",
@@ -76,7 +75,6 @@
         "applyChildren": "CDCP-APPL-ADCH-0016"
       },
       "child": {
-        "applicationDelegate": "CDCP-APPL-CH-0001",
         "taxFiling": "CDCP-APPL-CH-0002",
         "fileYourTaxes": "CDCP-APPL-CH-0003",
         "dateOfBirth": "CDCP-APPL-CH-0004",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -110,16 +110,6 @@
       "cancel-btn": "Cancel",
       "save-btn": "Save"
     },
-    "application-delegate": {
-      "page-title": "Applying on behalf of someone cannot be completed online at this time",
-      "contact-representative": "You must <contactServiceCanada>speak to a Service Canada representative</contactServiceCanada> to apply on behalf of someone. Please contact Service Canada at <span>1-833-537-4342</span> or visit a Service Canada office.",
-      "prepare-to-apply": "<preparingToApply>Preparing to apply on behalf of someone</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
-      "preparing-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#helping",
-      "back-btn": "Back",
-      "return-btn": "Return to main page",
-      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-    },
     "file-your-taxes": {
       "page-title": "File your taxes",
       "ineligible-to-apply": "You are not eligible to apply for the Canadian Dental Care Plan at this time.",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -206,16 +206,6 @@
       "cancel-btn": "Cancel",
       "save-btn": "Save"
     },
-    "application-delegate": {
-      "page-title": "Applying on behalf of someone cannot be completed online at this time",
-      "contact-representative": "You must <contactServiceCanada>speak to a Service Canada representative</contactServiceCanada> to apply on behalf of someone. Please contact Service Canada at <span>1-833-537-4342</span> or visit a Service Canada office.",
-      "prepare-to-apply": "<preparingToApply>Preparing to apply on behalf of someone</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
-      "preparing-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#helping",
-      "back-btn": "Back",
-      "return-btn": "Return to main page",
-      "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
-    },
     "file-your-taxes": {
       "page-title": "File your taxes",
       "ineligible-to-apply": "You are not eligible to apply for the Canadian Dental Care Plan at this time.",

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -1,4 +1,14 @@
 {
+  "application-delegate": {
+    "page-title": "Applying on behalf of someone cannot be completed online at this time",
+    "contact-representative": "You must <contactServiceCanada>speak to a Service Canada representative</contactServiceCanada> to apply on behalf of someone. Please contact Service Canada at <span>1-833-537-4342</span> or visit a Service Canada office.",
+    "prepare-to-apply": "<preparingToApply>Preparing to apply on behalf of someone</preparingToApply>",
+    "contact-service-canada-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/contact.html",
+    "preparing-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#helping",
+    "back-btn": "Back",
+    "return-btn": "Return to main page",
+    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
   "disability-tax-credit": {
     "page-title": "Disability tax credit",
     "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -205,16 +205,6 @@
       "cancel-btn": "Annuler",
       "save-btn": "Enregistrer"
     },
-    "application-delegate": {
-      "page-title": "La demande au nom d'une autre personne ne peut pas être effectuée en ligne pour le moment.",
-      "contact-representative": "Vous devez <contactServiceCanada>parler à un représentant de Service Canada</contactServiceCanada> pour présenter une demande au nom de quelqu'un. Veuillez communiquer avec Service Canada au <span>1-833-537-4342</span> ou vous rendre dans un bureau de Service Canada.",
-      "prepare-to-apply": "<preparingToApply>Se préparer à présenter une demande au nom de quelqu'un</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
-      "preparing-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#aide",
-      "back-btn": "Retour",
-      "return-btn": "Revenir à la page principale",
-      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-    },
     "file-your-taxes": {
       "page-title": "Produire votre déclaration de revenus",
       "ineligible-to-apply": "Vous n'êtes pas admissible au Régime canadien de soins dentaires pour le moment.",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -206,16 +206,6 @@
       "cancel-btn": "Annuler",
       "save-btn": "Enregistrer"
     },
-    "application-delegate": {
-      "page-title": "La demande au nom d'une autre personne ne peut pas être effectuée en ligne pour le moment.",
-      "contact-representative": "Vous devez <contactServiceCanada>parler à un représentant de Service Canada</contactServiceCanada> pour présenter une demande au nom de quelqu'un. Veuillez communiquer avec Service Canada au <span>1-833-537-4342</span> ou vous rendre dans un bureau de Service Canada.",
-      "prepare-to-apply": "<preparingToApply>Se préparer à présenter une demande au nom de quelqu'un</preparingToApply>",
-      "contact-service-canada-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
-      "preparing-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#aide",
-      "back-btn": "Retour",
-      "return-btn": "Revenir à la page principale",
-      "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
-    },
     "file-your-taxes": {
       "page-title": "Produire votre déclaration de revenus",
       "ineligible-to-apply": "Vous n'êtes pas admissible au Régime canadien de soins dentaires pour le moment.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -1,4 +1,14 @@
 {
+  "application-delegate": {
+    "page-title": "La demande au nom d'une autre personne ne peut pas être effectuée en ligne pour le moment.",
+    "contact-representative": "Vous devez <contactServiceCanada>parler à un représentant de Service Canada</contactServiceCanada> pour présenter une demande au nom de quelqu'un. Veuillez communiquer avec Service Canada au <span>1-833-537-4342</span> ou vous rendre dans un bureau de Service Canada.",
+    "prepare-to-apply": "<preparingToApply>Se préparer à présenter une demande au nom de quelqu'un</preparingToApply>",
+    "contact-service-canada-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
+    "preparing-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#aide",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale",
+    "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
   "disability-tax-credit": {
     "page-title": "(FR) Disability tax credit",
     "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",


### PR DESCRIPTION
### Description
`/application-delegate` should be moved to `/$id+` since it's common to the three apply flows.

### Related Azure Boards Work Items
[AB#3397](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3397)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`