### PR TITLE
add support for page heading interpolation

### DIFF
--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -16,7 +16,7 @@ import { SkipNavigationLinks } from '~/components/skip-navigation-links';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
+import { useI18nNamespaces, usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -27,12 +27,14 @@ export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 export function PublicLayout({ children }: PropsWithChildren) {
   const { t } = useTranslation(useI18nNamespaces());
   const pageTitleI18nKey = usePageTitleI18nKey();
+  const i18nOptions = usePageTitleI18nOptions();
+
   return (
     <>
       <PageHeader />
       <PageBreadcrumbs />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        {pageTitleI18nKey && <AppPageTitle>{t(pageTitleI18nKey)}</AppPageTitle>}
+        {pageTitleI18nKey && <AppPageTitle>{t(pageTitleI18nKey, i18nOptions)}</AppPageTitle>}
         {children}
         <PageDetails />
       </main>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/dental-insurance.tsx
@@ -42,9 +42,9 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const childName = state.information?.firstName ?? '<Child 1 name>';
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.dental-insurance.title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.dental-insurance.title', { childName }) }) };
 
-  return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode });
+  return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -133,6 +133,13 @@ export function usePageTitleI18nKey() {
     .reduce(coalesce);
 }
 
+export function usePageTitleI18nOptions() {
+  return useMatches()
+    .map(({ data }) => data as { i18nOptions?: { [key: string]: string } } | undefined)
+    .map((data) => data?.i18nOptions)
+    .reduce(coalesce);
+}
+
 export function findRouteById(id: string, routes: Array<Route> = []): Route | undefined {
   for (const route of routes) {
     const match = route.id === id ? route : findRouteById(id, route.children);


### PR DESCRIPTION
### Description
Some page headings in the `adult-child` and `child` flow require string interpolation in the i18n.  This PR addresses that.

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/4fcf98bf-74a3-40d4-b189-7de3859938be)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
