### PR TITLE
review contact-apply-child screen

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
@@ -211,6 +211,10 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
+  if (ageCategory === 'children') {
+    return redirect(getPathById('$lang/_public/apply/$id/child/contact-apply-child', params));
+  }
+
   if (state.editMode) {
     return redirect(getPathById('$lang/_public/apply/$id/child/review-adult-information', params));
   }

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -286,12 +286,12 @@
     }
   },
   "contact-apply-child": {
-    "page-title": "(FR) Contact us to apply for your child",
-    "speak-service-canada": "(FR) You must speak to a Service Canada representative if you are under 16 and applying for your child.",
-    "contact-service-canada": "(FR) Please contact Service Canada by calling <noWrap>1-833-537-4342</noWrap> or visit a <serviceCanadaOfficeLink>Service Canada Office</serviceCanadaOfficeLink>.",
+    "page-title": "Communiquez avec nous pour faire une demande pour votre enfant",
+    "speak-service-canada": "Vous devez parler à un représentant de Service Canada si vous avez moins de 16 ans et présentez une demande pour votre enfant.",
+    "contact-service-canada": "Veuillez communiquer avec Service Canada au <noWrap>1-833-537-4342<noWrap> ou vous rendre dans un <serviceCanadaOfficeLink>bureau de Service Canada</serviceCanadaOfficeLink>.",
     "service-canada-office-link": "https://www.servicecanada.gc.ca/tbsc-fsco/sc-hme.jsp?lang=fra",
-    "back-btn": "(FR) Back",
-    "return-btn": "(FR) Return to main page",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
   "eligibility": {


### PR DESCRIPTION
### Description
-review screen C12-1 Under 16 applying
-english locales unchanged
-french locales updated
-conditional redirect added to `/child/applicant-information` if the `ageCategory==='children'` (<16 years old)

### Related Azure Boards Work Items
[AB#3935](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3935)