### PR TITLE
3581 conditionally render confirmEmail

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/communication-preference.tsx
@@ -96,12 +96,14 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+        if (!state.personalInformation?.email) {
+          if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          } else if (!validator.isEmail(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
+          } else if (val.email !== val.confirmEmail) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+          }
         }
       }
     }) satisfies z.ZodType<CommunicationPreferencesState>;
@@ -203,20 +205,21 @@ export default function ApplyFlowCommunicationPreferencePage() {
             required
             readOnly={isReadOnlyEmail}
           />
-          <InputField
-            id="confirm-email"
-            type="email"
-            inputMode="email"
-            className="w-full"
-            label={t('apply-adult-child:communication-preference.confirm-email')}
-            maxLength={100}
-            name="confirmEmail"
-            errorMessage={errorMessages['confirm-email']}
-            autoComplete="email"
-            defaultValue={defaultState.email ?? ''}
-            required
-            readOnly={isReadOnlyEmail}
-          />
+          {!isReadOnlyEmail && (
+            <InputField
+              id="confirm-email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              label={t('apply-adult-child:communication-preference.confirm-email')}
+              maxLength={100}
+              name="confirmEmail"
+              errorMessage={errorMessages['confirm-email']}
+              autoComplete="email"
+              defaultValue={defaultState.email ?? ''}
+              required
+            />
+          )}
         </div>
       ),
       onChange: handleOnPreferredMethodChecked,

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/communication-preference.tsx
@@ -96,12 +96,14 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+        if (!state.personalInformation?.email) {
+          if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          } else if (!validator.isEmail(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
+          } else if (val.email !== val.confirmEmail) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+          }
         }
       }
     }) satisfies z.ZodType<CommunicationPreferencesState>;
@@ -203,20 +205,21 @@ export default function ApplyFlowCommunicationPreferencePage() {
             required
             readOnly={isReadOnlyEmail}
           />
-          <InputField
-            id="confirm-email"
-            type="email"
-            inputMode="email"
-            className="w-full"
-            label={t('apply-adult:communication-preference.confirm-email')}
-            maxLength={100}
-            name="confirmEmail"
-            errorMessage={errorMessages['confirm-email']}
-            autoComplete="email"
-            defaultValue={defaultState.email ?? ''}
-            required
-            readOnly={isReadOnlyEmail}
-          />
+          {!isReadOnlyEmail && (
+            <InputField
+              id="confirm-email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              label={t('apply-adult:communication-preference.confirm-email')}
+              maxLength={100}
+              name="confirmEmail"
+              errorMessage={errorMessages['confirm-email']}
+              autoComplete="email"
+              defaultValue={defaultState.email ?? ''}
+              required
+            />
+          )}
         </div>
       ),
       onChange: handleOnPreferredMethodChecked,

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -96,12 +96,14 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['email'] });
         }
 
-        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-        } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
-        } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+        if (!state.personalInformation?.email) {
+          if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          } else if (!validator.isEmail(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-valid'), path: ['confirmEmail'] });
+          } else if (val.email !== val.confirmEmail) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+          }
         }
       }
     }) satisfies z.ZodType<CommunicationPreferencesState>;
@@ -203,20 +205,21 @@ export default function ApplyFlowCommunicationPreferencePage() {
             required
             readOnly={isReadOnlyEmail}
           />
-          <InputField
-            id="confirm-email"
-            type="email"
-            inputMode="email"
-            className="w-full"
-            label={t('apply-child:communication-preference.confirm-email')}
-            maxLength={100}
-            name="confirmEmail"
-            errorMessage={errorMessages['confirm-email']}
-            autoComplete="email"
-            defaultValue={defaultState.email ?? ''}
-            required
-            readOnly={isReadOnlyEmail}
-          />
+          {!isReadOnlyEmail && (
+            <InputField
+              id="confirm-email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              label={t('apply-child:communication-preference.confirm-email')}
+              maxLength={100}
+              name="confirmEmail"
+              errorMessage={errorMessages['confirm-email']}
+              autoComplete="email"
+              defaultValue={defaultState.email ?? ''}
+              required
+            />
+          )}
         </div>
       ),
       onChange: handleOnPreferredMethodChecked,


### PR DESCRIPTION
### Description
The email field on `/communication-preference` should be read-only and the confirmEmail field should be hidden if the applicant has filled out their email on the preceding page `/personal-information`. 

### Related Azure Boards Work Items
[AB#3581](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3581)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/44a39661-9c18-40b8-8082-9c956ab425b2)