### PR TITLE
AB#3927 Add UUID stub sin editor

### DIFF
--- a/frontend/public/locales/en/stub-sin-editor.json
+++ b/frontend/public/locales/en/stub-sin-editor.json
@@ -6,6 +6,6 @@
     "error-message": {
       "valid-sin": "Must be a valid SIN"
     },
-		"UUID-label":"Edit the UUID of the user (for user SUB and SID)"
+    "UUID-label":"Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/en/stub-sin-editor.json
+++ b/frontend/public/locales/en/stub-sin-editor.json
@@ -6,6 +6,6 @@
     "error-message": {
       "valid-sin": "Must be a valid SIN"
     },
-    "UUID-label":"Edit the UUID of the user (for user SUB and SID)"
+    "UUID-label": "Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/en/stub-sin-editor.json
+++ b/frontend/public/locales/en/stub-sin-editor.json
@@ -5,6 +5,7 @@
     "edit-id-button": "Apply SIN",
     "error-message": {
       "valid-sin": "Must be a valid SIN"
-    }
+    },
+		"UUID-label":"Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/fr/stub-sin-editor.json
+++ b/frontend/public/locales/fr/stub-sin-editor.json
@@ -6,6 +6,6 @@
     "error-message": {
       "valid-sin": "Must be a valid SIN"
     },
-		"UUID-label":"Edit the UUID of the user (for user SUB and SID)"
+    "UUID-label":"Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/fr/stub-sin-editor.json
+++ b/frontend/public/locales/fr/stub-sin-editor.json
@@ -6,6 +6,6 @@
     "error-message": {
       "valid-sin": "Must be a valid SIN"
     },
-    "UUID-label":"Edit the UUID of the user (for user SUB and SID)"
+    "UUID-label": "Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/fr/stub-sin-editor.json
+++ b/frontend/public/locales/fr/stub-sin-editor.json
@@ -5,6 +5,7 @@
     "edit-id-button": "Apply SIN",
     "error-message": {
       "valid-sin": "Must be a valid SIN"
-    }
+    },
+		"UUID-label":"Edit the UUID of the user (for user SUB and SID)"
   }
 }


### PR DESCRIPTION
### Description
Modified the stub sin page to allow modifying the userinfo.sub used in the session. 
Also edited the API to return the same response when there are no subscriptions found for a user. 


### Related Azure Boards Work Items
[AB#3927](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3927)
### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

