### PR TITLE
More refinement of subscribing/unsubscribing routes

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/index.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/index.tsx
@@ -150,9 +150,9 @@ export default function UnsubscribeAlerts() {
   }, [errorMessages]);
 
   return (
-    <>
+    <div className="max-w-prose">
       {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-      <fetcher.Form className="max-w-prose" method="post" noValidate>
+      <fetcher.Form method="post" noValidate>
         <input type="hidden" name="_csrf" value={csrfToken} />
         <div>
           <p>
@@ -172,6 +172,6 @@ export default function UnsubscribeAlerts() {
           </ButtonLink>
         </div>
       </fetcher.Form>
-    </>
+    </div>
   );
 }

--- a/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/success.tsx
+++ b/frontend/app/routes/$lang+/_protected+/alerts+/unsubscribe+/success.tsx
@@ -58,7 +58,7 @@ export default function UnsubscribeAlertsSuccess() {
   const subscribelink = <InlineLink routeId="$lang+/_protected+/alerts+/subscribe+/index" params={params} />;
 
   return (
-    <>
+    <div className="max-w-prose">
       <p className="mb-4">{t('alerts:success.unsubscribe-successful')}</p>
       <p className="mb-4">
         <Trans ns={handle.i18nNamespaces} i18nKey="alerts:success.subscribe-again" components={{ subscribelink }} />
@@ -68,6 +68,6 @@ export default function UnsubscribeAlertsSuccess() {
           {t('alerts:success.return-dashboard')}
         </ButtonLink>
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
### Description
This PR, which is a continuation of https://github.com/DTS-STN/canadian-dental-care-plan/pull/1469, includes:
- Adding `max-w-prose` to all pages and outside of error summary
- Adding auditing to `/alerts/subscribe/confirm` and `/alerts/subscribe/expired`
- Removing use of `userInfoToken.sin ?? ''` in `/alerts/subscribe` and `/alerts/subscribe/expired` in favour of throwing early
- Removing some `TODO`s in `/alerts/subscribe/expired` that can now be addressed

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`