### PR TITLE
children sin confirm page

### DIFF
--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/confirmation.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/adult-child/confirmation.tsx
@@ -378,7 +378,7 @@ export default function ApplyFlowConfirm() {
                 <DescriptionListItem term={t('confirm.full-name')}>{`${childInfo.firstName} ${childInfo.lastName}`}</DescriptionListItem>
                 <DescriptionListItem term={t('confirm.dob')}>{childInfo.birthday}</DescriptionListItem>
                 <DescriptionListItem term={t('confirm.sin')}>
-                  <span className="text-nowrap">{formatSin(childInfo.sin ?? '')}</span>
+                  <span className="text-nowrap">{childInfo.sin && formatSin(childInfo.sin)}</span>
                 </DescriptionListItem>
                 <DescriptionListItem term={t('confirm.dental-private')}> {dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
                 <DescriptionListItem term={t('confirm.dental-public')}>


### PR DESCRIPTION
### Description
child SINs are optional and `formatSin` throws an exception if the SIN is invalid.  `formatSin` should probably just return the input if it's invalid, but for now, this will do.