### PR TITLE
Add `user` and `user_attribute` tables

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserAttributeEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserAttributeEntity.java
@@ -1,0 +1,66 @@
+package ca.gov.dtsstn.cdcp.api.data.entity;
+
+import java.time.Instant;
+
+import org.immutables.builder.Builder;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+@Entity(name = "UserAttribute")
+@SuppressWarnings({ "serial" })
+public class UserAttributeEntity extends AbstractEntity {
+
+	@Column(length = 256, nullable = false, updatable = false)
+	private String name;
+
+	@Column(length = 2048, nullable = true)
+	private String value;
+
+	public UserAttributeEntity() {
+		super();
+	}
+
+	@Builder.Constructor
+	public UserAttributeEntity(
+			@Nullable String id,
+			@Nullable String name,
+			@Nullable String value,
+			@Nullable String createdBy,
+			@Nullable Instant createdDate,
+			@Nullable String lastModifiedBy,
+			@Nullable Instant lastModifiedDate,
+			@Nullable Boolean isNew) {
+		super(id, createdBy, createdDate, lastModifiedBy, lastModifiedDate, isNew);
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+			.append("super", super.toString())
+			.append("name", name)
+			.append("value", value)
+			.toString();
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
@@ -1,0 +1,91 @@
+package ca.gov.dtsstn.cdcp.api.data.entity;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.immutables.builder.Builder;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.Nullable;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+
+@Entity(name = "User")
+@SuppressWarnings({ "serial" })
+public class UserEntity extends AbstractEntity {
+
+	@Column(length = 256, nullable = true)
+	private String email;
+
+	@Column(nullable = true)
+	private Boolean emailVerified;
+
+	@JoinColumn(name = "userId", nullable = false)
+	@OneToMany(cascade = { CascadeType.ALL }, orphanRemoval = true)
+	private Set<UserAttributeEntity> userAttributes = new HashSet<>();
+
+	public UserEntity() {
+		super();
+	}
+
+	@Builder.Constructor
+	public UserEntity(
+			@Nullable String id,
+			@Nullable String email,
+			@Nullable Boolean emailVerified,
+			@Nullable Iterable<UserAttributeEntity> userAttributes,
+			@Nullable String createdBy,
+			@Nullable Instant createdDate,
+			@Nullable String lastModifiedBy,
+			@Nullable Instant lastModifiedDate,
+			@Nullable Boolean isNew) {
+		super(id, createdBy, createdDate, lastModifiedBy, lastModifiedDate, isNew);
+		this.email = email;
+		this.emailVerified = emailVerified;
+
+		if (userAttributes != null) {
+			this.userAttributes = StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
+		}
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public Boolean getEmailVerified() {
+		return emailVerified;
+	}
+
+	public void setEmailVerified(Boolean emailVerified) {
+		this.emailVerified = emailVerified;
+	}
+
+	public Set<UserAttributeEntity> getUserAttributes() {
+		return userAttributes;
+	}
+
+	public void setUserAttributes(Iterable<UserAttributeEntity> userAttributes) {
+		this.userAttributes = StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+			.append("super", super.toString())
+			.append("email", email)
+			.append("emailVerified", emailVerified)
+			.append("userAttributes", userAttributes)
+			.toString();
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/UserRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/UserRepository.java
@@ -1,0 +1,29 @@
+package ca.gov.dtsstn.cdcp.api.data.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.UserEntity;
+
+public interface UserRepository extends JpaRepository<UserEntity, String> {
+
+	List<UserEntity> findByEmail(String email);
+
+	@Query("""
+		SELECT user FROM User user JOIN FETCH user.userAttributes userAttribute
+		 WHERE userAttribute.name=:name
+		   AND userAttribute.value=:value
+	""")
+	List<UserEntity> findByUserAttributeValue(String name, String value);
+
+	default Optional<UserEntity> findByRaoidcUserId(String raoidcUserId) {
+		final var users = findByUserAttributeValue("RAOIDC_USER_ID", raoidcUserId);
+		if (users.size() > 1) { throw new IncorrectResultSizeDataAccessException("findByRaoidcUserId() returned more than one result", 1); }
+		return users.stream().findFirst();
+	}
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -43,6 +43,7 @@ spring:
     open-in-view: false
     properties:
       '[hibernate.batch_versioned_data]': true
+      '[hibernate.globally_quoted_identifiers]': true
       '[hibernate.jdbc.batch_size]': 100
       '[hibernate.order_inserts]': true
       '[hibernate.order_updates]': true

--- a/backend/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
+++ b/backend/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
@@ -1,33 +1,83 @@
-CREATE TABLE alert_type (
-	id VARCHAR(64) NOT NULL,
+CREATE TABLE `user` (
+	`id` VARCHAR(64) NOT NULL,
 
-	code VARCHAR(64) NOT NULL,
-	description VARCHAR(256),
-
-	-- audit fields
-	created_by VARCHAR(64) NOT NULL,
-	created_date TIMESTAMP NOT NULL,
-	last_modified_by VARCHAR(64),
-	last_modified_date TIMESTAMP,
-
-	CONSTRAINT pk_status_code PRIMARY KEY (id)
-);
-
-CREATE TABLE subscription (
-	id VARCHAR(64) NOT NULL,
-	user_id VARCHAR(9) NOT NULL,
-	email VARCHAR(50) NOT NULL,
-	registered BOOLEAN,
-	subscribed BOOLEAN,
-	preferred_language BIGINT,
-	alert_type_id VARCHAR(64) NOT NULL,
+	`email` VARCHAR(256),
+	`email_verified` BOOLEAN,
 
 	-- audit fields
-	created_by VARCHAR(64) NOT NULL,
-	created_date TIMESTAMP WITH TIME ZONE NOT NULL,
-	last_modified_by VARCHAR(64),
-	last_modified_date TIMESTAMP WITH TIME ZONE,
+	`created_by` VARCHAR(64) NOT NULL,
+	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
+	`last_modified_by` VARCHAR(64),
+	`last_modified_date` TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT pk_subscription PRIMARY KEY (id),
-	CONSTRAINT fk_subscription_alert_type FOREIGN KEY (alert_type_id) REFERENCES alert_type(id)
+	CONSTRAINT `pk_user` PRIMARY KEY (`id`)
 );
+
+CREATE INDEX `ix_user_email` ON `user` (`email`);
+
+
+create TABLE `user_attribute` (
+	`id` VARCHAR(64) NOT NULL,
+
+	`name` VARCHAR(256) NOT NULL,
+	`value` VARCHAR(2048),
+	`user_id` VARCHAR(64) NOT NULL,
+
+	-- audit fields
+	`created_by` VARCHAR(64) NOT NULL,
+	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
+	`last_modified_by` VARCHAR(64),
+	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+
+	CONSTRAINT `pk_user_attribute` PRIMARY KEY (`id`),
+	CONSTRAINT `fk_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+	CONSTRAINT `uq_user_attribute` UNIQUE (`name`, `user_id`)
+);
+
+CREATE INDEX `ix_user_attribute_user_id` on `user_attribute` (`user_id`);
+CREATE INDEX `ix_user_attribute_name_value` ON `user_attribute` (`name`, `value`);
+
+
+
+CREATE TABLE `alert_type` (
+	`id` VARCHAR(64) NOT NULL,
+
+	`code` VARCHAR(64) NOT NULL,
+	`description` VARCHAR(256),
+
+	-- audit fields
+	`created_by` VARCHAR(64) NOT NULL,
+	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
+	`last_modified_by` VARCHAR(64),
+	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+
+	CONSTRAINT `pk_alert_type` PRIMARY KEY (`id`)
+);
+
+CREATE INDEX `ix_alert_type_code` on `alert_type` (`code`);
+
+
+
+CREATE TABLE `subscription` (
+	`id` VARCHAR(64) NOT NULL,
+
+	`user_id` VARCHAR(9) NOT NULL,
+	`email` VARCHAR(50) NOT NULL,
+	`registered` BOOLEAN,
+	`subscribed` BOOLEAN,
+	`preferred_language` BIGINT,
+	`alert_type_id` VARCHAR(64) NOT NULL,
+
+	-- audit fields
+	`created_by` VARCHAR(64) NOT NULL,
+	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
+	`last_modified_by` VARCHAR(64),
+	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+
+	CONSTRAINT `pk_subscription` PRIMARY KEY (`id`),
+	CONSTRAINT `fk_subscription_alert_type` FOREIGN KEY (`alert_type_id`) REFERENCES `alert_type` (`id`)
+);
+
+CREATE INDEX `ix_subscription_alert_type_id` on `subscription` (`alert_type_id`);
+CREATE INDEX `ix_subscription_email` on `subscription` (`email`);
+CREATE INDEX `ix_subscription_user_id` on `subscription` (`user_id`);

--- a/backend/src/main/resources/db-migrations/h2/v0.1-[vendor]-data-init.sql
+++ b/backend/src/main/resources/db-migrations/h2/v0.1-[vendor]-data-init.sql
@@ -1,11 +1,22 @@
-INSERT INTO alert_type 
-	(id, code, description, created_by, created_date, last_modified_by, last_modified_date)
+INSERT INTO `user` (`id`, `email`, `email_verified`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`)
 VALUES
-	('cf185099-8a17-4086-a890-c456250822a3', 'cdcp', 'cdcp email alerts', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
-	('daf8b8d9-95f4-4f38-9ee3-17ac7826c1e7', 'ei', 'ei email alerts', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
+	('76c48130-e1d4-4c2f-8dd0-1c17f9bbb4f6', 'unverified@example.com', false, 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('f9f33652-0ebd-46bc-8d93-04cef538a689', 'verified@example.com', true, 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
 
-INSERT INTO subscription 
-	(id, user_id, email, registered, subscribed, preferred_language, alert_type_id, created_by, created_date, last_modified_by, last_modified_date)
+
+INSERT INTO `user_attribute` (`id`, `name`, `value`, `user_id`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`)
 VALUES
-	('a6ea4925-f813-493e-80ec-a5b90ca28b6c', '800011819', 'example@gmail.com', true, true, 1033, 'cf185099-8a17-4086-a890-c456250822a3', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
-	('d3419bcb-5e46-4678-831b-c9211d479429', '800011819', 'example@gmail.com', true, false, 1033, 'daf8b8d9-95f4-4f38-9ee3-17ac7826c1e7', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
+	('291e1ebb-8298-4c47-8903-87b2a57ccfd1', 'RAOIDC_USER_ID', 'b5336580-d93d-4da9-9e19-c2a5e098bd08', '76c48130-e1d4-4c2f-8dd0-1c17f9bbb4f6', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('7da43bfb-cb58-4ed2-8fea-436fda24020e', 'RAOIDC_USER_ID', 'd827416b-f808-4035-9ccc-7572f3297015', 'f9f33652-0ebd-46bc-8d93-04cef538a689', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
+
+
+INSERT INTO `alert_type` (`id`, `code`, `description`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`)
+VALUES
+	('cf185099-8a17-4086-a890-c456250822a3', 'cdcp', 'CDCP email alerts', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('daf8b8d9-95f4-4f38-9ee3-17ac7826c1e7', 'ei', 'EI email alerts', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
+
+
+INSERT INTO `subscription` (`id`, `user_id`, `email`, `registered`, `subscribed`, `preferred_language`, `alert_type_id`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`)
+VALUES
+	('a6ea4925-f813-493e-80ec-a5b90ca28b6c', '800011819', 'user0001@example.com', true, true, 1033, 'cf185099-8a17-4086-a890-c456250822a3', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('d3419bcb-5e46-4678-831b-c9211d479429', '800011819', 'user0002@example.com', true, false, 1033, 'daf8b8d9-95f4-4f38-9ee3-17ac7826c1e7', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/UserRepositoryIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/UserRepositoryIT.java
@@ -1,0 +1,64 @@
+package ca.gov.dtsstn.cdcp.api.data.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.test.context.ActiveProfiles;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserEntityBuilder;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class UserRepositoryIT {
+
+	@Autowired UserRepository userRepository;
+
+	@Test
+	@DisplayName("Test userRepository.findByEmail(..)")
+	void testFindByEmail() {
+		assertThat(userRepository.findByEmail("verified@example.com")).isNotEmpty();
+		assertThat(userRepository.findByEmail("unknown@example.com")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test userRepository.findByUserAttributeValue(..)")
+	void testFindByUserAttributeValue() {
+		assertThat(userRepository.findByUserAttributeValue("RAOIDC_USER_ID", "d827416b-f808-4035-9ccc-7572f3297015")).isNotEmpty();
+		assertThat(userRepository.findByUserAttributeValue("RAOIDC_USER_ID", null)).isEmpty();
+		assertThat(userRepository.findByUserAttributeValue("RAOIDC_USER_ID", "")).isEmpty();
+		assertThat(userRepository.findByUserAttributeValue("NON_EXISTENT", "d827416b-f808-4035-9ccc-7572f3297015")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test userRepository.findByRaoidcUserId(..)")
+	void testFindByRaoidcUserId() {
+		assertThat(userRepository.findByRaoidcUserId("d827416b-f808-4035-9ccc-7572f3297015")).isNotEmpty();
+
+		// create a new user with the same RAOIDC user id
+		userRepository.save(new UserEntityBuilder()
+			.userAttributes(List.of(new UserAttributeEntityBuilder()
+				.name("RAOIDC_USER_ID")
+				.value("d827416b-f808-4035-9ccc-7572f3297015")
+				.createdBy("JUnit Test")
+				.createdDate(Instant.now())
+				.build()))
+			.createdBy("JUnit Test")
+			.createdDate(Instant.now())
+			.build());
+
+		assertThrows(IncorrectResultSizeDataAccessException.class, () -> userRepository.findByRaoidcUserId("d827416b-f808-4035-9ccc-7572f3297015"));
+	}
+
+}


### PR DESCRIPTION
### Add `user` and `user_attribute` tables

This is the first PR of many that will progressively add a `user` entity to the API. Implementation will be broken into multiple PRs to keep the PRs small and managable.

### Related Azure Boards Work Items

- [AB#3371](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3371)
- [AB#3369](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3369) 

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
