### PR TITLE
Remove SIN validation from `/stub-sin-editor`

### DIFF
--- a/frontend/app/routes/$lang/_protected/stub-sin-editor.tsx
+++ b/frontend/app/routes/$lang/_protected/stub-sin-editor.tsx
@@ -17,7 +17,6 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { UserinfoToken } from '~/utils/raoidc-utils.server';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { isValidSin } from '~/utils/sin-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('stub-sin-editor', 'gcweb'),
@@ -43,7 +42,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const sinToStubSchema = z.object({
-    socialInsuranceNumberToStub: z.string().refine(isValidSin, { message: 'valid-sin' }),
+    socialInsuranceNumberToStub: z.string(),
     userUUIDToStub: z.string(),
   });
 

--- a/frontend/public/locales/en/stub-sin-editor.json
+++ b/frontend/public/locales/en/stub-sin-editor.json
@@ -3,9 +3,6 @@
     "page-title": "Edit the SIN",
     "edit-id-field": "SIN to use/stub",
     "edit-id-button": "Apply SIN",
-    "error-message": {
-      "valid-sin": "Must be a valid SIN"
-    },
     "UUID-label": "Edit the UUID of the user (for user SUB and SID)"
   }
 }

--- a/frontend/public/locales/fr/stub-sin-editor.json
+++ b/frontend/public/locales/fr/stub-sin-editor.json
@@ -3,9 +3,6 @@
     "page-title": "Edit the SIN",
     "edit-id-field": "SIN to use/stub",
     "edit-id-button": "Apply SIN",
-    "error-message": {
-      "valid-sin": "Must be a valid SIN"
-    },
     "UUID-label": "Edit the UUID of the user (for user SUB and SID)"
   }
 }


### PR DESCRIPTION
### Description
When testing `/applicant` stuff, I was using a test SIN of `200000002` which isn't actually a valid SIN. I am removing the SIN validation in `/stub-sin-editor` in case we need to use other invalid "SIN"s to test.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/en/stub-sin/editor`. Enter `200000002`. No validation error should appear.