### PR TITLE
Cleanup of alerts --> manage and unsubscribe routes

### DIFF
--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -52,14 +52,14 @@
     "breadcrumbs": {
       "subscribe": "Unsubscribe from CDCP email alerts"
     },
-    "note": "If you unsubscribe from CDCP email alerts, you will no longer receive emails when important new CDCP information is available. Email address to be cancelled is: ",
+    "note": "If you unsubscribe from CDCP email alerts, you will no longer receive emails when important new CDCP information is available. Email address to be cancelled is: <strong>{{email}}</strong>",
     "agree": "I Agree",
     "button": {
       "unsubscribe": "Unsubscribe from CDCP email alerts",
       "cancel": "Cancel"
     },
     "error-message": {
-      "agree-required": "Check \"I Agree\" piror to select Unsubscribe from CDCP email alerts."
+      "agree-required": "Check \"I Agree\" prior to selecting Unsubscribe from CDCP email alerts."
     }
   },
   "confirm": {
@@ -90,6 +90,6 @@
     "page-title": "Unsubscribe Confirmation",
     "unsubscribe-successful": "You have successfully unsubscribed from Canada Dental Care Plan. You will no longer receive emails when important new Canada Dental Care Plan information is available in your My Service Canada Account.",
     "subscribe-again": "You may subscribe again to Canada Dental Care Plan alerts by <subscribelink>completing the subscription process</subscribelink>.",
-    "return-home": "Return <homeLink>Home</homeLink>"
+    "return-dashboard": "Return to dashboard"
   }
 }

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -52,14 +52,14 @@
     "breadcrumbs": {
       "subscribe": "(FR) Unsubscribe from CDCP email alerts"
     },
-    "note": "(FR) If you unsubscribe from CDCP email alerts, you will no longer receive emails when important new CDCP information is available. Email address to be cancelled is: ",
+    "note": "(FR) If you unsubscribe from CDCP email alerts, you will no longer receive emails when important new CDCP information is available. Email address to be cancelled is: <strong>{{email}}</strong>",
     "agree": "(FR) I Agree",
     "button": {
       "unsubscribe": "(FR) Unsubscribe from CDCP email alerts",
       "cancel": "Annuler"
     },
     "error-message": {
-      "agree-required": "(FR) Check \"I Agree\" piror to select Unsubscribe from CDCP email alerts."
+      "agree-required": "(FR) Check \"I Agree\" prior to selecting Unsubscribe from CDCP email alerts."
     }
   },
   "confirm": {
@@ -88,6 +88,6 @@
     "page-title": "(FR) Unsubscribe Confirmation",
     "unsubscribe-successful": "(FR) You have successfully unsubscribed from Canada Dental Care Plan. You will no longer receive emails when important new Canada Dental Care Plan information is available in your My Service Canada Account.",
     "subscribe-again": "(FR) You may subscribe again to Canada Dental Care Plan alerts by <subscribelink>completing the subscription process</subscribelink>.",
-    "return-home": "(FR) Return <homeLink>Home</homeLink>"
+    "return-dashboard": "(FR) Return to dashboard"
   }
 }


### PR DESCRIPTION
### Description
Changes to `/alerts/manage` and `/alerts/unsubscribe` routes include:
- Adding auditing and instrumentation where missing
- Failing early if `sin` does not exist in `userInfoToken`
- Remove defaulting to empty string where originally existed
- Minor text and flow changes

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and navigate to `/en/alerts/manage`. Click the Unsubscribe link at the bottom. Ensure that nothing is broken.

### Additional notes
Will attempt `/alerts/subscribe` routes in a future PR.