### PR TITLE
AB#3401 Adjust optional field disclaimer text

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
@@ -380,7 +380,7 @@ export default function ApplyFlowPersonalInformation() {
       </div>
       <div className="max-w-prose">
         <p className="mb-6">{t('apply-adult:contact-information.form-instructions')}</p>
-        <p className="mb-6 italic">{t('apply:required-label')}</p>
+        <p className="mb-6 italic">{t('apply:optional-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -52,7 +52,8 @@
   "progress": {
     "label": "Application Progress Tracking"
   },
-  "required-label": "Complete all fields unless marked as optional",
+  "required-label": "Complete all fields",
+  "optional-label": "Complete all fields unless marked as optional",
   "terms-and-conditions": {
     "page-title": "Terms and conditions",
     "page-heading": "Terms and conditions of use and privacy notice statement",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -52,7 +52,8 @@
   "progress": {
     "label": "Suivi de la progression de l'application"
   },
-  "required-label": "Remplir tous les champs sauf s'ils sont indiqués facultatifs",
+  "required-label": "Remplir tous les champs",
+  "optional-label": "Remplir tous les champs sauf s'ils sont indiqués facultatifs",
   "terms-and-conditions": {
     "page-title": "Présentation d'une demande d'adhésion au Régime canadien de soins dentaires",
     "page-heading": "Conditions générales d'utilisation et énoncé de confidentialité",


### PR DESCRIPTION
### Description
The disclaimer text changes if the page has optional fields.
If the page has required fields only, the disclaimer text should be `Complete all fields`

### Related Azure Boards Work Items
[AB#3401](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3401)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`