### PR TITLE
Use react phone number input in "adult" flow

### DIFF
--- a/frontend/__tests__/components/input-phone-field.test.tsx
+++ b/frontend/__tests__/components/input-phone-field.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 
-import { parsePhoneNumber } from 'libphonenumber-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { InputPhoneField } from '~/components/input-phone-field';
@@ -18,7 +17,7 @@ describe('InputPhoneField', () => {
   });
 
   it('should render', () => {
-    const phoneNumber = parsePhoneNumber('+15146667777').number;
+    const phoneNumber = '+15146667777';
     render(<InputPhoneField id="test-id" name="test" label="label test" defaultValue={phoneNumber} />);
 
     const actual: HTMLInputElement = screen.getByTestId('input-phone-field');
@@ -26,13 +25,27 @@ describe('InputPhoneField', () => {
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAccessibleName('label test');
     expect(actual).toHaveAttribute('id', 'test-id');
-    expect(actual).toHaveValue('+1 514 666 7777');
+    expect(actual).toHaveValue('(514) 666-7777');
+    expect(actual).not.toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render international phone number', () => {
+    const phoneNumber = '+50644444444';
+    render(<InputPhoneField id="test-id" name="test" label="label test" defaultValue={phoneNumber} />);
+
+    const actual: HTMLInputElement = screen.getByTestId('input-phone-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('+506 4444 4444');
     expect(actual).not.toBeRequired();
     expect(actual).not.toHaveAccessibleDescription();
   });
 
   it('should render with help message', () => {
-    const phoneNumber = parsePhoneNumber('+15146667777').number;
+    const phoneNumber = '+15146667777';
     render(<InputPhoneField id="test-id" name="test" label="label test" defaultValue={phoneNumber} helpMessageSecondary="help message" />);
 
     const actual = screen.getByTestId('input-phone-field');
@@ -41,25 +54,25 @@ describe('InputPhoneField', () => {
     expect(actual).toHaveAccessibleDescription('help message');
     expect(actual).toHaveAccessibleName('label test');
     expect(actual).toHaveAttribute('id', 'test-id');
-    expect(actual).toHaveValue('+1 514 666 7777');
+    expect(actual).toHaveValue('(514) 666-7777');
     expect(actual).not.toBeRequired();
   });
 
   it('should render with required', () => {
-    const phoneNumber = parsePhoneNumber('+15146667777').number;
+    const phoneNumber = '+15146667777';
     render(<InputPhoneField id="test-id" name="test" label="label test" defaultValue={phoneNumber} required />);
 
     const actual = screen.getByTestId('input-phone-field');
 
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAttribute('id', 'test-id');
-    expect(actual).toHaveValue('+1 514 666 7777');
+    expect(actual).toHaveValue('(514) 666-7777');
     expect(actual).toBeRequired();
     expect(actual).not.toHaveAccessibleDescription();
   });
 
   it('should render with error message', () => {
-    const phoneNumber = parsePhoneNumber('+15146667777').number;
+    const phoneNumber = '+15146667777';
     render(<InputPhoneField id="test-id" name="test" label="label test" defaultValue={phoneNumber} errorMessage="error message" />);
 
     const actual = screen.getByTestId('input-phone-field');

--- a/frontend/app/components/input-phone-field.tsx
+++ b/frontend/app/components/input-phone-field.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { E164Number } from 'libphonenumber-js';
-import PhoneInput, { FeatureProps } from 'react-phone-number-input';
+import PhoneInput, { FeatureProps } from 'react-phone-number-input/input';
 import enLabels from 'react-phone-number-input/locale/en';
 import frLabels from 'react-phone-number-input/locale/fr';
 
@@ -16,7 +16,7 @@ const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-n
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
 export interface InputPhoneFieldProps extends Omit<FeatureProps<React.InputHTMLAttributes<HTMLInputElement>>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'labels'> {
-  defaultValue?: E164Number;
+  defaultValue?: string;
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;
   helpMessagePrimaryClassName?: string;
@@ -29,7 +29,7 @@ export interface InputPhoneFieldProps extends Omit<FeatureProps<React.InputHTMLA
 }
 
 export function InputPhoneField(props: InputPhoneFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, locale, required, ...restProps } = props;
+  const { 'aria-describedby': ariaDescribedby, className, defaultValue, defaultCountry, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, locale, required, ...restProps } = props;
   const [value, setValue] = useState(defaultValue);
 
   const inputWrapperId = `input-phone-field-${id}`;
@@ -73,12 +73,11 @@ export function InputPhoneField(props: InputPhoneFieldProps) {
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        countryCallingCodeEditable={false}
         data-testid="input-phone-field"
+        defaultCountry={defaultCountry ?? 'CA'}
         id={id}
-        international
         labels={labels}
-        numberInputProps={{ className: cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className) }}
+        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
         onChange={handleOnPhoneInputChange}
         required={required}
         value={value}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/personal-information.tsx
@@ -16,6 +16,7 @@ import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToError
 import { InputCheckbox } from '~/components/input-checkbox';
 import { InputField } from '~/components/input-field';
 import { InputOptionProps } from '~/components/input-option';
+import { InputPhoneField } from '~/components/input-phone-field';
 import { InputSelect } from '~/components/input-select';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
@@ -376,7 +377,7 @@ export default function ApplyFlowPersonalInformation() {
             <legend className="mb-4 font-lato text-2xl font-bold">{t('apply-adult:contact-information.phone-header')}</legend>
             <p className="mb-4">{t('apply-adult:contact-information.add-phone')}</p>
             <div className="grid items-end gap-6">
-              <InputField
+              <InputPhoneField
                 id="phone-number"
                 name="phoneNumber"
                 type="tel"
@@ -389,7 +390,7 @@ export default function ApplyFlowPersonalInformation() {
                 maxLength={100}
                 aria-describedby="adding-phone"
               />
-              <InputField
+              <InputPhoneField
                 id="phone-number-alt"
                 name="phoneNumberAlt"
                 type="tel"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Use the React phone number input component in the "adult" flow. It will automatically format the phone number as the client types it. The default country for the input is set to `CA`, but this can be overridden if necessary (though it is not required at the moment).

https://catamphetamine.gitlab.io/react-phone-number-input/#without-country-select

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->