### PR TITLE
3672 update child summary (hub) screen

### DIFF
--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -29,7 +29,8 @@
   "children": {
     "index": {
       "page-title": "Summary of child(ren)",
-      "children-added": "The following child(ren) has been added to the application.",
+      "you-have-completed": "You have completed your application for the Canadian Dental Care Plan.",
+      "in-this-section": "In this section you will add your child(ren) to the application.",
       "dob-title": "Date of birth",
       "dob-change": "Change date of birth",
       "sin-title": "Social Insurance Number (SIN)",
@@ -40,7 +41,15 @@
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",
-      "save-btn": "Save"
+      "save-btn": "Save",
+      "dental-insurance-title": "Access to other dental insurance or coverage",
+      "dental-insurance-change": "Change answer to dental insurance",
+      "dental-benefit-title": "Access to government dental benefit",
+      "dental-benefit-change": "Change answer to public dental benefits",
+      "dental-benefit-has-access": "Has access to the following benefits:",
+      "dental-benefit-has-no-access": "Has access to the following benefits:",
+      "yes": "Yes",
+      "no": "No"
     },
     "information": {
       "page-title": "Child 1: information",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -29,7 +29,8 @@
   "children": {
     "index": {
       "page-title": "(FR) Summary of child(ren)",
-      "children-added": "(FR) The following child(ren) has been added to the application.",
+      "you-have-completed": "(FR) You have completed your application for the Canadian Dental Care Plan.",
+      "in-this-section": "(FR) In this section you will add your child(ren) to the application.",
       "dob-title": "(FR) Date of birth",
       "dob-change": "(FR) Change date of birth",
       "sin-title": "(FR) Social Insurance Number (SIN)",
@@ -39,7 +40,15 @@
       "remove-child": "(FR) Back",
       "continue-btn": "(FR) Continue with application",
       "cancel-btn": "(FR) Cancel",
-      "save-btn": "(FR) Save"
+      "save-btn": "(FR) Save",
+      "dental-insurance-title": "(FR) Access to other dental insurance or coverage",
+      "dental-insurance-change": "(FR) Change answer to dental insurance",
+      "dental-benefit-title": "(FR) Access to government dental benefit",
+      "dental-benefit-change": "(FR) Change answer to public dental benefits",
+      "dental-benefit-has-access": "(FR) Has access to the following benefits:",
+      "dental-benefit-has-no-access": "(FR) Has access to the following benefits:",
+      "yes": "(FR) Yes",
+      "no": "(FR) No"
     },
     "information": {
       "page-title": "(FR) Child 1: information",


### PR DESCRIPTION
### Description
Update the 'add/edit/remove children hub' in the adult-child flow.  This PR adds the ability to remove children from state and adds the remaining detail fields that should be displayed to applicants.

There are some outstanding TODOs that will have to be addressed in future PRs: make the 'remove child' button open a modal instead of just removing a child, handle editing state correctly, translations, etc.

### Related Azure Boards Work Items
[AB#3672](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3672)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/361bfcf0-d6fa-48de-9f86-8ab5f6154d37)
