### PR TITLE
update child state route helper

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -472,7 +472,7 @@
                             "index": true,
                             "paths": {
                               "en": "/:lang/apply/:id/child/children",
-                              "fr": "/:lang/demander/:id/adulte-enfant/enfants"
+                              "fr": "/:lang/demander/:id/enfant/enfants"
                             }
                           },
                           {

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/applicant-information.tsx
@@ -251,7 +251,7 @@ export default function ApplyFlowApplicationInformation() {
                 {t('apply-child:applicant-information.continue-btn')}
                 <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
               </Button>
-              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/child/date-of-birth" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant information click">
+              <ButtonLink id="back-button" routeId="$lang+/_public+/apply+/$id+/child/children/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Applicant information click">
                 <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
                 {t('apply-child:applicant-information.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/dental-insurance.tsx
@@ -15,7 +15,7 @@ import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
 import { Progress } from '~/components/progress';
-import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const state = loadApplyAdultSingleChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const childName = state.information?.firstName ?? '<Child 1 name>';
 
@@ -50,8 +50,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/dental-insurance');
 
-  const state = loadApplyAdultSingleChildState({ params, request, session });
-  const applyState = loadApplyAdultChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
+  const applyState = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // state validation schema

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -16,7 +16,7 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputRadios } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
 import { Progress } from '~/components/progress';
-import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
@@ -53,7 +53,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const { CANADA_COUNTRY_ID } = getEnv();
 
   const lookupService = getLookupService();
-  const state = loadApplyAdultSingleChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const childName = state.information?.firstName ?? '<Child 1 name>';
@@ -84,8 +84,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/federal-provincial-territorial-benefits');
 
-  const state = loadApplyAdultSingleChildState({ params, request, session });
-  const applyState = loadApplyAdultChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
+  const applyState = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // NOTE: state validation schemas are independent otherwise user have to anwser

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/information.tsx
@@ -17,7 +17,7 @@ import { InputField } from '~/components/input-field';
 import { InputRadios, InputRadiosProps } from '~/components/input-radios';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { Progress } from '~/components/progress';
-import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { ChildInformationState, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
@@ -45,7 +45,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const state = loadApplyAdultSingleChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const childName = state.isNew ? t('apply-child:children.information.child-number', { childNumber: state.childNumber }) : `${state.information?.firstName}`;
 
@@ -58,8 +58,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/information');
 
-  const state = loadApplyAdultSingleChildState({ params, request, session });
-  const applyState = loadApplyAdultChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
+  const applyState = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const formData = await request.formData();

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/parent-or-guardian.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import pageIds from '../../../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
-import { loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
+import { loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const state = loadApplyAdultSingleChildState({ params, request, session });
+  const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const csrfToken = String(session.get('csrfToken'));

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -135,7 +135,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/child/dental-insurance', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-information', params));
 }
 
 export default function ApplyFlowCommunicationPreferencePage() {


### PR DESCRIPTION
### Description
- Add `loadApplySingleChildState` (this is for fetching state for a singular child when an applicant is creating/reading/updating and is a direct copy/paste from adult-child flow)
- modify routes to use the child state
- heavily modify `child/review-information` to get it to render (we'll have to split the review into 2 screen exactly like the adult-child flow, so this isn't a big deal)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`