### PR TITLE
Add mapping methods to support entity updating

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/UserEntity.java
@@ -1,10 +1,9 @@
 package ca.gov.dtsstn.cdcp.api.data.entity;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -32,11 +31,11 @@ public class UserEntity extends AbstractEntity {
 
 	@JoinColumn(name = "userId", nullable = false)
 	@OneToMany(cascade = { CascadeType.ALL }, orphanRemoval = true)
-	private Set<UserAttributeEntity> userAttributes = new HashSet<>();
+	private Set<SubscriptionEntity> subscriptions = new HashSet<>();
 
 	@JoinColumn(name = "userId", nullable = false)
 	@OneToMany(cascade = { CascadeType.ALL }, orphanRemoval = true)
-	private Set<SubscriptionEntity> subscriptions = new HashSet<>();	
+	private Set<UserAttributeEntity> userAttributes = new HashSet<>();
 
 	public UserEntity() {
 		super();
@@ -46,31 +45,31 @@ public class UserEntity extends AbstractEntity {
 	public UserEntity(
 			@Nullable Boolean isNew,
 			@Nullable String id,
-			@Nullable String email,
-			@Nullable Boolean emailVerified,
-			@Nullable Iterable<UserAttributeEntity> userAttributes,
-			@Nullable Iterable<SubscriptionEntity> subscriptions,			
 			@Nullable String createdBy,
 			@Nullable Instant createdDate,
 			@Nullable String lastModifiedBy,
 			@Nullable Instant lastModifiedDate,
-			@Nullable Iterable<ConfirmationCodeEntity> confirmationCodes) {
+			@Nullable Collection<ConfirmationCodeEntity> confirmationCodes,
+			@Nullable String email,
+			@Nullable Boolean emailVerified,
+			@Nullable Collection<SubscriptionEntity> subscriptions,
+			@Nullable Collection<UserAttributeEntity> userAttributes) {
 		super(isNew, id, createdBy, createdDate, lastModifiedBy, lastModifiedDate);
 
 		this.email = email;
 		this.emailVerified = emailVerified;
 
-		if (confirmationCodes != null) {
-			this.confirmationCodes = StreamSupport.stream(confirmationCodes.spliterator(), false).collect(Collectors.toSet());
-		}
+		if (confirmationCodes != null) { this.confirmationCodes = new HashSet<>(confirmationCodes); }
+		if (subscriptions != null) { this.subscriptions = new HashSet<>(subscriptions); }
+		if (userAttributes != null) { this.userAttributes = new HashSet<>(userAttributes); }
+	}
 
-		if (userAttributes != null) {
-			this.userAttributes = StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
-		}
+	public Set<ConfirmationCodeEntity> getConfirmationCodes() {
+		return confirmationCodes;
+	}
 
-		if (subscriptions != null) {
-			this.subscriptions = StreamSupport.stream(subscriptions.spliterator(), false).collect(Collectors.toSet());
-		}		
+	public void setConfirmationCodes(Collection<ConfirmationCodeEntity> confirmationCodes) {
+		this.confirmationCodes = confirmationCodes == null ? new HashSet<> () : new HashSet<>(confirmationCodes);
 	}
 
 	public String getEmail() {
@@ -93,24 +92,16 @@ public class UserEntity extends AbstractEntity {
 		return userAttributes;
 	}
 
-	public void setUserAttributes(Iterable<UserAttributeEntity> userAttributes) {
-		this.userAttributes = StreamSupport.stream(userAttributes.spliterator(), false).collect(Collectors.toSet());
-	}
-
-	public Set<ConfirmationCodeEntity> getConfirmationCodes() {
-		return confirmationCodes;
-	}
-
-	public void setConfirmationCodes(Set<ConfirmationCodeEntity> confirmationCodes) {
-		this.confirmationCodes = confirmationCodes;
+	public void setUserAttributes(Collection<UserAttributeEntity> userAttributes) {
+		this.userAttributes = userAttributes == null ? new HashSet<> () : new HashSet<>(userAttributes);
 	}
 
 	public Set<SubscriptionEntity> getSubscriptions() {
 		return subscriptions;
 	}
 
-	public void setSubscriptions(Iterable<SubscriptionEntity> subscriptions) {
-		this.subscriptions = StreamSupport.stream(subscriptions.spliterator(), false).collect(Collectors.toSet());
+	public void setSubscriptions(Collection<SubscriptionEntity> subscriptions) {
+		this.subscriptions = subscriptions == null ? new HashSet<> () : new HashSet<>(subscriptions);
 	}
 
 	@Override
@@ -120,8 +111,8 @@ public class UserEntity extends AbstractEntity {
 			.append("confirmationCodes", confirmationCodes)
 			.append("email", email)
 			.append("emailVerified", emailVerified)
+			.append("subscriptions", subscriptions)
 			.append("userAttributes", userAttributes)
-			.append("subscriptions", subscriptions)			
 			.toString();
 	}
 

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/AlertTypeService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/AlertTypeService.java
@@ -28,13 +28,13 @@ public class AlertTypeService {
 	@Cacheable(key = "{ 'id', #id }", sync = true)
 	public Optional<AlertType> readById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
-		return alertTypeRepository.findById(id).map(alertTypeMapper::toDomainObject);
+		return alertTypeRepository.findById(id).map(alertTypeMapper::toAlertType);
 	}
 
 	@Cacheable(key = "{ 'code', #code }", sync = true)
 	public Optional<AlertType> readByCode(String code) {
 		Assert.hasText(code, "code is required; it must not be null or blank");
-		return alertTypeRepository.findByCode(code).map(alertTypeMapper::toDomainObject);
+		return alertTypeRepository.findByCode(code).map(alertTypeMapper::toAlertType);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
@@ -28,25 +28,25 @@ public class LanguageService {
 	@Cacheable(key = "{ 'id', #id }", sync = true)
 	public Optional<Language> readById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
-		return languageRepository.findById(id).map(languageMapper::toDomainObject);
+		return languageRepository.findById(id).map(languageMapper::toLanguage);
 	}
 
 	@Cacheable(key = "{ 'code', #code }", sync = true)
 	public Optional<Language> readByCode(String code) {
 		Assert.hasText(code, "code is required; it must not be null or blank");
-		return languageRepository.findByCode(code).map(languageMapper::toDomainObject);
+		return languageRepository.findByCode(code).map(languageMapper::toLanguage);
 	}
 
 	@Cacheable(key = "{ 'isoCode', #isoCode }", sync = true)
 	public Optional<Language> readByIsoCode(String isoCode) {
 		Assert.hasText(isoCode, "isoCode is required; it must not be null or blank");
-		return languageRepository.findByIsoCode(isoCode).map(languageMapper::toDomainObject);
+		return languageRepository.findByIsoCode(isoCode).map(languageMapper::toLanguage);
 	}
 
 	@Cacheable(key = "{ 'msLocaleCode', #msLocaleCode }", sync = true)
 	public Optional<Language> readByMsLocaleCode(String msLocaleCode) {
 		Assert.hasText(msLocaleCode, "msLocaleCode is required; it must not be null or blank");
-		return languageRepository.findByMsLocaleCode(msLocaleCode).map(languageMapper::toDomainObject);
+		return languageRepository.findByMsLocaleCode(msLocaleCode).map(languageMapper::toLanguage);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
 		Assert.notNull(user, "user is required; it must not be null");
 		Assert.isNull(user.getId(), "user.id must be null when creating new instance");
 
-		return userMapper.toDomainObject(userRepository.save(userMapper.toEntity(user)));
+		return userMapper.toUser(userRepository.save(userMapper.toUserEntity(user)));
 	}
 
 	public ConfirmationCode createConfirmationCodeForUser(String userId) {
@@ -91,7 +91,7 @@ public class UserService {
 		// return the persisted entity so it includes the id and audit fields
 		return userRepository.save(user).getConfirmationCodes().stream()
 			.filter(byCode(confirmationCode.getCode())).findFirst()
-			.map(confirmationCodeMapper::toDomainObject).orElseThrow();
+			.map(confirmationCodeMapper::toConfirmationCode).orElseThrow();
 	}
 
 	public Subscription createSubscriptionForUser(String userId, String alertTypeId, String languageId) {
@@ -126,12 +126,12 @@ public class UserService {
 
 		return userRepository.save(user).getSubscriptions().stream()
 			.filter(byAlertTypeId(alertType.getId())).findFirst()
-			.map(subscriptionMapper::toDomainObject).orElseThrow();
+			.map(subscriptionMapper::toSubscription).orElseThrow();
 	}
 
 	public Optional<User> getUserById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
-		return userRepository.findById(id).map(userMapper::toDomainObject);
+		return userRepository.findById(id).map(userMapper::toUser);
 	}
 
 	public void updateUser(String userId, String email) {
@@ -161,9 +161,9 @@ public class UserService {
 		final var subscription = user.getSubscriptions().stream()
 			.filter(byId(subscriptionId)).findFirst().orElseThrow();
 		subscription.setLanguage(preferredLanguage);
-			
+
 		userRepository.save(user);
-	}	
+	}
 
 	public void deleteSubscriptionForUser(String userId, String subscriptionId) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
@@ -187,6 +187,6 @@ public class UserService {
 	private Predicate<SubscriptionEntity> byId(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return subscription -> id.equals(subscription.getId());
-	}	
+	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AbstractDomainMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AbstractDomainMapper.java
@@ -1,0 +1,30 @@
+package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
+
+import static java.util.Collections.emptyList;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.AbstractEntity;
+import ca.gov.dtsstn.cdcp.api.service.domain.BaseDomainObject;
+import jakarta.annotation.Nullable;
+
+/**
+ * Abstract base class for domain mappers.
+ * Used to provide helpful methods to subclasses.
+ */
+public abstract class AbstractDomainMapper {
+
+	/**
+	 * Creates a predicate that checks if an {@link AbstractEntity} exists within a given collection of {@link BaseDomainObject}s.
+	 *
+	 * This method takes an {@link Collection} of {@link BaseDomainObject}s and returns a {@link Predicate} that can be used to test
+	 * if a specific {@link AbstractEntity} exists within that collection. The predicate checks for equality based on the entity IDs.
+	 */
+	protected Predicate<? super AbstractEntity> entityIn(@Nullable Collection<? extends BaseDomainObject> domainObjects) {
+		return entity -> Optional.ofNullable(domainObjects).orElse(emptyList()).stream()
+			.anyMatch(domainObject -> entity.getId().equals(domainObject.getId()));
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AlertTypeMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/AlertTypeMapper.java
@@ -2,19 +2,28 @@ package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.springframework.lang.Nullable;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.AlertTypeEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.AlertType;
+import jakarta.annotation.Nullable;
 
+/**
+ * Mapper for converting between {@link AlertType} domain objects and {@link AlertTypeEntity} entities.
+ */
 @Mapper
-public interface AlertTypeMapper {
+public abstract class AlertTypeMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts an {@link AlertTypeEntity} to an {@link AlertType} domain object.
+	 */
 	@Nullable
-	AlertType toDomainObject(@Nullable AlertTypeEntity alertType);
+	public abstract AlertType toAlertType(@Nullable AlertTypeEntity alertType);
 
+	/**
+	 * Converts an {@link AlertType} domain object to an {@link AlertTypeEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	AlertTypeEntity toEntity(@Nullable AlertType alertType);
+	public abstract AlertTypeEntity toAlertTypeEntity(@Nullable AlertType alertType);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapper.java
@@ -1,20 +1,55 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static java.util.Collections.emptyList;
+import static java.util.function.Predicate.not;
+
+import java.util.Collection;
+import java.util.Optional;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.ConfirmationCode;
 import jakarta.annotation.Nullable;
 
+/**
+ * Mapper for converting between {@link ConfirmationCode} domain objects and {@link ConfirmationCodeEntity} entities.
+ */
 @Mapper
-public interface ConfirmationCodeMapper {
+public abstract class ConfirmationCodeMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts a {@link ConfirmationCodeEntity} to a {@link ConfirmationCode} domain object.
+	 */
 	@Nullable
-	ConfirmationCode toDomainObject(@Nullable ConfirmationCodeEntity confirmationCode);
+	public abstract ConfirmationCode toConfirmationCode(@Nullable ConfirmationCodeEntity confirmationCode);
 
+	/**
+	 * Converts a {@link ConfirmationCode} domain object to a {@link ConfirmationCodeEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	ConfirmationCodeEntity toEntity(@Nullable ConfirmationCode confirmationCode);
+	public abstract ConfirmationCodeEntity toConfirmationCodeEntity(@Nullable ConfirmationCode confirmationCode);
+
+	/**
+	 * Updates a set of {@link ConfirmationCodeEntity} entities based on a provided collection of {@link ConfirmationCode} objects.
+	 *
+	 * This method iterates through the given `confirmationCodes` collection (if not null). For each `ConfirmationCode`:
+	 *  - If it's not already present in the `confirmationCodeEntities` set (based on ID comparison), it's converted to a
+	 *    `ConfirmationCodeEntity` using the `toEntity` method and added to the set.
+	 *  - If it's present in the `confirmationCodeEntities` set but not in the `confirmationCodes` collection, it's removed from the set.
+	 *
+	 * Essentially, this method synchronizes the `confirmationCodeEntities` set with the provided `confirmationCodes` collection
+	 * based on ID equality.
+	 */
+	@Named("updateConfirmationCodeEntities")
+	protected void updateConfirmationCodeEntities(@MappingTarget Collection<ConfirmationCodeEntity> confirmationCodeEntities, @Nullable Collection<ConfirmationCode> confirmationCodes) {
+		final var collection = Optional.ofNullable(confirmationCodes).orElse(emptyList());
+		confirmationCodeEntities.addAll(collection.stream().map(this::toConfirmationCodeEntity).toList());
+		confirmationCodeEntities.removeIf(not(entityIn(collection)));
+	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/LanguageMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/LanguageMapper.java
@@ -7,14 +7,23 @@ import org.springframework.lang.Nullable;
 import ca.gov.dtsstn.cdcp.api.data.entity.LanguageEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.Language;
 
+/**
+ * Mapper for converting between {@link Language} domain objects and {@link LanguageEntity} entities.
+ */
 @Mapper
-public interface LanguageMapper {
+public abstract class LanguageMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts a {@link LanguageEntity} to a {@link Language} domain object.
+	 */
 	@Nullable
-	Language toDomainObject(@Nullable LanguageEntity language);
+	public abstract Language toLanguage(@Nullable LanguageEntity language);
 
+	/**
+	 * Converts a {@link Language} domain object to a {@link LanguageEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	LanguageEntity toEntity(@Nullable Language language);
+	public abstract LanguageEntity toLanguageEntity(@Nullable Language language);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapper.java
@@ -1,43 +1,55 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
-import java.util.List;
-import java.util.stream.StreamSupport;
+import static java.util.Collections.emptyList;
+import static java.util.function.Predicate.not;
 
-import org.mapstruct.BeanMapping;
+import java.util.Collection;
+import java.util.Optional;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.Named;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.Subscription;
 import jakarta.annotation.Nullable;
 
-@Mapper(uses = { AlertTypeMapper.class })
-public interface SubscriptionMapper {
+/**
+ * Mapper for converting between {@link Subscription} domain objects and {@link SubscriptionEntity} entities.
+ */
+@Mapper(uses = { AlertTypeMapper.class, LanguageMapper.class })
+public abstract class SubscriptionMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts a {@link SubscriptionEntity} entity to a {@link Subscription} domain object.
+	 */
 	@Nullable
-	public default List<Subscription> toDomainObjects(@Nullable Iterable<SubscriptionEntity> subscriptions) {
-		if (subscriptions == null) { return null; }
-		return StreamSupport.stream(subscriptions.spliterator(), false).map(this::toDomainObject).toList();
-	}
+	public abstract Subscription toSubscription(@Nullable SubscriptionEntity subscription);
 
-	@Nullable
-	Subscription toDomainObject(@Nullable SubscriptionEntity subscription);
-
-	@Nullable
-	public default List<SubscriptionEntity> toEntities(@Nullable Iterable<Subscription> subscriptions) {
-		if (subscriptions == null) { return null; }
-		return StreamSupport.stream(subscriptions.spliterator(), false).map(this::toEntity).toList();
-	}
-
+	/**
+	 * Converts a {@link Subscription} domain object to a {@link SubscriptionEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	SubscriptionEntity toEntity(@Nullable Subscription subscription);
+	public abstract SubscriptionEntity toSubscriptionEntity(@Nullable Subscription subscription);
 
-	@Nullable
-	@Mapping(target = "isNew", ignore = true)
-	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-	SubscriptionEntity update(@MappingTarget SubscriptionEntity target, @Nullable Subscription subscription);
+	/**
+	 * Updates a set of {@link SubscriptionEntity} entities based on a provided collection of {@link Subscription} objects.
+	 *
+	 * This method iterates through the given `subscriptions` collection (if not null). For each `Subscription`:
+	 *  - If it's not already present in the `subscriptionEntities` set (based on ID comparison), it's converted to a
+	 *    `SubscriptionEntity` using the `toEntity` method and added to the set.
+	 *  - If it's present in the `subscriptionEntities` set but not in the `subscriptions` collection, it's removed from the set.
+	 *
+	 * Essentially, this method synchronizes the `subscriptionEntities` set with the provided `subscriptions` collection
+	 * based on ID equality.
+	 */
+	@Named("updateSubscriptionEntities")
+	protected void updateSubscriptionEntities(@MappingTarget Collection<SubscriptionEntity> subscriptionEntities, @Nullable Collection<Subscription> subscriptions) {
+		final var collection = Optional.ofNullable(subscriptions).orElse(emptyList());
+		subscriptionEntities.addAll(collection.stream().map(this::toSubscriptionEntity).toList());
+		subscriptionEntities.removeIf(not(entityIn(collection)));
+	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserAttributeMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserAttributeMapper.java
@@ -1,17 +1,55 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
+import static java.util.Collections.emptyList;
+import static java.util.function.Predicate.not;
+
+import java.util.Collection;
+import java.util.Optional;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.UserAttribute;
 import jakarta.annotation.Nullable;
 
+/**
+ * Mapper for converting between {@link UserAttribute} domain objects and {@link UserAttributeEntity} entities.
+ */
 @Mapper
-public interface UserAttributeMapper {
+public abstract class UserAttributeMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts a {@link UserAttributeEntity} entity to a {@link UserAttribute} domain object.
+	 */
+	@Nullable
+	public abstract UserAttribute toUserAttribute(UserAttributeEntity userAttributeEntity);
+
+	/**
+	 * Converts a {@link UserAttribute} domain object to a {@link UserAttributeEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	UserAttributeEntity toEntity(UserAttribute userAttribute);
+	public abstract UserAttributeEntity toUserAttributeEntity(UserAttribute userAttribute);
+
+	/**
+	 * Updates a set of {@link UserAttributeEntity} entities based on a provided collection of {@link UserAttribute} objects.
+	 *
+	 * This method iterates through the given `userAttributes` collection (if not null). For each `UserAttribute`:
+	 *  - If it's not already present in the `userAttributeEntities` set (based on ID comparison), it's converted to a
+	 *    `UserAttributeEntity` using the `toEntity` method and added to the set.
+	 *  - If it's present in the `userAttributeEntities` set but not in the `userAttributes` collection, it's removed from the set.
+	 *
+	 * Essentially, this method synchronizes the `userAttributeEntities` set with the provided `userAttributes` collection
+	 * based on ID equality.
+	 */
+	@Named("updateUserAttributeEntities")
+	protected void updateUserAttributeEntities(@MappingTarget Collection<UserAttributeEntity> userAttributeEntities, @Nullable Collection<UserAttribute> userAttributes) {
+		final var collection = Optional.ofNullable(userAttributes).orElse(emptyList());
+		userAttributeEntities.addAll(collection.stream().map(this::toUserAttributeEntity).toList());
+		userAttributeEntities.removeIf(not(entityIn(collection)));
+	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserMapper.java
@@ -1,28 +1,45 @@
 package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
 
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import ca.gov.dtsstn.cdcp.api.data.entity.UserEntity;
 import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import jakarta.annotation.Nullable;
 
-@Mapper(uses = { ConfirmationCodeMapper.class, UserAttributeMapper.class })
-public interface UserMapper {
+/**
+ * Mapper for converting between {@link User} domain objects and {@link UserEntity} entities.
+ */
+@Mapper(uses = { ConfirmationCodeMapper.class, SubscriptionMapper.class, UserAttributeMapper.class })
+public abstract class UserMapper extends AbstractDomainMapper {
 
+	/**
+	 * Converts a {@link UserEntity} entity to a {@link User} domain object.
+	 */
+	@Nullable
+	public abstract User toUser(@Nullable UserEntity user);
+
+	/**
+	 * Converts a {@link User} domain object to a {@link UserEntity} entity.
+	 */
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	UserEntity toEntity(@Nullable User user);
+	public abstract UserEntity toUserEntity(@Nullable User user);
 
+	/**
+	 * Updates a {@link UserEntity} entity with the values from a {@link User} domain object.
+	 */
 	@Nullable
-	User toDomainObject(@Nullable UserEntity user);
-
-	@Nullable
+	@Mapping(target = "id", ignore = true)
 	@Mapping(target = "isNew", ignore = true)
-	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-	UserEntity update(@MappingTarget UserEntity existingUser, @Nullable User user);
+	@Mapping(target = "createdBy", ignore = true)
+	@Mapping(target = "createdDate", ignore = true)
+	@Mapping(target = "lastModifiedBy", ignore = true)
+	@Mapping(target = "lastModifiedDate", ignore = true)
+	@Mapping(target = "confirmationCodes", qualifiedByName = { "updateConfirmationCodeEntities" })
+	@Mapping(target = "subscriptions", qualifiedByName = { "updateSubscriptionEntities" })
+	@Mapping(target = "userAttributes", qualifiedByName = { "updateUserAttributeEntities" })
+	public abstract void updateUserEntity(@MappingTarget UserEntity userEntity, @Nullable User user);
 
 }

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapperTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/ConfirmationCodeMapperTests.java
@@ -1,0 +1,78 @@
+package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.service.domain.ConfirmationCode;
+import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableConfirmationCode;
+
+@SuppressWarnings({ "serial" })
+@ExtendWith({ MockitoExtension.class })
+class ConfirmationCodeMapperTests {
+
+	ConfirmationCodeMapper confirmationCodeMapper = Mappers.getMapper(ConfirmationCodeMapper.class);
+
+	@Test
+	@DisplayName("Test confirmationCodeMapper.updateEntities(..)")
+	void testUpdateEntities() {
+		final var confirmationCodeEntities = new HashSet<ConfirmationCodeEntity>() {{
+			add(new ConfirmationCodeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new ConfirmationCodeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		final var confirmationCodes = new HashSet<ConfirmationCode>() {{
+			add(ImmutableConfirmationCode.builder().id("00000000-0000-0000-0000-000000000000").build());
+			add(ImmutableConfirmationCode.builder().id("22222222-2222-2222-2222-222222222222").build());
+		}};
+
+		confirmationCodeMapper.updateConfirmationCodeEntities(confirmationCodeEntities, confirmationCodes);
+
+		assertThat(confirmationCodeEntities).hasSize(2);
+		assertThat(hasEntityWithId(confirmationCodeEntities, "00000000-0000-0000-0000-000000000000")).isTrue();
+		assertThat(hasEntityWithId(confirmationCodeEntities, "11111111-1111-1111-1111-111111111111")).isFalse();
+		assertThat(hasEntityWithId(confirmationCodeEntities, "22222222-2222-2222-2222-222222222222")).isTrue();
+
+		confirmationCodeMapper.updateConfirmationCodeEntities(confirmationCodeEntities, null);
+		assertThat(confirmationCodeEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test confirmationCodeMapper.updateEntities(..) w/ null collection")
+	void testUpdateEntities_NullCollection() {
+		final var confirmationCodeEntities = new HashSet<ConfirmationCodeEntity>() {{
+			add(new ConfirmationCodeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new ConfirmationCodeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		confirmationCodeMapper.updateConfirmationCodeEntities(confirmationCodeEntities, null);
+		assertThat(confirmationCodeEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test confirmationCodeMapper.updateEntities(..) w/ empty collection")
+	void testUpdateEntities_EmptyCollection() {
+		final var confirmationCodeEntities = new HashSet<ConfirmationCodeEntity>() {{
+			add(new ConfirmationCodeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new ConfirmationCodeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		confirmationCodeMapper.updateConfirmationCodeEntities(confirmationCodeEntities, emptySet());
+		assertThat(confirmationCodeEntities).isEmpty();
+	}
+
+	boolean hasEntityWithId(Collection<ConfirmationCodeEntity> confirmationCodes, String id) {
+		return confirmationCodes.stream().anyMatch(confirmationCode -> confirmationCode.getId().equals(id));
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapperTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/SubscriptionMapperTests.java
@@ -1,0 +1,78 @@
+package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableSubscription;
+import ca.gov.dtsstn.cdcp.api.service.domain.Subscription;
+
+@SuppressWarnings({ "serial" })
+@ExtendWith({ MockitoExtension.class })
+class SubscriptionMapperTests {
+
+	SubscriptionMapper subscriptionMapper = Mappers.getMapper(SubscriptionMapper.class);
+
+	@Test
+	@DisplayName("Test subscriptionMapper.updateEntities(..)")
+	void testUpdateEntities() {
+		final var subscriptionEntities = new HashSet<SubscriptionEntity>() {{
+			add(new SubscriptionEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new SubscriptionEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		final var subscriptions = new HashSet<Subscription>() {{
+			add(ImmutableSubscription.builder().id("00000000-0000-0000-0000-000000000000").build());
+			add(ImmutableSubscription.builder().id("22222222-2222-2222-2222-222222222222").build());
+		}};
+
+		subscriptionMapper.updateSubscriptionEntities(subscriptionEntities, subscriptions);
+
+		assertThat(subscriptionEntities).hasSize(2);
+		assertThat(hasEntityWithId(subscriptionEntities, "00000000-0000-0000-0000-000000000000")).isTrue();
+		assertThat(hasEntityWithId(subscriptionEntities, "11111111-1111-1111-1111-111111111111")).isFalse();
+		assertThat(hasEntityWithId(subscriptionEntities, "22222222-2222-2222-2222-222222222222")).isTrue();
+
+		subscriptionMapper.updateSubscriptionEntities(subscriptionEntities, null);
+		assertThat(subscriptionEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test subscriptionMapper.updateEntities(..) w/ null collection")
+	void testUpdateEntities_NullCollection() {
+		final var subscriptionEntities = new HashSet<SubscriptionEntity>() {{
+			add(new SubscriptionEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new SubscriptionEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		subscriptionMapper.updateSubscriptionEntities(subscriptionEntities, null);
+		assertThat(subscriptionEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test subscriptionMapper.updateEntities(..) w/ empty collection")
+	void testUpdateEntities_EmptyCollection() {
+		final var subscriptionEntities = new HashSet<SubscriptionEntity>() {{
+			add(new SubscriptionEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new SubscriptionEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		subscriptionMapper.updateSubscriptionEntities(subscriptionEntities, emptySet());
+		assertThat(subscriptionEntities).isEmpty();
+	}
+
+	boolean hasEntityWithId(Collection<SubscriptionEntity> subscriptions, String id) {
+		return subscriptions.stream().anyMatch(subscription -> subscription.getId().equals(id));
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserAttributeMapperTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/service/domain/mapper/UserAttributeMapperTests.java
@@ -1,0 +1,78 @@
+package ca.gov.dtsstn.cdcp.api.service.domain.mapper;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableUserAttribute;
+import ca.gov.dtsstn.cdcp.api.service.domain.UserAttribute;
+
+@SuppressWarnings({ "serial" })
+@ExtendWith({ MockitoExtension.class })
+class UserAttributeMapperTests {
+
+	UserAttributeMapper userAttributeMapper = Mappers.getMapper(UserAttributeMapper.class);
+
+	@Test
+	@DisplayName("Test userAttributeMapper.updateEntities(..)")
+	void testUpdateEntities() {
+		final var userAttributeEntities = new HashSet<UserAttributeEntity>() {{
+			add(new UserAttributeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new UserAttributeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		final var userAttributes = new HashSet<UserAttribute>() {{
+			add(ImmutableUserAttribute.builder().id("00000000-0000-0000-0000-000000000000").build());
+			add(ImmutableUserAttribute.builder().id("22222222-2222-2222-2222-222222222222").build());
+		}};
+
+		userAttributeMapper.updateUserAttributeEntities(userAttributeEntities, userAttributes);
+
+		assertThat(userAttributeEntities).hasSize(2);
+		assertThat(hasEntityWithId(userAttributeEntities, "00000000-0000-0000-0000-000000000000")).isTrue();
+		assertThat(hasEntityWithId(userAttributeEntities, "11111111-1111-1111-1111-111111111111")).isFalse();
+		assertThat(hasEntityWithId(userAttributeEntities, "22222222-2222-2222-2222-222222222222")).isTrue();
+
+		userAttributeMapper.updateUserAttributeEntities(userAttributeEntities, null);
+		assertThat(userAttributeEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test userAttributeMapper.updateEntities(..) w/ null collection")
+	void testUpdateEntities_NullCollection() {
+		final var userAttributeEntities = new HashSet<UserAttributeEntity>() {{
+			add(new UserAttributeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new UserAttributeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		userAttributeMapper.updateUserAttributeEntities(userAttributeEntities, null);
+		assertThat(userAttributeEntities).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test userAttributeMapper.updateEntities(..) w/ empty collection")
+	void testUpdateEntities_EmptyCollection() {
+		final var userAttributeEntities = new HashSet<UserAttributeEntity>() {{
+			add(new UserAttributeEntityBuilder().id("00000000-0000-0000-0000-000000000000").build());
+			add(new UserAttributeEntityBuilder().id("11111111-1111-1111-1111-111111111111").build());
+		}};
+
+		userAttributeMapper.updateUserAttributeEntities(userAttributeEntities, emptySet());
+		assertThat(userAttributeEntities).isEmpty();
+	}
+
+	boolean hasEntityWithId(Collection<UserAttributeEntity> userAttributes, String id) {
+		return userAttributes.stream().anyMatch(userAttribute -> userAttribute.getId().equals(id));
+	}
+
+}


### PR DESCRIPTION
### Add mapping methods to support entity updating

This PR adds some MapStruct mapping methods that will eventually be used to support updating entities via http PATCH requests.

These new methods are necessary to ensure that JOINs are correctly handled when adding or removing an association.

### Additional info

The entities were modified to use `Collection<T>` as the base collection class instead of `Iterable<T>` to make it easier to add and remove items when updating associations.