### PR TITLE
AB#3571 SYSTEST - BUG in communication preference

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -90,17 +90,19 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+        const email = val.email ?? state.personalInformation?.email;
+        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
+        if (typeof email !== 'string' || validator.isEmpty(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(val.email)) {
+        } else if (!validator.isEmail(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
+        } else if (!validator.isEmail(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
+        } else if (email !== confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -90,19 +90,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        const email = val.email ?? state.personalInformation?.email;
-        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
-        if (typeof email !== 'string' || validator.isEmpty(email)) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(email)) {
+        } else if (!validator.isEmail(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(confirmEmail)) {
+        } else if (!validator.isEmail(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (email !== confirmEmail) {
+        } else if (val.email !== val.confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
@@ -203,7 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -217,7 +215,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
         </div>
       ),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -102,7 +102,7 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
         } else if (!validator.isEmail(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
+        } else if (email !== confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -90,19 +90,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        const email = val.email ?? state.personalInformation?.email;
-        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
-        if (typeof email !== 'string' || validator.isEmpty(email)) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(email)) {
+        } else if (!validator.isEmail(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(confirmEmail)) {
+        } else if (!validator.isEmail(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (email !== confirmEmail) {
+        } else if (val.email !== val.confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
@@ -203,7 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -217,7 +215,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
         </div>
       ),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -90,15 +90,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+        const email = val.email ?? state.personalInformation?.email;
+        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
+        if (typeof email !== 'string' || validator.isEmpty(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(val.email)) {
+        } else if (!validator.isEmail(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
+        } else if (!validator.isEmail(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
         } else if (val.email !== val.confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-match'), path: ['confirmEmail'] });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -90,19 +90,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        const email = val.email ?? state.personalInformation?.email;
-        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
-        if (typeof email !== 'string' || validator.isEmpty(email)) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(email)) {
+        } else if (!validator.isEmail(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(confirmEmail)) {
+        } else if (!validator.isEmail(val.confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (email !== confirmEmail) {
+        } else if (val.email !== val.confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
@@ -203,7 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
           <InputField
             id="confirm-email"
@@ -217,7 +215,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             autoComplete="email"
             defaultValue={defaultState.email ?? ''}
             required
-            disabled={isReadOnlyEmail}
+            readOnly={isReadOnlyEmail}
           />
         </div>
       ),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -90,17 +90,19 @@ export async function action({ context: { session }, params, request }: ActionFu
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+        const email = val.email ?? state.personalInformation?.email;
+        const confirmEmail = val.confirmEmail ?? state.personalInformation?.email;
+        if (typeof email !== 'string' || validator.isEmpty(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(val.email)) {
+        } else if (!validator.isEmail(email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+        if (typeof confirmEmail !== 'string' || validator.isEmpty(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
+        } else if (!validator.isEmail(confirmEmail)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
+        } else if (email !== confirmEmail) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
         }
       }


### PR DESCRIPTION
### Description
When the email is pre-populated from the previous page, the validation error still gets triggered
Updated the validation logic for email field to check if the field is pre-populated

### Related Azure Boards Work Items
[AB#3571](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3571)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`