### PR TITLE
AB#3912 format date on review-child-information and children hub

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
@@ -17,6 +17,7 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import { getChildrenState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -108,7 +109,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 }
 
 export default function ApplyFlowChildSummary() {
-  const { t } = useTranslation(handle.i18nNamespaces);
+  const { t, i18n } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, children, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -140,12 +141,13 @@ export default function ApplyFlowChildSummary() {
           <div className="mt-6 space-y-8">
             {children.map((child) => {
               const childName = `${child.information?.firstName} ${child.information?.lastName}`;
+              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language) : '';
               return (
                 <section key={child.id}>
                   <h2 className="mb-4 font-lato text-2xl font-bold">{childName}</h2>
                   <dl className="mb-6 divide-y border-y">
                     <DescriptionListItem term={t('apply-adult-child:children.index.dob-title')}>
-                      <p>{child.information?.dateOfBirth}</p>
+                      <p>{dateOfBirth}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-adult-child:children.index.sin-title')}>
                       <p>{child.information?.socialInsuranceNumber}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-child-information.tsx
@@ -23,6 +23,7 @@ import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-hel
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getBenefitApplicationService } from '~/services/benefit-application-service.server';
 import { getLookupService } from '~/services/lookup-service.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getEnv } from '~/utils/env.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -162,6 +163,7 @@ export default function ReviewInformation() {
         <div className="space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
+            const dateOfBirth = toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language);
             return (
               <section key={child.id} className="space-y-8">
                 <h2 className="font-lato text-3xl font-bold">{child.information.firstName}</h2>
@@ -177,7 +179,7 @@ export default function ReviewInformation() {
                       </p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-adult-child:review-child-information.dob-title')}>
-                      {child.information.dateOfBirth}
+                      {dateOfBirth}
                       <p className="mt-4">
                         <InlineLink id="change-date-of-birth" routeId="$lang/_public/apply/$id/adult-child/children/$childId/information" params={childParams}>
                           {t('apply-adult-child:review-child-information.dob-change')}

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
@@ -17,6 +17,7 @@ import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { getChildrenState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -108,7 +109,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 }
 
 export default function ApplyFlowChildSummary() {
-  const { t } = useTranslation(handle.i18nNamespaces);
+  const { t, i18n } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, children, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -141,12 +142,13 @@ export default function ApplyFlowChildSummary() {
           <div className="mt-6 space-y-8">
             {children.map((child) => {
               const childName = `${child.information?.firstName} ${child.information?.lastName}`;
+              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language) : '';
               return (
                 <section key={child.id}>
                   <h2 className="mb-4 font-lato text-2xl font-bold">{childName}</h2>
                   <dl className="mb-6 divide-y border-y">
                     <DescriptionListItem term={t('apply-child:children.index.dob-title')}>
-                      <p>{child.information?.dateOfBirth}</p>
+                      <p>{dateOfBirth}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-child:children.index.sin-title')}>
                       <p>{child.information?.socialInsuranceNumber}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
@@ -19,6 +19,7 @@ import { loadApplyChildState, validateApplyChildStateForReview } from '~/route-h
 import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getEnv } from '~/utils/env.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -154,6 +155,7 @@ export default function ReviewInformation() {
         <div className="mb-8 space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
+            const dateOfBirth = toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language);
             return (
               <section key={child.id} className="space-y-10">
                 <h2 className="font-lato text-3xl font-bold">{child.information.firstName}</h2>
@@ -169,7 +171,7 @@ export default function ReviewInformation() {
                       </p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-child:review-child-information.dob-title')}>
-                      {child.information.dateOfBirth}
+                      {dateOfBirth}
                       <p className="mt-4">
                         <InlineLink id="change-date-of-birth" routeId="$lang/_public/apply/$id/child/children/$childId/information" params={childParams}>
                           {t('apply-child:review-child-information.dob-change')}


### PR DESCRIPTION
### Description
format date on review-child-information and children hub, it should be the same format with the review-adult-information

### Related Azure Boards Work Items
[AB#3912](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3912)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
