### PR TITLE
review child information screen

### DIFF
--- a/frontend/app/route-helpers/apply-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-route-helpers.server.ts
@@ -37,9 +37,9 @@ export interface ApplyState {
       firstName: string;
       lastName: string;
       dateOfBirth: string;
+      isParent: boolean;
       hasSocialInsuranceNumber: boolean;
       socialInsuranceNumber?: string;
-      isParent: boolean;
     };
   }[];
   readonly communicationPreferences?: {
@@ -104,6 +104,7 @@ export type ChildState = ApplyState['children'][number];
 export type ChildDentalBenefitsState = NonNullable<ChildState['dentalBenefits']>;
 export type ChildDentalInsuranceState = NonNullable<ChildState['dentalInsurance']>;
 export type ChildInformationState = NonNullable<ChildState['information']>;
+export type ChildSinState = Pick<NonNullable<ChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
 export type CommunicationPreferencesState = NonNullable<ApplyState['communicationPreferences']>;
 export type DentalFederalBenefitsState = Pick<NonNullable<ApplyState['dentalBenefits']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
 export type DentalInsuranceState = NonNullable<ApplyState['dentalInsurance']>;

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/children/$childId/information.tsx
@@ -18,7 +18,7 @@ import { InputRadios, InputRadiosProps } from '~/components/input-radios';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { Progress } from '~/components/progress';
 import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
-import { ChildInformationState, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { ChildInformationState, ChildSinState, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -100,27 +100,9 @@ export async function action({ context: { session }, params, request }: ActionFu
         .int()
         .positive(),
       dateOfBirth: z.string(),
-      hasSocialInsuranceNumber: z.boolean({ errorMap: () => ({ message: t('apply-child:children.information.error-message.has-social-insurance-number') }) }),
-      socialInsuranceNumber: z.string().trim().optional(),
       isParent: z.boolean({ errorMap: () => ({ message: t('apply-child:children.information.error-message.is-parent') }) }),
     })
     .superRefine((val, ctx) => {
-      if (val.hasSocialInsuranceNumber) {
-        if (!val.socialInsuranceNumber) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-required'), path: ['socialInsuranceNumber'] });
-        } else if (!isValidSin(val.socialInsuranceNumber)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-valid'), path: ['socialInsuranceNumber'] });
-        } else if (
-          val.socialInsuranceNumber &&
-          [applyState.applicantInformation?.socialInsuranceNumber, applyState.partnerInformation?.socialInsuranceNumber, ...applyState.children.filter((child) => state.id !== child.id).map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin as string))
-            .includes(formatSin(val.socialInsuranceNumber))
-        ) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'] });
-        }
-      }
-
       // At this point the year, month and day should have been validated as positive integer
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
@@ -152,7 +134,30 @@ export async function action({ context: { session }, params, request }: ActionFu
         ...val,
         dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
       };
-    }) satisfies z.ZodType<ChildInformationState>;
+    }) satisfies z.ZodType<Omit<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
+
+  const childSinSchema = z
+    .object({
+      hasSocialInsuranceNumber: z.boolean({ errorMap: () => ({ message: t('apply-child:children.information.error-message.has-social-insurance-number') }) }),
+      socialInsuranceNumber: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasSocialInsuranceNumber) {
+        if (!val.socialInsuranceNumber) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-required'), path: ['socialInsuranceNumber'] });
+        } else if (!isValidSin(val.socialInsuranceNumber)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-valid'), path: ['socialInsuranceNumber'] });
+        } else if (
+          val.socialInsuranceNumber &&
+          [applyState.applicantInformation?.socialInsuranceNumber, applyState.partnerInformation?.socialInsuranceNumber, ...applyState.children.filter((child) => state.id !== child.id).map((child) => child.information?.socialInsuranceNumber)]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin as string))
+            .includes(formatSin(val.socialInsuranceNumber))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'] });
+        }
+      }
+    }) satisfies z.ZodType<ChildSinState>;
 
   const data = {
     firstName: String(formData.get('firstName') ?? ''),
@@ -167,8 +172,14 @@ export async function action({ context: { session }, params, request }: ActionFu
   };
 
   const parsedDataResult = childInformationSchema.safeParse(data);
-  if (!parsedDataResult.success) {
-    return json({ errors: parsedDataResult.error.format() });
+  const parsedSinDataResult = childSinSchema.safeParse(data);
+  if (!parsedDataResult.success || !parsedSinDataResult.success) {
+    return json({
+      errors: {
+        ...(!parsedDataResult.success ? parsedDataResult.error.format() : {}),
+        ...(!parsedSinDataResult.success ? parsedSinDataResult.error.format() : {}),
+      },
+    });
   }
 
   saveApplyState({
@@ -177,7 +188,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     state: {
       children: applyState.children.map((child) => {
         if (child.id !== state.id) return child;
-        return { ...child, information: parsedDataResult.data };
+        return { ...child, information: { ...parsedDataResult.data, ...parsedSinDataResult.data } };
       }),
     },
   });

--- a/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang+/_public+/apply+/$id+/child/communication-preference.tsx
@@ -132,10 +132,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   saveApplyState({ params, session, state: { communicationPreferences: parsedDataResult.data } });
 
   if (state.editMode) {
-    return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-information', params));
+    return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-adult-information', params));
   }
 
-  return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-information', params));
+  return redirect(getPathById('$lang+/_public+/apply+/$id+/child/review-adult-information', params));
 }
 
 export default function ApplyFlowCommunicationPreferencePage() {

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -81,8 +81,8 @@
         "sin": "Enter the 9-digit SIN"
       },
       "error-message": {
-        "first-name-required": "Enter first name",
-        "last-name-required": "Enter last name",
+        "first-name-required": "Enter child's first name",
+        "last-name-required": "Enter child's last name",
         "sin-required": "Enter 9-digit SIN, for example 123 456 789",
         "sin-valid": "Must be a valid SIN",
         "sin-unique": "The Social Insurance Number (SIN) must be unique",
@@ -94,8 +94,8 @@
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",
         "date-of-birth-year-required": "Date of birth must include a year",
-        "has-social-insurance-number": "Select whether or not this child has a social insurance number",
-        "is-parent": "Select whether or not you are this child's parent or legal guardian"
+        "has-social-insurance-number": "Select whether the child has a SIN",
+        "is-parent": "Select whether you are the parent or legal guardian of the child"
       }
     },
     "dental-insurance": {

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -81,8 +81,8 @@
         "sin": "Enter the 9-digit SIN"
       },
       "error-message": {
-        "first-name-required": "Enter first name",
-        "last-name-required": "Enter last name",
+        "first-name-required": "Enter child's first name",
+        "last-name-required": "Enter child's last name",
         "sin-required": "Enter 9-digit SIN, for example 123 456 789",
         "sin-valid": "Must be a valid SIN",
         "sin-unique": "The Social Insurance Number (SIN) must be unique",
@@ -94,8 +94,8 @@
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",
         "date-of-birth-year-required": "Date of birth must include a year",
-        "has-social-insurance-number": "Select whether or not this child has a social insurance number",
-        "is-parent": "Select whether or not you are this child's parent or legal guardian"
+        "has-social-insurance-number": "Select whether the child has a SIN",
+        "is-parent": "Select whether you are the parent or legal guardian of the child"
       }
     },
     "dental-insurance": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -80,7 +80,8 @@
         "sin": "Entrez un NAS de 9 chiffres"
       },
       "error-message": {
-        "first-name-required": "Entrez le prénom",
+        "first-name-required": "Entrez le prénom de l'enfant",
+        "last-name-required": "Entrez le nom de famille de l'enfant",
         "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
         "sin-valid": "Le NAS doit être valide",
         "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
@@ -92,8 +93,8 @@
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
         "date-of-birth-year-required": "La date de naissance doit inclure une année",
-        "has-social-insurance-number": "(FR) Select whether or not this child has a social insurance number",
-        "is-parent": "(FR) Select whether or not you are this child's parent or legal guardian"
+        "has-social-insurance-number": "Sélectionnez si l'enfant a un NAS",
+        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant"
       }
     },
     "dental-insurance": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -80,7 +80,8 @@
         "sin": "Entrez un NAS de 9 chiffres"
       },
       "error-message": {
-        "first-name-required": "Entrez le prénom",
+        "first-name-required": "Entrez le prénom de l'enfant",
+        "last-name-required": "Entrez le nom de famille de l'enfant",
         "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
         "sin-valid": "Le NAS doit être valide",
         "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
@@ -92,8 +93,8 @@
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
         "date-of-birth-year-required": "La date de naissance doit inclure une année",
-        "has-social-insurance-number": "(FR) Select whether or not this child has a social insurance number",
-        "is-parent": "(FR) Select whether or not you are this child's parent or legal guardian"
+        "has-social-insurance-number": "Sélectionnez si l'enfant a un NAS",
+        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant"
       }
     },
     "dental-insurance": {


### PR DESCRIPTION
### Description
Review `child/information`.

NOTE: because `hasSocialInsurance` toggles `socialInsuranceNumber` to be displayed, the validation schema has to be split into two objects, similar to how it's being done in the Federal and Provincial benefits screens, otherwise validation can't proceed for when the SIN input is displayed. I've done my best to appease TS, but I'll admit I'm no expert. 

Also fixed some of the "bugs" (a.k.a. text changes), that were on the board relevant to this screen.

### Related Azure Boards Work Items
[AB#3841](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3841), [AB#3865](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3865), [AB#3866](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3866),[AB#3864](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3864)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`