### PR TITLE
3526 read only email if pre-filled on contact information page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -76,6 +76,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
       confirmEmail: state.adultChildState.communicationPreferences?.confirmEmail ?? state.adultChildState.personalInformation?.confirmEmail,
     },
     editMode: state.adultChildState.editMode,
+    isReadOnlyEmail: !!state.adultChildState.personalInformation?.email,
   });
 }
 
@@ -144,7 +145,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowCommunicationPreferencePage() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -210,6 +211,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -223,6 +225,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.confirmEmail ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
         </div>
       ),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -76,6 +76,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
       confirmEmail: state.adultState.communicationPreferences?.confirmEmail ?? state.adultState.personalInformation?.confirmEmail,
     },
     editMode: state.adultState.editMode,
+    isReadOnlyEmail: !!state.adultState.personalInformation?.email,
   });
 }
 
@@ -144,7 +145,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowCommunicationPreferencePage() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -210,6 +211,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -223,6 +225,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.confirmEmail ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
         </div>
       ),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -76,6 +76,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
       confirmEmail: state.childState.communicationPreferences?.confirmEmail ?? state.childState.personalInformation?.confirmEmail,
     },
     editMode: state.childState.editMode,
+    isReadOnlyEmail: !!state.childState.personalInformation?.email,
   });
 }
 
@@ -144,7 +145,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowCommunicationPreferencePage() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -210,6 +211,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -223,6 +225,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.confirmEmail ?? ''}
             required
+            disabled={isReadOnlyEmail}
           />
         </div>
       ),


### PR DESCRIPTION
### Description
Business wants the email fields on the `/communication-preference` page to be 'read only' if they we supplied on the preceding screen (`/personal-information`).

### Related Azure Boards Work Items
[AB#3526](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3526) 