### PR TITLE
add type and inputmode to telephone and email inputs

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -201,6 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-adult-child:communication-preference.email')}
             maxLength={100}
@@ -213,6 +214,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="confirm-email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-adult-child:communication-preference.confirm-email')}
             maxLength={100}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/personal-information.tsx
@@ -390,6 +390,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="phone-number"
               name="phoneNumber"
+              type="tel"
+              inputMode="tel"
               className="w-full"
               autoComplete="tel"
               defaultValue={defaultState?.phoneNumber ?? ''}
@@ -401,6 +403,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="phone-number-alt"
               name="phoneNumberAlt"
+              type="tel"
+              inputMode="tel"
               className="w-full"
               autoComplete="tel"
               defaultValue={defaultState?.phoneNumberAlt ?? ''}
@@ -417,6 +421,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="email"
               name="email"
+              type="email"
+              inputMode="email"
               className="w-full"
               autoComplete="email"
               defaultValue={defaultState?.email ?? ''}
@@ -428,6 +434,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="confirm-email"
               name="confirmEmail"
+              type="email"
+              inputMode="email"
               className="w-full"
               autoComplete="email"
               defaultValue={defaultState?.confirmEmail ?? ''}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -201,6 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-adult:communication-preference.email')}
             maxLength={100}
@@ -213,6 +214,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="confirm-email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-adult:communication-preference.confirm-email')}
             maxLength={100}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/personal-information.tsx
@@ -389,6 +389,8 @@ export default function ApplyFlowPersonalInformation() {
               <InputField
                 id="phone-number"
                 name="phoneNumber"
+                type="tel"
+                inputMode="tel"
                 className="w-full"
                 autoComplete="tel"
                 defaultValue={defaultState?.phoneNumber ?? ''}
@@ -400,6 +402,8 @@ export default function ApplyFlowPersonalInformation() {
               <InputField
                 id="phone-number-alt"
                 name="phoneNumberAlt"
+                type="tel"
+                inputMode="tel"
                 className="w-full"
                 autoComplete="tel"
                 defaultValue={defaultState?.phoneNumberAlt ?? ''}
@@ -419,6 +423,8 @@ export default function ApplyFlowPersonalInformation() {
               <InputField
                 id="email"
                 name="email"
+                type="email"
+                inputMode="email"
                 className="w-full"
                 autoComplete="email"
                 defaultValue={defaultState?.email ?? ''}
@@ -430,6 +436,8 @@ export default function ApplyFlowPersonalInformation() {
               <InputField
                 id="confirm-email"
                 name="confirmEmail"
+                type="email"
+                inputMode="email"
                 className="w-full"
                 autoComplete="email"
                 defaultValue={defaultState?.confirmEmail ?? ''}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -201,6 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-child:communication-preference.email')}
             maxLength={100}
@@ -213,6 +214,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
           <InputField
             id="confirm-email"
             type="email"
+            inputMode="email"
             className="w-full"
             label={t('apply-child:communication-preference.confirm-email')}
             maxLength={100}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/personal-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/personal-information.tsx
@@ -390,6 +390,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="phone-number"
               name="phoneNumber"
+              type="tel"
+              inputMode="tel"
               className="w-full"
               autoComplete="tel"
               defaultValue={defaultState?.phoneNumber ?? ''}
@@ -401,6 +403,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="phone-number-alt"
               name="phoneNumberAlt"
+              type="tel"
+              inputMode="tel"
               className="w-full"
               autoComplete="tel"
               defaultValue={defaultState?.phoneNumberAlt ?? ''}
@@ -417,6 +421,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="email"
               name="email"
+              type="email"
+              inputMode="email"
               className="w-full"
               autoComplete="email"
               defaultValue={defaultState?.email ?? ''}
@@ -428,6 +434,8 @@ export default function ApplyFlowPersonalInformation() {
             <InputField
               id="confirm-email"
               name="confirmEmail"
+              type="email"
+              inputMode="email"
               className="w-full"
               autoComplete="email"
               defaultValue={defaultState?.confirmEmail ?? ''}


### PR DESCRIPTION
### Description
It's possible to have both `inputmode` and `type` on input fields.  The reason we would do this is signal what virtual keyboard the input field should have (useful on mobile devices) when specifying the `inputmode`. The `type` indicates what the field should expect and also provides some amount of client side validation.  

This PR adds these attributes to email and telephone fields in the apply flow.
