### PR TITLE
Add 'Cannot apply for child' screen for adult-child flow

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -281,7 +281,15 @@
                                 "file": "routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/parent-or-guardian.tsx",
                                 "paths": {
                                   "en": "/:lang/apply/:id/adult-child/children/:childId/parent-or-guardian",
-                                  "fr": "/:lang/demander/:id/adulte-enfant/children/:childId/parent-or-guardian"
+                                  "fr": "/:lang/demander/:id/adulte-enfant/enfants/:childId/parent-or-guardian"
+                                }
+                              },
+                              {
+                                "id": "$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child",
+                                "file": "routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child.tsx",
+                                "paths": {
+                                  "en": "/:lang/apply/:id/adult-child/children/:childId/cannot-apply-child",
+                                  "fr": "/:lang/demander/:id/adulte-enfant/enfants/:childId/cannot-apply-child"
                                 }
                               }
                             ]

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/cannot-apply-child.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/cannot-apply-child.tsx
@@ -1,0 +1,102 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { InlineLink } from '~/components/inline-link';
+import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { RouteHandleData, getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { cn } from '~/utils/tw-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adultChild.applySelf,
+  pageTitleI18nKey: 'apply-adult-child:eligibility.apply-yourself.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadApplyAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.apply-yourself.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('apply/adult-child/apply-yourself');
+  loadApplyAdultChildState({ params, request, session });
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+  const state = loadApplyAdultChildState({ params, request, session });
+
+  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  saveApplyState({
+    params,
+    session,
+    state: {
+      editMode: false,
+      typeOfApplication: 'adult',
+    },
+  });
+
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
+}
+
+export default function ApplyForYourself() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <div className="max-w-prose">
+      <div className="mb-6 space-y-4">
+        <p>{t('apply-adult-child:eligibility.apply-yourself.ineligible-to-apply')}</p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-2025')}</p>
+        <p>
+          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.when-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank">
+            {t('apply-adult-child:eligibility.apply-yourself.when-to-apply')}
+          </InlineLink>
+        </p>
+        <p>{t('apply-adult-child:eligibility.apply-yourself.submit-application')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Apply for yourself">
+          <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
+          {t('apply-adult-child:eligibility.apply-yourself.back-btn')}
+        </ButtonLink>
+        <Button type="submit" variant="primary" id="proceed-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Proceed - Apply for yourself click">
+          {t('apply-adult-child:eligibility.apply-yourself.proceed-btn')}
+          <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+        </Button>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 
-import pageIds from '../../../../page-ids.json';
+import pageIds from '../../../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
@@ -22,7 +22,7 @@ import { cn } from '~/utils/tw-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'gcweb'),
   pageIdentifier: pageIds.public.apply.adultChild.applySelf,
-  pageTitleI18nKey: 'apply-adult-child:eligibility.apply-yourself.page-title',
+  pageTitleI18nKey: 'apply-adult-child:eligibility.cannot-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -34,7 +34,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));
-  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.apply-yourself.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.cannot-apply-child.page-title') }) };
 
   return json({ id: state.id, csrfToken, meta });
 }
@@ -63,7 +63,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/applicant-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/adult/review-information', params));
 }
 
 export default function ApplyForYourself() {
@@ -76,19 +76,18 @@ export default function ApplyForYourself() {
   return (
     <div className="max-w-prose">
       <div className="mb-6 space-y-4">
-        <p>{t('apply-adult-child:eligibility.apply-yourself.ineligible-to-apply')}</p>
-        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</p>
-        <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-2025')}</p>
+        <p>{t('apply-adult-child:eligibility.cannot-apply-child.ineligible-to-apply')}</p>
+        <p>{t('apply-adult-child:eligibility.cannot-apply-child.eligibility-info')}</p>
+        <p>{t('apply-adult-child:eligibility.cannot-apply-child.eligibility-2025')}</p>
         <p>
-          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.when-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank">
-            {t('apply-adult-child:eligibility.apply-yourself.when-to-apply')}
+          <InlineLink to={t('apply-adult-child:eligibility.cannot-apply-child.when-to-apply-href')} className="external-link font-lato font-semibold" newTabIndicator target="_blank">
+            {t('apply-adult-child:eligibility.cannot-apply-child.when-to-apply')}
           </InlineLink>
         </p>
-        <p>{t('apply-adult-child:eligibility.apply-yourself.submit-application')}</p>
       </div>
       <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
         <input type="hidden" name="_csrf" value={csrfToken} />
-        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Apply for yourself">
+        <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/adult-child/children/$childId/information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Apply for yourself">
           <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
           {t('apply-adult-child:eligibility.apply-yourself.back-btn')}
         </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child.tsx
@@ -58,7 +58,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     params,
     session,
     state: {
-      editMode: false,
+      editMode: true,
       typeOfApplication: 'adult',
     },
   });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/information.tsx
@@ -185,7 +185,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/children/$childId/parent-or-guardian', params));
   }
 
-  if (ageCategory === 'adults') {
+  if (ageCategory === 'adults' || ageCategory === 'seniors') {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child', params));
   }
 

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/information.tsx
@@ -17,7 +17,7 @@ import { InputField } from '~/components/input-field';
 import { InputRadios, InputRadiosProps } from '~/components/input-radios';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
-import { ChildInformationState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { ChildInformationState, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -179,8 +179,14 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
+  const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
+
   if (!parsedDataResult.data.isParent) {
     return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/children/$childId/parent-or-guardian', params));
+  }
+
+  if (ageCategory === 'adults') {
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/children/$childId/cannot-apply-child', params));
   }
 
   return redirect(getPathById('$lang+/_public+/apply+/$id+/adult-child/children/$childId/dental-insurance', params));

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -497,13 +497,12 @@
       "proceed-btn": "Proceed to apply for yourself"
     },
     "cannot-apply-child": {
-      "page-title": "Apply for yourself",
-      "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan.",
+      "page-title": "You cannot apply for your child",
+      "ineligible-to-apply": "Your child is not currently eligible for the Canadian Dental Care Plan.",
       "eligibility-info": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
-      "eligibility-2025": "Adults 18 to 64 who do not have a valid disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
-      "when-to-apply": "Find out when they can apply for the Canadian Dental Care Plan",
+      "eligibility-2025": "Adults 18 to 64 who do not have a disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
+      "when-to-apply": "Find out when you can apply for the Canadian Dental Care Plan",
       "when-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
-      "submit-application": "You can still submit an application for yourself.",
       "back-btn": "Back",
       "proceed-btn": "Proceed to apply for yourself"
     }

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -495,6 +495,17 @@
       "submit-application": "You can still submit an application for yourself.",
       "back-btn": "Back",
       "proceed-btn": "Proceed to apply for yourself"
+    },
+    "cannot-apply-child": {
+      "page-title": "Apply for yourself",
+      "ineligible-to-apply": "Your children are not currently eligible to apply for the Canadian Dental Care Plan.",
+      "eligibility-info": "The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+      "eligibility-2025": "Adults 18 to 64 who do not have a valid disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
+      "when-to-apply": "Find out when they can apply for the Canadian Dental Care Plan",
+      "when-to-apply-href": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when",
+      "submit-application": "You can still submit an application for yourself.",
+      "back-btn": "Back",
+      "proceed-btn": "Proceed to apply for yourself"
     }
   },
   "exit-application": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -492,6 +492,16 @@
       "submit-application": "(FR) You can still submit an application for yourself.",
       "back-btn": "Retour",
       "proceed-btn": "(FR) Proceed to apply for yourself"
+    },
+    "cannot-apply-child": {
+      "page-title": "(FR) You cannot apply for your child",
+      "ineligible-to-apply": "(FR) Your child is not currently eligible for the Canadian Dental Care Plan.",
+      "eligibility-info": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+      "eligibility-2025": "(FR) Adults 18 to 64 who do not have a disability tax credit will be able to apply for the Canadian Dental Care Plan in 2025.",
+      "when-to-apply": "(FR) Find out when you can apply for the Canadian Dental Care Plan",
+      "when-to-apply-href": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#quand",
+      "back-btn": "Retour",
+      "proceed-btn": "(FR) Proceed to apply for yourself"
     }
   },
   "exit-application": {


### PR DESCRIPTION
### Description
From the child Information page, if the child's age is over 18, the next screen will be `You cannot apply for your child` screen (B10). The 'procees to apply for yourself' button will redirect to /adult/review-information

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`