### PR TITLE
Refactoring HTTP proxy so that it can be used for multiple API calls (and not just RAOIDC)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -40,9 +40,6 @@ AUTH_RAOIDC_BASE_URL=http://localhost:3000/auth
 # RAOIDC client ID -- the OAuth client id used for all RAOIDC calls
 # (required; use the example below)
 AUTH_RAOIDC_CLIENT_ID=CDCP
-# RAOIDC proxy URL -- used to proxy all outgoing RAOIDC calls
-# (optional; default: undefined)
-AUTH_RAOIDC_PROXY_URL=
 # RASCL logout URL -- used when no RAOIDC session is found during logout
 # (required; use the example below)
 AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
@@ -65,6 +62,12 @@ HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
 # hCaptcha verify URL -- used to verify hCaptcha tokens
 # (optional; default: https://api.hcaptcha.com/siteverify)
 HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
+
+
+# HTTP proxy URL -- used to proxy specified outgoing HTTP calls
+# (optional; default: undefined)
+HTTP_PROXY_URL=
+
 
 # Interop API base url
 # (required; use the example below)

--- a/frontend/app/services/benefit-application-service.server.ts
+++ b/frontend/app/services/benefit-application-service.server.ts
@@ -6,6 +6,7 @@ import { BenefitApplicationRequest, benefitApplicationRequestSchema, benefitAppl
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getEnv } from '~/utils/env.server';
+import { getFetchFn } from '~/utils/fetch-utils';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('benefit-application-service.server');
@@ -13,11 +14,14 @@ const log = getLogger('benefit-application-service.server');
 function createBenefitApplicationService() {
   // prettier-ignore
   const {
+    HTTP_PROXY_URL,
     INTEROP_API_BASE_URI,
     INTEROP_API_SUBSCRIPTION_KEY,
     INTEROP_BENEFIT_APPLICATION_API_BASE_URI,
     INTEROP_BENEFIT_APPLICATION_API_SUBSCRIPTION_KEY,
   } = getEnv();
+
+  const fetchFn = getFetchFn(HTTP_PROXY_URL);
 
   /**
    * Application submission to Power Platform
@@ -41,7 +45,7 @@ function createBenefitApplicationService() {
 
     const url = new URL(`${INTEROP_BENEFIT_APPLICATION_API_BASE_URI ?? INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/benefit-application`);
 
-    const response = await fetch(url, {
+    const response = await fetchFn(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -90,7 +94,7 @@ function createBenefitApplicationService() {
 
     const url = new URL(`${INTEROP_BENEFIT_APPLICATION_API_BASE_URI ?? INTEROP_API_BASE_URI}/v1/users/${userId}/applications`);
 
-    const response = await fetch(url, {
+    const response = await fetchFn(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/app/services/letters-service.server.ts
+++ b/frontend/app/services/letters-service.server.ts
@@ -6,6 +6,7 @@ import letterTypesJson from '~/resources/power-platform/letter-types.json';
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getEnv } from '~/utils/env.server';
+import { getFetchFn } from '~/utils/fetch-utils';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('letters-service.server');
@@ -21,12 +22,15 @@ function createLettersService() {
     GET_ALL_LETTER_TYPES_CACHE_TTL_SECONDS,
     ENGLISH_LANGUAGE_CODE,
     FRENCH_LANGUAGE_CODE,
+    HTTP_PROXY_URL,
     INTEROP_API_BASE_URI,
     INTEROP_API_SUBSCRIPTION_KEY,
     INTEROP_CCT_API_BASE_URI,
     INTEROP_CCT_API_SUBSCRIPTION_KEY,
     INTEROP_CCT_API_COMMUNITY,
   } = getEnv();
+
+  const fetchFn = getFetchFn(HTTP_PROXY_URL);
 
   /**
    * @returns returns all the letter types
@@ -63,7 +67,7 @@ function createLettersService() {
     const url = new URL(`${INTEROP_CCT_API_BASE_URI ?? INTEROP_API_BASE_URI}/dental-care/client-letters/cct/v1/GetDocInfoByClientId`);
     url.searchParams.set('clientid', clientId);
 
-    const response = await fetch(url, {
+    const response = await fetchFn(url, {
       headers: {
         'Content-Type': 'application/json',
         'Ocp-Apim-Subscription-Key': INTEROP_CCT_API_SUBSCRIPTION_KEY ?? INTEROP_API_SUBSCRIPTION_KEY,
@@ -119,7 +123,7 @@ function createLettersService() {
 
     auditService.audit('pdf.get', { letterId, userId });
 
-    const response = await fetch(url, {
+    const response = await fetchFn(url, {
       headers: {
         'Content-Type': 'application/json',
         'Ocp-Apim-Subscription-Key': INTEROP_CCT_API_SUBSCRIPTION_KEY ?? INTEROP_API_SUBSCRIPTION_KEY,

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -110,7 +110,6 @@ const serverEnv = z.object({
   AUTH_LOGOUT_REDIRECT_URL: z.string().url(),
   AUTH_RAOIDC_BASE_URL: z.string().trim().min(1),
   AUTH_RAOIDC_CLIENT_ID: z.string().trim().min(1),
-  AUTH_RAOIDC_PROXY_URL: z.string().trim().transform(emptyToUndefined).optional(),
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
   // hCaptcha settings
@@ -118,6 +117,9 @@ const serverEnv = z.object({
   HCAPTCHA_SECRET_KEY: z.string().trim().min(1),
   HCAPTCHA_SITE_KEY: z.string().trim().min(1),
   HCAPTCHA_VERIFY_URL: z.string().url().default('https://api.hcaptcha.com/siteverify'),
+
+  // http proxy settings
+  HTTP_PROXY_URL: z.string().trim().transform(emptyToUndefined).optional(),
 
   // session configuration
   SESSION_STORAGE_TYPE: z.enum(['file', 'redis']).default('file'),

--- a/frontend/app/utils/fetch-utils.ts
+++ b/frontend/app/utils/fetch-utils.ts
@@ -1,0 +1,39 @@
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { toNodeReadable } from 'web-streams-node';
+
+import { getLogger } from './logging.server';
+
+const log = getLogger('fetch-utils.server');
+
+/**
+ * A custom fetch(..) function that can be used for making HTTP requests.
+ * Primarily used for intercepting responses or configuring an HTTP proxy.
+ */
+export interface FetchFunction {
+  (input: string | URL, init?: FetchFunctionInit): Promise<Response>;
+}
+
+/**
+ * Init options for FetchFunction.
+ */
+export interface FetchFunctionInit extends RequestInit {
+  body?: string; // forces compatibility between node.fetch() and undici.fetch()
+}
+
+/**
+ * Return a custom fetch() function if a proxy URL has been provided.
+ * If no proxy has been provided, simply return global.fetch().
+ */
+export function getFetchFn(proxyUrl?: string) {
+  if (proxyUrl) {
+    log.debug('A proxy has been configured: [%s]; using custom fetch', proxyUrl);
+    return async (input: string | URL, init?: FetchFunctionInit) => {
+      const dispatcher = new ProxyAgent({ uri: proxyUrl, proxyTls: { timeout: 30000 } }); // TODO :: GjB :: make timeout configurable?
+      const response = await undiciFetch(input, { ...init, dispatcher });
+      return new Response(toNodeReadable(response.body));
+    };
+  }
+
+  log.debug('No proxy configured; using global fetch');
+  return global.fetch;
+}

--- a/frontend/app/utils/raoidc-utils.server.ts
+++ b/frontend/app/utils/raoidc-utils.server.ts
@@ -5,6 +5,7 @@ import { UTCDate } from '@date-fns/utc';
 import { JWTPayload, JWTVerifyResult, SignJWT, compactDecrypt, importJWK, jwtVerify } from 'jose';
 import { createHash, subtle } from 'node:crypto';
 
+import { FetchFunction } from './fetch-utils';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('raoidc-utils.server');
@@ -128,21 +129,6 @@ export interface ServerMetadata extends Record<string, unknown> {
   revocation_endpoint?: string;
   token_endpoint_auth_methods_supported?: Array<string>;
   token_endpoint_auth_signing_alg_values_supported?: Array<string>;
-}
-
-/**
- * A custom fetch(..) function that can be used when calling OIDC endpoints.
- * Primarily used for intercepting responses or configuring an http proxy.
- */
-export interface FetchFunction {
-  (input: string | URL, init?: FetchFunctionInit): Promise<Response>;
-}
-
-/**
- * Init options for FetchFunction.
- */
-export interface FetchFunctionInit extends RequestInit {
-  body?: string; // forces compatibility between node.fetch() and undici.fetch()
 }
 
 /**


### PR DESCRIPTION
### Description
This PR refactors the existing HTTP proxy functionality to be more generic. Previously, it was limited to handling RAOIDC endpoints. The proxy can now be used within services for making requests to APIs hosted within the ESDC network. Changes include:
- Separating the proxy logic into a reusable utility function
- Removing any specific references to RAOIDC in the utility function
- Updating the service to utilize the generic proxy functionality for applicable API calls

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
1. Set up port-forwarding to the Squid proxy service in the cluster:
```
kubectl \
  --kubeconfig <path-to-kubeconfig> \
  --namespace canada-dental-care-plan \
  port-forward service/squid 3128:3128
```
2. Copy the newly changed `.env.example` file into your `.env` and make the following changes:
```
LOG_LEVEL=trace # so we can see requests hitting on-prem API
HTTP_PROXY_URL=http://localhost:3128
INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/int/stream1
INTEROP_API_SUBSCRIPTION_KEY=# get this value from vault
```
3. Run the application locally and navigate to `/en/status/myself` (you can also complete a CDCP application intake form). Enter Application code of `2461733341149` and SIN of  `931102511` and hit "Check status"
4. In the console, you'll notice a line like the following indicating the response from the on-prem API is being returned:
```
TRACE --- […on-status-service.server]: Status id: [{"BenefitApplication":{"BenefitApplicationStatus":[{"ReferenceDataID":"504fba6e-604e-ee11-be6f-000d3a09d640","ReferenceDataName":"Dental Status Code"}]}}]
```