### PR TITLE
3420 add communication preferences screen to adult-child

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -300,6 +300,14 @@
                         }
                       },
                       {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/communication-preference",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/communication-preference",
+                          "fr": "/:lang/demander/:id/adulte-enfant/preference-communication"
+                        }
+                      },
+                      {
                         "id": "$lang+/_public+/apply+/$id+/adult-child/apply-yourself",
                         "file": "routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx",
                         "paths": {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -1,0 +1,302 @@
+import { ChangeEventHandler, useEffect, useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { InputRadios, InputRadiosProps } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { getLookupService } from '~/services/lookup-service.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { getEnv } from '~/utils/env.server';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+export interface CommunicationPreferencesState {
+  confirmEmail?: string;
+  email?: string;
+  preferredLanguage: string;
+  preferredMethod: string;
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.communicationPreference,
+  pageTitleI18nKey: 'apply-adult-child:communication-preference.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+
+  const lookupService = getLookupService();
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const preferredLanguages = await lookupService.getAllPreferredLanguages();
+  const preferredCommunicationMethods = await lookupService.getAllPreferredCommunicationMethods();
+
+  const communicationMethodEmail = preferredCommunicationMethods.find((method) => method.id === COMMUNICATION_METHOD_EMAIL_ID);
+  if (!communicationMethodEmail) {
+    throw new Response('Expected communication method email not found!', { status: 500 });
+  }
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:communication-preference.page-title') }) };
+
+  return json({
+    communicationMethodEmail,
+    id: state.id,
+    csrfToken,
+    meta,
+    preferredCommunicationMethods,
+    preferredLanguages,
+    defaultState: {
+      ...(state.adultChildState.communicationPreferences ?? {}),
+      email: state.adultChildState.communicationPreferences?.email ?? state.adultChildState.personalInformation?.email,
+      confirmEmail: state.adultChildState.communicationPreferences?.confirmEmail ?? state.adultChildState.personalInformation?.confirmEmail,
+    },
+    editMode: state.adultChildState.editMode,
+  });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/communication-preference');
+
+  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formSchema = z
+    .object({
+      preferredLanguage: z.string().trim().min(1, t('apply-adult-child:communication-preference.error-message.preferred-language-required')),
+      preferredMethod: z.string().trim().min(1, t('apply-adult-child:communication-preference.error-message.preferred-method-required')),
+      email: z.string().trim().max(100).optional(),
+      confirmEmail: z.string().trim().max(100).optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-required'), path: ['email'] });
+        } else if (!validator.isEmail(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['email'] });
+        }
+
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+        } else if (!validator.isEmail(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
+        } else if (val.email !== val.confirmEmail) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+        }
+      }
+    }) satisfies z.ZodType<CommunicationPreferencesState>;
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = {
+    confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail') ?? '') : undefined,
+    email: formData.get('email') ? String(formData.get('email') ?? '') : undefined,
+    preferredLanguage: String(formData.get('preferredLanguage') ?? ''),
+    preferredMethod: String(formData.get('preferredMethod') ?? ''),
+  };
+  const parsedDataResult = formSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format() });
+  }
+
+  saveApplyAdultChildState({ params, request, session, state: { communicationPreferences: parsedDataResult.data } });
+
+  if (state.adultChildState.editMode) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/review-information', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/dental-insurance', params));
+}
+
+export default function ApplyFlowCommunicationPreferencePage() {
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');
+  const errorSummaryId = 'error-summary';
+
+  const handleOnPreferredMethodChecked: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setPreferredMethodValue(e.target.value);
+  };
+
+  // Keys order should match the input IDs order.
+  const errorMessages = useMemo(
+    () => ({
+      'input-radio-preferred-language-option-0': fetcher.data?.errors.preferredLanguage?._errors[0],
+      'input-radio-preferred-methods-option-0': fetcher.data?.errors.preferredMethod?._errors[0],
+      email: fetcher.data?.errors.email?._errors[0],
+      'confirm-email': fetcher.data?.errors.confirmEmail?._errors[0],
+    }),
+    [fetcher.data?.errors.confirmEmail?._errors, fetcher.data?.errors.email?._errors, fetcher.data?.errors.preferredLanguage?._errors, fetcher.data?.errors.preferredMethod?._errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorMessages]);
+
+  const nonEmailOptions: InputRadiosProps['options'] = preferredCommunicationMethods
+    .filter((method) => method.id !== communicationMethodEmail.id)
+    .map((method) => ({
+      children: i18n.language === 'fr' ? method.nameFr : method.nameEn,
+      value: method.id,
+      defaultChecked: defaultState.preferredMethod === method.id,
+      onChange: handleOnPreferredMethodChecked,
+    }));
+
+  const options: InputRadiosProps['options'] = [
+    {
+      children: getNameByLanguage(i18n.language, communicationMethodEmail),
+      value: communicationMethodEmail.id,
+      defaultChecked: defaultState.preferredMethod === communicationMethodEmail.id,
+      append: preferredMethodValue === communicationMethodEmail.id && (
+        <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+          <p className="md:col-span-2" id="email-note">
+            {t('apply-adult-child:communication-preference.email-note')}
+          </p>
+          <InputField
+            id="email"
+            type="email"
+            className="w-full"
+            label={t('apply-adult-child:communication-preference.email')}
+            maxLength={100}
+            name="email"
+            errorMessage={errorMessages.email}
+            autoComplete="email"
+            defaultValue={defaultState.email ?? ''}
+            required
+          />
+          <InputField
+            id="confirm-email"
+            type="email"
+            className="w-full"
+            label={t('apply-adult-child:communication-preference.confirm-email')}
+            maxLength={100}
+            name="confirmEmail"
+            errorMessage={errorMessages['confirm-email']}
+            autoComplete="email"
+            defaultValue={defaultState.confirmEmail ?? ''}
+            required
+          />
+        </div>
+      ),
+      onChange: handleOnPreferredMethodChecked,
+    },
+    ...nonEmailOptions,
+  ];
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={70} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-6">{t('apply-adult-child:communication-preference.note')}</p>
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="mb-8 space-y-6">
+            {preferredLanguages.length > 0 && (
+              <InputRadios
+                id="preferred-language"
+                name="preferredLanguage"
+                legend={t('apply-adult-child:communication-preference.preferred-language')}
+                options={preferredLanguages.map((language) => ({
+                  defaultChecked: defaultState.preferredLanguage === language.id,
+                  children: getNameByLanguage(i18n.language, language),
+                  value: language.id,
+                }))}
+                errorMessage={errorMessages['input-radio-preferred-language-option-0']}
+                required
+              />
+            )}
+            {preferredCommunicationMethods.length > 0 && (
+              <InputRadios id="preferred-methods" legend={t('apply-adult-child:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errorMessages['input-radio-preferred-methods-option-0']} required />
+            )}
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Communication preference click">
+                {t('apply-adult-child:communication-preference.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult-child/review-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Communication preference click"
+              >
+                {t('apply-adult-child:communication-preference.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Communication preference click">
+                {t('apply-adult-child:communication-preference.continue')}
+                <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult-child/personal-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Communication preference click"
+              >
+                <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+                {t('apply-adult-child:communication-preference.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -268,6 +268,27 @@
       "sin-unique": "The Social Insurance Number (SIN) must be unique"
     }
   },
+  "communication-preference": {
+    "page-title": "Communication",
+    "note": "If you're eligible, we will share your information with Sun Life Assurance Company of Canada (Sun Life). Sun Life will be responsible for handling member enrolment and administering claims processing and benefits for the Canadian Dental Care Plan.",
+    "preferred-method": "What is your preferred method of communication for Sun Life?",
+    "preferred-language": "What is your preferred official language of communication?",
+    "email": "Email address",
+    "email-note": "Service Canada and Health Canada may use this email for future communication about the Canadian Dental Care Plan.",
+    "confirm-email": "Confirm email address",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com",
+      "preferred-language-required": "Select preferred language of communication",
+      "preferred-method-required": "Select preferred method of communication"
+    }
+  },
   "contact-information": {
     "page-title": "Contact information",
     "form-instructions": "Adding a phone number helps Service Canada contact you if there is an issue with your application. Otherwise, we'll contact you by mail.",


### PR DESCRIPTION
### Description
add `/apply/adut-child/communication/preference`

### Related Azure Boards Work Items
[AB#3420](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3420)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
