### PR TITLE
AB#3871 Use of HATEOAS links to retrieve the user and subscriprions

### DIFF
--- a/frontend/app/services/subscription-service.server.ts
+++ b/frontend/app/services/subscription-service.server.ts
@@ -56,7 +56,7 @@ function createSubscriptionService() {
         }),
       }),
     });
-    instrumentationService.countHttpStatus('http.client.cdcp-api.user.gets', response.status);
+    instrumentationService.countHttpStatus('http.client.cdcp-api.users.gets', response.status);
     const userParsed = userSchema.parse(await response.json());
 
     const userSubscriptionsURL = userParsed._links.subscriptions.href;
@@ -69,7 +69,7 @@ function createSubscriptionService() {
 
     instrumentationService.countHttpStatus('http.client.cdcp-api.alert-subscription.gets', response.status);
 
-    const subscriptionSchema = z.object({
+    const subscriptionsSchema = z.object({
       _embedded: z.object({
         subscriptions: z.array(
           z.object({
@@ -86,7 +86,7 @@ function createSubscriptionService() {
       }),
     });
 
-    const subscriptions = subscriptionSchema.parse(await subscriptionsResponse.json())._embedded.subscriptions.map((subscription) => ({
+    const subscriptions = subscriptionsSchema.parse(await subscriptionsResponse.json())._embedded.subscriptions.map((subscription) => ({
       id: subscription.id,
       preferredLanguage: subscription.msLanguageCode,
       alertType: subscription.alertTypeCode,

--- a/frontend/app/services/subscription-service.server.ts
+++ b/frontend/app/services/subscription-service.server.ts
@@ -29,10 +29,38 @@ function createSubscriptionService() {
     const auditService = getAuditService();
     const instrumentationService = getInstrumentationService();
     auditService.audit('alert-subscription.get', { userId });
-    //TODO, for a future PR, use HATEOAS links to get the /subscriptions endpoint
-    const url = new URL(`${CDCP_API_BASE_URI}/api/v1/users/${userId}/subscriptions`);
-
+    const url = new URL(`${CDCP_API_BASE_URI}/api/v1/users/${userId}`);
     const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const userSchema = z.object({
+      id: z.string(),
+      email: z.string(),
+      emailVerified: z.boolean(),
+      userAttributes: z.array(
+        z.object({
+          name: z.string(),
+          value: z.string(),
+        }),
+      ),
+      _links: z.object({
+        self: z.object({
+          href: z.string(),
+        }),
+        subscriptions: z.object({
+          href: z.string(),
+        }),
+      }),
+    });
+    instrumentationService.countHttpStatus('http.client.cdcp-api.user.gets', response.status);
+    const userParsed = userSchema.parse(await response.json());
+
+    const userSubscriptionsURL = userParsed._links.subscriptions.href;
+    const subscriptionsResponse = await fetch(userSubscriptionsURL, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -41,7 +69,7 @@ function createSubscriptionService() {
 
     instrumentationService.countHttpStatus('http.client.cdcp-api.alert-subscription.gets', response.status);
 
-    const newSchema = z.object({
+    const subscriptionSchema = z.object({
       _embedded: z.object({
         subscriptions: z.array(
           z.object({
@@ -58,7 +86,7 @@ function createSubscriptionService() {
       }),
     });
 
-    const subscriptions = newSchema.parse(await response.json())._embedded.subscriptions.map((subscription) => ({
+    const subscriptions = subscriptionSchema.parse(await subscriptionsResponse.json())._embedded.subscriptions.map((subscription) => ({
       id: subscription.id,
       preferredLanguage: subscription.msLanguageCode,
       alertType: subscription.alertTypeCode,


### PR DESCRIPTION
### Description
Use of HATEOAS links to retrieve the user and subscriprions

### Related Azure Boards Work Items
[AB#3871](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3871)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

