### PR TITLE
Update apply index document title

### DIFF
--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -10,7 +10,7 @@
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   },
   "index": {
-    "page-title": "Applying for the Canadian Dental Care Plan"
+    "page-title": "Apply"
   },
   "progress": {
     "label": "Application Progress Tracking"

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -10,7 +10,7 @@
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
   "index": {
-    "page-title": "(FR) Applying for the Canadian Dental Care Plan"
+    "page-title": "Présenter une demande"
   },
   "progress": {
     "label": "Suivi de la progression de l'application"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Update apply index document title since it wasn't translated since first release. That `document.title` is only present on `/apply` when the state is being created and UI skeleton is displayed.