### PR TITLE
Initial refactoring of `/subscribe/confirm` route

### DIFF
--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -63,11 +63,10 @@
     }
   },
   "confirm": {
-    "page-title": "Submission Confirmation",
+    "page-title": "Confirmation code",
     "breadcrumbs": {
       "subscribe": "Confirm to subscribe to CDCP email alerts"
     },
-    "no-preferred-language-on-file": "No preferred language on file",
     "confirmation-information-text": "A confirmation code, required to finish the registration process, will be sent to <strong>{{userEmailAddress}}</strong>. This step must be completed within the next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "Selected language preference:",
@@ -75,7 +74,10 @@
     "submit-code": "Submit Confirmation Code",
     "request-new-code": "Request New Confirmation Code",
     "code-sent-by-email": "You have requested a new confirmation code and will receive an email at <strong>{{userEmailAddress}}</strong> to finish the registration process. This final step which must be completed within the next <strong>48 hours</strong>, will allow you to reveive emails when important new Canadian Dental Care plan information is available in your My Service Canada Account.",
-    "back": "Back"
+    "back": "Back",
+    "error-message": {
+      "code-required": "Enter confirmation code"
+    }
   },
   "expired": {
     "page-title": "Confirmation Code Expired",

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -63,11 +63,10 @@
     }
   },
   "confirm": {
-    "page-title": "(FR) Submission Confirmation",
+    "page-title": "(FR) Confirmation code",
     "breadcrumbs": {
       "subscribe": "(FR) Confirm to subscribe to CDCP email alerts"
     },
-    "no-preferred-language-on-file": "(FR) No preferred language on file",
     "confirmation-information-text": "(FR) A confirmation code, required to finish the registration process, will be sent to <strong>{{userEmailAddress}}</strong>. This step must be completed within the next 48 hours or by immediately entering the confirmation code below.",
     "confirmation-completed-text": "(FR) Upon completion, you will begin to receive email alerts when important information for your Canada Dental Care Plan application is available.",
     "confirmation-selected-language": "(FR) Selected language preference:",
@@ -75,7 +74,10 @@
     "submit-code": "(FR) Submit Confirmation Code",
     "request-new-code": "(FR) Request New Confirmation Code",
     "code-sent-by-email": "(FR) You have requested a new confirmation code and will receive an email at <strong>{{userEmailAddress}}</strong> to finish the registration process. This final step which must be completed within the next <strong>48 hours</strong>, will allow you to reveive emails when important new Canadian Dental Care plan information is available in your My Service Canada Account.",
-    "back": "(FR) Back"
+    "back": "(FR) Back",
+    "error-message": {
+      "code-required": "(FR) Enter confirmation code"
+    }
   },
   "expired": {
     "page-title": "(FR) Confirmation Code Expired",


### PR DESCRIPTION
### Description
When doing some cleanup, I found and addressed issues in the `/subscribe/confirm` route including:
- Removing unnecessary Zod schemas - there is now only one schema used for form validation
- Removing unnecessary uses of `session.set(..)` and `session.get(..)`
- Error message displays if user doesn't enter a confirmation code
- Preferred language displays rather than "No preferred language on file"
- Throwing early rather than defaulting variables to an empty string when their values are `null` or `undefined`
- Adding `enum` that is used to display different messages within the `<ContextualAlert>` at the top of the form

Note for reviewer: Sorry for large PR as I didn't feel like splitting up the above fixes into separate PRs for the same existing route.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Run the application locally and navigate to `/en/alerts/subscribe/confirm`.
- Verify that the "Selected language preference:" displays an actual language.
- Verify that if you enter an empty confirmation code, an error message appears.

### Additional Notes
Found a known issue where if you request a new confirmation code then submit the form without entering a confirmation code, the alert message changes back to the default. This will be addressed in a future PR.