### PR TITLE
change max length of email fields to be 64 characters

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/communication-preference.tsx
@@ -85,8 +85,8 @@ export async function action({ context: { session }, params, request }: ActionFu
     .object({
       preferredLanguage: z.string().trim().min(1, t('apply-adult-child:communication-preference.error-message.preferred-language-required')),
       preferredMethod: z.string().trim().min(1, t('apply-adult-child:communication-preference.error-message.preferred-method-required')),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
@@ -197,7 +197,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             inputMode="email"
             className="w-full"
             label={t('apply-adult-child:communication-preference.email')}
-            maxLength={100}
+            maxLength={64}
             name="email"
             errorMessage={errorMessages.email}
             autoComplete="email"
@@ -212,7 +212,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
               inputMode="email"
               className="w-full"
               label={t('apply-adult-child:communication-preference.confirm-email')}
-              maxLength={100}
+              maxLength={64}
               name="confirmEmail"
               errorMessage={errorMessages['confirm-email']}
               autoComplete="email"

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/personal-information.tsx
@@ -91,8 +91,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .max(100)
         .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('apply-adult-child:contact-information.error-message.phone-number-alt-valid'))
         .optional(),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
       mailingAddress: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.address-required')).max(30),
       mailingApartment: z.string().trim().max(30).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.country-required')),
@@ -421,7 +421,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['email']}
                 label={t('apply-adult-child:contact-information.email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
               <InputField
@@ -434,7 +434,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['confirm-email']}
                 label={t('apply-adult-child:contact-information.confirm-email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/communication-preference.tsx
@@ -85,8 +85,8 @@ export async function action({ context: { session }, params, request }: ActionFu
     .object({
       preferredLanguage: z.string().trim().min(1, t('apply-adult:communication-preference.error-message.preferred-language-required')),
       preferredMethod: z.string().trim().min(1, t('apply-adult:communication-preference.error-message.preferred-method-required')),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
@@ -201,7 +201,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             inputMode="email"
             className="w-full"
             label={t('apply-adult:communication-preference.email')}
-            maxLength={100}
+            maxLength={64}
             name="email"
             errorMessage={errorMessages.email}
             autoComplete="email"
@@ -216,7 +216,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
               inputMode="email"
               className="w-full"
               label={t('apply-adult:communication-preference.confirm-email')}
-              maxLength={100}
+              maxLength={64}
               name="confirmEmail"
               errorMessage={errorMessages['confirm-email']}
               autoComplete="email"

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
@@ -91,8 +91,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .max(100)
         .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('apply-adult:contact-information.error-message.phone-number-alt-valid'))
         .optional(),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
       mailingAddress: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.address-required')).max(30),
       mailingApartment: z.string().trim().max(30).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.country-required')),
@@ -425,7 +425,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['email']}
                 label={t('apply-adult:contact-information.email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
               <InputField
@@ -438,7 +438,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['confirm-email']}
                 label={t('apply-adult:contact-information.confirm-email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/communication-preference.tsx
@@ -85,8 +85,8 @@ export async function action({ context: { session }, params, request }: ActionFu
     .object({
       preferredLanguage: z.string().trim().min(1, t('apply-child:communication-preference.error-message.preferred-language-required')),
       preferredMethod: z.string().trim().min(1, t('apply-child:communication-preference.error-message.preferred-method-required')),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
@@ -197,7 +197,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
             inputMode="email"
             className="w-full"
             label={t('apply-child:communication-preference.email')}
-            maxLength={100}
+            maxLength={64}
             name="email"
             errorMessage={errorMessages.email}
             autoComplete="email"
@@ -212,7 +212,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
               inputMode="email"
               className="w-full"
               label={t('apply-child:communication-preference.confirm-email')}
-              maxLength={100}
+              maxLength={64}
               name="confirmEmail"
               errorMessage={errorMessages['confirm-email']}
               autoComplete="email"

--- a/frontend/app/routes/$lang/_public/apply/$id/child/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/personal-information.tsx
@@ -91,8 +91,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .max(100)
         .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('apply-child:contact-information.error-message.phone-number-alt-valid'))
         .optional(),
-      email: z.string().trim().max(100).optional(),
-      confirmEmail: z.string().trim().max(100).optional(),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
       mailingAddress: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.address-required')).max(30),
       mailingApartment: z.string().trim().max(30).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.country-required')),
@@ -415,7 +415,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['email']}
                 label={t('apply-child:contact-information.email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
               <InputField
@@ -428,7 +428,7 @@ export default function ApplyFlowPersonalInformation() {
                 defaultValue={defaultState?.email ?? ''}
                 errorMessage={errorMessages['confirm-email']}
                 label={t('apply-child:contact-information.confirm-email')}
-                maxLength={100}
+                maxLength={64}
                 aria-describedby="adding-email"
               />
             </div>


### PR DESCRIPTION
### Description
Client side and server side validation changed to ensure max length is respected across ALL email fields in the online application.

### Related Azure Boards Work Items
[AB#3873](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3873)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/002cf0be-947d-408c-9bce-4158f75f004f)