### PR TITLE
AB#4060 SYSTEST - Comma is missing between the City and Province/Territory

### DIFF
--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -25,7 +25,7 @@ function formatAddress(address: string, city: string, country: string, provinceS
   // prettier-ignore
   const linesAlt = [
     formattedAddress,
-    `${city}${provinceState ? ` ${provinceState}` : ''}`,
+    `${city}${provinceState ? `, ${provinceState}` : ''}`,
     `${postalZipCode ? `${postalZipCode}` : ''}`,
     `${country}`
   ];

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/confirmation.tsx
@@ -348,7 +348,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={mailingAddressInfo.postalCode}
                 country={i18n.language === 'en' ? mailingAddressInfo.country?.nameEn ?? '' : mailingAddressInfo.country?.nameFr ?? ''}
                 apartment={mailingAddressInfo.apartment}
-                altFormat={true}
               />
             </DescriptionListItem>
             <DescriptionListItem term={t('confirm.home')}>
@@ -359,7 +358,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={homeAddressInfo.postalCode}
                 country={i18n.language === 'en' ? homeAddressInfo.country?.nameEn ?? '' : homeAddressInfo.country?.nameFr ?? ''}
                 apartment={homeAddressInfo.apartment}
-                altFormat={true}
               />
             </DescriptionListItem>
           </dl>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
@@ -353,7 +353,6 @@ export default function ReviewInformation() {
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={i18n.language === 'en' ? mailingAddressInfo.country.nameEn : mailingAddressInfo.country.nameFr}
                   apartment={mailingAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <p className="mt-4">
                   <InlineLink id="change-mailing-address" routeId="$lang/_public/apply/$id/adult-child/contact-information" params={params}>
@@ -369,7 +368,6 @@ export default function ReviewInformation() {
                   postalZipCode={homeAddressInfo.postalCode}
                   country={i18n.language === 'en' ? homeAddressInfo.country.nameEn : homeAddressInfo.country.nameFr}
                   apartment={homeAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <p className="mt-4">
                   <InlineLink id="change-home-address" routeId="$lang/_public/apply/$id/adult-child/contact-information" params={params}>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/confirmation.tsx
@@ -308,7 +308,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={mailingAddressInfo.postalCode}
                 country={i18n.language === 'en' ? mailingAddressInfo.country?.nameEn ?? '' : mailingAddressInfo.country?.nameFr ?? ''}
                 apartment={mailingAddressInfo.apartment}
-                altFormat={true}
               />
             </DescriptionListItem>
             <DescriptionListItem term={t('confirm.home')}>
@@ -319,7 +318,6 @@ export default function ApplyFlowConfirm() {
                 postalZipCode={homeAddressInfo.postalCode ?? ''}
                 country={i18n.language === 'en' ? homeAddressInfo.country?.nameEn ?? '' : homeAddressInfo.country?.nameFr ?? ''}
                 apartment={homeAddressInfo.apartment}
-                altFormat={true}
               />
             </DescriptionListItem>
           </dl>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
@@ -363,7 +363,6 @@ export default function ReviewInformation() {
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={i18n.language === 'en' ? mailingAddressInfo.country.nameEn : mailingAddressInfo.country.nameFr}
                   apartment={mailingAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <div className="mt-4">
                   <InlineLink id="change-mailing-address" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
@@ -379,7 +378,6 @@ export default function ReviewInformation() {
                   postalZipCode={homeAddressInfo.postalCode}
                   country={i18n.language === 'en' ? homeAddressInfo.country.nameEn : homeAddressInfo.country.nameFr}
                   apartment={homeAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <div className="mt-4">
                   <InlineLink id="change-home-address" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/confirmation.tsx
@@ -354,7 +354,6 @@ export default function ApplyFlowConfirm() {
                     postalZipCode={mailingAddressInfo.postalCode}
                     country={i18n.language === 'en' ? mailingAddressInfo.country?.nameEn ?? '' : mailingAddressInfo.country?.nameFr ?? ''}
                     apartment={mailingAddressInfo.apartment}
-                    altFormat={true}
                   />
                 </DescriptionListItem>
                 <DescriptionListItem term={t('confirm.home')}>
@@ -365,7 +364,6 @@ export default function ApplyFlowConfirm() {
                     postalZipCode={homeAddressInfo.postalCode ?? ''}
                     country={i18n.language === 'en' ? homeAddressInfo.country?.nameEn ?? '' : homeAddressInfo.country?.nameFr ?? ''}
                     apartment={homeAddressInfo.apartment}
-                    altFormat={true}
                   />
                 </DescriptionListItem>
               </dl>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/review-adult-information.tsx
@@ -335,7 +335,6 @@ export default function ReviewInformation() {
                   postalZipCode={mailingAddressInfo.postalCode}
                   country={i18n.language === 'en' ? mailingAddressInfo.country.nameEn : mailingAddressInfo.country.nameFr}
                   apartment={mailingAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <p className="mt-4">
                   <InlineLink id="change-mailing-address" routeId="$lang/_public/apply/$id/child/contact-information" params={params}>
@@ -351,7 +350,6 @@ export default function ReviewInformation() {
                   postalZipCode={homeAddressInfo.postalCode}
                   country={i18n.language === 'en' ? homeAddressInfo.country.nameEn : homeAddressInfo.country.nameFr}
                   apartment={homeAddressInfo.apartment}
-                  altFormat={true}
                 />
                 <p className="mt-4">
                   <InlineLink id="change-home-address" routeId="$lang/_public/apply/$id/child/contact-information" params={params}>


### PR DESCRIPTION
### Description
Add comma after city in the `Address` component

### Related Azure Boards Work Items
[AB#4060](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4060)

### Screenshots (if applicable)
<img width="592" alt="Screenshot 2024-06-10 at 12 50 20 PM" src="https://github.com/DTS-STN/canadian-dental-care-plan/assets/64853947/bdb712bf-c9ed-494f-b293-2160bea209e8">


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->