### PR TITLE
Add and integrate input SIN field in "adult" flow

### DIFF
--- a/frontend/__tests__/components/input-sin-field.test.tsx
+++ b/frontend/__tests__/components/input-sin-field.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { InputSinField } from '~/components/input-sin-field';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('InputSinField', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it.each([
+    ['800000002', '800 000 002'],
+    ['800 000 002', '800 000 002'],
+    ['800-000-002', '800 000 002'],
+    ['800 000-002', '800 000 002'],
+    ['800000 002', '800 000 002'],
+    ['800000-002', '800 000 002'],
+  ])('should render %s -> %s', (sin, expected) => {
+    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} />);
+
+    const actual: HTMLInputElement = screen.getByTestId('input-sin-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue(expected);
+    expect(actual).not.toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with help message', () => {
+    const sin = '800000002';
+    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} helpMessageSecondary="help message" />);
+
+    const actual = screen.getByTestId('input-sin-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleDescription('help message');
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('800 000 002');
+    expect(actual).not.toBeRequired();
+  });
+
+  it('should render with required', () => {
+    const sin = '800000002';
+    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} required />);
+
+    const actual = screen.getByTestId('input-sin-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue('800 000 002');
+    expect(actual).toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with error message', () => {
+    const sin = '800000002';
+    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} errorMessage="error message" />);
+
+    const actual = screen.getByTestId('input-sin-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toBeInvalid();
+    expect(actual).toHaveAccessibleErrorMessage('error message');
+  });
+});

--- a/frontend/app/components/input-sin-field.tsx
+++ b/frontend/app/components/input-sin-field.tsx
@@ -1,0 +1,79 @@
+import { PatternFormat } from 'react-number-format';
+
+import { InputError } from './input-error';
+import { InputHelp } from './input-help';
+import { InputLabel } from '~/components/input-label';
+import { cn } from '~/utils/tw-utils';
+
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
+const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
+const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
+const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
+
+export interface InputSinFieldProps extends Omit<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value' | 'onChange' | 'format'> {
+  defaultValue: string;
+  errorMessage?: string;
+  helpMessagePrimary?: React.ReactNode;
+  helpMessagePrimaryClassName?: string;
+  helpMessageSecondary?: React.ReactNode;
+  helpMessageSecondaryClassName?: string;
+  id: string;
+  label: string;
+  locale?: string;
+  name: string;
+}
+
+export function InputSinField(props: InputSinFieldProps) {
+  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
+
+  const inputWrapperId = `input-sin-field-${id}`;
+  const inputErrorId = `${inputWrapperId}-error`;
+  const inputHelpMessagePrimaryId = `${inputWrapperId}-help-primary`;
+  const inputHelpMessageSecondaryId = `${inputWrapperId}-help-secondary`;
+  const inputLabelId = `${inputWrapperId}-label`;
+
+  function getAriaDescribedby() {
+    const describedby = [];
+    if (ariaDescribedby) describedby.push(ariaDescribedby);
+    if (helpMessagePrimary) describedby.push(inputHelpMessagePrimaryId);
+    if (helpMessageSecondary) describedby.push(inputHelpMessageSecondaryId);
+    return describedby.length > 0 ? describedby.join(' ') : undefined;
+  }
+
+  return (
+    <div id={inputWrapperId} data-testid={inputWrapperId}>
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
+        {label}
+      </InputLabel>
+      {errorMessage && (
+        <p className="mb-2">
+          <InputError id={inputErrorId}>{errorMessage}</InputError>
+        </p>
+      )}
+      {helpMessagePrimary && (
+        <InputHelp id={inputHelpMessagePrimaryId} className={cn('mb-2', helpMessagePrimaryClassName)} data-testid="input-sin-field-help-primary">
+          {helpMessagePrimary}
+        </InputHelp>
+      )}
+      <PatternFormat
+        aria-describedby={getAriaDescribedby()}
+        aria-errormessage={errorMessage ? inputErrorId : undefined}
+        aria-invalid={!!errorMessage}
+        aria-labelledby={inputLabelId}
+        aria-required={required}
+        data-testid="input-sin-field"
+        format="### ### ###"
+        id={id}
+        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        required={required}
+        value={defaultValue}
+        {...restProps}
+      />
+      {helpMessageSecondary && (
+        <InputHelp id={inputHelpMessageSecondaryId} className={cn('mt-2', helpMessageSecondaryClassName)} data-testid="input-sin-field-help-secondary">
+          {helpMessageSecondary}
+        </InputHelp>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/input-sin-field.tsx
+++ b/frontend/app/components/input-sin-field.tsx
@@ -19,7 +19,6 @@ export interface InputSinFieldProps extends Omit<React.ComponentProps<typeof Pat
   helpMessageSecondaryClassName?: string;
   id: string;
   label: string;
-  locale?: string;
   name: string;
 }
 

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -15,6 +15,7 @@ import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { InputRadios } from '~/components/input-radios';
+import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import { ApplicantInformationState, applicantInformationStateHasPartner, getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -231,7 +232,7 @@ export default function ApplyFlowApplicationInformation() {
                 required
               />
             </div>
-            <InputField
+            <InputSinField
               id="social-insurance-number"
               name="socialInsuranceNumber"
               label={t('applicant-information.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -15,6 +15,7 @@ import { DatePickerField } from '~/components/date-picker-field';
 import { ErrorSummary, ErrorSummaryItem, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { InputField } from '~/components/input-field';
+import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import { PartnerInformationState, applicantInformationStateHasPartner, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -264,7 +265,7 @@ export default function ApplyFlowApplicationInformation() {
               }}
               required
             />
-            <InputField
+            <InputSinField
               id="social-insurance-number"
               name="socialInsuranceNumber"
               label={t('apply-adult:partner-information.sin')}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^14.1.2",
         "react-idle-timer": "^5.7.2",
+        "react-number-format": "^5.4.0",
         "react-phone-number-input": "^3.4.3",
         "sanitize-filename-ts": "^1.0.2",
         "source-map-support": "^0.5.21",
@@ -12438,6 +12439,18 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/react-number-format": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.0.tgz",
+      "integrity": "sha512-NWdICrqLhI7rAS8yUeLVd6Wr4cN7UjJ9IBTS0f/a9i7UB4x4Ti70kGnksBtZ7o4Z7YRbvCMMR/jQmkoOBa/4fg==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-phone-number-input": {
       "version": "3.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^14.1.2",
     "react-idle-timer": "^5.7.2",
+    "react-number-format": "^5.4.0",
     "react-phone-number-input": "^3.4.3",
     "sanitize-filename-ts": "^1.0.2",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add and integrate input SIN field in "adult" flow.

React number format | Pattern Format
https://s-yadav.github.io/react-number-format/docs/pattern_format

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#3641](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/3641)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->