### PR TITLE
AB#3643 -- Changed confirm exit button to display a modal popup

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/confirmation.tsx
@@ -11,6 +11,7 @@ import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { DescriptionListItem } from '~/components/description-list-item';
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { InlineLink } from '~/components/inline-link';
 import { useFeature } from '~/root';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
@@ -333,26 +334,47 @@ export default function ApplyFlowConfirm() {
           </dl>
         </div>
       </div>
-
-      <Button
-        className="mt-5 print:hidden"
-        size="lg"
-        variant="primary"
-        onClick={(event) => {
-          event.preventDefault();
-          window.print();
-        }}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Print a copy of your application bottom click"
-      >
-        {t('confirm.print-btn')}
-      </Button>
-
-      <fetcher.Form method="post" noValidate className="mt-5 flex flex-wrap items-center gap-3">
-        <input type="hidden" name="_csrf" value={csrfToken} />
-        <Button variant="primary" onClick={() => sessionStorage.removeItem('flow.state')} size="lg" className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Confirmation click">
-          {t('apply-adult:confirm.exit')}
+      <div className="my-6">
+        <Button
+          className="px-12 print:hidden"
+          size="lg"
+          variant="primary"
+          onClick={(event) => {
+            event.preventDefault();
+            window.print();
+          }}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Print a copy of your application bottom click"
+        >
+          {t('confirm.print-btn')}
         </Button>
-      </fetcher.Form>
+      </div>
+      <Dialog>
+        <DialogTrigger>
+          <button className="text-slate-700 underline outline-offset-4 hover:text-blue-700 focus:text-blue-700 print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Exit click">
+            {t('apply-adult:confirm.close-application')}
+          </button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('apply-adult:confirm.modal.header')}</DialogTitle>
+          </DialogHeader>
+          <p>{t('apply-adult:confirm.modal.info')}</p>
+          <p>{t('apply-adult:confirm.modal.are-you-sure')}</p>
+          <DialogFooter>
+            <DialogClose>
+              <Button id="confirm-modal-back" variant="default" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Back click">
+                {t('apply-adult:confirm.modal.back-btn')}
+              </Button>
+            </DialogClose>
+            <fetcher.Form method="post" noValidate>
+              <input type="hidden" name="_csrf" value={csrfToken} />
+              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => sessionStorage.removeItem('flow.state')} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Exit - Confirmation click">
+                {t('apply-adult:confirm.modal.close-btn')}
+              </Button>
+            </fetcher.Form>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -95,9 +95,16 @@
     "application-code": "Application code",
     "yes": "Yes",
     "no": "No",
-    "exit": "Exit",
+    "close-application": "Close application",
     "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html",
-    "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html"
+    "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",
+    "modal": {
+      "header": "Close application",
+      "info": "By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
+      "are-you-sure": "Are you sure you want to close the application?",
+      "back-btn": "Back",
+      "close-btn": "Close application"
+    }
   },
   "dental-benefits": {
     "title": "Access to other federal, provincial or territorial dental benefits",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -95,9 +95,16 @@
     "application-code": "Code de demande",
     "yes": "Oui",
     "no": "Non",
-    "exit": "Sortie",
+    "close-application": "(FR) Close application",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
-    "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
+    "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html",
+    "modal": {
+      "header": "(FR) Close application",
+      "info": "(FR) By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
+      "are-you-sure": "Are you sure you want to close the application?",
+      "back-btn": "(FR) Back",
+      "close-btn": "(FR) Close application"
+    }
   },
   "dental-benefits": {
     "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",


### PR DESCRIPTION
### Description
Changed confirm exit button to display a modal popup

-styled button as link
-added modal

### Related Azure Boards Work Items
[AB#3643](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3643)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/65557555-7ec5-49f9-885c-cb2437ed28df)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Click close application on the confirm page to view modal popup

### Additional Notes
n/a