### PR TITLE
AB#3666 Issues with /adult-child/apply-yourself

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
@@ -86,9 +86,13 @@ export default function ApplyForYourself() {
   return (
     <div className="max-w-prose">
       <div className="mb-6 space-y-4">
+        <p>{t('apply-adult-child:eligibility.apply-yourself.ineligible-to-apply')}</p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-2025')}</p>
         <p>
-          {t('apply-adult-child:eligibility.apply-yourself.ineligible-to-apply')}&nbsp;
-          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.eligibility-info-href')}>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</InlineLink>
+          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.when-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank">
+            {t('apply-adult-child:eligibility.apply-yourself.when-to-apply')}
+          </InlineLink>
         </p>
         <p>{t('apply-adult-child:eligibility.apply-yourself.submit-application')}</p>
       </div>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/apply-yourself.tsx
@@ -10,7 +10,7 @@ import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
-import { getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -63,17 +63,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
-
-  if (ageCategory === 'children') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/contact-apply-child', params));
-  } else if (ageCategory === 'youth') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/living-independently', params));
-  } else if (ageCategory === 'adults') {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/disability-tax-credit', params));
-  } else {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
-  }
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
 }
 
 export default function ApplyForYourself() {

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -468,9 +468,11 @@
     },
     "apply-yourself": {
       "page-title": "Apply for yourself",
-      "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
-      "eligibility-info": "Find out when they can apply.",
-      "eligibility-info-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan.",
+      "eligibility-info": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+      "eligibility-2025": "Adults 18 to 64 who do not have a valid disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
+      "when-to-apply": "Find out when they can apply for the Canadian Dental Care Plan",
+      "when-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
       "submit-application": "You can still submit an application for yourself.",
       "back-btn": "Back",
       "proceed-btn": "Proceed to apply for yourself"

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -465,9 +465,11 @@
     },
     "apply-yourself": {
       "page-title": "(FR) Apply for yourself",
-      "ineligible-to-apply": "(FR) Your children are not currently eligible to apply for the Canadian Dental Care Plan. Only children under 18 are eligible at this time.",
-      "eligibility-info": "(FR) Find out when they can apply.",
-      "eligibility-info-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
+      "ineligible-to-apply": "(FR) Your children are not currently eligible to apply for the Canadian Dental Care Plan.",
+      "eligibility-info": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+      "eligibility-2025": "(FR) Adults 18 to 64 who do not have a valid disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
+      "when-to-apply": "(FR) Find out when they can apply for the Canadian Dental Care Plan",
+      "when-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
       "submit-application": "(FR) You can still submit an application for yourself.",
       "back-btn": "Retour",
       "proceed-btn": "(FR) Proceed to apply for yourself"


### PR DESCRIPTION
### Description
Update content for /adult-child/apply-yourself screen
This page will always go to adult/applicant-information regardless of age category

[AB#3666](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3666)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`