### PR TITLE
3916 update email validation conditional on /personal-information screens

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/personal-information.tsx
@@ -108,7 +108,7 @@ export async function action({ context: { session }, params, request }: ActionFu
       homePostalCode: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.email) {
+      if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
@@ -108,7 +108,7 @@ export async function action({ context: { session }, params, request }: ActionFu
       homePostalCode: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.email) {
+      if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {

--- a/frontend/app/routes/$lang/_public/apply/$id/child/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/personal-information.tsx
@@ -108,7 +108,7 @@ export async function action({ context: { session }, params, request }: ActionFu
       homePostalCode: z.string().trim().max(100).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.email) {
+      if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {


### PR DESCRIPTION
### Description
Validation should be triggered when an applicant enters their email in the `confirmEmail` field first.

### Related Azure Boards Work Items
[AB#3916](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3916)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/a78675e8-3276-4360-8b22-1c7d00dc63c6)