### PR TITLE
AB#3664 Issues with /adult-child/contact-apply-child

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/contact-apply-child.tsx
@@ -88,7 +88,7 @@ export default function ApplyFlowContactApplyChild() {
       </div>
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Contact us to apply for child click">
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Contact us to apply for child click">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply-adult-child:contact-apply-child.back-btn')}
         </ButtonLink>

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -204,7 +204,7 @@
     "page-title": "Contact us to apply for your child",
     "contact-service-canada": "You must speak to a Service Canada representative if you are under 16 and applying for your child. Please contact Service Canada by calling <noWrap>1-833-537-4342</noWrap> or visit a <serviceCanadaOfficeLink>Service Canada Office</serviceCanadaOfficeLink>.",
     "serviceCanadaOfficeLink": "https://www.servicecanada.gc.ca/tbsc-fsco/sc-hme.jsp?lang=eng",
-    "parent-guardian": "You must have your parent or guardian apply on your behalf.",
+    "parent-guardian": "A parent or legal guardian needs to apply to enrol you to the Canadian Dental Care Plan.",
     "back-btn": "Back",
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -200,7 +200,7 @@
     "page-title": "(FR) Contact us to apply for your child",
     "contact-service-canada": "(FR) You must speak to a Service Canada representative if you are under 16 and applying for your child. Please contact Service Canada by calling <noWrap>1-833-537-4342</noWrap> or visit a <serviceCanadaOfficeLink>Service Canada Office</serviceCanadaOfficeLink>.",
     "serviceCanadaOfficeLink": "https://www.servicecanada.gc.ca/tbsc-fsco/sc-hme.jsp?lang=fra",
-    "parent-guardian": "(FR) You must have your parent or guardian apply on your behalf.",
+    "parent-guardian": "(FR) A parent or legal guardian needs to apply to enrol you to the Canadian Dental Care Plan.",
     "back-btn": "Retour",
     "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"


### PR DESCRIPTION
### Description
Update text to match Figma
Link for go back button should go back to adult-child/date-of-birth

### Related Azure Boards Work Items
[AB#3664](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3664)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`