### PR TITLE
[gitops] enabling subscription and application history mocks in `dev`

### DIFF
--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -16,7 +16,7 @@ ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applic
 #
 # Global mock configuration
 #
-ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress
+ENABLED_MOCKS=cct,lookup,power-platform,raoidc,status-check,wsaddress,subscription,application-history
 
 #
 # Session/redis configuration


### PR DESCRIPTION
### Description
As per title.