### PR TITLE
AB#3826 -- More refinement of `/subscribe/confirm` route 

### DIFF
--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -74,6 +74,7 @@
     "submit-code": "Submit Confirmation Code",
     "request-new-code": "Request New Confirmation Code",
     "code-sent-by-email": "You have requested a new confirmation code and will receive an email at <strong>{{userEmailAddress}}</strong> to finish the registration process. This final step which must be completed within the next <strong>48 hours</strong>, will allow you to reveive emails when important new Canadian Dental Care plan information is available in your My Service Canada Account.",
+    "invalid": "The confirmation code you entered does not match our records. Please request a new confirmation code or ensure you are entering the correct confirmation code you received.",
     "back": "Back",
     "error-message": {
       "code-required": "Enter confirmation code"

--- a/frontend/public/locales/fr/alerts.json
+++ b/frontend/public/locales/fr/alerts.json
@@ -74,6 +74,7 @@
     "submit-code": "(FR) Submit Confirmation Code",
     "request-new-code": "(FR) Request New Confirmation Code",
     "code-sent-by-email": "(FR) You have requested a new confirmation code and will receive an email at <strong>{{userEmailAddress}}</strong> to finish the registration process. This final step which must be completed within the next <strong>48 hours</strong>, will allow you to reveive emails when important new Canadian Dental Care plan information is available in your My Service Canada Account.",
+    "invalid": "(FR) The confirmation code you entered does not match our records. Please request a new confirmation code or ensure you are entering the correct confirmation code you received.",
     "back": "(FR) Back",
     "error-message": {
       "code-required": "(FR) Enter confirmation code"


### PR DESCRIPTION
### Description

This PR, which is a continuation of https://github.com/DTS-STN/canadian-dental-care-plan/pull/1489 and https://github.com/DTS-STN/canadian-dental-care-plan/pull/1469, includes:
- Fixing the issue where if you request a new confirmation code then submit the form without entering a confirmation code, the alert message changes back to the default.
- Adding a message if confirmation code is invalid.

### Related Azure Boards Work Items
[AB#3826](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3826)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
1. Run application locally and navigate to `/en/alerts/subscribe/confirm`. 
2. Enter "1" as the confirmation code. There should be a message that appears indicating that the confirmation code is invalid.
3. Request a new confirmation code and enter "1" as the confirmation code. The message that a new confirmation code has been requested should remain on the page with the error message indicating that the confirmation code is invalid.