### PR TITLE
3352 Create child summary screen

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -330,6 +330,14 @@
                           "en": "/:lang/apply/:id/adult-child/living-independently",
                           "fr": "/:lang/demander/:id/adulte-enfant/living-independently"
                         }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/child-summary",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/child-summary.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/child-summary",
+                          "fr": "/:lang/demander/:id/adulte-enfant/child-summary"
+                        }
                       }
                     ]
                   },

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/child-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/child-information.tsx
@@ -83,12 +83,14 @@ export async function action({ context: { session }, params, request }: ActionFu
     throw new Response('Invalid CSRF token', { status: 400 });
   }
 
+  await saveApplyAdultChildState({ params, request, session, state: { editMode: false } });
+
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Cancel) {
     invariant(state.adultChildState.childInformation, 'Expected state.childInformation to be defined');
 
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/child-summary', params));
   }
 
   // Form action Continue & Save
@@ -184,11 +186,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   await saveApplyAdultChildState({ params, request, session, state: { childInformation: parsedDataResult.data } });
 
-  if (state.adultChildState.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
-  }
-
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/personal-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/child-summary', params));
 }
 
 export default function ApplyFlowChildInformation() {
@@ -366,7 +364,7 @@ export default function ApplyFlowChildInformation() {
                 {t('apply-adult-child:eligibility.child-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply-adult-child:eligibility.child-information.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/child-summary.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/child-summary.tsx
@@ -1,0 +1,140 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faPlus, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { DescriptionListItem } from '~/components/description-list-item';
+import { InlineLink } from '~/components/inline-link';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import '~/route-helpers/apply-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.childInformation,
+  pageTitleI18nKey: 'apply-adult-child:child-summary.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:child-summary.page-title') }) };
+
+  await saveApplyAdultChildState({ params, request, session, state: { editMode: true } });
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.adultChildState.childInformation });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/child-summary');
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/personal-information', params));
+}
+
+export default function ApplyFlowChildSummary() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={40} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <fetcher.Form method="post" aria-describedby="form-instructions-sin form-instructions" noValidate>
+          {defaultState?.firstName && (
+            <>
+              <p className="mb-6">{t('apply-adult-child:child-summary.children-added')}</p>
+              <input type="hidden" name="_csrf" value={csrfToken} />
+              <DescriptionListItem
+                term={
+                  <>
+                    <h2 className="text-2xl font-semibold">{`${defaultState.firstName} ${defaultState.lastName}`}</h2>
+                    <InlineLink className="text-sm font-normal" id="remove-child" routeId="$lang+/_public+/apply+/$id+/adult-child/child-information" params={params}>
+                      {t('apply-adult-child:child-summary.remove-child')}
+                    </InlineLink>
+                  </>
+                }
+              >
+                <dl className="divide-y border-y">
+                  <DescriptionListItem term={t('apply-adult-child:child-summary.dob-title')}>
+                    <p>{defaultState.dateOfBirth}</p>
+                    <p className="mt-4">
+                      <InlineLink id="change-date-of-birth" routeId="$lang+/_public+/apply+/$id+/adult-child/child-information" params={params}>
+                        {t('apply-adult-child:child-summary.dob-change')}
+                      </InlineLink>
+                    </p>
+                  </DescriptionListItem>
+                  <DescriptionListItem term={t('apply-adult-child:child-summary.sin-title')}>
+                    <p>{defaultState.socialInsuranceNumber}</p>
+                    <p className="mt-4">
+                      <InlineLink id="change-sin" routeId="$lang+/_public+/apply+/$id+/adult-child/child-information" params={params}>
+                        {t('apply-adult-child:child-summary.sin-change')}
+                      </InlineLink>
+                    </p>
+                  </DescriptionListItem>
+                </dl>
+              </DescriptionListItem>
+            </>
+          )}
+
+          {!defaultState?.firstName && <p>{t('apply-adult-child:child-summary.no-children')}</p>}
+
+          <ButtonLink
+            className="mb-10"
+            id="add-child"
+            routeId="$lang+/_public+/apply+/$id+/adult-child/child-information"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click"
+          >
+            <FontAwesomeIcon icon={faPlus} className="me-3 block size-4" />
+            {t('apply-adult-child:child-summary.add-child')}
+          </ButtonLink>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <Button id="continue-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Applicant Information click">
+              {t('apply-adult-child:child-summary.continue-btn')}
+              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+            </Button>
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/child-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+              <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+              {t('apply-adult-child:child-summary.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
@@ -127,7 +127,6 @@ export async function action({ context: { session }, params, request }: ActionFu
       homePostalCode: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
-      console.log(val);
       if (val.email) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.email-required'), path: ['email'] });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/personal-information.tsx
@@ -127,7 +127,6 @@ export async function action({ context: { session }, params, request }: ActionFu
       homePostalCode: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
-      console.log(val);
       if (val.email) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.email-required'), path: ['email'] });

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -80,7 +80,8 @@
         "applySelf": "CDCP-APPL-ADCH-0017",
         "disabilityTaxCredit": "CDCP-APPL-ADCH-0018",
         "parentOrGuardian": "CDCP-APPL-ADCH-0019",
-        "livingIndependently": "CDCP-APPL-ADCH-0020"
+        "livingIndependently": "CDCP-APPL-ADCH-0020",
+        "childSummary": "CDCP-APPL-ADCH-0021"
       },
       "child": {
         "taxFiling": "CDCP-APPL-CH-0002",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -1,4 +1,19 @@
 {
+  "child-summary": {
+    "page-title": "Summary of child(ren)",
+    "children-added": "The following child(ren) has been added to the application.",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "sin-title": "Social Insurance Number (SIN)",
+    "sin-change": "Change SIN",
+    "add-child": "Add another child",
+    "no-children": "There are currently no child in this application.",
+    "remove-child": "Remove child",
+    "back-btn": "Back",
+    "continue-btn": "Continue with application",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save"
+  },
   "dental-benefits": {
     "title": "{{childName}}: access to other federal, provincial or territorial dental benefits",
     "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact the child's eligibility for the Canadian Dental Care Plan.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -1,4 +1,18 @@
 {
+  "child-summary": {
+    "page-title": "(FR) Summary of child(ren)",
+    "children-added": "(FR) The following child(ren) has been added to the application.",
+    "dob-title": "(FR) Date of birth",
+    "dob-change": "(FR) Change date of birth",
+    "sin-title": "(FR) Social Insurance Number (SIN)",
+    "sin-change": "(FR) Change SIN",
+    "add-child": "(FR) Add another child",
+    "no-children": "(FR) There are currently no child in this application.",
+    "remove-child": "(FR) Back",
+    "continue-btn": "(FR) Continue with application",
+    "cancel-btn": "(FR) Cancel",
+    "save-btn": "(FR) Save"
+  },
   "applicant-information": {
     "page-title": "Renseignements sur le demandeur",
     "form-instructions-sin": "Veuillez indiquer votre nom légal tel qu'indiqué sur votre carte ou votre lettre de numéro d'assurance sociale (NAS).",


### PR DESCRIPTION
### Description
Add `/adult-child/child-summary` screen to display an applicant's child's information.

Note: more work will need to be done to hook up the logic to this screen. This PR is mostly structural work.

### Related Azure Boards Work Items
[AB#3352](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3352)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/44f54658-c67e-44da-9a7b-6a1c1182c013)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`