### PR TITLE
4059 SYSTEST - The application information page is missing error message when input same sin as child

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
@@ -100,18 +100,14 @@ export async function action({ context: { session }, params, request }: ActionFu
       .min(1, t('apply-adult-child:applicant-information.error-message.sin-required'))
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:applicant-information.error-message.sin-valid'), fatal: true });
-          return z.NEVER;
-        }
-
-        if (
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:applicant-information.error-message.sin-valid') });
+        } else if (
           [applyState.partnerInformation?.socialInsuranceNumber, ...applyState.children.map((child) => child.information?.socialInsuranceNumber)]
             .filter((sin) => sin !== undefined)
             .map((sin) => formatSin(sin as string))
             .includes(formatSin(sin))
         ) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'], fatal: true });
-          return z.NEVER;
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique') });
         }
       }),
     firstName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.first-name-required')).max(100),

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
@@ -97,17 +97,13 @@ export async function action({ context: { session }, params, request }: ActionFu
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:partner-information.error-message.sin-valid') });
-            return z.NEVER;
-          }
-
-          if (
+          } else if (
             [applyState.applicantInformation?.socialInsuranceNumber, ...applyState.children.map((child) => child.information?.socialInsuranceNumber)]
               .filter((sin) => sin !== undefined)
               .map((sin) => formatSin(sin as string))
               .includes(formatSin(sin))
           ) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'], fatal: true });
-            return z.NEVER;
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique') });
           }
         }),
     })

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -99,13 +99,9 @@ export async function action({ context: { session }, params, request }: ActionFu
       .min(1, t('apply-adult:applicant-information.error-message.sin-required'))
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-valid'), fatal: true });
-          return z.NEVER;
-        }
-
-        if (state.partnerInformation && formatSin(sin) === formatSin(state.partnerInformation.socialInsuranceNumber)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-unique'), fatal: true });
-          return z.NEVER;
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-valid') });
+        } else if (state.partnerInformation && formatSin(sin) === formatSin(state.partnerInformation.socialInsuranceNumber)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-unique') });
         }
       }),
     firstName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.first-name-required')).max(100),

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -96,12 +96,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-valid') });
-            return z.NEVER;
-          }
-
-          if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
+          } else if (state.applicantInformation && formatSin(sin) === formatSin(state.applicantInformation.socialInsuranceNumber)) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:partner-information.error-message.sin-unique') });
-            return z.NEVER;
           }
         }),
     })


### PR DESCRIPTION
### Description
More zod fun...
What's happening with this issue is that the validation was happening successfully, but because `path` was specified as an attribute in the custom error (and `superRefine` is being applied on a field level and not on the form object level), it was being added as a nested object in the returned errors after zod does it's validation. This messes with how we extract the error because we only expect flat objects.  

I ended up removing unnecessary attributes and returns, and standardizing the SIN validation across all of the flows.  The errors should successfully display now. 

### Related Azure Boards Work Items
[AB#4059](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4059)