### PR TITLE
adult-child/dental-insurance French content not rendering

### DIFF
--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -116,8 +116,8 @@
           "title": "Renseignements supplémentaires",
           "eligible": "Un enfant est toujours considéré comme ayant accès à une assurance dentaire ou à une couverture si un parent ou un tuteur légal choisit de se retirer des prestations offertes par\u00a0:",
           "eligible-list": {
-            "employer": "un employeur",
-            "pension": "un régime de retraite (voir exception)",
+            "employer": "un employeur;",
+            "pension": "un régime de retraite (voir exception);",
             "professional": "une organisation professionnelle ou étudiante"
           },
           "not-eligible": "Par conséquent, un enfant n'est pas admissible au Régime canadien de soins dentaires.",
@@ -391,17 +391,19 @@
     "detail": {
       "additional-info": {
         "title": "Renseignements supplémentaires",
-        "eligible": "Exception\u00a0: Vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
-        "list": {
-          "opted": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023, et",
-          "cannot-opt": "vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite"
+        "eligible": "Vous êtes toujours considéré comme ayant accès à l'assurance ou à la couverture dentaire si vous choisissez de ne pas bénéficier des prestations fournies par votre assurance ou celle d'un membre de votre famille\u00a0:",
+        "eligible-list": {
+          "employer": "un employeur;",
+          "pension": "un régime de retraite (voir exception);",
+          "professional": "une organisation professionnelle ou étudiante."
         },
-        "not-eligible": "Vous êtes toujours considéré comme ayant accès à l'assurance ou à la couverture dentaire si vous choisissez de ne pas bénéficier des prestations fournies par votre assurance ou celle d'un membre de votre famille\u00a0:",
-        "not-eligible-employer": "un employeur;",
-        "not-eligible-pension": "un régime de retraite (voir exception);",
-        "not-eligible-organization": "une organisation professionnelle ou étudiante.",
-        "not-eligible-note": "À ce titre, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
-        "not-eligible-purchased": "Si vous avez souscrit votre police d'assurance dentaire actuelle de votre propre chef, vous n'êtes pas admissible au Régime canadien de soins dentaires pendant que cette protection est en vigueur."
+        "not-eligible": "À ce titre, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
+        "not-eligible-purchased": "Si vous avez souscrit votre police d'assurance dentaire actuelle de votre propre chef, vous n'êtes pas admissible au Régime canadien de soins dentaires pendant que cette protection est en vigueur.",
+        "excepton": "Exception\u00a0: Vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
+        "exception-list": {
+          "opted-out": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023, et",
+          "opt-back": "vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite"
+        }
       }
     },
     "error-message": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -124,8 +124,8 @@
           "title": "Renseignements supplémentaires",
           "eligible": "Un enfant est toujours considéré comme ayant accès à une assurance dentaire ou à une couverture si un parent ou un tuteur légal choisit de se retirer des prestations offertes par\u00a0:",
           "eligible-list": {
-            "employer": "un employeur",
-            "pension": "un régime de retraite (voir exception)",
+            "employer": "un employeur;",
+            "pension": "un régime de retraite (voir exception);",
             "professional": "une organisation professionnelle ou étudiante"
           },
           "not-eligible": "Par conséquent, un enfant n'est pas admissible au Régime canadien de soins dentaires.",


### PR DESCRIPTION
### Description
Additional information French content on adult-child/dental-insurance not rendering properly

### Screenshots (if applicable)
<img width="667" alt="Screenshot 2024-06-10 at 11 18 36 AM" src="https://github.com/DTS-STN/canadian-dental-care-plan/assets/64853947/ee81bea1-d6e6-40ff-9f01-79706b511aab">


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->