### PR TITLE
AB#4040 -- Refactoring of personal information service, mapper and schema

### DIFF
--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { toPersonalInformation } from '~/mappers/personal-information-service-mappers.server';
 import { db } from '~/mocks/db';
 import { BenefitApplicationResponse, benefitApplicationRequestSchema } from '~/schemas/benefit-application-service-schemas.server';
-import { PersonalInfo, personalInformationApiSchema } from '~/schemas/personal-informaton-service-schemas.server';
+import { PersonalInformation, updateApplicantRequestSchema } from '~/schemas/personal-informaton-service-schemas.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('power-platform-api.server');
@@ -27,7 +27,7 @@ export function getPowerPlatformApiMockHandlers() {
     //
     // Retrieve personal details information (using POST instead of GET due the sin params logging with GET)
     //
-    http.post('https://api.example.com/dental-care/applicant-information/dts/v1/applicant/', async ({ request }) => {
+    http.post('https://api.example.com/dental-care/applicant-information/dts/v1/applicant', async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');
       if (!subscriptionKey) {
@@ -219,7 +219,7 @@ export function getPowerPlatformApiMockHandlers() {
       }
 
       const requestBody = await request.json();
-      const parsedPersonalInformationApiRequest = await personalInformationApiSchema.safeParseAsync(requestBody);
+      const parsedPersonalInformationApiRequest = await updateApplicantRequestSchema.safeParseAsync(requestBody);
       if (!parsedPersonalInformationApiRequest.success) {
         log.debug('Invalid request body [%j]', requestBody);
         return new HttpResponse('Invalid request body!', { status: 400 });
@@ -247,7 +247,7 @@ function getPersonalInformation(personalSinId: string) {
       });
 }
 
-function toPersonalInformationDB(personalInformation: PersonalInfo) {
+function toPersonalInformationDB(personalInformation: PersonalInformation) {
   return {
     mailingAddressStreet: personalInformation.mailingAddress?.streetName,
     mailingAddressSecondaryUnitText: personalInformation.mailingAddress?.secondAddressLine,

--- a/frontend/app/route-helpers/personal-information-route-helpers.server.ts
+++ b/frontend/app/route-helpers/personal-information-route-helpers.server.ts
@@ -1,7 +1,7 @@
 import { Session, redirect } from '@remix-run/node';
 import { Params } from '@remix-run/react';
 
-import { PersonalInfo } from '~/schemas/personal-informaton-service-schemas.server';
+import { PersonalInformation } from '~/schemas/personal-informaton-service-schemas.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
 import { getLogger } from '~/utils/logging.server';
 import { UserinfoToken } from '~/utils/raoidc-utils.server';
@@ -26,7 +26,7 @@ async function getPersonalInformation(userInfoToken: UserinfoToken, params: Para
     throw new Response(null, { status: 401 });
   }
 
-  const personalInformationFromSession: PersonalInfo | undefined = session.get('personalInformation');
+  const personalInformationFromSession: PersonalInformation | undefined = session.get('personalInformation');
   if (personalInformationFromSession && !session.get('personal-info-updated')) {
     log.debug('Returning personal information that already exists in session for userId [%s]', userInfoToken.sub);
     return personalInformationFromSession;

--- a/frontend/app/routes/$lang/_protected/personal-information/phone-number/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/phone-number/edit.tsx
@@ -13,7 +13,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-information-route-helpers.server';
-import { PersonalInfo } from '~/schemas/personal-informaton-service-schemas.server';
+import { PersonalInformation } from '~/schemas/personal-informaton-service-schemas.server';
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getPersonalInformationService } from '~/services/personal-information-service.server';
@@ -57,7 +57,7 @@ export async function loader({ context: { session }, request, params }: LoaderFu
   const personalInformationRouteHelper = getPersonalInformationRouteHelpers();
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  const personalInformation: PersonalInfo = await personalInformationRouteHelper.getPersonalInformation(userInfoToken, params, request, session);
+  const personalInformation: PersonalInformation = await personalInformationRouteHelper.getPersonalInformation(userInfoToken, params, request, session);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('personal-information:phone-number.edit.page-title') }) };
@@ -75,7 +75,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const personalInformationRouteHelper = getPersonalInformationRouteHelpers();
 
   const userInfoTokenAction: UserinfoToken = session.get('userInfoToken');
-  const personalInformation: PersonalInfo = await personalInformationRouteHelper.getPersonalInformation(userInfoTokenAction, params, request, session);
+  const personalInformation: PersonalInformation = await personalInformationRouteHelper.getPersonalInformation(userInfoTokenAction, params, request, session);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   await raoidcService.handleSessionValidation(request, session);

--- a/frontend/app/schemas/personal-informaton-service-schemas.server.ts
+++ b/frontend/app/schemas/personal-informaton-service-schemas.server.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const personalInformationApiSchema = z.object({
+export const getApplicantResponseSchema = z.object({
   BenefitApplication: z.object({
     Applicant: z
       .object({
@@ -139,9 +139,14 @@ export const personalInformationApiSchema = z.object({
   }),
 });
 
-export type PersonalInformationApi = z.infer<typeof personalInformationApiSchema>;
+export type GetApplicantResponse = z.infer<typeof getApplicantResponseSchema>;
 
-export const personalInfoDtoSchema = z.object({
+// TODO definition for request to update applicant is not yet available from Interop; Using getApplicantResponseSchema for now
+export const updateApplicantRequestSchema = getApplicantResponseSchema;
+
+export type UpdateApplicantRequest = z.infer<typeof updateApplicantRequestSchema>;
+
+export const personalInformationSchema = z.object({
   applicantCategoryCode: z.string().optional(),
   applictantId: z.string().optional(),
   clientId: z.string().optional(),
@@ -182,4 +187,4 @@ export const personalInfoDtoSchema = z.object({
   benefitApplicationIdentification: z.string().optional(),
 });
 
-export type PersonalInfo = z.infer<typeof personalInfoDtoSchema>;
+export type PersonalInformation = z.infer<typeof personalInformationSchema>;


### PR DESCRIPTION
### Description
This PR improves the readability and maintainability of `personal-information-service` by refactoring mappers and schemas to better reflect their purpose.
- The `toPersonalInformationApi` mapper function has been refactored into separate functions: `toGetApplicantRequest` and `toUpdateApplicantRequest`
- `personalInformationApiSchema` has been refactored into `getApplicantResponseSchema` and `updateApplicantRequestSchema`
- Changed `PersonalInfo` type to `PersonalInformation` to be consistent with naming conventions for the rest of the application

### Related Azure Boards Work Items
AB#4040

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application and navigate to `/en/personal-information`. Click around, make some personal information changes. It should still work as before with no issues.