### PR TITLE
update parent guardian French content

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -80,7 +80,7 @@ export default function ApplyFlowParentOrGuardian() {
   const noWrap = <span className="whitespace-nowrap" />;
 
   return (
-    <>
+    <div className="max-w-prose">
       <div className="mb-8 space-y-4">
         <p>{t('apply-adult-child:parent-or-guardian.unable-to-apply-child')}</p>
         <p>{t('apply-adult-child:parent-or-guardian.unable-to-apply')}</p>
@@ -108,6 +108,6 @@ export default function ApplyFlowParentOrGuardian() {
           {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
         </Button>
       </fetcher.Form>
-    </>
+    </div>
   );
 }

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -551,11 +551,11 @@
     "continue-btn": "Continuer"
   },
   "parent-or-guardian": {
-    "page-title": "(FR) Parent or legal guardian needs to apply",
-    "unable-to-apply-child": "(FR) Your child is not currently eligible to apply for the Canadian Dental Care Plan at this time.",
-    "unable-to-apply": "(FR) You are not able to apply for the Canadian Dental Care Plan for yourself. Please have a parent or legal guardian apply on your behalf.",
-    "service-canada": "(FR) If you have already applied for your child and now want to apply for yourself, you must speak to a Service Canada representative. Contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>.",
-    "eligibility": "(FR) The Canadian Dental Care Plan is currently accepting applications for people aged 65 and above, children under 18, and adults with a valid disability tax credit.",
+    "page-title": "Le parent ou le tuteur légal doit faire la demande",
+    "unable-to-apply-child": "Votre enfant n'est actuellement pas admissible au Régime canadien de soins dentaires pour le moment.",
+    "unable-to-apply": "Vous ne pouvez pas présenter une demande d'adhésion au Régime canadien de soins dentaires pour vous même. Veuillez demander à votre parent ou tuteur légal de présenter une demande en votre nom.",
+    "service-canada": "Si vous avez déjà fait une demande pour votre enfant et que vous souhaitez maintenant présenter une demande pour vous-même, vous devez parler à un représentant de Service Canada. Contactez Service Canada en appelant au <noWrap>1-833-537-4342</noWrap>.",
+    "eligibility": "Le Régime canadien de soins dentaires accepte actuellement les demandes d'adhésion des personnes âgées de 65 ans et plus, des enfants de moins de 18 ans et des adultes qui reçoivent le crédit d'impôt pour personnes handicapées valide.",
     "back-btn": "Retour",
     "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"


### PR DESCRIPTION
### Description
Add French content for /adult-child/parent-or-guardian.

Client age is 16 or 17, child is NOT under 18, go to B3-5
Client age is under 16, child is NOT under 18, go to B3-6

### Related Azure Boards Work Items
[AB#3980](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3980)
[AB#3982](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3982)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
