### PR TITLE
3448 add access to dental insurance to adult-child

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -308,6 +308,14 @@
                         }
                       },
                       {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/dental-insurance",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/dental-insurance.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/dental-insurance",
+                          "fr": "/:lang/demander/:id/adulte-enfant/assurance-dentaire"
+                        }
+                      },
+                      {
                         "id": "$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit",
                         "file": "routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx",
                         "paths": {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/dental-insurance.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { Collapsible } from '~/components/collapsible';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { Progress } from '~/components/progress';
+import { loadApplyAdultChildState, saveApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+export type DentalInsuranceState = boolean;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.dentalInsurance,
+  pageTitleI18nKey: 'apply-adult-child:dental-insurance.title',
+};
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:dental-insurance.title') }) };
+
+  return json({ id: state, csrfToken, meta, defaultState: state.adultChildState.dentalInsurance, editMode: state.adultChildState.editMode });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/dental-insurance');
+
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // state validation schema
+  const dentalInsuranceSchema: z.ZodType<DentalInsuranceState> = z.boolean({ errorMap: () => ({ message: t('apply-adult-child:dental-insurance.error-message.dental-insurance-required') }) });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const dentalInsurance = formData.get('dentalInsurance') ? formData.get('dentalInsurance') === 'yes' : undefined;
+  const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
+
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format()._errors });
+  }
+
+  saveApplyAdultChildState({ params, request, session, state: { dentalInsurance: parsedDataResult.data } });
+
+  if (state.adultChildState.editMode) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/review-information', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/federal-provincial-territorial-benefits', params));
+}
+
+export default function AccessToDentalInsuranceQuestion() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errorSummaryId = 'error-summary';
+
+  // Keys order should match the input IDs order.
+  const errorMessages = useMemo(
+    () => ({
+      'input-radio-dental-insurance-option-0': fetcher.data?.errors[0],
+    }),
+    [fetcher.data?.errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorMessages]);
+
+  const helpMessage = (
+    <div className="my-4 space-y-4">
+      <ul className="list-disc space-y-1 pl-7">
+        <li>{t('dental-insurance.list.employment')}</li>
+        <li>{t('dental-insurance.list.pension')}</li>
+        <li>{t('dental-insurance.list.purchased')}</li>
+        <li>{t('dental-insurance.list.professional')}</li>
+      </ul>
+      <Collapsible summary={t('dental-insurance.detail.additional-info.title')}>
+        <div className="space-y-4">
+          <p>{t('dental-insurance.detail.additional-info.not-eligible')}</p>
+          <p>{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
+          <p>{t('dental-insurance.detail.additional-info.eligible')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
+            <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
+          </ul>
+        </div>
+      </Collapsible>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <p id="progress-label" className="sr-only mb-2">
+          {t('apply:progress.label')}
+        </p>
+        <Progress aria-labelledby="progress-label" value={80} size="lg" />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-6 italic">{t('apply:required-label')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="my-6">
+            <InputRadios
+              id="dental-insurance"
+              name="dentalInsurance"
+              legend={t('dental-insurance.legend')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance.option-yes" />,
+                  value: 'yes',
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance.option-no" />,
+                  value: 'no',
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              helpMessagePrimary={helpMessage}
+              helpMessagePrimaryClassName="text-black"
+              errorMessage={errorMessages['input-radio-dental-insurance-option-0']}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Save - Access to other dental insurance click">
+                {t('dental-insurance.button.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult-child/review-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Cancel - Access to other dental insurance click"
+              >
+                {t('dental-insurance.button.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Access to other dental insurance click">
+                {t('dental-insurance.button.continue')}
+                <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="$lang+/_public+/apply+/$id+/adult-child/communication-preference"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Access to other dental insurance click"
+              >
+                <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+                {t('dental-insurance.button.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### Description
add `/apply-adult-child/dental-insurance` to adult-child flow

### Related Azure Boards Work Items
[AB#3448](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3448)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`