### PR TITLE
Upgrade UuidGenerator to address Hibernate 6.2 deprecation

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/Uuid.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/Uuid.java
@@ -1,0 +1,15 @@
+package ca.gov.dtsstn.cdcp.api.data;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.annotations.IdGeneratorType;
+import org.hibernate.annotations.ValueGenerationType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@IdGeneratorType(UuidGenerator.class)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@ValueGenerationType(generatedBy = UuidGenerator.class)
+public @interface Uuid {}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/UuidGenerator.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/UuidGenerator.java
@@ -1,25 +1,20 @@
 package ca.gov.dtsstn.cdcp.api.data;
 
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.id.IdentifierGenerator;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * A Hibernate {@link IdentifierGenerator} that will generate a string-representation of a {@link UUID}.
- * <p>
- * Usage example:
- * <pre>
- * {@code @Id}
- * {@code @Column(nullable = false, updatable = false)}
- * {@code @GeneratedValue(generator = "uuid-generator")}
- * {@code @GenericGenerator(name = "uuid-generator", strategy = UuidGenerator.STRATEGY)}
- * {@code private String id;}
- * </pre>
- */
 @SuppressWarnings({ "serial" })
-public class UuidGenerator implements IdentifierGenerator {
+public class UuidGenerator implements BeforeExecutionGenerator {
+
+	private static final Logger log = LoggerFactory.getLogger(UuidGenerator.class);
 
 	private final transient ValueGenerator valueGenerator;
 
@@ -32,9 +27,15 @@ public class UuidGenerator implements IdentifierGenerator {
 	}
 
 	@Override
-	public Object generate(SharedSessionContractImplementor session, Object object) {
-		final var id = session.getEntityPersister(null, object).getIdentifier(object, session);
-		return Optional.ofNullable(id).orElseGet(() -> valueGenerator.generateUuid().toString());
+	public Object generate(SharedSessionContractImplementor session, Object owner, Object currentValue, EventType eventType) {
+		final var id = Optional.ofNullable(session.getEntityPersister(null, owner).getIdentifier(owner, session));
+		id.ifPresent(val -> log.debug("Not generating ID for [{}] because it already has id [{}]", owner.getClass().getSimpleName(), val));
+		return id.orElseGet(() -> valueGenerator.generateUuid().toString());
+	}
+
+	@Override
+	public EnumSet<EventType> getEventTypes() {
+		return EventTypeSets.INSERT_ONLY;
 	}
 
 	public interface ValueGenerator {

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/AbstractEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/AbstractEntity.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.hibernate.annotations.GenericGenerator;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,11 +14,10 @@ import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.lang.Nullable;
 
-import ca.gov.dtsstn.cdcp.api.data.UuidGenerator;
+import ca.gov.dtsstn.cdcp.api.data.Uuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
@@ -43,9 +41,8 @@ public abstract class AbstractEntity implements Persistable<String>, Serializabl
 	protected Boolean isNew;
 
 	@Id
-	@GeneratedValue(generator = "uuid-generator")
+	@Uuid
 	@Column(length = 64, nullable = false, updatable = false)
-	@GenericGenerator(name = "uuid-generator", type = UuidGenerator.class)
 	protected String id;
 
 	@CreatedBy

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/SubscriptionEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/SubscriptionEntity.java
@@ -6,7 +6,6 @@ import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/UuidGeneratorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/UuidGeneratorTests.java
@@ -23,7 +23,7 @@ class UuidGeneratorTests {
 	final UUID id = UUID.randomUUID();
 
 	@BeforeEach
-	void setUp() {
+	void beforeEach() {
 		this.uuidGenerator = new UuidGenerator(() -> id);
 	}
 
@@ -31,14 +31,14 @@ class UuidGeneratorTests {
 	void testGenerate_withId() {
 		final var sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
 		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(id.toString());
-		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, null, new Object(), EventType.INSERT)).asString().isEqualTo(id.toString());
+		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object(), null, EventType.INSERT)).asString().isEqualTo(id.toString());
 	}
 
 	@Test
 	void testGenerate_withNullId() {
 		final var sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
 		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(null);
-		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, null, new Object(), EventType.INSERT)).asString().isEqualTo(id.toString());
+		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object(), null, EventType.INSERT)).asString().isEqualTo(id.toString());
 	}
 
 }


### PR DESCRIPTION
# Upgrade UuidGenerator to address Hibernate 6.2 deprecation

This PR updates the `UuidGenerator` class to adhere to the changes introduced in Hibernate 6.2. The `IdentifierGenerator` interface has been deprecated in favor of `BeforeExecutionGenerator`.
