### PR TITLE
configure tls timeout for custom fetch function

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -68,6 +68,10 @@ HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify
 # (optional; default: undefined)
 HTTP_PROXY_URL=
 
+# HTTP proxy TLS timeout -- used to specifiy the timeout in milliseconds
+# (optional; default: 30000)
+HTTP_PROXY_TLS_TIMEOUT=30000
+
 
 # Interop API base url
 # (required; use the example below)

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -120,6 +120,7 @@ const serverEnv = z.object({
 
   // http proxy settings
   HTTP_PROXY_URL: z.string().trim().transform(emptyToUndefined).optional(),
+  HTTP_PROXY_TLS_TIMEOUT: z.coerce.number().default(30*1000),
 
   // session configuration
   SESSION_STORAGE_TYPE: z.enum(['file', 'redis']).default('file'),


### PR DESCRIPTION
### Description
Configure the TLS timeout and use the default or a supplied value when constructing a new `ProxyAgent` in the custom fetch function. 

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`