### PR TITLE
Adding "Myself" page for status checker in public

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -565,13 +565,41 @@
             ]
           },
           {
-            "id": "$lang+/_public+/status+/index",
-            "file": "routes/$lang+/_public+/status+/index.tsx",
-            "index": true,
+            "id": "$lang+/_public+/status+/_route",
+            "file": "routes/$lang+/_public+/status+/_route.tsx",
             "paths": {
               "en": "/:lang/status",
               "fr": "/:lang/statut"
-            }
+            },
+            "children": [
+              {
+                "id": "$lang+/_public+/status+/index",
+                "file": "routes/$lang+/_public+/status+/index.tsx",
+                "index": true,
+                "paths": {
+                  "en": "/:lang/status",
+                  "fr": "/:lang/statut"
+                }
+              },
+              {
+                "id": "$lang+/_public+/status+/myself+/_route",
+                "file": "routes/$lang+/_public+/status+/myself+/_route.tsx",
+                "paths": {
+                  "en": "/:lang/status",
+                  "fr": "/:lang/statut"
+                },
+                "children": [
+                  {
+                    "id": "$lang+/_public+/status+/myself+/index",
+                    "file": "routes/$lang+/_public+/status+/myself+/index.tsx",
+                    "paths": {
+                      "en": "/:lang/status/myself",
+                      "fr": "/:lang/statut/moi-meme"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           {
             "id": "$lang+/_public+/unable-to-process-request",

--- a/frontend/app/routes/$lang+/_public+/status+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/_route.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from '@remix-run/react';
+
+/**
+ * Do-nothing parent route.
+ * (placeholder for future code)
+ */
+export default function Route() {
+  return <Outlet />;
+}

--- a/frontend/app/routes/$lang+/_public+/status+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/index.tsx
@@ -57,7 +57,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const log = getLogger('status/index');
   const { ENABLED_FEATURES } = getEnv();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
-
+  const t = await getFixedT(request, handle.i18nNamespaces);
   const formData = await request.formData();
   const expectedCsrfToken = String(session.get('csrfToken'));
   const submittedCsrfToken = String(formData.get('_csrf'));
@@ -68,7 +68,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
   const checkForSchema = z.nativeEnum(CheckFor, {
     errorMap: () => {
-      return { message: 'Must select a value.' };
+      return { message: t('status:form.error-message.selection-required') };
     },
   });
   const statusCheckFor = formData.get('statusCheckFor');

--- a/frontend/app/routes/$lang+/_public+/status+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent } from 'react';
+import { FormEvent, useEffect, useMemo } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
@@ -8,14 +8,17 @@ import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
 
 import pageIds from '../../page-ids.json';
 import { Button } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
 import { InputRadios } from '~/components/input-radios';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { featureEnabled, getEnv } from '~/utils/env.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -31,7 +34,7 @@ enum CheckFor {
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
-  pageIdentifier: pageIds.public.status,
+  pageIdentifier: pageIds.public.status.index,
   pageTitleI18nKey: 'status:page-title',
 } as const satisfies RouteHandleData;
 
@@ -63,8 +66,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
     throw new Response('Invalid CSRF token', { status: 400 });
   }
-
+  const checkForSchema = z.nativeEnum(CheckFor, {
+    errorMap: () => {
+      return { message: 'Must select a value.' };
+    },
+  });
   const statusCheckFor = formData.get('statusCheckFor');
+  const parsedCheckFor = checkForSchema.safeParse(statusCheckFor);
+
+  if (!parsedCheckFor.success) {
+    return json({ errors: parsedCheckFor.error.format()._errors });
+  }
 
   const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
   if (hCaptchaEnabled) {
@@ -74,12 +86,11 @@ export async function action({ context: { session }, params, request }: ActionFu
     }
   }
 
-  if (statusCheckFor === CheckFor.Myself) {
-    //TODO: redirect to $lang+/_public+/status+/myself
-  } else if (statusCheckFor === CheckFor.Child) {
-    //TODO: redirect to $lang+/_public+/status+/child
+  if (parsedCheckFor.data === CheckFor.Myself) {
+    return redirect(getPathById('$lang+/_public+/status+/myself+/index', params));
   }
-  //Temporary retrun null until redirects are implemented.
+  // Child selected
+  //TODO: redirect to $lang+/_public+/status+/child
   return null;
 }
 
@@ -89,6 +100,27 @@ export default function StatusChecker() {
   const isSubmitting = fetcher.state !== 'idle';
   const { t } = useTranslation(handle.i18nNamespaces);
   const { captchaRef } = useHCaptcha();
+  const errorSummaryId = 'error-summary';
+
+  const errorMessages = useMemo(
+    () => ({
+      'input-radio-status-check-option-0': fetcher.data?.errors[0],
+    }),
+    [fetcher.data?.errors],
+  );
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (adobeAnalytics.isConfigured()) {
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorMessages]);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -166,26 +198,24 @@ export default function StatusChecker() {
             </p>
           </div>
         </Collapsible>
+        <p className="mb-4 italic">{t('status:form.complete-fields')}</p>
+        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
           <input type="hidden" name="_csrf" value={csrfToken} />
           {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
-          <p className="italic">{t('status:form.complete-fields')}</p>
           <fieldset>
             <InputRadios
               id="status-check-for"
               name="statusCheckFor"
-              legend={<Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.myself" />}
+              legend={<Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-legend" />}
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.myself" />,
                   value: CheckFor.Myself,
-                  defaultChecked: true,
-                  inputClassName: 'p-4 focus:bg-slate-700 active:bg-slate-700 checked:bg-slate-700 hover:ring-2',
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.child" />,
                   value: CheckFor.Child,
-                  inputClassName: 'p-4 focus:bg-slate-700 active:bg-slate-700 checked:bg-slate-700 hover:ring-2',
                 },
               ]}
               required

--- a/frontend/app/routes/$lang+/_public+/status+/myself+/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/myself+/_route.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from '@remix-run/react';
+
+/**
+ * Do-nothing parent route.
+ * (placeholder for future code)
+ */
+export default function Route() {
+  return <Outlet />;
+}

--- a/frontend/app/routes/$lang+/_public+/status+/myself+/index.tsx
+++ b/frontend/app/routes/$lang+/_public+/status+/myself+/index.tsx
@@ -1,0 +1,230 @@
+import { FormEvent, useEffect, useMemo } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { ContextualAlert } from '~/components/contextual-alert';
+import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { PublicLayout } from '~/components/layouts/public-layout';
+import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
+import { getApplicationStatusService } from '~/services/application-status-service.server';
+import { getLookupService } from '~/services/lookup-service.server';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+import { isValidApplicationCode } from '~/utils/application-code-utils';
+import { featureEnabled, getEnv } from '~/utils/env.server';
+import { useHCaptcha } from '~/utils/hcaptcha-utils';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { cn } from '~/utils/tw-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
+  pageIdentifier: pageIds.public.status.myself.index,
+  pageTitleI18nKey: 'status:myself.page-title',
+} as const satisfies RouteHandleData;
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  featureEnabled('status');
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+
+  const csrfToken = String(session.get('csrfToken'));
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('status:myself.page-title') }) };
+
+  return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  featureEnabled('status');
+  const log = getLogger('status/myself/index');
+  const { CLIENT_STATUS_SUCCESS_ID, ENABLED_FEATURES } = getEnv();
+  const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formDataSchema = z.object({
+    sin: z
+      .string({ required_error: t('status:myself.form.error-message.sin-required') })
+      .trim()
+      .min(1)
+      .refine(isValidSin, t('status:myself.form.error-message.sin-valid'))
+      .transform((sin) => formatSin(sin, '')),
+    code: z
+      .string({ required_error: t('status:myself.form.error-message.application-code-required') })
+      .trim()
+      .min(1)
+      .refine(isValidApplicationCode, t('status:myself.form.error-message.application-code-valid')),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = {
+    sin: formData.get('sin') ? String(formData.get('sin')) : undefined,
+    code: formData.get('code') ? String(formData.get('code')) : undefined,
+  };
+
+  const parsedDataResult = formDataSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({ errors: parsedDataResult.error.format() });
+  }
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  if (hCaptchaEnabled) {
+    const hCaptchaResponse = String(formData.get('h-captcha-response') ?? '');
+    if (!(await hCaptchaRouteHelpers.verifyHCaptchaResponse(hCaptchaResponse, request))) {
+      return redirect(getPathById('$lang+/_public+/unable-to-process-request', params));
+    }
+  }
+
+  const applicationStatusService = getApplicationStatusService();
+  const lookupService = getLookupService();
+  const { sin, code } = parsedDataResult.data;
+  const statusId = await applicationStatusService.getStatusId({ sin, applicationCode: code });
+  const clientStatusList = await lookupService.getAllClientFriendlyStatuses();
+  const clientFriendlyStatus = clientStatusList.find((status) => status.id === statusId);
+
+  function getAlertType() {
+    if (!statusId) return 'danger';
+    if (clientFriendlyStatus?.id === CLIENT_STATUS_SUCCESS_ID) return 'success';
+    return 'info';
+  }
+
+  return json({
+    status: {
+      ...(clientFriendlyStatus ?? {}),
+      alertType: getAlertType(),
+    },
+    statusId,
+  } as const);
+}
+
+export default function StatusCheckerMyself() {
+  const { csrfToken, hCaptchaEnabled, siteKey } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { captchaRef } = useHCaptcha();
+  const params = useParams();
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch (error) {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  const errorSummaryId = 'error-summary';
+
+  const errorMessages = useMemo(() => {
+    const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+    return {
+      code: errors?.code?._errors[0],
+      sin: errors?.sin?._errors[0],
+    };
+  }, [fetcher.data]);
+
+  const errorSummaryItems = createErrorSummaryItems(errorMessages);
+
+  useEffect(() => {
+    if (hasErrors(errorMessages)) {
+      scrollAndFocusToErrorSummary(errorSummaryId);
+
+      if (hasErrors(errorMessages) && adobeAnalytics.isConfigured()) {
+        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
+        adobeAnalytics.pushValidationErrorEvent(fieldIds);
+      }
+    }
+  }, [errorMessages]);
+
+  useEffect(() => {
+    if (fetcher.data && 'status' in fetcher.data) {
+      const targetElement = document.getElementById('status');
+      if (targetElement) {
+        targetElement.scrollIntoView({ behavior: 'smooth' });
+        targetElement.focus();
+      }
+    }
+  }, [fetcher.data]);
+
+  return (
+    <PublicLayout>
+      <div className="max-w-prose">
+        {fetcher.data && 'status' in fetcher.data ? (
+          <>
+            <ContextualAlert type={fetcher.data.status.alertType}>
+              <div>
+                <h2 className="mb-2 font-bold" tabIndex={-1} id="status">
+                  {t('status:myself.status-heading')}
+                </h2>
+                {fetcher.data.status.id ? getNameByLanguage(i18n.language, fetcher.data.status) : t('status:myself.empty-status')}
+              </div>
+            </ContextualAlert>
+            <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang+/_public+/status+/index" params={params} className="mt-12">
+              {t('status:myself.check-another')}
+              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+            </ButtonLink>
+          </>
+        ) : (
+          <>
+            <p className="mb-4 italic">{t('status:myself.form.complete-fields')}</p>
+            {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+            <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+              <input type="hidden" name="_csrf" value={csrfToken} />
+              {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+              <div className="mb-8 space-y-6">
+                <InputField
+                  id="code"
+                  name="code"
+                  label={t('status:myself.form.application-code-label')}
+                  helpMessagePrimary={t('status:myself.form.application-code-description')}
+                  placeholder={t('status:myself.form.application-code-placeholder')}
+                  required
+                  errorMessage={errorMessages.code}
+                />
+                <InputField id="sin" name="sin" label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errorMessages.sin} />
+              </div>
+              <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit">
+                {t('status:myself.form.submit')}
+                <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+              </Button>
+            </fetcher.Form>
+          </>
+        )}
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/app/routes/$lang+/page-ids.json
+++ b/frontend/app/routes/$lang+/page-ids.json
@@ -104,7 +104,12 @@
         "confirmation": "CDCP-APPL-CH-0014"
       }
     },
-    "status": "CDCP-STAT-0001",
+    "status": {
+      "index": "CDCP-STAT-0001",
+      "myself": {
+        "index": "CDCP-STAT-0002"
+      }
+    },
     "unableToProcessRequest": "CDCP-UNAB-0001",
     "notFound": "CDCP-ERR-0404"
   }

--- a/frontend/public/locales/en/status.json
+++ b/frontend/public/locales/en/status.json
@@ -58,7 +58,7 @@
     "continue": "Continue",
     "submit": "Check status",
     "error-message": {
-      "selection-required":"(FR) Select an option."
+      "selection-required": "(FR) Select an option."
     }
   },
   "myself": {

--- a/frontend/public/locales/en/status.json
+++ b/frontend/public/locales/en/status.json
@@ -63,5 +63,26 @@
       "application-code-required": "The application code or client number is required",
       "application-code-valid": "The application code or client number must be valid"
     }
+  },
+  "myself": {
+    "page-title": "Status Checker",
+    "status-heading": "Status",
+    "empty-status": "The information you gave us doesn't match the information in our system.",
+    "check-another": "Check another status",
+    "form": {
+      "complete-fields": "Complete all fields.",
+      "application-code-label": "Application Code or Client Number",
+      "application-code-description": "Enter the number you received after applying online, or the number found in the upper right-hand corner from the letter you may have reveived from Service Canada",
+      "application-code-placeholder": "Your Application Code or Client Number",
+      "sin-label": "Social Insurance Number (SIN)",
+      "sin-description": "Enter the 9-digit SIN",
+      "submit": "Check status",
+      "error-message": {
+        "sin-required": "The Social Insurance Number (SIN) is required.",
+        "sin-valid": "The Social Insurance Number (SIN) must be valid.",
+        "application-code-required": "The application code or client number is required",
+        "application-code-valid": "The application code or client number must be valid"
+      }
+    }
   }
 }

--- a/frontend/public/locales/en/status.json
+++ b/frontend/public/locales/en/status.json
@@ -58,10 +58,7 @@
     "continue": "Continue",
     "submit": "Check status",
     "error-message": {
-      "sin-required": "The Social Insurance Number (SIN) is required.",
-      "sin-valid": "The Social Insurance Number (SIN) must be valid.",
-      "application-code-required": "The application code or client number is required",
-      "application-code-valid": "The application code or client number must be valid"
+      "selection-required":"(FR) Select an option."
     }
   },
   "myself": {

--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -58,10 +58,7 @@
     "continue": "Continuer",
     "submit": "Vérifier l'état de votre demande",
     "error-message": {
-      "sin-required": "Le numéro d'assurance sociale (NAS) est requis.",
-      "sin-valid": "Le numéro d'assurance sociale (NAS) doit être valide.",
-      "application-code-required": "(FR) The application code or client number is required",
-      "application-code-valid": "(FR) The application code or client number must be valid"
+      "selection-required":"(FR) Select an option."
     }
   },
   "myself": {

--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -58,7 +58,7 @@
     "continue": "Continuer",
     "submit": "Vérifier l'état de votre demande",
     "error-message": {
-      "selection-required":"(FR) Select an option."
+      "selection-required": "(FR) Select an option."
     }
   },
   "myself": {

--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -63,5 +63,26 @@
       "application-code-required": "(FR) The application code or client number is required",
       "application-code-valid": "(FR) The application code or client number must be valid"
     }
+  },
+  "myself": {
+    "page-title": "Vérificateur de l'état d'une demande",
+    "status-heading": "Statut",
+    "empty-status": "Les informations que vous nous avez fournies ne correspondent pas aux informations dans notre système.",
+    "check-another": "Vérifier un autre état",
+    "form": {
+      "complete-fields": "Remplir tous les champs",
+      "application-code-label": "Code de demande ou numéro de client",
+      "application-code-description": "Entrez le numéro que vous avez reçu sur la page de confirmation de la demande en ligne ou le numéro figurant dans le coin supérieur droit de la lettre que vous avez peut-être reçue de Service Canada.",
+      "application-code-placeholder": "Code de demande ou numéro de client",
+      "sin-label": "Numéro d'assurance sociale (NAS)",
+      "sin-description": "Entrez un NAS de 9 chiffres",
+      "submit": "Vérifier l'état",
+      "error-message": {
+        "sin-required": "Le numéro d'assurance sociale (NAS) est requis.",
+        "sin-valid": "Le numéro d'assurance sociale (NAS) doit être valide.",
+        "application-code-required": "(FR) The application code or client number is required",
+        "application-code-valid": "(FR) The application code or client number must be valid"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description
Adding "Myself" page for status checker in public

### Related Azure Boards Work Items
[AB#3546](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3546)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Navigate to `http://localhost:3000/en/status`
- Select Myself
- Enter: 694913 and 903002863

### Additional Notes
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/77116011/763d2232-b924-41f6-bdf8-f31669dc95d7)
Should the hcaptcha references be removed in the myself page?