### PR TITLE
AB#4052 -- Updated confirm page status checker text

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/confirmation.tsx
@@ -13,7 +13,6 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { InlineLink } from '~/components/inline-link';
-import { useFeature } from '~/root';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import { clearApplyState, getChildrenState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
@@ -213,7 +212,6 @@ export default function ApplyFlowConfirm() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
   const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, csrfToken } = useLoaderData<typeof loader>();
-  const powerPlatformStatusCheckerEnabled = useFeature('power-platform-status-checker');
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -262,7 +260,7 @@ export default function ApplyFlowConfirm() {
         <p className="mt-4">
           <Trans ns={handle.i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
         </p>
-        <p className="mt-4">{powerPlatformStatusCheckerEnabled ? t('confirm.use-code') : t('confirm.use-code-one-week')}</p>
+        <p className="mt-4">{t('confirm.use-code')}</p>
         <p className="mt-4">{t('confirm.mail-letter')}</p>
       </section>
 

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/confirmation.tsx
@@ -13,7 +13,6 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { InlineLink } from '~/components/inline-link';
-import { useFeature } from '~/root';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import { clearApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
@@ -175,7 +174,6 @@ export default function ApplyFlowConfirm() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
   const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, csrfToken } = useLoaderData<typeof loader>();
-  const powerPlatformStatusCheckerEnabled = useFeature('power-platform-status-checker');
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -224,7 +222,7 @@ export default function ApplyFlowConfirm() {
         <p className="mt-4">
           <Trans ns={handle.i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
         </p>
-        <p className="mt-4">{powerPlatformStatusCheckerEnabled ? t('confirm.use-code') : t('confirm.use-code-one-week')}</p>
+        <p className="mt-4">{t('confirm.use-code')}</p>
         <p className="mt-4">{t('confirm.mail-letter')}</p>
       </section>
 

--- a/frontend/app/routes/$lang/_public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/confirmation.tsx
@@ -13,7 +13,6 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { InlineLink } from '~/components/inline-link';
-import { useFeature } from '~/root';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { clearApplyState, getChildrenState } from '~/route-helpers/apply-route-helpers.server';
 import { getLookupService } from '~/services/lookup-service.server';
@@ -196,7 +195,6 @@ export default function ApplyFlowConfirm() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
   const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo, csrfToken } = useLoaderData<typeof loader>();
-  const powerPlatformStatusCheckerEnabled = useFeature('power-platform-status-checker');
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -240,7 +238,7 @@ export default function ApplyFlowConfirm() {
         <p className="mt-4">
           <Trans ns={handle.i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
         </p>
-        <p className="mt-4">{powerPlatformStatusCheckerEnabled ? t('confirm.use-code') : t('confirm.use-code-one-week')}</p>
+        <p className="mt-4">{t('confirm.use-code')}</p>
         <p className="mt-4">{t('confirm.mail-letter')}</p>
       </section>
       <section>

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -35,7 +35,6 @@ const validFeatureNames = [
   'show-prototype-banner',
   'authenticated-status-check',
   'update-governmental-benefit',
-  'power-platform-status-checker',
   'dependent-status-checker',
   'view-payload',
 ] as const;

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -210,7 +210,6 @@
     "begin-process": "We have received your application. Nothing further is required from you at this time.",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application or to receive more information.",
     "use-code": "You can use your application code to track the progress within 48 hours of applying.",
-    "use-code-one-week": "You can use your application code to track the progress of your application one week after applying.",
     "mail-letter": "Once your application is processed, we will mail you a letter to inform you whether your application has been accepted or rejected.",
     "register-msca-title": "Register for a My Service Canada Account (MSCA) - Coming soon",
     "register-msca-text": "Prepare to get important updates about your Canadian Dental Care Plan application by registering for a <mscaLinkAccount>My Service Canada Account (MSCA)</mscaLinkAccount>.",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -57,7 +57,6 @@
     "begin-process": "We have received your application. Nothing further is required from you at this time.",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application or to receive more information.",
     "use-code": "You can use your application code to track the progress within 48 hours of applying.",
-    "use-code-one-week": "You can use your application code to track the progress of your application one week after applying.",
     "mail-letter": "Once your application is processed, we will mail you a letter to inform you whether your application has been accepted or rejected.",
     "register-msca-title": "Register for a My Service Canada Account (MSCA) - Coming soon",
     "register-msca-text": "Prepare to get important updates about your Canadian Dental Care Plan application by registering for a <mscaLinkAccount>My Service Canada Account (MSCA)</mscaLinkAccount>.",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -230,7 +230,6 @@
     "begin-process": "We have received your application. Nothing further is required from you at this time.",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application or to receive more information.",
     "use-code": "You can use your application code to track the progress within 48 hours of applying.",
-    "use-code-one-week": "You can use your application code to track the progress of your application one week after applying.",
     "mail-letter": "Once your application is processed, we will mail you a letter to inform you whether your application has been accepted or rejected.",
     "register-msca-title": "Register for a My Service Canada Account (MSCA) - Coming soon",
     "register-msca-text": "Prepare to get important updates about your Canadian Dental Care Plan application by registering for a <mscaLinkAccount>My Service Canada Account (MSCA)</mscaLinkAccount>.",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -210,7 +210,6 @@
     "begin-process": "Nous avons reçu votre demande. Vous n'avez rien d'autre à fournir pour l'instant.",
     "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
     "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
-    "use-code-one-week": "You can use your application code to track the progress of your application one week after applying.",
     "mail-letter": "Once your application is processed, we will mail you a letter to inform you whether your application has been accepted or rejected.",
     "register-msca-title": "Inscrivez-vous à Mon dossier Service Canada (MDSC) - À venir prochainement",
     "register-msca-text": "Préparez-vous à recevoir des mises à jour importantes concernant votre demande d'adhésion au Régime canadien de soins dentaires en vous inscrivant à <mscaLinkAccount>Mon dossier Service Canada (MDSC)</mscaLinkAccount>.",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -57,7 +57,6 @@
     "begin-process": "Nous avons reçu votre demande. Vous n'avez rien d'autre à fournir pour l'instant.",
     "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
     "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
-    "use-code-one-week": "Vous pouvez utiliser votre code de demande pour suivre la progression de votre candidature une semaine après avoir postulé.",
     "mail-letter": "Une fois que votre demande aura été traitée, nous vous enverrons une lettre pour vous informer si votre demande a été acceptée ou refusée.",
     "register-msca-title": "Inscrivez-vous à Mon dossier Service Canada (MDSC) - À venir prochainement",
     "register-msca-text": "Préparez-vous à recevoir des mises à jour importantes concernant votre demande d'adhésion au Régime canadien de soins dentaires en vous inscrivant à <mscaLinkAccount>Mon dossier Service Canada (MDSC)</mscaLinkAccount>.",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -230,7 +230,6 @@
     "begin-process": "Nous avons reçu votre demande. Vous n'avez rien d'autre à fournir pour l'instant.",
     "cdcp-checker": "Vous pouvez utiliser <cdcpLink>le Vérificateur d'état du Régime canadien de soins</cdcpLink> dentaires ou composer le 1-833-537-4342 pour vérifier l'état de votre demande ou pour recevoir plus d'informations.",
     "use-code": "Au plus tard 48 heures après avoir présenté votre demande, vous pourrez commencer à suivre l'état de votre demande en vous servant de votre code de demande.",
-    "use-code-one-week": "Vous pouvez utiliser votre code de demande pour en suivre la progression dans les 48 heures suivant la présentation de la demande.",
     "mail-letter": "Une fois que votre demande aura été traitée, nous vous enverrons une lettre pour vous informer si votre demande a été acceptée ou refusée.",
     "register-msca-title": "Inscrivez-vous à Mon dossier Service Canada (MDSC) - À venir prochainement",
     "register-msca-text": "Préparez-vous à recevoir des mises à jour importantes concernant votre demande d'adhésion au Régime canadien de soins dentaires en vous inscrivant à <mscaLinkAccount>Mon dossier Service Canada (MDSC)</mscaLinkAccount>.",

--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,power-platform-status-checker
+ENABLED_FEATURES=hcaptcha
 
 #
 # Session/redis configuration

--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha
+ENABLED_FEATURES=hcaptcha,power-platform-status-checker
 
 #
 # Session/redis configuration


### PR DESCRIPTION
### Description
Updated confirm page status checker text to show "48 hours" text, removed unused text and env var. (SYSTEST - Fix Confirmation Page - Old Text)

### Related Azure Boards Work Items
[AB#4052](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4052)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/1265500d-d4e2-4369-9718-a22c293052eb)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
View confirmation page to confirm changes.

### Additional Notes
n/a