### PR TITLE
Add transform AA url for child routes for adult-child flow

### DIFF
--- a/frontend/__tests__/route-helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/route-helpers/apply-adult-child-route-helpers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/apply-adult-child-route-helpers';
+
+describe('transformChildrenRouteAdobeAnalyticsUrl', () => {
+  it.each([
+    ['https://example.com/en/'],
+    ['https://example.com/fr/'],
+    ['https://example.com/en/status'],
+    ['https://example.com/fr/statut'],
+    ['https://example.com/en/apply/00000000-0000-0000-0000-000000000000/somepage/'],
+    ['https://example.com/en/demander/00000000-0000-0000-0000-000000000000/somepage/'],
+  ])('should return as is for %s when not matching the apply route regex', (url) => {
+    const actual = transformChildrenRouteAdobeAnalyticsUrl(url);
+    expect(actual).toEqual(new URL(url));
+  });
+
+  it.each([
+    ['https://example.com/en/apply/00000000-0000-0000-0000-000000000000/adult-child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/apply/adult-child/children/somepage/'],
+    ['https://example.com/fr/apply/00000000-0000-0000-0000-000000000000/adult-child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/apply/adult-child/children/somepage/'],
+    ['https://example.com/en/demander/00000000-0000-0000-0000-000000000000/adulte-enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/demander/adulte-enfant/enfants/somepage/'],
+    ['https://example.com/fr/demander/00000000-0000-0000-0000-000000000000/adulte-enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/demander/adulte-enfant/enfants/somepage/'],
+  ])('should remove the session id path segment for %s when matching the apply route regex', (url, expectedUrl) => {
+    const actual = transformChildrenRouteAdobeAnalyticsUrl(url);
+    expect(actual).toEqual(new URL(expectedUrl));
+  });
+});

--- a/frontend/app/route-helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/route-helpers/apply-adult-child-route-helpers.ts
@@ -1,0 +1,19 @@
+import { removePathSegment } from '~/utils/url-utils';
+
+/**
+ * Adobe Analytics needs us to clean up URLs before sending event data. This ensures their reports focus
+ * on the core content, not things like tracking codes, because they don't want those to mess up their
+ * website visitor categories.
+ * @param url
+ * @returns
+ */
+export function transformChildrenRouteAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  const applyRouteRegex = /^\/(en|fr)\/(apply|demander)\/.*\/(adult-child|adulte-enfant)\/(children|enfants)\//i;
+  if (!applyRouteRegex.test(urlObj.pathname)) return urlObj;
+  // remove apply state id
+  let transofrmedUrl = removePathSegment(urlObj, 2);
+  // remove apply child state id
+  transofrmedUrl = removePathSegment(transofrmedUrl, 4);
+  return new URL(transofrmedUrl);
+}

--- a/frontend/app/routes/$lang+/_protected+/access-to-governmental-benefits+/view.tsx
+++ b/frontend/app/routes/$lang+/_protected+/access-to-governmental-benefits+/view.tsx
@@ -75,7 +75,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   await raoidcService.handleSessionValidation(request, session);
 
   instrumentationService.countHttpStatus('access-to-governmental-benefits.view', 302);
-  return redirect(getPathById('$lang+/_protected+/personal-information+/view', params));
+  return redirect(getPathById('$lang+/_protected+/access-to-governmental-benefits+/view', params));
 }
 
 export default function AccessToGovernmentalsBenefitsView() {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/_route.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/children/$childId/_route.tsx
@@ -1,5 +1,12 @@
 import { Outlet } from '@remix-run/react';
 
+import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/apply-adult-child-route-helpers';
+import { RouteHandleData } from '~/utils/route-utils';
+
+export const handle = {
+  transformAdobeAnalyticsUrl: transformChildrenRouteAdobeAnalyticsUrl,
+} as const satisfies RouteHandleData;
+
 /**
  * Do-nothing parent route.
  * (placeholder for future code)


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add transform Adobe Analytics url for child routes for `adult-child` flow.

If the url matches the regex pattern for a child route in the `adult-child` flow then it transforms the url by removing all instances of UUIDs.

Matching url
```
http://localhost:3000/en/apply/d3764bd3-1450-487a-8f29-598cac9c50d4/adult-child/children/1605af1b-a3c4-462b-a31d-9cd323fd3eb4/information
```

Result
```
http://localhost:3000/en/apply/adult-child/children/information
```

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->