### PR TITLE
API cleanup (language validation handling)

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/LanguageRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/LanguageRepository.java
@@ -12,6 +12,8 @@ public interface LanguageRepository extends JpaRepository<LanguageEntity, String
 
 	Optional<LanguageEntity> findByCode(String code);
 
+	Optional<LanguageEntity> findByIsoCode(String isoCode);
+
 	Optional<LanguageEntity> findByMsLocaleCode(String msLocaleCode);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
@@ -37,11 +37,16 @@ public class LanguageService {
 		return languageRepository.findByCode(code).map(languageMapper::toDomainObject);
 	}
 
-	@Cacheable(key = "{ 'msLocaleCode', #mslocalecode }", sync = true)
+	@Cacheable(key = "{ 'isoCode', #isoCode }", sync = true)
+	public Optional<Language> readByIsoCode(String isoCode) {
+		Assert.hasText(isoCode, "isoCode is required; it must not be null or blank");
+		return languageRepository.findByIsoCode(isoCode).map(languageMapper::toDomainObject);
+	}
+
+	@Cacheable(key = "{ 'msLocaleCode', #msLocaleCode }", sync = true)
 	public Optional<Language> readByMsLocaleCode(String msLocaleCode) {
 		Assert.hasText(msLocaleCode, "msLocaleCode is required; it must not be null or blank");
 		return languageRepository.findByMsLocaleCode(msLocaleCode).map(languageMapper::toDomainObject);
 	}
-
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/SubscriptionCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/SubscriptionCreateModel.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import ca.gov.dtsstn.cdcp.api.web.validation.AlertTypeCode;
 import ca.gov.dtsstn.cdcp.api.web.validation.LanguageCode;
+import ca.gov.dtsstn.cdcp.api.web.validation.LanguageCodeValidator.CodeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,7 +20,7 @@ public interface SubscriptionCreateModel {
 	String getAlertTypeCode();
 
 	@Schema(example = "1033")
-	@LanguageCode(message = "Preferred language code does not exist")
+	@LanguageCode(codeType = CodeType.MS_LOCALE_CODE, message = "Preferred language code does not exist")
 	String getMsLanguageCode();
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCode.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCode.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import ca.gov.dtsstn.cdcp.api.web.validation.LanguageCodeValidator.CodeType;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
@@ -12,6 +13,8 @@ import jakarta.validation.Payload;
 @Constraint(validatedBy = { LanguageCodeValidator.class })
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE_USE })
 public @interface LanguageCode {
+
+	CodeType codeType();
 
 	String message();
 

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidator.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidator.java
@@ -10,6 +10,14 @@ import jakarta.validation.ConstraintValidatorContext;
 @Component
 public class LanguageCodeValidator implements ConstraintValidator<LanguageCode, String> {
 
+	public enum CodeType {
+		INTERNAL_CODE,
+		ISO_CODE,
+		MS_LOCALE_CODE
+	};
+
+	private CodeType codeType;
+
 	private final LanguageService languageService;
 
 	public LanguageCodeValidator(LanguageService languageService) {
@@ -18,9 +26,19 @@ public class LanguageCodeValidator implements ConstraintValidator<LanguageCode, 
 	}
 
 	@Override
+	public void initialize(LanguageCode constraintAnnotation) {
+		this.codeType = constraintAnnotation.codeType();
+	}
+
+	@Override
 	public boolean isValid(String value, ConstraintValidatorContext context) {
 		if (value == null) { return true; }
-		return languageService.readByMsLocaleCode(value).isPresent();
+
+		return switch (codeType) {
+			case CodeType.INTERNAL_CODE -> languageService.readByCode(value).isPresent();
+			case CodeType.ISO_CODE -> languageService.readByIsoCode(value).isPresent();
+			case CodeType.MS_LOCALE_CODE -> languageService.readByMsLocaleCode(value).isPresent();
+		};
 	}
 
 }

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/LanguageRepositoryIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/LanguageRepositoryIT.java
@@ -36,6 +36,19 @@ class LanguageRepositoryIT {
 	}
 
 	@Test
+	@DisplayName("Test languageRepository.findByIsoCode(..)")
+	void testFindByIsoCode() {
+		assertThat(languageRepository.findByIsoCode("ISO_CODE")).isEmpty();
+
+		languageRepository.save(new LanguageEntityBuilder()
+			.code("CODE")
+			.isoCode("ISO_CODE")
+			.build());
+
+		assertThat(languageRepository.findByIsoCode("ISO_CODE")).isNotEmpty();
+	}
+
+	@Test
 	@DisplayName("Test languageRepository.findByMsLocaleCode(..)")
 	void testFindByMsLocaleCode() {
 		assertThat(languageRepository.findByMsLocaleCode("MS_LOCALE_CODE")).isEmpty();

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/LanguageServiceTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/LanguageServiceTests.java
@@ -54,6 +54,18 @@ class LanguageServiceTests {
 	}
 
 	@Test
+	@DisplayName("Test languageService.readByIsoCode(..)")
+	void testReadByIsoCode() {
+		assertThrows(IllegalArgumentException.class, () -> languageService.readByIsoCode(null));
+
+		when(languageRepository.findByIsoCode(any())).thenReturn(Optional.empty());
+		assertThat(languageService.readByIsoCode("CODE")).isEmpty();
+
+		when(languageRepository.findByIsoCode(any())).thenReturn(Optional.of(new LanguageEntity()));
+		assertThat(languageService.readByIsoCode("CODE")).isNotEmpty();
+	}
+
+	@Test
 	@DisplayName("Test languageService.readByMsLocaleCode(..)")
 	void testReadByMsLocaleCode() {
 		assertThrows(IllegalArgumentException.class, () -> languageService.readByMsLocaleCode(null));

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidatorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidatorTests.java
@@ -1,0 +1,102 @@
+package ca.gov.dtsstn.cdcp.api.web.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ca.gov.dtsstn.cdcp.api.service.LanguageService;
+import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableLanguage;
+import ca.gov.dtsstn.cdcp.api.web.validation.LanguageCodeValidator.CodeType;
+import jakarta.validation.ConstraintValidatorContext;
+
+@ExtendWith({ MockitoExtension.class })
+class LanguageCodeValidatorTests {
+
+	@Mock LanguageCode languageCode;
+
+	@Mock LanguageService languageService;
+
+	LanguageCodeValidator validator;
+
+	@BeforeEach
+	void beforeEach() {
+		this.validator = new LanguageCodeValidator(languageService);
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ null value")
+	void testIsValid_NullValue() {
+		assertThat(validator.isValid(null, mock(ConstraintValidatorContext.class))).isTrue();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ unknown INTERNAL code")
+	void testIsValid_UnknownInternalCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.INTERNAL_CODE);
+		when(languageService.readByCode(any())).thenReturn(Optional.empty());
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isFalse();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ known INTERNAL code")
+	void testIsValid_KnownInternalCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.INTERNAL_CODE);
+		when(languageService.readByCode(any())).thenReturn(Optional.of(ImmutableLanguage.builder().build()));
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isTrue();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ unknown ISO code")
+	void testIsValid_UnknownIsoCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.ISO_CODE);
+		when(languageService.readByIsoCode(any())).thenReturn(Optional.empty());
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isFalse();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ known ISO code")
+	void testIsValid_KnownIsoCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.ISO_CODE);
+		when(languageService.readByIsoCode(any())).thenReturn(Optional.of(ImmutableLanguage.builder().build()));
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isTrue();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ unknown MS_LOCALE code")
+	void testIsValid_UnknownMsLocaleCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.MS_LOCALE_CODE);
+		when(languageService.readByMsLocaleCode(any())).thenReturn(Optional.empty());
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isFalse();
+	}
+
+	@Test
+	@DisplayName("Test isValid(..) w/ known MS_LOCALE code")
+	void testIsValid_KnownMsLocaleCode() {
+		when(languageCode.codeType()).thenReturn(CodeType.MS_LOCALE_CODE);
+		when(languageService.readByMsLocaleCode(any())).thenReturn(Optional.of(ImmutableLanguage.builder().build()));
+
+		validator.initialize(languageCode);
+		assertThat(validator.isValid("00000000-0000-0000-0000-000000000000", mock(ConstraintValidatorContext.class))).isTrue();
+	}
+
+}


### PR DESCRIPTION
### API cleanup (language validation handling)

Update language JSR validator to allow validation against any of the language codes.