### PR TITLE
AB#3665 Issues with /adult-child/living-independently

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/living-independently.tsx
@@ -79,11 +79,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data === LivingIndependentlyOption.Yes } });
 
-  if (parsedDataResult.data === LivingIndependentlyOption.Yes) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
-  }
-
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/parent-or-guardian', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/applicant-information', params));
 }
 
 export default function ApplyFlowLivingIndependently() {
@@ -152,7 +148,7 @@ export default function ApplyFlowLivingIndependently() {
               {t('apply-adult-child:living-independently.continue-btn')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
-            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Living independently click">
+            <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Living independently click">
               <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
               {t('apply-adult-child:living-independently.back-btn')}
             </ButtonLink>


### PR DESCRIPTION
### Description
Both 'yes' and 'no' option should go to Applicant information page. Back button should go to date-of-birth

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`