### PR TITLE
3901 format sin on child summary screens

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
@@ -24,6 +24,7 @@ import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin } from '~/utils/sin-utils';
 
 enum FormAction {
   Add = 'add',
@@ -158,7 +159,7 @@ export default function ApplyFlowChildSummary() {
                       <p>{dateOfBirth}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-adult-child:children.index.sin-title')}>
-                      <p>{child.information?.socialInsuranceNumber}</p>
+                      <p>{child.information?.socialInsuranceNumber ? formatSin(child.information.socialInsuranceNumber) : ''}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-adult-child:children.index.dental-insurance-title')}>{child.dentalInsurance ? t('apply-adult-child:children.index.yes') : t('apply-adult-child:children.index.no')}</DescriptionListItem>
                     <DescriptionListItem term={t('apply-adult-child:children.index.dental-benefit-title')}>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
@@ -24,6 +24,7 @@ import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin } from '~/utils/sin-utils';
 
 enum FormAction {
   Add = 'add',
@@ -150,7 +151,7 @@ export default function ApplyFlowChildSummary() {
                       <p>{dateOfBirth}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-child:children.index.sin-title')}>
-                      <p>{child.information?.socialInsuranceNumber}</p>
+                      <p>{child.information?.socialInsuranceNumber ? formatSin(child.information.socialInsuranceNumber) : ''}</p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('apply-child:children.index.dental-insurance-title')}>{child.dentalInsurance ? t('apply-child:children.index.yes') : t('apply-child:children.index.no')}</DescriptionListItem>
                     <DescriptionListItem term={t('apply-child:children.index.dental-benefit-title')}>


### PR DESCRIPTION
### Description
- add formatSin to child summary screens
- modify sin-utils to return the input if the SIN is invalid instead of throwing an error  

### Related Azure Boards Work Items
[AB#3901](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3901)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/28dd104a-4f7e-4d47-968b-93d57446ca37)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->