### PR TITLE
AB#3825 -- Removing potential empty string arguments from service calls

### DIFF
--- a/frontend/app/routes/$lang+/_protected+/personal-information+/email-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/email-address+/edit.tsx
@@ -5,6 +5,7 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../page-ids.json';
@@ -106,6 +107,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   instrumentationService.countHttpStatus('email-address.edit', 302);
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformationService = getPersonalInformationService();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
@@ -114,7 +117,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     ...personalInformation,
     emailAddress: parsedDataResult.data.emailAddress,
   };
-  await personalInformationService.updatePersonalInformation(userInfoToken.sin ?? '', newPersonalInformation);
+  await personalInformationService.updatePersonalInformation(userInfoToken.sin, newPersonalInformation);
 
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('update-data.email-address', { userId: idToken.sub });

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/home-address+/edit.tsx
@@ -5,6 +5,7 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import validator from 'validator';
 import { z } from 'zod';
 
@@ -151,6 +152,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   instrumentationService.countHttpStatus('home-address.edit', 302);
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
   const personalInformationService = getPersonalInformationService();
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
@@ -179,7 +182,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         }
       : personalInformation.mailingAddress,
   };
-  await personalInformationService.updatePersonalInformation(userInfoToken.sin ?? '', newPersonalInformation);
+  await personalInformationService.updatePersonalInformation(userInfoToken.sin, newPersonalInformation);
 
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('update-data.home-address', { userId: idToken.sub });

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/mailing-address+/edit.tsx
@@ -5,6 +5,7 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import validator from 'validator';
 import { z } from 'zod';
 
@@ -147,6 +148,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   instrumentationService.countHttpStatus('mailing-address.edit', 302);
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
   const personalInformationService = getPersonalInformationService();
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
@@ -175,7 +178,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         }
       : personalInformation.homeAddress,
   };
-  await personalInformationService.updatePersonalInformation(userInfoToken.sin ?? '', newPersonalInformation);
+  await personalInformationService.updatePersonalInformation(userInfoToken.sin, newPersonalInformation);
 
   const idToken: IdToken = session.get('idToken');
   getAuditService().audit('update-data.mailing-address', { userId: idToken.sub });

--- a/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
+++ b/frontend/app/routes/$lang+/_protected+/personal-information+/preferred-language+/edit.tsx
@@ -5,6 +5,7 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../page-ids.json';
@@ -99,6 +100,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   instrumentationService.countHttpStatus('preferred-language.edit', 302);
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
   const personalInformationService = getPersonalInformationService();
@@ -106,7 +109,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     ...personalInformation,
     preferredLanguageId: parsedDataResult.data.preferredLanguage,
   };
-  await personalInformationService.updatePersonalInformation(userInfoToken.sin ?? '', newPersonalInformation);
+  await personalInformationService.updatePersonalInformation(userInfoToken.sin, newPersonalInformation);
 
   instrumentationService.countHttpStatus('preferred-language.edit', 302);
   session.set('personal-info-updated', true);


### PR DESCRIPTION
### Description
There are a few occurrences where we pass an empty string to services if the SIN does not exist in the `userInfoToken`, which could result in the downstream API returning a 500.

Since the SIN should always be defined in the protected/authenticated space, this PR adds checks that would fail early if the SIN is undefined (or null) in the `userInfoToken`.

### Related Azure Boards Work Items
[AB#3825](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3825)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`