### PR TITLE
Add French content for adult-child confirmation page

### DIFF
--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -200,14 +200,14 @@
     }
   },
   "confirm": {
-    "page-title": "(FR) Application successfully submitted",
+    "page-title": "Demande soumise avec succès",
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Conservez une copie de votre demande",
     "print-copy-text": "Vous <strong>ne recevrez pas</strong> de <strong>courriel de confirmation</strong>. Il est important de conserver une copie de votre demande. <noPrint>Vous pouvez utiliser ce bouton pour imprimer.<noPrint>",
     "print-btn": "Imprimer",
     "whats-next": "Prochaines étapes",
-    "begin-process": "(FR) We have received your application. Nothing further is required from you at this time.",
+    "begin-process": "Nous avons reçu votre demande. Vous n'avez rien d'autre à fournir pour l'instant.",
     "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
     "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
     "use-code-one-week": "You can use your application code to track the progress of your application one week after applying.",
@@ -228,9 +228,9 @@
     "dental-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/contactez.html",
     "application-summ": "Sommaire de la demande",
     "applicant-title": "Renseignements sur le demandeur",
-    "child-title": "(FR) {{childName}} information",
-    "is-parent": "(FR) Parent or legal guardian of child",
-    "spouse-info": "(FR) Spouse or common-law partner information",
+    "child-title": "Renseignements sur {{childName}}",
+    "is-parent": "Parent ou tuteur légal de l'enfant",
+    "spouse-info": "Renseignements sur l'époux/l'épouse ou le conjoint/la conjointe de fait",
     "contact-info": "Coordonnées",
     "comm-prefs": "Communication",
     "dental-insurance": "Accès à une assurance ou une couverture dentaire",
@@ -253,15 +253,15 @@
     "yes": "Oui",
     "no": "Non",
     "exit": "Sortie",
-    "close-application": "(FR) Close application",
+    "close-application": "Fermer la demande",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
     "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html",
     "modal": {
-      "header": "(FR) Close application",
-      "info": "(FR) By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
-      "are-you-sure": "Are you sure you want to close the application?",
-      "back-btn": "(FR) Back",
-      "close-btn": "(FR) Close application"
+      "header": "Fermer la demande",
+      "info": "En fermant cette demande, vous mettrez fin à votre session et les informations saisies seront effacées de votre navigateur. Assurez-vous d'avoir une copie de votre code de demande.",
+      "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
+      "back-btn": "Retour",
+      "close-btn": "Fermer la demande"
     }
   },
   "contact-apply-child": {


### PR DESCRIPTION
### Description
Add French content for confirmation page and exit modal

### Related Azure Boards Work Items
[AB#4002](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4002)
[AB#4003](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4003)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->