### PR TITLE
AB#3600 -- Updated routes for adult-child apply-yourself page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
@@ -68,7 +68,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   if (ageCategory === 'children') {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/contact-apply-child', params));
   } else if (ageCategory === 'youth') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/living-independently', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/living-independently', params));
   } else if (ageCategory === 'adults') {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/disability-tax-credit', params));
   } else {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
@@ -96,15 +96,15 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-children', params));
   }
 
-  if (parsedDataResult.data === DisabilityTaxCreditOption.Yes && state.allChildrenUnder18) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
+  if (parsedDataResult.data === DisabilityTaxCreditOption.No) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
   }
 
-  if (parsedDataResult.data === DisabilityTaxCreditOption.Yes) {
+  if (!state.allChildrenUnder18) {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-yourself', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
 }
 
 export default function ApplyFlowDisabilityTaxCredit() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit.tsx
@@ -96,11 +96,15 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-children', params));
   }
 
-  if (parsedDataResult.data === DisabilityTaxCreditOption.No) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
+  if (parsedDataResult.data === DisabilityTaxCreditOption.Yes && state.allChildrenUnder18) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
+  if (parsedDataResult.data === DisabilityTaxCreditOption.Yes) {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/apply-yourself', params));
+  }
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
 }
 
 export default function ApplyFlowDisabilityTaxCredit() {


### PR DESCRIPTION
### Description
Updated routes for adult-child apply-yourself page (Issue with /adult-child/apply-yourself  - Redirect to proper screen)

### Related Azure Boards Work Items
[AB#3600](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3600)

### Screenshots (if applicable)
n/a

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Confirm figma flow on DTC page with all children over/under 18 options selected.

### Additional Notes
n/a