### PR TITLE
Adds synchronous version of FileSessionStorage

### DIFF
--- a/frontend/__tests__/services/session-service.server.test.ts
+++ b/frontend/__tests__/services/session-service.server.test.ts
@@ -1,10 +1,11 @@
 /* eslint @typescript-eslint/no-unused-vars: ["error", { "varsIgnorePattern": "^_" }] */
-import { createFileSessionStorage, createSessionStorage } from '@remix-run/node';
+import { createSessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getRedisService } from '~/services/redis-service.server';
 import { getEnv } from '~/utils/env.server';
+import { createFileSessionStorage } from '~/utils/session-utils';
 
 vi.mock('@remix-run/node', () => ({
   createCookie: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock('~/utils/logging.server', () => ({
     info: vi.fn(),
     warn: vi.fn(),
   }),
+}));
+
+vi.mock('~/utils/session-utils', () => ({
+  createFileSessionStorage: vi.fn(),
 }));
 
 describe('session-service.server tests', () => {

--- a/frontend/app/services/session-service.server.ts
+++ b/frontend/app/services/session-service.server.ts
@@ -21,7 +21,7 @@
  *
  * @see https://remix.run/docs/en/main/utils/sessions
  */
-import { CookieParseOptions, Session, createCookie, createFileSessionStorage, createSessionStorage } from '@remix-run/node';
+import { CookieParseOptions, Session, createCookie, createSessionStorage } from '@remix-run/node';
 import type { CookieSerializeOptions } from '@remix-run/node';
 
 import moize from 'moize';
@@ -30,6 +30,7 @@ import { randomUUID } from 'node:crypto';
 import { getRedisService } from '~/services/redis-service.server';
 import { getEnv } from '~/utils/env.server';
 import { getLogger } from '~/utils/logging.server';
+import { createFileSessionStorage } from '~/utils/session-utils';
 
 const log = getLogger('session-service.server');
 

--- a/frontend/app/utils/session-utils.ts
+++ b/frontend/app/utils/session-utils.ts
@@ -1,0 +1,79 @@
+import type { Cookie } from '@remix-run/node';
+import { createSessionStorage } from '@remix-run/node';
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+interface FileSessionStorageOptions {
+  cookie: Cookie;
+  dir: string;
+}
+
+/**
+ * Creates a synchronous FileSessionStorage version so the file isn't corrupted on concurrent writes.
+ *
+ * @remarks
+ * The remix's node file session storage implementation doesn't work well since loaders can run in parallel.
+ * There is no file-locking on the current one so it's very possible to corrupt session data.
+ *
+ * @see https://github.com/remix-run/remix/issues/4353
+ */
+export function createFileSessionStorage({ cookie, dir }: FileSessionStorageOptions) {
+  return createSessionStorage({
+    cookie,
+    async createData(data, expires) {
+      const content = JSON.stringify({ data, expires });
+      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        const id = crypto.randomUUID({ disableEntropyCache: true });
+        try {
+          const file = getFile(dir, id);
+          fs.mkdirSync(path.dirname(file), { recursive: true });
+          fs.writeFileSync(file, content, { encoding: 'utf-8', flag: 'wx' });
+          return id;
+        } catch (error) {
+          if (error instanceof Error && 'code' in error && error.code !== 'EEXIST') throw error;
+        }
+      }
+    },
+    async readData(id) {
+      try {
+        const file = getFile(dir, id);
+        const content = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        if (!isExpired(content.expires)) return content.data;
+        fs.unlinkSync(file);
+        return null;
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') throw error;
+        return null;
+      }
+    },
+    async updateData(id, data, expires) {
+      const content = JSON.stringify({ data, expires });
+      const file = getFile(dir, id);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, content, 'utf-8');
+    },
+    async deleteData(id) {
+      try {
+        fs.unlinkSync(getFile(dir, id));
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') throw error;
+      }
+    },
+  });
+}
+
+// Divide the session id up into a directory (first 2 bytes) and filename
+// (remaining 6 bytes) to reduce the chance of having very large directories,
+// which should speed up file access. This is a maximum of 2^16 directories,
+// each with 2^48 files.
+function getFile(dir: string, id: string) {
+  return path.join(dir, id.slice(0, 4), id.slice(4));
+}
+
+function isExpired(date?: string) {
+  const expires = typeof date === 'string' ? new Date(date) : null;
+  return expires ? expires < new Date() : false;
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Adds synchronous version of FileSessionStorage since Remix implementation occasionally throw error when reading session data from file system.

> The file session storage implementation doesn't work well since loaders can run in parallel. There is no file-locking on the current one so it's very possible to corrupt session data.
https://github.com/remix-run/remix/issues/4353

FileSessionStorage is only used this in local dev. Redis is used when deployed.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->