### PR TITLE
AB#3668 Issues with /adult-child/applicant-information

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
@@ -17,7 +17,7 @@ import { InputField } from '~/components/input-field';
 import { InputRadios } from '~/components/input-radios';
 import { Progress } from '~/components/progress';
 import { applicantInformationStateHasPartner, loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
-import { ApplicantInformationState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { ApplicantInformationState, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -54,7 +54,9 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:applicant-information.page-title') }) };
 
-  return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, editMode: state.editMode });
+  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth ?? '');
+
+  return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, ageCategory, editMode: state.editMode });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
@@ -141,11 +143,23 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowApplicationInformation() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
+  const { ageCategory, csrfToken, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errorSummaryId = 'error-summary';
+
+  function getBackButtonRouteId() {
+    if (ageCategory === 'adults') {
+      return '$lang+/_public+/apply+/$id+/adult-child/disability-tax-credit';
+    }
+
+    if (ageCategory === 'youth') {
+      return '$lang+/_public+/apply+/$id+/adult-child/living-independently';
+    }
+
+    return '$lang+/_public+/apply+/$id+/adult-child/date-of-birth';
+  }
 
   // Keys order should match the input IDs order.
   const errorMessages = useMemo(
@@ -251,7 +265,7 @@ export default function ApplyFlowApplicationInformation() {
                 {t('apply-adult-child:applicant-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
+              <ButtonLink id="back-button" routeId={getBackButtonRouteId()} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant Information click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply-adult-child:applicant-information.back-btn')}
               </ButtonLink>


### PR DESCRIPTION
### Description
The back button on /adult-child/applicant-information should **NOT** always go back to date-of-birth screen, it should go back the the correct screen based on the age category

IF 65+ GOTO /adult-child/date-of-birth
IF 18-64 GOTO /adult-child/disability-tax-credit
IF 16-17 GOTO /adult-child/living-independently

### Related Azure Boards Work Items
AB#3668

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`