### PR TITLE
3599 New screen for when a child's age is over 18

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -407,6 +407,14 @@
                           "en": "/:lang/apply/:id/adult-child/contact-apply-child",
                           "fr": "/:lang/demander/:id/adulte-enfant/contact-demande-enfant"
                         }
+                      },
+                      {
+                        "id": "$lang+/_public+/apply+/$id+/adult-child/ineligible",
+                        "file": "routes/$lang+/_public+/apply+/$id+/adult-child/ineligible.tsx",
+                        "paths": {
+                          "en": "/:lang/apply/:id/adult-child/ineligible",
+                          "fr": "/:lang/demander/:id/adult-child/ineligible"
+                        }
                       }
                     ]
                   },

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/ineligible.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/ineligible.tsx
@@ -1,0 +1,99 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Trans, useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { InlineLink } from '~/components/inline-link';
+import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { getAgeCategoryFromDateString } from '~/route-helpers/apply-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.ineligible,
+  pageTitleI18nKey: 'apply-adult-child:ineligible.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:ineligible.page-title') }) };
+
+  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+
+  // TODO validate age and properly
+  if (ageCategory !== 'children') {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/date-of-birth', params));
+  }
+
+  return json({ id: state.id, csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/ineligible');
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  // TODO update redirect with correct path
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/tax-filing', params));
+}
+
+export default function ApplyFlowInelgible() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <>
+      <div className="mb-8 space-y-4">
+        <p>{t('apply-adult-child:ineligible.currently-ineligible')}</p>
+        <p>{t('apply-adult-child:ineligible.accepting-applications')}</p>
+        <p>{t('apply-adult-child:ineligible.adults-dtc')}</p>
+        <p>
+          <Trans
+            ns={handle.i18nNamespaces}
+            i18nKey="apply-adult-child:ineligible.find-out-when"
+            components={{ findOutWhen: <InlineLink to={t('apply-adult-child:ineligible.find-out-when-link')} className="external-link font-lato font-semibold" newTabIndicator target="_blank" /> }}
+          />
+        </p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Parent or guardian needs to apply click">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply-adult-child:ineligible.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Parent or guardian needs to apply click">
+          {t('apply-adult-child:ineligible.continue-btn')}
+          {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
+        </Button>
+      </fetcher.Form>
+    </>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -85,7 +85,8 @@
         "parentOrGuardian": "CDCP-APPL-ADCH-0019",
         "livingIndependently": "CDCP-APPL-ADCH-0020",
         "childSummary": "CDCP-APPL-ADCH-0021",
-        "contactapplychild": "CDCP-APPL-0022"
+        "contactapplychild": "CDCP-APPL-0022",
+        "ineligible": "CDCP-APPL-ADCH-0023"
       },
       "child": {
         "taxFiling": "CDCP-APPL-CH-0002",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -457,6 +457,16 @@
     "back-btn": "Back",
     "continue-btn": "Continue"
   },
+  "ineligible": {
+    "page-title": "You cannot apply for your child",
+    "currently-ineligible": "Your child is not currently eligible for the Canadian Dental Care Plan.",
+    "accepting-applications": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+    "adults-dtc": "Adults 18 to 64 who do not have a disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025",
+    "find-out-when": "<findOutWhen>Find out when you can apply for the Canadian Dental Care Plan</findOutWhen>",
+    "find-out-when-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+    "back-btn": "Back",
+    "continue-btn": "Proceed to apply for yourself"
+  },
   "parent-or-guardian": {
     "page-title": "Parent or guardian needs to apply",
     "unable-to-apply": "You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or legal guardian apply on your behalf.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -454,6 +454,16 @@
     "back-btn": "Retour",
     "continue-btn": "Continuer"
   },
+  "ineligible": {
+    "page-title": "(FR) You cannot apply for your child",
+    "currently-ineligible": "(FR) Your child is not currently eligible for the Canadian Dental Care Plan.",
+    "accepting-applications": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+    "adults-dtc": "(FR) Adults 18 to 64 who do not have a disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025",
+    "find-out-when": "<findOutWhen>(FR) Find out when you can apply for the Canadian Dental Care Plan</findOutWhen>",
+    "find-out-when-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
+    "back-btn": "Retour",
+    "continue-btn": "(FR) Proceed to apply for yourself"
+  },
   "parent-or-guardian": {
     "page-title": "(FR) Parent or guardian needs to apply",
     "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or legal guardian apply on your behalf.",


### PR DESCRIPTION
### Description
Add screen B.10.

Note: the logic for this screen hasn't been implemented.  This PR just addresses the scaffolding.

### Related Azure Boards Work Items
[AB#3599](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3599)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`