### PR TITLE
AB#4010 -- Renaming and rendering apartment/suite number in protected space

### DIFF
--- a/frontend/app/mappers/personal-information-service-mappers.server.ts
+++ b/frontend/app/mappers/personal-information-service-mappers.server.ts
@@ -110,7 +110,7 @@ export function toPersonalInformation(getApplicantResponse: GetApplicantResponse
     homeAddress: homeAddressList
       ?.map((aHomeAddress) => ({
         streetName: aHomeAddress.AddressStreet.StreetName,
-        secondAddressLine: aHomeAddress.AddressSecondaryUnitText,
+        apartment: aHomeAddress.AddressSecondaryUnitText,
         cityName: aHomeAddress.AddressCityName,
         provinceTerritoryStateId: aHomeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
         countryId: aHomeAddress.AddressCountry.CountryCode.ReferenceDataID,
@@ -120,7 +120,7 @@ export function toPersonalInformation(getApplicantResponse: GetApplicantResponse
     mailingAddress: mailingAddressList
       ?.map((aMailingAddress) => ({
         streetName: aMailingAddress.AddressStreet.StreetName,
-        secondAddressLine: aMailingAddress.AddressSecondaryUnitText,
+        apartment: aMailingAddress.AddressSecondaryUnitText,
         cityName: aMailingAddress.AddressCityName,
         provinceTerritoryStateId: aMailingAddress.AddressProvince.ProvinceCode.ReferenceDataID,
         countryId: aMailingAddress.AddressCountry.CountryCode.ReferenceDataID,
@@ -137,16 +137,16 @@ export function toPersonalInformation(getApplicantResponse: GetApplicantResponse
 }
 
 interface ToUpdateAddressRequestArgs {
+  apartment?: string;
   category: string;
   cityName?: string;
   countryId?: string;
-  secondAddressLine?: string;
   streetName?: string;
   postalCode?: string;
   provinceTerritoryStateId?: string;
 }
 
-function toUpdateAddressRequest({ category, cityName, countryId, secondAddressLine, streetName, postalCode, provinceTerritoryStateId }: ToUpdateAddressRequestArgs) {
+function toUpdateAddressRequest({ apartment, category, cityName, countryId, streetName, postalCode, provinceTerritoryStateId }: ToUpdateAddressRequestArgs) {
   return {
     AddressCategoryCode: {
       ReferenceDataName: category,
@@ -163,7 +163,7 @@ function toUpdateAddressRequest({ category, cityName, countryId, secondAddressLi
         ReferenceDataID: provinceTerritoryStateId,
       },
     },
-    AddressSecondaryUnitText: secondAddressLine,
+    AddressSecondaryUnitText: apartment,
     AddressStreet: {
       StreetName: streetName,
     },

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -250,13 +250,13 @@ function getPersonalInformation(personalSinId: string) {
 function toPersonalInformationDB(personalInformation: PersonalInformation) {
   return {
     mailingAddressStreet: personalInformation.mailingAddress?.streetName,
-    mailingAddressSecondaryUnitText: personalInformation.mailingAddress?.secondAddressLine,
+    mailingAddressSecondaryUnitText: personalInformation.mailingAddress?.apartment,
     mailingAddressCityName: personalInformation.mailingAddress?.cityName,
     mailingAddressProvince: personalInformation.mailingAddress?.provinceTerritoryStateId,
     mailingAddressCountryReferenceId: personalInformation.mailingAddress?.countryId,
     mailingAddressPostalCode: personalInformation.mailingAddress?.postalCode,
     homeAddressStreet: personalInformation.homeAddress?.streetName,
-    homeAddressSecondaryUnitText: personalInformation.homeAddress?.secondAddressLine,
+    homeAddressSecondaryUnitText: personalInformation.homeAddress?.apartment,
     homeAddressCityName: personalInformation.homeAddress?.cityName,
     homeAddressProvince: personalInformation.homeAddress?.provinceTerritoryStateId,
     homeAddressCountryReferenceId: personalInformation.homeAddress?.countryId,

--- a/frontend/app/routes/$lang/_protected/personal-information/home-address/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/home-address/edit.tsx
@@ -99,7 +99,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const formDataSchema = z
     .object({
       streetName: z.string().trim().min(1, t('personal-information:home-address.edit.error-message.address-required')).max(30),
-      secondAddressLine: z.string().trim().max(30).optional(),
+      apartment: z.string().trim().max(30).optional(),
       countryId: z.string().trim().min(1, t('personal-information:home-address.edit.error-message.country-required')),
       provinceTerritoryStateId: z.string().trim().min(1, t('personal-information:home-address.edit.error-message.province-required')).optional(),
       cityName: z.string().trim().min(1, t('personal-information:home-address.edit.error-message.city-required')).max(100),
@@ -139,7 +139,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   const data = {
     streetName: String(formData.get('streetName') ?? ''),
-    secondAddressLine: formData.get('secondAddressLine') ? String(formData.get('secondAddressLine')) : undefined,
+    apartment: formData.get('apartment') ? String(formData.get('apartment')) : undefined,
     countryId: String(formData.get('countryId') ?? ''),
     provinceTerritoryStateId: formData.get('provinceTerritoryStateId') ? String(formData.get('provinceTerritoryStateId')) : undefined,
     cityName: String(formData.get('cityName') ?? ''),
@@ -161,13 +161,13 @@ export async function action({ context: { session }, params, request }: ActionFu
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
 
-  const { streetName, secondAddressLine, countryId, provinceTerritoryStateId, cityName, postalCode } = parsedDataResult.data;
+  const { streetName, apartment, countryId, provinceTerritoryStateId, cityName, postalCode } = parsedDataResult.data;
 
   const newPersonalInformation = {
     ...personalInformation,
     homeAddress: {
       streetName,
-      secondAddressLine,
+      apartment,
       countryId,
       provinceTerritoryStateId,
       cityName,
@@ -177,7 +177,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     mailingAddress: parsedDataResult.data.homeAndMailingAddressTheSame
       ? {
           streetName,
-          secondAddressLine,
+          apartment,
           countryId,
           provinceTerritoryStateId,
           cityName,
@@ -208,7 +208,7 @@ export default function PersonalInformationHomeAddressEdit() {
   const errorMessages = useMemo(
     () => ({
       'street-name': fetcher.data?.errors.streetName?._errors[0],
-      'apartment-number': fetcher.data?.errors.secondAddressLine?._errors[0],
+      'apartment-number': fetcher.data?.errors.apartment?._errors[0],
       'country-id': fetcher.data?.errors.countryId?._errors[0],
       'province-id': fetcher.data?.errors.provinceTerritoryStateId?._errors[0],
       'city-name': fetcher.data?.errors.cityName?._errors[0],
@@ -216,7 +216,7 @@ export default function PersonalInformationHomeAddressEdit() {
     }),
     [
       fetcher.data?.errors.streetName?._errors,
-      fetcher.data?.errors.secondAddressLine?._errors,
+      fetcher.data?.errors.apartment?._errors,
       fetcher.data?.errors.countryId?._errors,
       fetcher.data?.errors.provinceTerritoryStateId?._errors,
       fetcher.data?.errors.cityName?._errors,
@@ -281,15 +281,7 @@ export default function PersonalInformationHomeAddressEdit() {
               errorMessage={errorMessages['street-name']}
               disabled={isSubmitting}
             />
-            <InputField
-              id="apartment-number"
-              name="secondAddressLine"
-              className="w-full"
-              label={t('personal-information:home-address.edit.field.apartment')}
-              maxLength={30}
-              defaultValue={addressInfo.secondAddressLine}
-              errorMessage={errorMessages['apartment-number']}
-            />
+            <InputField id="apartment-number" name="apartment" className="w-full" label={t('personal-information:home-address.edit.field.apartment')} maxLength={30} defaultValue={addressInfo.apartment} errorMessage={errorMessages['apartment-number']} />
             <InputSelect
               id="country-id"
               name="countryId"

--- a/frontend/app/routes/$lang/_protected/personal-information/index.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/index.tsx
@@ -94,6 +94,7 @@ export default function PersonalInformationIndex() {
               {personalInformation.homeAddress ? (
                 <Address
                   address={personalInformation.homeAddress.streetName ?? ''}
+                  apartment={personalInformation.homeAddress.apartment}
                   city={personalInformation.homeAddress.cityName ?? ''}
                   provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.homeAddress!.provinceTerritoryStateId)?.abbr}
                   postalZipCode={personalInformation.homeAddress.postalCode}
@@ -117,6 +118,7 @@ export default function PersonalInformationIndex() {
               {personalInformation.mailingAddress ? (
                 <Address
                   address={personalInformation.mailingAddress.streetName ?? ''}
+                  apartment={personalInformation.mailingAddress.apartment}
                   city={personalInformation.mailingAddress.cityName ?? ''}
                   provinceState={regionList.find((region) => region.provinceTerritoryStateId === personalInformation.mailingAddress!.provinceTerritoryStateId)?.abbr}
                   postalZipCode={personalInformation.mailingAddress.postalCode}

--- a/frontend/app/routes/$lang/_protected/personal-information/mailing-address/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/mailing-address/edit.tsx
@@ -97,7 +97,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const formDataSchema = z
     .object({
       streetName: z.string().trim().min(1, t('personal-information:mailing-address.edit.error-message.address-required')).max(30),
-      secondAddressLine: z.string().trim().max(30).optional(),
+      apartment: z.string().trim().max(30).optional(),
       countryId: z.string().trim().min(1, t('personal-information:mailing-address.edit.error-message.country-required')),
       provinceTerritoryStateId: z.string().trim().min(1, t('personal-information:mailing-address.edit.error-message.province-required')).optional(),
       cityName: z.string().trim().min(1, t('personal-information:mailing-address.edit.error-message.city-required')).max(100),
@@ -136,7 +136,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
   const data = {
     streetName: String(formData.get('streetName') ?? ''),
-    secondAddressLine: formData.get('secondAddressLine') ? String(formData.get('secondAddressLine')) : undefined,
+    apartment: formData.get('apartment') ? String(formData.get('apartment')) : undefined,
     countryId: String(formData.get('countryId') ?? ''),
     provinceTerritoryStateId: formData.get('provinceTerritoryStateId') ? String(formData.get('provinceTerritoryStateId')) : undefined,
     cityName: String(formData.get('cityName') ?? ''),
@@ -158,13 +158,13 @@ export async function action({ context: { session }, params, request }: ActionFu
   const personalInformationRouteHelpers = getPersonalInformationRouteHelpers();
   const personalInformation = await personalInformationRouteHelpers.getPersonalInformation(userInfoToken, params, request, session);
 
-  const { streetName, secondAddressLine, countryId, provinceTerritoryStateId, cityName, postalCode } = parsedDataResult.data;
+  const { streetName, apartment, countryId, provinceTerritoryStateId, cityName, postalCode } = parsedDataResult.data;
 
   const newPersonalInformation = {
     ...personalInformation,
     mailingAddress: {
       streetName,
-      secondAddressLine,
+      apartment,
       countryId,
       provinceTerritoryStateId,
       cityName,
@@ -174,7 +174,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     homeAddress: parsedDataResult.data.homeAndMailingAddressTheSame
       ? {
           streetName,
-          secondAddressLine,
+          apartment,
           countryId,
           provinceTerritoryStateId,
           cityName,
@@ -205,7 +205,7 @@ export default function PersonalInformationMailingAddressEdit() {
   const errorMessages = useMemo(
     () => ({
       'street-name': fetcher.data?.errors.streetName?._errors[0],
-      'apartment-number': fetcher.data?.errors.secondAddressLine?._errors[0],
+      'apartment-number': fetcher.data?.errors.apartment?._errors[0],
       'country-id': fetcher.data?.errors.countryId?._errors[0],
       'province-id': fetcher.data?.errors.provinceTerritoryStateId?._errors[0],
       'city-name': fetcher.data?.errors.cityName?._errors[0],
@@ -213,7 +213,7 @@ export default function PersonalInformationMailingAddressEdit() {
     }),
     [
       fetcher.data?.errors.streetName?._errors,
-      fetcher.data?.errors.secondAddressLine?._errors,
+      fetcher.data?.errors.apartment?._errors,
       fetcher.data?.errors.countryId?._errors,
       fetcher.data?.errors.provinceTerritoryStateId?._errors,
       fetcher.data?.errors.cityName?._errors,
@@ -281,15 +281,7 @@ export default function PersonalInformationMailingAddressEdit() {
               defaultValue={addressInfo.streetName}
               errorMessage={errorMessages['street-name']}
             />
-            <InputField
-              id="apartment-number"
-              name="secondAddressLine"
-              className="w-full"
-              label={t('personal-information:home-address.edit.field.apartment')}
-              maxLength={30}
-              defaultValue={addressInfo.secondAddressLine}
-              errorMessage={errorMessages['apartment-number']}
-            />
+            <InputField id="apartment-number" name="apartment" className="w-full" label={t('personal-information:home-address.edit.field.apartment')} maxLength={30} defaultValue={addressInfo.apartment} errorMessage={errorMessages['apartment-number']} />
             <InputSelect
               id="country-id"
               name="countryId"

--- a/frontend/app/schemas/personal-informaton-service-schemas.server.ts
+++ b/frontend/app/schemas/personal-informaton-service-schemas.server.ts
@@ -158,7 +158,7 @@ export const personalInformationSchema = z.object({
   homeAddress: z
     .object({
       streetName: z.string().optional(),
-      secondAddressLine: z.string().optional(),
+      apartment: z.string().optional(),
       cityName: z.string().optional(),
       provinceTerritoryStateId: z.string().optional(),
       countryId: z.string().optional(),
@@ -168,7 +168,7 @@ export const personalInformationSchema = z.object({
   mailingAddress: z
     .object({
       streetName: z.string().optional(),
-      secondAddressLine: z.string().optional(),
+      apartment: z.string().optional(),
       cityName: z.string().optional(),
       provinceTerritoryStateId: z.string().optional(),
       countryId: z.string().optional(),


### PR DESCRIPTION
### Description
Apartment wasn't displaying on protected space's `/personal-information` page.

Domain model's field name was `secondAddressLine`, which didn't really represent what the value meant in my opinion, so it has been renamed to `apartment` to be consistent with the `/apply` flow names.

### Related Azure Boards Work Items
[AB#4010](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4010)

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/c60ab7a0-dde6-4dd5-966c-c62fca26172c)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/69828d39-3342-44c1-89c2-1da18abc60d8)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run the application locally and navigate to `/en/personal-information`. The user's address should display with an apartment number.

### Additional Notes
I tested this with a connection to Interop's API as well.