### PR TITLE
3730 review applicant info and spouse info screens

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
@@ -197,7 +197,7 @@ export default function ApplyFlowApplicationInformation() {
       <div className="max-w-prose">
         <p className="mb-4">{t('applicant-information.form-instructions-sin')}</p>
         <p className="mb-6">{t('applicant-information.form-instructions-info')}</p>
-        <p className="italic">{t('apply:required-label')}</p>
+        <p className="mb-4 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/partner-information.tsx
@@ -213,7 +213,7 @@ export default function ApplyFlowApplicationInformation() {
       <div className="max-w-prose">
         <p className="mb-4">{t('partner-information.provide-sin')}</p>
         <p className="mb-6">{t('partner-information.required-information')}</p>
-        <p className="italic">{t('apply:required-label')}</p>
+        <p className="mb-4 italic">{t('apply:required-label')}</p>
         {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />


### PR DESCRIPTION
### Description
review of:
- `/applicant-information`,
- `/partner-information`

Only changes were to the margin on the "required label" based on the adult flow and figma

### Related Azure Boards Work Items
[AB#3730](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3730)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->