### PR TITLE
3915 make isParent field readonly in edit mode

### DIFF
--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -5,6 +5,7 @@ import { cn } from '~/utils/tw-utils';
 const inputBaseClassName = 'h-4 w-4 border-gray-500 bg-gray-50 text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500';
 const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
 const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
+const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 
 export interface InputRadioProps extends Omit<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
   append?: ReactNode;
@@ -24,7 +25,7 @@ export function InputRadio({ append, appendClassName, children, className, hasEr
     <div className={className}>
       <div className="flex items-center">
         <input type="radio" id={inputRadioId} aria-labelledby={inputLabelId} className={cn(inputBaseClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)} data-testid="input-radio" {...restProps} />
-        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block pl-3 leading-6', restProps.disabled && inputDisabledClassName, labelClassName)}>
+        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block pl-3 leading-6', restProps.readOnly && inputReadOnlyClassName, restProps.disabled && inputDisabledClassName, labelClassName)}>
           {children}
         </label>
       </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -358,11 +358,10 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-adult-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true },
-                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false },
+                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: editMode },
+                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: editMode },
               ]}
               errorMessage={fetcher.data?.errors.isParent?._errors[0]}
-              required
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -358,8 +358,8 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true },
-                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false },
+                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: editMode },
+                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: editMode },
               ]}
               errorMessage={fetcher.data?.errors.isParent?._errors[0]}
               required


### PR DESCRIPTION
### Description
per the ticket:

> There is a bug if you go in when editMode=1, if you switch from yes to no on "Are you parent or legal guardian...", hit back, then > click cancel, it goes back to the legal guardian page instead of the review page.
> 
> Since Figma design doesnt allow the "Are you parent or legal guardian..." to be updated, instead of spending time fixing that bug, disable it to prevent the user from changing it at all (in editMode=1). 

### Related Azure Boards Work Items
[AB#3915](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3915)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`