### PR TITLE
add sin unique check to applicant/spouse info pages

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/applicant-information.tsx
@@ -64,6 +64,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const log = getLogger('apply/adult-child/applicant-information');
 
   const state = loadApplyAdultChildState({ params, request, session });
+  const applyState = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const formData = await request.formData();
@@ -102,8 +103,13 @@ export async function action({ context: { session }, params, request }: ActionFu
           return z.NEVER;
         }
 
-        if (state.partnerInformation && formatSin(sin) === formatSin(state.partnerInformation.socialInsuranceNumber)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:applicant-information.error-message.sin-unique'), fatal: true });
+        if (
+          [applyState.partnerInformation?.socialInsuranceNumber, ...applyState.children.map((child) => child.information?.socialInsuranceNumber)]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin as string))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'], fatal: true });
           return z.NEVER;
         }
       }),


### PR DESCRIPTION
### Description
Check for SIN uniqueness on `/adult-child/applicant-information` and `/adult-child/partner-information`.  This is needed because an applicant can go back and edit their application, therefore we need a way to verify that their potentially edited SIN is unique.

### Related Azure Boards Work Items
[AB#3824](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3824)