### PR TITLE
3404 move apply flow routes to respective folders

### DIFF
--- a/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
+++ b/frontend/__tests__/routes/_public+/date-of-birth.test.tsx
@@ -127,7 +127,7 @@ describe('_public.apply.id.date-of-birth', () => {
       });
 
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/en/apply/123/disability-tax-credit');
+      expect(response.headers.get('location')).toBe('/en/apply/123/adult/disability-tax-credit');
       expect(parse).toBeCalled();
       expect(differenceInYears).toBeCalled();
     });

--- a/frontend/app/route-helpers/apply-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-adult-child-route-helpers.server.ts
@@ -5,6 +5,8 @@ import { ApplyState, loadApplyState, saveApplyState } from '~/route-helpers/appl
 import { DentalBenefitsState } from '~/routes/$lang+/_protected+/access-to-governmental-benefits+/edit';
 import { ChildInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/child-information';
 import { AllChildrenUnder18State, DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/date-of-birth';
+import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit';
+import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently';
 import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/tax-filing';
 import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/applicant-information';
 import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/adult/communication-preference';
@@ -12,8 +14,6 @@ import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/adult
 import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/partner-information';
 import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
 import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/adult/review-information';
-import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/disability-tax-credit';
-import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/living-independently';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 import { getPathById } from '~/utils/route-utils';

--- a/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-adult-route-helpers.server.ts
@@ -6,13 +6,13 @@ import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/
 import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/adult/communication-preference';
 import { AllChildrenUnder18State, DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth';
 import { DentalInsuranceState } from '~/routes/$lang+/_public+/apply+/$id+/adult/dental-insurance';
+import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/adult/disability-tax-credit';
 import { DentalBenefitsState } from '~/routes/$lang+/_public+/apply+/$id+/adult/federal-provincial-territorial-benefits';
+import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/adult/living-independently';
 import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/partner-information';
 import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/adult/personal-information';
 import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/adult/review-information';
 import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/adult/tax-filing';
-import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/disability-tax-credit';
-import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/living-independently';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 import { getPathById } from '~/utils/route-utils';

--- a/frontend/app/route-helpers/apply-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-child-route-helpers.server.ts
@@ -2,6 +2,8 @@ import { Session, redirect } from '@remix-run/node';
 import { Params } from '@remix-run/react';
 
 import { ApplyState, loadApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit';
+import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently';
 import { ApplicantInformationState } from '~/routes/$lang+/_public+/apply+/$id+/child/applicant-information';
 import { CommunicationPreferencesState } from '~/routes/$lang+/_public+/apply+/$id+/child/communication-preference';
 import { AllChildrenUnder18State, DateOfBirthState } from '~/routes/$lang+/_public+/apply+/$id+/child/date-of-birth';
@@ -11,8 +13,6 @@ import { PartnerInformationState } from '~/routes/$lang+/_public+/apply+/$id+/ch
 import { PersonalInformationState } from '~/routes/$lang+/_public+/apply+/$id+/child/personal-information';
 import { SubmissionInfoState } from '~/routes/$lang+/_public+/apply+/$id+/child/review-information';
 import { TaxFilingState } from '~/routes/$lang+/_public+/apply+/$id+/child/tax-filing';
-import { DisabilityTaxCreditState } from '~/routes/$lang+/_public+/apply+/$id+/disability-tax-credit';
-import { LivingIndependentlyState } from '~/routes/$lang+/_public+/apply+/$id+/living-independently';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
 import { getPathById } from '~/utils/route-utils';

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -204,6 +204,30 @@
                           "en": "/:lang/apply/:id/adult/tax-filing",
                           "fr": "/:lang/demander/:id/adulte/declaration-impot"
                         }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult/disability-tax-credit",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult/disability-tax-credit.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult/disability-tax-credit",
+                          "fr": "/:lang/demander/:id/adulte/disability-tax-credit"
+                        }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult/parent-or-guardian",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult/parent-or-guardian.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult/parent-or-guardian",
+                          "fr": "/:lang/demander/:id/adulte/parent-or-guardian"
+                        }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult/living-independently",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult/living-independently.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult/living-independently",
+                          "fr": "/:lang/demander/:id/adulte/living-independently"
+                        }
                       }
                     ]
                   },
@@ -281,6 +305,30 @@
                         "paths": {
                           "en": "/:lang/apply/:id/adult-child/apply-yourself",
                           "fr": "/:lang/demander/:id/adulte-enfant/postulez-vous-meme"
+                        }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/disability-tax-credit",
+                          "fr": "/:lang/demander/:id/adulte-enfant/disability-tax-credit"
+                        }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/parent-or-guardian",
+                          "fr": "/:lang/demander/:id/adulte-enfant/parent-or-guardian"
+                        }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/living-independently",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/living-independently.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/living-independently",
+                          "fr": "/:lang/demander/:id/adulte-enfant/living-independently"
                         }
                       }
                     ]
@@ -417,30 +465,6 @@
                     "paths": {
                       "en": "/:lang/apply/:id/application-delegate",
                       "fr": "/:lang/demander/:id/delegue-demande"
-                    }
-                  },
-                  {
-                    "id": "$lang+/_public+/apply+/$id+/disability-tax-credit",
-                    "file": "routes/$lang+/_public+/apply+/$id+/disability-tax-credit.tsx",
-                    "paths": {
-                      "en": "/:lang/apply/:id/disability-tax-credit",
-                      "fr": "/:lang/demander/:id/disability-tax-credit"
-                    }
-                  },
-                  {
-                    "id": "$lang+/_public+/apply+/$id+/parent-or-guardian",
-                    "file": "routes/$lang+/_public+/apply+/$id+/parent-or-guardian.tsx",
-                    "paths": {
-                      "en": "/:lang/apply/:id/parent-or-guardian",
-                      "fr": "/:lang/demander/:id/parent-or-guardian"
-                    }
-                  },
-                  {
-                    "id": "$lang+/_public+/apply+/$id+/living-independently",
-                    "file": "routes/$lang+/_public+/apply+/$id+/living-independently.tsx",
-                    "paths": {
-                      "en": "/:lang/apply/:id/living-independently",
-                      "fr": "/:lang/demander/:id/living-independently"
                     }
                   }
                 ]

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/date-of-birth.tsx
@@ -161,7 +161,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   if (age >= 18 && age < 65) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/disability-tax-credit', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit', params));
   }
 
   if (age >= 65 && allChildrenUnder18 === 'no') {
@@ -259,7 +259,7 @@ export default function ApplyFlowDateOfBirth() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Date of birth click">
                 {t('apply-adult-child:eligibility.date-of-birth.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Date of birth click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Date of birth click">
                 {t('apply-adult-child:eligibility.date-of-birth.cancel-btn')}
               </ButtonLink>
             </div>
@@ -269,7 +269,7 @@ export default function ApplyFlowDateOfBirth() {
                 {t('apply-adult-child:eligibility.date-of-birth.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Date of birth click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Date of birth click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply-adult-child:eligibility.date-of-birth.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useMemo } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { Link, useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { differenceInYears, parse } from 'date-fns';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+enum DisabilityTaxCreditOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export type DisabilityTaxCreditState = `${DisabilityTaxCreditOption}`;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.disabilityTaxCredit,
+  pageTitleI18nKey: 'apply-adult-child:disability-tax-credit.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:disability-tax-credit.page-title') }) };
+
+  const parseDateOfBirth = parse(state.adultChildState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
+  const age = differenceInYears(new Date(), parseDateOfBirth);
+  if (age < 18 || age > 64) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/date-of-birth', params));
+  }
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultChildState.disabilityTaxCredit });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/disability-tax-credit');
+  const state = loadApplyAdultChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const disabilityTaxCreditSchema: z.ZodType<DisabilityTaxCreditState> = z.nativeEnum(DisabilityTaxCreditOption, {
+    errorMap: () => ({ message: t('apply-adult-child:disability-tax-credit.error-message.disability-tax-credit-required') }),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = formData.get('disabilityTaxCredit');
+  const parsedDataResult = disabilityTaxCreditSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format()._errors });
+  }
+
+  saveApplyAdultChildState({ params, request, session, state: { disabilityTaxCredit: parsedDataResult.data } });
+
+  const parseDateOfBirth = parse(state.adultChildState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
+  const age = differenceInYears(new Date(), parseDateOfBirth);
+  if (age < 18 || age > 64) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/date-of-birth', params));
+  }
+
+  if (parsedDataResult.data === DisabilityTaxCreditOption.No && state.adultChildState.allChildrenUnder18) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-children', params));
+  }
+
+  if (parsedDataResult.data === DisabilityTaxCreditOption.No) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
+}
+
+export default function ApplyFlowDisabilityTaxCredit() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errorSummaryId = 'error-summary';
+
+  // Keys order should match the input IDs order.
+  const errorMessages = useMemo(
+    () => ({
+      'input-radio-disability-tax-credit-radios-option-0': fetcher.data?.errors[0],
+    }),
+    [fetcher.data?.errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+    }
+  }, [errorMessages]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={35} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-5">{t('apply-adult-child:disability-tax-credit.non-refundable')}</p>
+        <p className="mb-5">
+          <Trans
+            ns={handle.i18nNamespaces}
+            i18nKey="apply-adult-child:disability-tax-credit.more-info"
+            components={{ dtcLink: <Link to={t('apply-adult-child:disability-tax-credit.dtc-link')} className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" /> }}
+          />
+        </p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <InputRadios
+            id="disability-tax-credit-radios"
+            name="disabilityTaxCredit"
+            legend={t('apply-adult-child:disability-tax-credit.form-label')}
+            options={[
+              { value: DisabilityTaxCreditOption.Yes, children: t('apply-adult-child:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === DisabilityTaxCreditOption.Yes },
+              { value: DisabilityTaxCreditOption.No, children: t('apply-adult-child:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === DisabilityTaxCreditOption.No },
+            ]}
+            errorMessage={errorMessages['input-radio-disability-tax-credit-radios-option-0']}
+            required
+          />
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Disability tax credit click">
+              {t('apply-adult-child:disability-tax-credit.continue-btn')}
+              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+            </Button>
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
+              <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+              {t('apply-adult-child:disability-tax-credit.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently.tsx
@@ -8,12 +8,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
 import { Progress } from '~/components/progress';
-import { loadApplyAdultState, saveApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
+import { loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -31,9 +31,9 @@ enum LivingIndependentlyOption {
 export type LivingIndependentlyState = `${LivingIndependentlyOption}`;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.livingIndependently,
-  pageTitleI18nKey: 'apply:living-independently.page-title',
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.livingIndependently,
+  pageTitleI18nKey: 'apply-adult-child:living-independently.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -41,17 +41,17 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const state = loadApplyAdultState({ params, request, session });
+  const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:living-independently.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:living-independently.page-title') }) };
 
-  return json({ id: state.id, csrfToken, meta, defaultState: state.adultState.livingIndependently });
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultChildState.livingIndependently });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/living-independently');
+  const log = getLogger('apply/adult-child/living-independently');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -59,7 +59,7 @@ export async function action({ context: { session }, params, request }: ActionFu
    * Schema for living independently.
    */
   const livingIndependentlySchema: z.ZodType<LivingIndependentlyState> = z.nativeEnum(LivingIndependentlyOption, {
-    errorMap: () => ({ message: t('apply:living-independently.error-message.living-independently-required') }),
+    errorMap: () => ({ message: t('apply-adult-child:living-independently.error-message.living-independently-required') }),
   });
 
   const formData = await request.formData();
@@ -78,13 +78,13 @@ export async function action({ context: { session }, params, request }: ActionFu
     return json({ errors: parsedDataResult.error.format()._errors });
   }
 
-  saveApplyAdultState({ params, request, session, state: { livingIndependently: parsedDataResult.data } });
+  saveApplyAdultChildState({ params, request, session, state: { livingIndependently: parsedDataResult.data } });
 
   if (parsedDataResult.data === LivingIndependentlyOption.Yes) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
 }
 
 export default function ApplyFlowLivingIndependently() {
@@ -124,7 +124,7 @@ export default function ApplyFlowLivingIndependently() {
         <Progress aria-labelledby="progress-label" value={10} size="lg" />
       </div>
       <div className="max-w-prose">
-        <p className="mb-6">{t('apply:living-independently.description')}</p>
+        <p className="mb-6">{t('apply-adult-child:living-independently.description')}</p>
         <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" noValidate>
@@ -132,16 +132,16 @@ export default function ApplyFlowLivingIndependently() {
           <InputRadios
             id="living-independently"
             name="livingIndependently"
-            legend={t('apply:living-independently.form-instructions')}
+            legend={t('apply-adult-child:living-independently.form-instructions')}
             options={[
               {
                 value: LivingIndependentlyOption.Yes,
-                children: t('apply:living-independently.radio-options.yes'),
+                children: t('apply-adult-child:living-independently.radio-options.yes'),
                 defaultChecked: defaultState === LivingIndependentlyOption.Yes,
               },
               {
                 value: LivingIndependentlyOption.No,
-                children: t('apply:living-independently.radio-options.no'),
+                children: t('apply-adult-child:living-independently.radio-options.no'),
                 defaultChecked: defaultState === LivingIndependentlyOption.No,
               },
             ]}
@@ -150,12 +150,12 @@ export default function ApplyFlowLivingIndependently() {
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Living independently click">
-              {t('apply:living-independently.continue-btn')}
+              {t('apply-adult-child:living-independently.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
-            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/terms-and-conditions" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Living independently click">
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Living independently click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-              {t('apply:living-independently.back-btn')}
+              {t('apply-adult-child:living-independently.back-btn')}
             </ButtonLink>
           </div>
         </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian.tsx
@@ -1,0 +1,97 @@
+import { FormEvent } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { differenceInYears, parse } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { clearApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.parentOrGuardian,
+  pageTitleI18nKey: 'apply-adult-child:parent-or-guardian.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:parent-or-guardian.page-title') }) };
+
+  const parseDateOfBirth = parse(state.adultChildState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
+  const age = differenceInYears(new Date(), parseDateOfBirth);
+  if (age > 16) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
+  }
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultChildState.disabilityTaxCredit });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/parent-or-guardian');
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  clearApplyState({ params, session });
+  return redirect(t('apply-adult-child:parent-or-guardian.return-btn-link'));
+}
+
+export default function ApplyFlowParentOrGuardian() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    fetcher.submit(event.currentTarget, { method: 'POST' });
+    sessionStorage.removeItem('flow.state');
+  }
+
+  return (
+    <>
+      <div className="mb-8 space-y-4">
+        <p>{t('apply-adult-child:parent-or-guardian.unable-to-apply')}</p>
+      </div>
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply-adult-child:parent-or-guardian.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Parent or guardian needs to apply click">
+          {t('apply-adult-child:parent-or-guardian.return-btn')}
+          {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
+        </Button>
+      </fetcher.Form>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/date-of-birth.tsx
@@ -154,7 +154,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   if (age >= 18 && age < 65) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/disability-tax-credit', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/disability-tax-credit', params));
   }
 
   if (state.adultState.editMode) {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/disability-tax-credit.tsx
@@ -9,7 +9,7 @@ import { differenceInYears, parse } from 'date-fns';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -31,9 +31,9 @@ enum DisabilityTaxCreditOption {
 export type DisabilityTaxCreditState = `${DisabilityTaxCreditOption}`;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.disabilityTaxCredit,
-  pageTitleI18nKey: 'apply:disability-tax-credit.page-title',
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adult.disabilityTaxCredit,
+  pageTitleI18nKey: 'apply-adult:disability-tax-credit.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -45,7 +45,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:disability-tax-credit.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:disability-tax-credit.page-title') }) };
 
   const parseDateOfBirth = parse(state.adultState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);
@@ -57,13 +57,13 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/disability-tax-credit');
+  const log = getLogger('apply/adult/disability-tax-credit');
   const state = loadApplyAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const disabilityTaxCreditSchema: z.ZodType<DisabilityTaxCreditState> = z.nativeEnum(DisabilityTaxCreditOption, {
-    errorMap: () => ({ message: t('apply:disability-tax-credit.error-message.disability-tax-credit-required') }),
+    errorMap: () => ({ message: t('apply-adult:disability-tax-credit.error-message.disability-tax-credit-required') }),
   });
 
   const formData = await request.formData();
@@ -87,15 +87,15 @@ export async function action({ context: { session }, params, request }: ActionFu
   const parseDateOfBirth = parse(state.adultState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);
   if (age < 18 || age > 64) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/date-of-birth', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
   }
 
   if (parsedDataResult.data === DisabilityTaxCreditOption.No && state.adultState.allChildrenUnder18) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/apply-children', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/apply-children', params));
   }
 
   if (parsedDataResult.data === DisabilityTaxCreditOption.No) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/dob-eligibility', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));
   }
 
   return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
@@ -134,9 +134,13 @@ export default function ApplyFlowDisabilityTaxCredit() {
         <Progress aria-labelledby="progress-label" value={35} size="lg" />
       </div>
       <div className="max-w-prose">
-        <p className="mb-5">{t('apply:disability-tax-credit.non-refundable')}</p>
+        <p className="mb-5">{t('apply-adult:disability-tax-credit.non-refundable')}</p>
         <p className="mb-5">
-          <Trans ns={handle.i18nNamespaces} i18nKey="apply:disability-tax-credit.more-info" components={{ dtcLink: <Link to={t('apply:disability-tax-credit.dtc-link')} className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" /> }} />
+          <Trans
+            ns={handle.i18nNamespaces}
+            i18nKey="apply-adult:disability-tax-credit.more-info"
+            components={{ dtcLink: <Link to={t('apply-adult:disability-tax-credit.dtc-link')} className="text-slate-700 underline hover:text-blue-700 focus:text-blue-700" /> }}
+          />
         </p>
         <p className="mb-6 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
@@ -145,22 +149,22 @@ export default function ApplyFlowDisabilityTaxCredit() {
           <InputRadios
             id="disability-tax-credit-radios"
             name="disabilityTaxCredit"
-            legend={t('apply:disability-tax-credit.form-label')}
+            legend={t('apply-adult:disability-tax-credit.form-label')}
             options={[
-              { value: DisabilityTaxCreditOption.Yes, children: t('apply:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === DisabilityTaxCreditOption.Yes },
-              { value: DisabilityTaxCreditOption.No, children: t('apply:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === DisabilityTaxCreditOption.No },
+              { value: DisabilityTaxCreditOption.Yes, children: t('apply-adult:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === DisabilityTaxCreditOption.Yes },
+              { value: DisabilityTaxCreditOption.No, children: t('apply-adult:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === DisabilityTaxCreditOption.No },
             ]}
             errorMessage={errorMessages['input-radio-disability-tax-credit-radios-option-0']}
             required
           />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Disability tax credit click">
-              {t('apply:disability-tax-credit.continue-btn')}
+              {t('apply-adult:disability-tax-credit.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
             <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Disability tax credit click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-              {t('apply:disability-tax-credit.back-btn')}
+              {t('apply-adult:disability-tax-credit.back-btn')}
             </ButtonLink>
           </div>
         </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/living-independently.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/living-independently.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultState, saveApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+enum LivingIndependentlyOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export type LivingIndependentlyState = `${LivingIndependentlyOption}`;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adult.livingIndependently,
+  pageTitleI18nKey: 'apply-adult:living-independently.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:living-independently.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultState.livingIndependently });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult/living-independently');
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  /**
+   * Schema for living independently.
+   */
+  const livingIndependentlySchema: z.ZodType<LivingIndependentlyState> = z.nativeEnum(LivingIndependentlyOption, {
+    errorMap: () => ({ message: t('apply-adult:living-independently.error-message.living-independently-required') }),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = String(formData.get('livingIndependently') ?? '');
+  const parsedDataResult = livingIndependentlySchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format()._errors });
+  }
+
+  saveApplyAdultState({ params, request, session, state: { livingIndependently: parsedDataResult.data } });
+
+  if (parsedDataResult.data === LivingIndependentlyOption.Yes) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/parent-or-guardian', params));
+}
+
+export default function ApplyFlowLivingIndependently() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errorSummaryId = 'error-summary';
+
+  // Keys order should match the input IDs order.
+  const errorMessages = useMemo(
+    () => ({
+      'input-radio-living-independently-option-0': fetcher.data?.errors[0],
+    }),
+    [fetcher.data?.errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        adobeAnalytics.pushValidationErrorEvent(errorSummaryItems.map(({ fieldId }) => fieldId));
+      }
+    }
+  }, [errorMessages, errorSummaryItems]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={10} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-6">{t('apply-adult:living-independently.description')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <InputRadios
+            id="living-independently"
+            name="livingIndependently"
+            legend={t('apply-adult:living-independently.form-instructions')}
+            options={[
+              {
+                value: LivingIndependentlyOption.Yes,
+                children: t('apply-adult:living-independently.radio-options.yes'),
+                defaultChecked: defaultState === LivingIndependentlyOption.Yes,
+              },
+              {
+                value: LivingIndependentlyOption.No,
+                children: t('apply-adult:living-independently.radio-options.no'),
+                defaultChecked: defaultState === LivingIndependentlyOption.No,
+              },
+            ]}
+            required
+            errorMessage={errorMessages['input-radio-living-independently-option-0']}
+          />
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Living independently click">
+              {t('apply-adult:living-independently.continue-btn')}
+              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+            </Button>
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Living independently click">
+              <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+              {t('apply-adult:living-independently.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/parent-or-guardian.tsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { differenceInYears, parse } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
-import pageIds from '../../../page-ids.json';
+import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import { clearApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -20,9 +20,9 @@ import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
-  pageIdentifier: pageIds.public.apply.parentOrGuardian,
-  pageTitleI18nKey: 'apply:parent-or-guardian.page-title',
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adult.parentOrGuardian,
+  pageTitleI18nKey: 'apply-adult:parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -34,7 +34,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply:parent-or-guardian.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:parent-or-guardian.page-title') }) };
 
   const parseDateOfBirth = parse(state.adultState.dateOfBirth ?? '', 'yyyy-MM-dd', new Date());
   const age = differenceInYears(new Date(), parseDateOfBirth);
@@ -46,7 +46,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  const log = getLogger('apply/parent-or-guardian');
+  const log = getLogger('apply/adult/parent-or-guardian');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +60,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   clearApplyState({ params, session });
-  return redirect(t('apply:parent-or-guardian.return-btn-link'));
+  return redirect(t('apply-adult:parent-or-guardian.return-btn-link'));
 }
 
 export default function ApplyFlowParentOrGuardian() {
@@ -79,16 +79,16 @@ export default function ApplyFlowParentOrGuardian() {
   return (
     <>
       <div className="mb-8 space-y-4">
-        <p>{t('apply:parent-or-guardian.unable-to-apply')}</p>
+        <p>{t('apply-adult:parent-or-guardian.unable-to-apply')}</p>
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
         <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
-          {t('apply:parent-or-guardian.back-btn')}
+          {t('apply-adult:parent-or-guardian.back-btn')}
         </ButtonLink>
         <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Parent or guardian needs to apply click">
-          {t('apply:parent-or-guardian.return-btn')}
+          {t('apply-adult:parent-or-guardian.return-btn')}
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -107,7 +107,6 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/child/tax-filing', params));
   }
 
-  // TODO: change this route to $lang+/_public+/apply+/$id+/application-delegate
   return redirect(getPathById('$lang+/_public+/apply+/$id+/application-delegate', params));
 }
 

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -56,7 +56,10 @@
         "federalProvincialTerritorialBenefits": "CDCP-APPL-AD-0011",
         "reviewInformation": "CDCP-APPL-AD-0012",
         "exitApplication": "CDCP-APPL-AD-0013",
-        "confirmation": "CDCP-APPL-AD-0014"
+        "confirmation": "CDCP-APPL-AD-0014",
+        "disabilityTaxCredit": "CDCP-APPL-AD-0015",
+        "parentOrGuardian": "CDCP-APPL-AD-0016",
+        "livingIndependently": "CDCP-APPL-AD-0017"
       },
       "adultChild": {
         "taxFiling": "CDCP-APPL-ADCH-0002",
@@ -74,7 +77,10 @@
         "confirmation": "CDCP-APPL-ADCH-0014",
         "childInformation": "CDCP-APPL-ADCH-0015",
         "applyChildren": "CDCP-APPL-ADCH-0016",
-        "applySelf": "CDCP-APPL-ADCH-0017"
+        "applySelf": "CDCP-APPL-ADCH-0017",
+        "disabilityTaxCredit": "CDCP-APPL-ADCH-0018",
+        "parentOrGuardian": "CDCP-APPL-ADCH-0019",
+        "livingIndependently": "CDCP-APPL-ADCH-0020"
       },
       "child": {
         "taxFiling": "CDCP-APPL-CH-0002",
@@ -90,10 +96,7 @@
         "reviewInformation": "CDCP-APPL-CH-0012",
         "exitApplication": "CDCP-APPL-CH-0013",
         "confirmation": "CDCP-APPL-CH-0014"
-      },
-      "disabilityTaxCredit": "CDCP-APPL-0018",
-      "parentOrGuardian": "CDCP-APPL-0019",
-      "livingIndependently": "CDCP-APPL-0020"
+      }
     },
     "status": "CDCP-STAT-0001",
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -362,5 +362,42 @@
     "exit-button": "Exit application",
     "yes": "Yes",
     "no": "No"
+  },
+  "disability-tax-credit": {
+    "page-title": "Disability tax credit",
+    "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
+    "more-info": "For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
+    "form-label": "Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
+    "dtc-link": "https://www.canada.ca/en/revenue-agency/services/tax/individuals/segments/tax-credits-deductions-persons-disabilities/disability-tax-credit.html",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "error-message": {
+      "disability-tax-credit-required": "Select whether or not you have a valid disability tax credit"
+    }
+  },
+  "living-independently": {
+    "page-title": "Living independently",
+    "description": "Living independently from your parents means you are 16 or 17, do not receive financial support from your parents, and your primary residence is different from theirs.",
+    "form-instructions": "Do you live independently from your parents?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "living-independently-required": "Select an option for living independently"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
+  },
+  "parent-or-guardian": {
+    "page-title": "Parent or guardian needs to apply",
+    "unable-to-apply": "You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Back",
+    "return-btn": "Return to main page",
+    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -380,5 +380,42 @@
     "exit-button": "Exit application",
     "yes": "Yes",
     "no": "No"
+  },
+  "disability-tax-credit": {
+    "page-title": "Disability tax credit",
+    "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
+    "more-info": "For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
+    "form-label": "Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
+    "dtc-link": "https://www.canada.ca/en/revenue-agency/services/tax/individuals/segments/tax-credits-deductions-persons-disabilities/disability-tax-credit.html",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "error-message": {
+      "disability-tax-credit-required": "Select whether or not you have a valid disability tax credit"
+    }
+  },
+  "living-independently": {
+    "page-title": "Living independently",
+    "description": "Living independently from your parents means you are 16 or 17, do not receive financial support from your parents, and your primary residence is different from theirs.",
+    "form-instructions": "Do you live independently from your parents?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "living-independently-required": "Select an option for living independently"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
+  },
+  "parent-or-guardian": {
+    "page-title": "Parent or guardian needs to apply",
+    "unable-to-apply": "You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Back",
+    "return-btn": "Return to main page",
+    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -9,45 +9,8 @@
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
-  "disability-tax-credit": {
-    "page-title": "Disability tax credit",
-    "non-refundable": "The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
-    "more-info": "For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
-    "form-label": "Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
-    "dtc-link": "https://www.canada.ca/en/revenue-agency/services/tax/individuals/segments/tax-credits-deductions-persons-disabilities/disability-tax-credit.html",
-    "radio-options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "continue-btn": "Continue",
-    "back-btn": "Back",
-    "error-message": {
-      "disability-tax-credit-required": "Select whether or not you have a valid disability tax credit"
-    }
-  },
   "index": {
     "page-title": "Applying for the Canadian Dental Care Plan"
-  },
-  "living-independently": {
-    "page-title": "Living independently",
-    "description": "Living independently from your parents means you are 16 or 17, do not receive financial support from your parents, and your primary residence is different from theirs.",
-    "form-instructions": "Do you live independently from your parents?",
-    "radio-options": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "error-message": {
-      "living-independently-required": "Select an option for living independently"
-    },
-    "back-btn": "Back",
-    "continue-btn": "Continue"
-  },
-  "parent-or-guardian": {
-    "page-title": "Parent or guardian needs to apply",
-    "unable-to-apply": "You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
-    "back-btn": "Back",
-    "return-btn": "Return to main page",
-    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
   "progress": {
     "label": "Application Progress Tracking"

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -457,5 +457,42 @@
     "exit-button": "Quitter la demande",
     "yes": "Oui",
     "no": "Non"
+  },
+  "disability-tax-credit": {
+    "page-title": "(FR) Disability tax credit",
+    "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
+    "more-info": "(FR) For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
+    "form-label": "(FR) Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
+    "dtc-link": "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/segments/deductions-credits-impot-personnes-handicapees/credit-impot-personnes-handicapees.html",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "continue-btn": "Continuer",
+    "back-btn": "Retour",
+    "error-message": {
+      "disability-tax-credit-required": "(FR) Select whether or not you have a valid disability tax credit"
+    }
+  },
+  "living-independently": {
+    "page-title": "Vivre de manière indépendante",
+    "description": "Vivre indépendamment de vos parents signifie que vous avez 16 ou 17 ans, que vous ne recevez aucune aide financière de vos parents et que votre résidence principale est différente de la leur.",
+    "form-instructions": "Vivez-vous indépendamment de vos parents ?",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "error-message": {
+      "living-independently-required": "Sélectionnez une option pour vivre de manière indépendante"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer"
+  },
+  "parent-or-guardian": {
+    "page-title": "(FR) Parent or guardian needs to apply",
+    "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale",
+    "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   }
 }

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -381,5 +381,42 @@
     "exit-button": "Quitter la demande",
     "yes": "Oui",
     "no": "Non"
+  },
+  "disability-tax-credit": {
+    "page-title": "(FR) Disability tax credit",
+    "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
+    "more-info": "(FR) For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
+    "form-label": "(FR) Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
+    "dtc-link": "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/segments/deductions-credits-impot-personnes-handicapees/credit-impot-personnes-handicapees.html",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "continue-btn": "Continuer",
+    "back-btn": "Retour",
+    "error-message": {
+      "disability-tax-credit-required": "(FR) Select whether or not you have a valid disability tax credit"
+    }
+  },
+  "living-independently": {
+    "page-title": "Vivre de manière indépendante",
+    "description": "Vivre indépendamment de vos parents signifie que vous avez 16 ou 17 ans, que vous ne recevez aucune aide financière de vos parents et que votre résidence principale est différente de la leur.",
+    "form-instructions": "Vivez-vous indépendamment de vos parents ?",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "error-message": {
+      "living-independently-required": "Sélectionnez une option pour vivre de manière indépendante"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer"
+  },
+  "parent-or-guardian": {
+    "page-title": "(FR) Parent or guardian needs to apply",
+    "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale",
+    "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   }
 }

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -9,45 +9,8 @@
     "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
-  "disability-tax-credit": {
-    "page-title": "(FR) Disability tax credit",
-    "non-refundable": "(FR) The disability tax credit (DTC) is a non-refundable federal tax credit that helps people with disabilities, or their supporting family member, reduce the amount of income tax they may have to pay.",
-    "more-info": "(FR) For more information visit <dtcLink>Disability tax credit (DTC)</dtcLink>",
-    "form-label": "(FR) Did you have a valid disability tax credit (DTC) with the Canada Revenue Agency for 2023?",
-    "dtc-link": "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/segments/deductions-credits-impot-personnes-handicapees/credit-impot-personnes-handicapees.html",
-    "radio-options": {
-      "yes": "Oui",
-      "no": "Non"
-    },
-    "continue-btn": "Continuer",
-    "back-btn": "Retour",
-    "error-message": {
-      "disability-tax-credit-required": "(FR) Select whether or not you have a valid disability tax credit"
-    }
-  },
   "index": {
     "page-title": "(FR) Applying for the Canadian Dental Care Plan"
-  },
-  "living-independently": {
-    "page-title": "Vivre de manière indépendante",
-    "description": "Vivre indépendamment de vos parents signifie que vous avez 16 ou 17 ans, que vous ne recevez aucune aide financière de vos parents et que votre résidence principale est différente de la leur.",
-    "form-instructions": "Vivez-vous indépendamment de vos parents ?",
-    "radio-options": {
-      "yes": "Oui",
-      "no": "Non"
-    },
-    "error-message": {
-      "living-independently-required": "Sélectionnez une option pour vivre de manière indépendante"
-    },
-    "back-btn": "Retour",
-    "continue-btn": "Continuer"
-  },
-  "parent-or-guardian": {
-    "page-title": "(FR) Parent or guardian needs to apply",
-    "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or guardian apply on your behalf.",
-    "back-btn": "Retour",
-    "return-btn": "Revenir à la page principale",
-    "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
   "progress": {
     "label": "Suivi de la progression de l'application"


### PR DESCRIPTION
### Description
Move `/living-independently`, `/disability-tax-credit`, `/parent-or-guardian`, to respective apply flow routes.

### Related Azure Boards Work Items
[AB#3404](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3404)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`