### PR TITLE
Removed "one application per child" note from type-of-application page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/type-application.tsx
@@ -159,7 +159,6 @@ export default function ApplyFlowTypeOfApplication() {
             <li>{t('apply:type-of-application.sixteen-or-older')}</li>
             <li>{t('apply:type-of-application.under-eighteen')}</li>
           </ul>
-          <p>{t('apply:type-of-application.note')}</p>
         </div>
         <Collapsible summary={t('apply:type-of-application.split-custody-summary')}>
           <p className="mb-4">{t('apply:type-of-application.split-custody-detail')}</p>

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -101,7 +101,6 @@
     "sixteen-or-older": "You are 16 or older and the parent or legal guardian of the child; and",
     "under-eighteen": "The child is under 18 years old",
     "form-instructions": "Who are you applying for?",
-    "note": "please note, only one application can be processed for each child.",
     "split-custody-summary": "If you split custody of a child",
     "split-custody-detail": "If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
     "multiple-application": "Do not submit multiple applications for a single child. Only one parent should apply per child.",

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -101,7 +101,6 @@
     "sixteen-or-older": "(FR) You are 16 or older and the parent or legal guardian of the child; and",
     "under-eighteen": "(FR) The child is under 18 years old",
     "form-instructions": "Qui présente la demande?",
-    "note": "(FR) please note, only one application can be processed for each child.",
     "split-custody-summary": "(FR) If you split custody of a child",
     "split-custody-detail": "(FR) If you have shared custody agreement for the child, eligibility for the plan and the amount covered is based on the parent or guardian that applies. The child's eligibility and amount covered may change if another parent or guardian applies for that child.",
     "multiple-application": "(FR) Do not submit multiple applications for a single child. Only one parent should apply per child.",


### PR DESCRIPTION
### Description
Removed the "please note, only one application can be processed for each child." note from the type-of-application page

### Related Azure Boards Work Items
n/a

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/8334acca-faa3-4d3e-af90-918289928aa2)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
View type-of-application page to confirm note removal

### Additional Notes
n/a