### PR TITLE
[gitops] Set frontend rolling update strategy

### DIFF
--- a/gitops/base/frontend/deployments.yaml
+++ b/gitops/base/frontend/deployments.yaml
@@ -42,3 +42,7 @@ spec:
       volumes:
         - name: audit-logs
           emptyDir: {}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0%
+      maxSurge: 100%


### PR DESCRIPTION
During the rollout of v1.2.0 today I noticed that some of the assets returned a 404 while the new pods were spinning up. Setting the rolling update strategy `maxUnavailable: 0%, maxSurge: 100%` should fix this by requiring that all the new pods are live before routing traffic to them.