### PR TITLE
Adobe Analytics properties added to buttons in governmental benefit update flow

### DIFF
--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
@@ -341,7 +341,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             routeId="$lang/_protected/access-to-governmental-benefits/view"
             params={params}
             disabled={isSubmitting}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - Edit click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - Edit click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.edit.button.back')}
           </ButtonLink>
@@ -350,7 +350,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             <FontAwesomeIcon
               icon={isSubmitting ? faSpinner : faChevronRight}
               className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Save - Edit click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Save - Edit click"
             />
           </Button>
         </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
@@ -336,12 +336,22 @@ export default function AccessToGovernmentalsBenefitsEdit() {
           />
         </fieldset>
         <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/view" params={params} disabled={isSubmitting}>
+          <ButtonLink
+            id="back-button"
+            routeId="$lang/_protected/access-to-governmental-benefits/view"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - Edit click"
+          >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.edit.button.back')}
           </ButtonLink>
           <Button id="save-button" variant="primary" disabled={isSubmitting}>
             {t('access-to-governmental-benefits:access-to-governmental-benefits.edit.button.save')}
-            <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+            <FontAwesomeIcon
+              icon={isSubmitting ? faSpinner : faChevronRight}
+              className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Save - Edit click"
+            />
           </Button>
         </div>
       </fetcher.Form>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
@@ -341,7 +341,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             routeId="$lang/_protected/access-to-governmental-benefits/view"
             params={params}
             disabled={isSubmitting}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - Edit click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to other federal, provincial or territorial dentail benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.edit.button.back')}
           </ButtonLink>
@@ -350,7 +350,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             <FontAwesomeIcon
               icon={isSubmitting ? faSpinner : faChevronRight}
               className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Save - Edit click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Access to other federal, provincial or territorial dentail benefits click"
             />
           </Button>
         </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/edit.tsx
@@ -341,7 +341,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             routeId="$lang/_protected/access-to-governmental-benefits/view"
             params={params}
             disabled={isSubmitting}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to other federal, provincial or territorial dentail benefits click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to other federal, provincial or territorial dental benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.edit.button.back')}
           </ButtonLink>
@@ -350,7 +350,7 @@ export default function AccessToGovernmentalsBenefitsEdit() {
             <FontAwesomeIcon
               icon={isSubmitting ? faSpinner : faChevronRight}
               className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Access to other federal, provincial or territorial dentail benefits click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Access to other federal, provincial or territorial dental benefits click"
             />
           </Button>
         </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
@@ -78,7 +78,12 @@ export default function AccessToGovernmentalsBenefitsIndex() {
         <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.index.body-text')}</p>
       </div>
       <div className="mb-5 space-y-4">
-        <InlineLink routeId="$lang/_protected/access-to-governmental-benefits/view" params={{ ...params }} className="font-lato font-semibold" data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Index - Update your dental benefits click">
+        <InlineLink
+          routeId="$lang/_protected/access-to-governmental-benefits/view"
+          params={{ ...params }}
+          className="font-lato font-semibold"
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Update your dental benefits click"
+        >
           {t('access-to-governmental-benefits:access-to-governmental-benefits.index.update-your-access-text')}
         </InlineLink>
       </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
@@ -82,7 +82,7 @@ export default function AccessToGovernmentalsBenefitsIndex() {
           routeId="$lang/_protected/access-to-governmental-benefits/view"
           params={{ ...params }}
           className="font-lato font-semibold"
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Index - Update click"
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Index - Update click"
         >
           {t('access-to-governmental-benefits:access-to-governmental-benefits.index.update-your-access-text')}
         </InlineLink>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
@@ -78,12 +78,7 @@ export default function AccessToGovernmentalsBenefitsIndex() {
         <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.index.body-text')}</p>
       </div>
       <div className="mb-5 space-y-4">
-        <InlineLink
-          routeId="$lang/_protected/access-to-governmental-benefits/view"
-          params={{ ...params }}
-          className="font-lato font-semibold"
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Index - Update click"
-        >
+        <InlineLink routeId="$lang/_protected/access-to-governmental-benefits/view" params={{ ...params }} className="font-lato font-semibold" data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Index - Update your dental benefits click">
           {t('access-to-governmental-benefits:access-to-governmental-benefits.index.update-your-access-text')}
         </InlineLink>
       </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/index.tsx
@@ -73,18 +73,21 @@ export default function AccessToGovernmentalsBenefitsIndex() {
 
   return (
     <div className="max-w-prose">
-      <>
-        <div className="mb-5 space-y-4">
-          <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.index.intro-text')}</h2>
-          <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.index.body-text')}</p>
-        </div>
-        <div className="mb-5 space-y-4">
-          <InlineLink routeId="$lang/_protected/access-to-governmental-benefits/view" params={{ ...params }} className="font-lato font-semibold">
-            {t('access-to-governmental-benefits:access-to-governmental-benefits.index.update-your-access-text')}
-          </InlineLink>
-        </div>
-        <fetcher.Form method="post" noValidate></fetcher.Form>
-      </>
+      <div className="mb-5 space-y-4">
+        <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.index.intro-text')}</h2>
+        <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.index.body-text')}</p>
+      </div>
+      <div className="mb-5 space-y-4">
+        <InlineLink
+          routeId="$lang/_protected/access-to-governmental-benefits/view"
+          params={{ ...params }}
+          className="font-lato font-semibold"
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Index - Update click"
+        >
+          {t('access-to-governmental-benefits:access-to-governmental-benefits.index.update-your-access-text')}
+        </InlineLink>
+      </div>
+      <fetcher.Form method="post" noValidate></fetcher.Form>
     </div>
   );
 }

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -129,7 +129,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             routeId="$lang/_protected/access-to-governmental-benefits/edit"
             params={{ ...params }}
             className="font-lato font-semibold"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Edit - View click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - View click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>
@@ -138,7 +138,7 @@ export default function AccessToGovernmentalsBenefitsView() {
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - View click">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - View click">
               {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
             </ButtonLink>
           </div>
@@ -162,7 +162,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             params={{ ...params }}
             className="external-link"
             target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Edit - View click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - View click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>
@@ -171,7 +171,7 @@ export default function AccessToGovernmentalsBenefitsView() {
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - View click">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - View click">
               {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
             </ButtonLink>
           </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -129,7 +129,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             routeId="$lang/_protected/access-to-governmental-benefits/edit"
             params={{ ...params }}
             className="font-lato font-semibold"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - Access to governmental benefits click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Access to governmental benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>
@@ -162,7 +162,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             params={{ ...params }}
             className="external-link"
             target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - Access to governmental benefits click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Access to governmental benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -129,7 +129,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             routeId="$lang/_protected/access-to-governmental-benefits/edit"
             params={{ ...params }}
             className="font-lato font-semibold"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - View click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - Access to governmental benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>
@@ -138,7 +138,7 @@ export default function AccessToGovernmentalsBenefitsView() {
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - View click">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to governmental benefits click">
               {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
             </ButtonLink>
           </div>
@@ -162,7 +162,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             params={{ ...params }}
             className="external-link"
             target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - View click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Edit - Access to governmental benefits click"
           >
             {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
           </InlineLink>
@@ -171,7 +171,7 @@ export default function AccessToGovernmentalsBenefitsView() {
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
           <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information - Access to Governmental Benefits:Back - View click">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to governmental benefits click">
               {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
             </ButtonLink>
           </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -90,85 +90,92 @@ export default function AccessToGovernmentalsBenefitsView() {
   if (hasDentalPlans) {
     return (
       <div className="max-w-prose">
-        <>
-          <div className="mb-5 space-y-4">
-            {updatedInfo && (
-              <ContextualAlert type="success">
-                <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
-              </ContextualAlert>
-            )}
-            {personalInformation.provincialTerritorialDentalPlanId ? (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
-                <ul className="list-disc space-y-6 pl-7">
-                  <li>{provincialAndTerritorialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.provincialTerritorialDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
-                </ul>
-              </div>
-            ) : (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
-              </div>
-            )}
-          </div>
-          <div className="mb-5 space-y-4">
-            {personalInformation.federalDentalPlanId ? (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
-
-                <ul className="list-disc space-y-6 pl-7">
-                  <li>{federalSocialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.federalDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
-                </ul>
-              </div>
-            ) : (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
-              </div>
-            )}
-          </div>
-          <div className="mb-5 space-y-4">
-            <InlineLink routeId="$lang/_protected/access-to-governmental-benefits/edit" params={{ ...params }} className="font-lato font-semibold">
-              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
-            </InlineLink>
-          </div>
-
-          <fetcher.Form method="post" noValidate>
-            <input type="hidden" name="_csrf" value={csrfToken} />
-            <div className="flex flex-wrap items-center gap-3">
-              <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params}>
-                {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
-              </ButtonLink>
-            </div>
-          </fetcher.Form>
-        </>
-      </div>
-    );
-  } else {
-    return (
-      <div className="max-w-prose">
-        <>
+        <div className="mb-5 space-y-4">
           {updatedInfo && (
             <ContextualAlert type="success">
               <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
             </ContextualAlert>
           )}
-          <div className="mb-5 space-y-4">
-            <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.view.no-government-benefits')}</p>
-          </div>
-          <div className="mb-5 space-y-4">
-            <InlineLink routeId="$lang/_protected/access-to-governmental-benefits/edit" params={{ ...params }} className="external-link" target="_blank">
-              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
-            </InlineLink>
-          </div>
-
-          <fetcher.Form method="post" noValidate>
-            <input type="hidden" name="_csrf" value={csrfToken} />
-            <div className="flex flex-wrap items-center gap-3">
-              <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params}>
-                {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
-              </ButtonLink>
+          {personalInformation.provincialTerritorialDentalPlanId ? (
+            <div className="mb-5 space-y-4">
+              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
+              <ul className="list-disc space-y-6 pl-7">
+                <li>{provincialAndTerritorialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.provincialTerritorialDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
+              </ul>
             </div>
-          </fetcher.Form>
-        </>
+          ) : (
+            <div className="mb-5 space-y-4">
+              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
+            </div>
+          )}
+        </div>
+        <div className="mb-5 space-y-4">
+          {personalInformation.federalDentalPlanId ? (
+            <div className="mb-5 space-y-4">
+              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
+
+              <ul className="list-disc space-y-6 pl-7">
+                <li>{federalSocialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.federalDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
+              </ul>
+            </div>
+          ) : (
+            <div className="mb-5 space-y-4">
+              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
+            </div>
+          )}
+        </div>
+        <div className="mb-5 space-y-4">
+          <InlineLink
+            routeId="$lang/_protected/access-to-governmental-benefits/edit"
+            params={{ ...params }}
+            className="font-lato font-semibold"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Edit - View click"
+          >
+            {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
+          </InlineLink>
+        </div>
+
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="flex flex-wrap items-center gap-3">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - View click">
+              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    );
+  } else {
+    return (
+      <div className="max-w-prose">
+        {updatedInfo && (
+          <ContextualAlert type="success">
+            <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
+          </ContextualAlert>
+        )}
+        <div className="mb-5 space-y-4">
+          <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.view.no-government-benefits')}</p>
+        </div>
+        <div className="mb-5 space-y-4">
+          <InlineLink
+            routeId="$lang/_protected/access-to-governmental-benefits/edit"
+            params={{ ...params }}
+            className="external-link"
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Edit - View click"
+          >
+            {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
+          </InlineLink>
+        </div>
+
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="flex flex-wrap items-center gap-3">
+            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form - Access to Governmental Benefits:Back - View click">
+              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
       </div>
     );
   }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Adobe Analytics properties added to buttons and links in the access governmental benefits flow.

Incidental changes:
Addressed a couple sonar lint warnings.

### Related Azure Boards Work Items

<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4036](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4036)
[AB#4073](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4073)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
