### PR TITLE
Add service-level bean validation

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
@@ -36,7 +36,7 @@ public class UserEntity extends AbstractEntity {
 
 	@JoinColumn(name = "userId", nullable = false)
 	@OneToMany(cascade = { CascadeType.ALL }, orphanRemoval = true)
-	private Set<SubscriptionEntity> subscriptions = new HashSet<>();	
+	private Set<SubscriptionEntity> subscriptions = new HashSet<>();
 
 	public UserEntity() {
 		super();
@@ -46,15 +46,15 @@ public class UserEntity extends AbstractEntity {
 	public UserEntity(
 			@Nullable Boolean isNew,
 			@Nullable String id,
+			@Nullable Iterable<ConfirmationCodeEntity> confirmationCodes,
 			@Nullable String email,
 			@Nullable Boolean emailVerified,
 			@Nullable Iterable<UserAttributeEntity> userAttributes,
-			@Nullable Iterable<SubscriptionEntity> subscriptions,			
+			@Nullable Iterable<SubscriptionEntity> subscriptions,
 			@Nullable String createdBy,
 			@Nullable Instant createdDate,
 			@Nullable String lastModifiedBy,
-			@Nullable Instant lastModifiedDate,
-			@Nullable Iterable<ConfirmationCodeEntity> confirmationCodes) {
+			@Nullable Instant lastModifiedDate) {
 		super(isNew, id, createdBy, createdDate, lastModifiedBy, lastModifiedDate);
 
 		this.email = email;
@@ -70,7 +70,7 @@ public class UserEntity extends AbstractEntity {
 
 		if (subscriptions != null) {
 			this.subscriptions = StreamSupport.stream(subscriptions.spliterator(), false).collect(Collectors.toSet());
-		}		
+		}
 	}
 
 	public String getEmail() {
@@ -94,15 +94,15 @@ public class UserEntity extends AbstractEntity {
 	}
 
 	public void setUserAttributes(Iterable<UserAttributeEntity> userAttributes) {
-		this.userAttributes = StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
+		this.userAttributes = userAttributes == null ? null : StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
 	}
 
 	public Set<ConfirmationCodeEntity> getConfirmationCodes() {
 		return confirmationCodes;
 	}
 
-	public void setConfirmationCodes(Set<ConfirmationCodeEntity> confirmationCodes) {
-		this.confirmationCodes = confirmationCodes;
+	public void setConfirmationCodes(Iterable<ConfirmationCodeEntity> confirmationCodes) {
+		this.confirmationCodes = confirmationCodes == null ? null : StreamSupport.stream(confirmationCodes.spliterator(), false).collect(Collectors.toSet());
 	}
 
 	public Set<SubscriptionEntity> getSubscriptions() {
@@ -110,7 +110,7 @@ public class UserEntity extends AbstractEntity {
 	}
 
 	public void setSubscriptions(Iterable<SubscriptionEntity> subscriptions) {
-		this.subscriptions = StreamSupport.stream(subscriptions.spliterator(), false).collect(Collectors.toSet());
+		this.subscriptions = subscriptions == null ? null :StreamSupport.stream(subscriptions.spliterator(), false).collect(Collectors.toSet());
 	}
 
 	@Override
@@ -120,8 +120,8 @@ public class UserEntity extends AbstractEntity {
 			.append("confirmationCodes", confirmationCodes)
 			.append("email", email)
 			.append("emailVerified", emailVerified)
+			.append("subscriptions", subscriptions)
 			.append("userAttributes", userAttributes)
-			.append("subscriptions", subscriptions)			
 			.toString();
 	}
 

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/BaseDomainObject.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/BaseDomainObject.java
@@ -4,21 +4,29 @@ import java.time.Instant;
 
 import org.springframework.lang.Nullable;
 
+import ca.gov.dtsstn.cdcp.api.service.domain.validation.ValidationGroup;
+import jakarta.validation.constraints.Null;
+
 public interface BaseDomainObject {
 
 	@Nullable
+	@Null(groups = { ValidationGroup.Create.class, ValidationGroup.Update.class }, message = "id must be null when creating/updating an entity")
 	String getId();
 
 	@Nullable
+	@Null(groups = { ValidationGroup.Create.class, ValidationGroup.Update.class }, message = "createdBy must be null when creating/updating an entity")
 	String getCreatedBy();
 
 	@Nullable
+	@Null(groups = { ValidationGroup.Create.class, ValidationGroup.Update.class }, message = "createdDate must be null when creating/updating an entity")
 	Instant getCreatedDate();
 
 	@Nullable
+	@Null(groups = { ValidationGroup.Create.class, ValidationGroup.Update.class }, message = "lastModifiedBy must be null when creating/updating an entity")
 	String getLastModifiedBy();
 
 	@Nullable
+	@Null(groups = { ValidationGroup.Create.class, ValidationGroup.Update.class }, message = "lastModifiedDate must be null when creating/updating an entity")
 	Instant getLastModifiedDate();
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/Subscription.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/Subscription.java
@@ -4,7 +4,6 @@ import org.immutables.value.Value.Immutable;
 
 import jakarta.annotation.Nullable;
 
-
 @Immutable
 public interface Subscription extends BaseDomainObject {
 

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/User.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/User.java
@@ -5,20 +5,26 @@ import java.util.Set;
 import org.immutables.value.Value.Immutable;
 
 import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 
 @Immutable
 public interface User extends BaseDomainObject {
 
-	Set<ConfirmationCode> getConfirmationCodes();
+	@Nullable
+	Set<@Valid ConfirmationCode> getConfirmationCodes();
 
+	@Email
 	@Nullable
 	String getEmail();
 
 	@Nullable
 	Boolean getEmailVerified();
 
-	Set<Subscription> getSubscriptions();
+	@Nullable
+	Set<@Valid Subscription> getSubscriptions();
 
-	Set<UserAttribute> getUserAttributes();
+	@Nullable
+	Set<@Valid UserAttribute> getUserAttributes();
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AlertTypeMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AlertTypeMapper.java
@@ -1,5 +1,8 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
+
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.lang.Nullable;
@@ -11,6 +14,7 @@ import ca.gov.dtsstn.cdcp.api.service.domain.AlertType;
 public interface AlertTypeMapper {
 
 	@Nullable
+	@IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)
 	AlertType toDomainObject(@Nullable AlertTypeEntity alertType);
 
 	@Nullable

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapper.java
@@ -1,5 +1,8 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
+
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -11,6 +14,7 @@ import jakarta.annotation.Nullable;
 public interface ConfirmationCodeMapper {
 
 	@Nullable
+	@IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)
 	ConfirmationCode toDomainObject(@Nullable ConfirmationCodeEntity confirmationCode);
 
 	@Nullable

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/LanguageMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/LanguageMapper.java
@@ -1,5 +1,8 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
+
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.lang.Nullable;
@@ -11,6 +14,7 @@ import ca.gov.dtsstn.cdcp.api.service.domain.Language;
 public interface LanguageMapper {
 
 	@Nullable
+	@IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)
 	Language toDomainObject(@Nullable LanguageEntity language);
 
 	@Nullable

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapper.java
@@ -1,28 +1,33 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
+import static org.mapstruct.NullValuePropertyMappingStrategy.IGNORE;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
 import org.mapstruct.BeanMapping;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.Subscription;
 import jakarta.annotation.Nullable;
 
-@Mapper(uses = { AlertTypeMapper.class })
+@Mapper(uses = { AlertTypeMapper.class, LanguageMapper.class })
 public interface SubscriptionMapper {
 
 	@Nullable
 	public default List<Subscription> toDomainObjects(@Nullable Iterable<SubscriptionEntity> subscriptions) {
-		if (subscriptions == null) { return null; }
+		if (subscriptions == null) { return Collections.emptyList(); }
 		return StreamSupport.stream(subscriptions.spliterator(), false).map(this::toDomainObject).toList();
 	}
 
 	@Nullable
+	@IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)
 	Subscription toDomainObject(@Nullable SubscriptionEntity subscription);
 
 	@Nullable
@@ -37,7 +42,7 @@ public interface SubscriptionMapper {
 
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-	SubscriptionEntity update(@MappingTarget SubscriptionEntity target, @Nullable Subscription subscription);
+	@BeanMapping(nullValuePropertyMappingStrategy = IGNORE)
+	SubscriptionEntity updateEntity(@MappingTarget SubscriptionEntity target, @Nullable Subscription subscription);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserMapper.java
@@ -1,28 +1,32 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
+import static org.mapstruct.NullValuePropertyMappingStrategy.IGNORE;
+
 import org.mapstruct.BeanMapping;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.UserEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import jakarta.annotation.Nullable;
 
-@Mapper(uses = { ConfirmationCodeMapper.class, UserAttributeMapper.class })
+@Mapper(uses = { ConfirmationCodeMapper.class, SubscriptionMapper.class, UserAttributeMapper.class })
 public interface UserMapper {
+
+	@Nullable
+	@IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)
+	User toDomainObject(@Nullable UserEntity user);
 
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
 	UserEntity toEntity(@Nullable User user);
 
 	@Nullable
-	User toDomainObject(@Nullable UserEntity user);
-
-	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-	UserEntity update(@MappingTarget UserEntity existingUser, @Nullable User user);
+	@BeanMapping(nullValuePropertyMappingStrategy = IGNORE)
+	UserEntity updateEntity(@MappingTarget UserEntity user, @Nullable User userUpdate);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/validation/ValidationGroup.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/validation/ValidationGroup.java
@@ -1,0 +1,8 @@
+package ca.gov.dtsstn.cdcp.api.service.domain.validation;
+
+public interface ValidationGroup {
+
+	public interface Create {};
+	public interface Update {};
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -4,14 +4,15 @@ import org.mapstruct.factory.Mappers;
 import org.springframework.util.Assert;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
+import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableUser;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserUpdateModel;
@@ -62,7 +63,7 @@ public class UsersController {
 		final var user = userService.getUserById(id)
 				.orElseThrow(() -> new ResourceNotFoundException("No user with id=[%s] was found".formatted(id)));
 
-		userService.updateUser(user.getId(), userUpdateModel.getEmail());
-	}	
+		userService.updateUser(user.getId(), ImmutableUser.builder().email(userUpdateModel.getEmail()).build());
+	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserUpdateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserUpdateModel.java
@@ -4,12 +4,14 @@ import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 @Immutable
 @JsonDeserialize(as = ImmutableUserUpdateModel.class)
 public interface UserUpdateModel {
 
+	@Email
 	@NotBlank
 	String getEmail();
 

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/UserServiceIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/UserServiceIT.java
@@ -3,7 +3,6 @@ package ca.gov.dtsstn.cdcp.api.service;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -12,14 +11,16 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
 import ca.gov.dtsstn.cdcp.api.config.properties.ApplicationProperties;
 import ca.gov.dtsstn.cdcp.api.data.entity.AlertTypeEntityBuilder;
@@ -31,39 +32,37 @@ import ca.gov.dtsstn.cdcp.api.data.repository.AlertTypeRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.LanguageRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.UserRepository;
 import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableUser;
+import jakarta.validation.ConstraintViolationException;
 
-@ExtendWith({ MockitoExtension.class })
-class UserServiceTests {
+@ActiveProfiles("test")
+@Import({ ValidationAutoConfiguration.class })
+@SpringBootTest(classes = { UserService.class })
+class UserServiceIT {
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	@MockBean(answer = Answers.RETURNS_DEEP_STUBS)
 	ApplicationProperties applicationProperties;
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	@MockBean(answer = Answers.RETURNS_DEEP_STUBS)
 	AlertTypeRepository alertTypeRepository;
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	@MockBean(answer = Answers.RETURNS_DEEP_STUBS)
 	LanguageRepository languageRepository;
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	@MockBean(answer = Answers.RETURNS_DEEP_STUBS)
 	UserRepository userRepository;
 
-	UserService userService;
-
-	@BeforeEach
-	void setUp() {
-		this.userService = new UserService(applicationProperties, alertTypeRepository, languageRepository, userRepository);
-	}
+	@Autowired UserService userService;
 
 	@Test()
 	@DisplayName("Test userService.createUser(..) with null user")
 	void testCreateUser_NullUser() {
-		assertThrowsExactly(IllegalArgumentException.class, () -> userService.createUser(null), "user is required; it must not be null");
+		assertThrows(IllegalArgumentException.class, () -> userService.createUser(null));
 	}
 
 	@Test()
 	@DisplayName("Test userService.createUser(..) with non-null user.id")
 	void testCreateUser_NonNullUserId() {
-		assertThrowsExactly(IllegalArgumentException.class, () -> userService.createUser(ImmutableUser.builder().id("id").build()), "user.id must be null when creating new instance");
+		assertThrows(ConstraintViolationException.class, () -> userService.createUser(ImmutableUser.builder().id("id").build()));
 	}
 
 	@Test()
@@ -76,7 +75,7 @@ class UserServiceTests {
 	@Test()
 	@DisplayName("Test userService.createConfirmationCodeForUser(..) with null userId")
 	void testCreateConfirmationCodeForUser_NullUserId() {
-		assertThrowsExactly(IllegalArgumentException.class, () -> userService.createConfirmationCodeForUser(""), "user is required; it must not be null");
+		assertThrows(IllegalArgumentException.class, () -> userService.createConfirmationCodeForUser(""));
 	}
 
 	@Test


### PR DESCRIPTION
### Add bean validation to service classes

This PR adds bean validation to the `UserService` class and defines different validation schemes for creating and updating data.