### PR TITLE
3699 Bug with /adult/partner-information

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/partner-information.tsx
@@ -95,12 +95,12 @@ export async function action({ context: { session }, params, request }: ActionFu
         .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.applicantInformation?.socialInsuranceNumber, t('apply-adult-child:partner-information.error-message.sin-unique'))
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:partner-information.error-message.sin-valid'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:partner-information.error-message.sin-valid') });
             return z.NEVER;
           }
 
           if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:partner-information.error-message.sin-unique'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:partner-information.error-message.sin-unique') });
             return z.NEVER;
           }
         }),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult/partner-information.tsx
@@ -95,12 +95,12 @@ export async function action({ context: { session }, params, request }: ActionFu
         .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.applicantInformation?.socialInsuranceNumber, t('apply-adult:partner-information.error-message.sin-unique'))
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-valid'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-valid') });
             return z.NEVER;
           }
 
           if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-unique'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-unique') });
             return z.NEVER;
           }
         }),

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/partner-information.tsx
@@ -95,12 +95,12 @@ export async function action({ context: { session }, params, request }: ActionFu
         .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.applicantInformation?.socialInsuranceNumber, t('apply-child:partner-information.error-message.sin-unique'))
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:partner-information.error-message.sin-valid'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:partner-information.error-message.sin-valid') });
             return z.NEVER;
           }
 
           if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:partner-information.error-message.sin-unique'), fatal: true });
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:partner-information.error-message.sin-unique') });
             return z.NEVER;
           }
         }),


### PR DESCRIPTION
### Description
Returning `fatal: true` in the zod `ctz.addIssue` causes the validation to abort early.  The SIN check is done before validating the date, which is why this "bug" happens.  By removing `fatal: true`, the validation can continue on to the date check in the `superRefine`, and everything should work as expected.

### Related Azure Boards Work Items
[AB#3699](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3699)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/7eab956c-4e29-4d4a-93bd-78d37307417c)
