### PR TITLE
3415 add applicant info screen to adult-child

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -362,6 +362,14 @@
                           "en": "/:lang/apply/:id/adult-child/partner-information",
                           "fr": "/:lang/demander/:id/adulte-enfant/renseignements-partenaire"
                         }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/applicant-information",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/applicant-information",
+                          "fr": "/:lang/demander/:id/adulte-enfant/renseignements-demandeur"
+                        }
                       }
                     ]
                   },

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo } from 'react';
+
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { Collapsible } from '~/components/collapsible';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { InputRadios } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { applicantInformationStateHasPartner, loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import '~/route-helpers/apply-route-helpers.server';
+import { getLookupService } from '~/services/lookup-service.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { cn } from '~/utils/tw-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+export type ApplicantInformationState = {
+  firstName: string;
+  lastName: string;
+  maritalStatus: string;
+  socialInsuranceNumber: string;
+};
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.applicantInformation,
+  pageTitleI18nKey: 'apply-adult-child:applicant-information.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const lookupService = getLookupService();
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const maritalStatuses = await lookupService.getAllMaritalStatuses();
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:applicant-information.page-title') }) };
+
+  return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.adultChildState.applicantInformation, editMode: state.adultChildState.editMode });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/applicant-information');
+
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+
+  if (formAction === FormAction.Cancel) {
+    invariant(state.adultChildState.applicantInformation, 'Expected state.applicantInformation to be defined');
+
+    if (applicantInformationStateHasPartner(state.adultChildState.applicantInformation) && state.adultChildState.partnerInformation === undefined) {
+      const errorMessage = t('apply-adult-child:applicant-information.error-message.marital-status-no-partner-information');
+      const errors: z.ZodFormattedError<ApplicantInformationState, string> = { _errors: [errorMessage], maritalStatus: { _errors: [errorMessage] } };
+      return json({ errors });
+    }
+
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/review-information', params));
+  }
+
+  // Form action Continue & Save
+  // state validation schema
+  const applicantInformationSchema = z.object({
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('apply-adult-child:applicant-information.error-message.sin-required'))
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:applicant-information.error-message.sin-valid'), fatal: true });
+          return z.NEVER;
+        }
+
+        if (state.adultChildState.partnerInformation && formatSin(sin) === formatSin(state.adultChildState.partnerInformation.socialInsuranceNumber)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:applicant-information.error-message.sin-unique'), fatal: true });
+          return z.NEVER;
+        }
+      }),
+    firstName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.first-name-required')).max(100),
+    lastName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.last-name-required')).max(100),
+    maritalStatus: z
+      .string({ errorMap: () => ({ message: t('apply-adult-child:applicant-information.error-message.marital-status-required') }) })
+      .trim()
+      .min(1, t('apply-adult-child:applicant-information.error-message.marital-status-required')),
+  }) satisfies z.ZodType<ApplicantInformationState>;
+
+  const data = {
+    socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),
+    firstName: String(formData.get('firstName') ?? ''),
+    lastName: String(formData.get('lastName') ?? ''),
+    maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,
+  };
+
+  const parsedDataResult = applicantInformationSchema.safeParse(data);
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format() });
+  }
+
+  const hasPartner = applicantInformationStateHasPartner(parsedDataResult.data);
+  const remove = !hasPartner ? 'partnerInformation' : undefined;
+  await saveApplyAdultChildState({ params, remove, request, session, state: { applicantInformation: parsedDataResult.data } });
+
+  if (state.adultChildState.editMode) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/review-information', params));
+  }
+
+  if (hasPartner) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/partner-information', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/personal-information', params));
+}
+
+export default function ApplyFlowApplicationInformation() {
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errorSummaryId = 'error-summary';
+
+  // Keys order should match the input IDs order.
+  const errorMessages = useMemo(
+    () => ({
+      'first-name': fetcher.data?.errors.firstName?._errors[0],
+      'last-name': fetcher.data?.errors.lastName?._errors[0],
+      'social-insurance-number': fetcher.data?.errors.socialInsuranceNumber?._errors[0],
+      'input-radio-marital-status-option-0': fetcher.data?.errors.maritalStatus?._errors[0],
+    }),
+    [fetcher.data?.errors.firstName?._errors, fetcher.data?.errors.lastName?._errors, fetcher.data?.errors.maritalStatus?._errors, fetcher.data?.errors.socialInsuranceNumber?._errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorMessages]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={40} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4">{t('applicant-information.form-instructions-sin')}</p>
+        <p className="mb-6">{t('applicant-information.form-instructions-info')}</p>
+        <p className="italic">{t('apply:required-label')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="mb-8 space-y-6">
+            <Collapsible id="name-instructions" summary={t('applicant-information.single-legal-name')}>
+              <p>{t('applicant-information.name-instructions')}</p>
+            </Collapsible>
+            <div className="grid items-end gap-6 md:grid-cols-2">
+              <InputField
+                id="first-name"
+                name="firstName"
+                label={t('applicant-information.first-name')}
+                className="w-full"
+                maxLength={100}
+                aria-describedby="name-instructions"
+                autoComplete="given-name"
+                errorMessage={errorMessages['first-name']}
+                defaultValue={defaultState?.firstName ?? ''}
+                required
+              />
+              <InputField
+                id="last-name"
+                name="lastName"
+                label={t('applicant-information.last-name')}
+                className="w-full"
+                maxLength={100}
+                autoComplete="family-name"
+                defaultValue={defaultState?.lastName ?? ''}
+                errorMessage={errorMessages['last-name']}
+                aria-describedby="name-instructions"
+                required
+              />
+            </div>
+            <InputField
+              id="social-insurance-number"
+              name="socialInsuranceNumber"
+              label={t('applicant-information.sin')}
+              placeholder="000-000-000"
+              defaultValue={defaultState?.socialInsuranceNumber ?? ''}
+              errorMessage={errorMessages['social-insurance-number']}
+              required
+            />
+            <InputRadios
+              id="marital-status"
+              name="maritalStatus"
+              legend={t('applicant-information.marital-status')}
+              options={maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState?.maritalStatus, children: getNameByLanguage(i18n.language, status), value: status.id }))}
+              errorMessage={errorMessages['input-radio-marital-status-option-0']}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Applicant Information click">
+                {t('apply-adult-child:applicant-information.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Applicant Information click">
+                {t('apply-adult-child:applicant-information.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button id="continue-button" name="_action" value={FormAction.Continue} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Applicant Information click">
+                {t('apply-adult-child:applicant-information.continue-btn')}
+                <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+              </Button>
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+                <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+                {t('apply-adult-child:applicant-information.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -1,4 +1,28 @@
 {
+  "applicant-information": {
+    "page-title": "Applicant Information",
+    "form-instructions-sin": "Please provide your legal name as indicated on your Social Insurance Number (SIN) card or letter.",
+    "form-instructions-info": "We'll use the information you provide to verify your identity. Any information that does not match the information on your SIN application may cause a delay in the processing of your application.",
+    "sin": "Social Insurance Number (SIN)",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "single-legal-name": "If you have a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "marital-status": "Marital status",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "marital-status-required": "Select marital status",
+      "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
+      "sin-required": "Enter 9-digit SIN",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
+  },
   "child-summary": {
     "page-title": "Summary of child(ren)",
     "children-added": "The following child(ren) has been added to the application.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -1,18 +1,4 @@
 {
-  "child-summary": {
-    "page-title": "(FR) Summary of child(ren)",
-    "children-added": "(FR) The following child(ren) has been added to the application.",
-    "dob-title": "(FR) Date of birth",
-    "dob-change": "(FR) Change date of birth",
-    "sin-title": "(FR) Social Insurance Number (SIN)",
-    "sin-change": "(FR) Change SIN",
-    "add-child": "(FR) Add another child",
-    "no-children": "(FR) There are currently no child in this application.",
-    "remove-child": "(FR) Back",
-    "continue-btn": "(FR) Continue with application",
-    "cancel-btn": "(FR) Cancel",
-    "save-btn": "(FR) Save"
-  },
   "applicant-information": {
     "page-title": "Renseignements sur le demandeur",
     "form-instructions-sin": "Veuillez indiquer votre nom légal tel qu'indiqué sur votre carte ou votre lettre de numéro d'assurance sociale (NAS).",
@@ -36,6 +22,20 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
     }
+  },
+  "child-summary": {
+    "page-title": "(FR) Summary of child(ren)",
+    "children-added": "(FR) The following child(ren) has been added to the application.",
+    "dob-title": "(FR) Date of birth",
+    "dob-change": "(FR) Change date of birth",
+    "sin-title": "(FR) Social Insurance Number (SIN)",
+    "sin-change": "(FR) Change SIN",
+    "add-child": "(FR) Add another child",
+    "no-children": "(FR) There are currently no child in this application.",
+    "remove-child": "(FR) Back",
+    "continue-btn": "(FR) Continue with application",
+    "cancel-btn": "(FR) Cancel",
+    "save-btn": "(FR) Save"
   },
   "communication-preference": {
     "page-title": "Communication",


### PR DESCRIPTION
### Description
Part of a series of PRs to add missing screens to adult-child flow.  This add the `/apply/adult-child/applicant-information` screen.

### Related Azure Boards Work Items
[AB#3415](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3415)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`