### PR TITLE
add utility to check for valid inputs based on business requirements

### DIFF
--- a/frontend/__tests__/utils/string-utils.test.ts
+++ b/frontend/__tests__/utils/string-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { expandTemplate, padWithZero, randomHexString, randomString } from '~/utils/string-utils';
+import { expandTemplate, isAllValidInputCharacters, padWithZero, randomHexString, randomString } from '~/utils/string-utils';
 
 describe('expandTemplate', () => {
   it('should expand a template', () => {
@@ -57,5 +57,15 @@ describe('padWithZero', () => {
   it('should return the value as a string if its length is greater than or equal to maxLength', () => {
     expect(padWithZero(12345, 5)).toBe('12345');
     expect(padWithZero(123456, 5)).toBe('123456');
+  });
+});
+
+describe('isAllValidInputCharacters', () => {
+  it('should return true for input containing the entire valid character set', () => {
+    expect(isAllValidInputCharacters("a-zA-Z0-9'(),-.ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ\u00a0 ")).toEqual(true);
+  });
+
+  it('should return false for input containing invalid characters', () => {
+    expect(isAllValidInputCharacters('!"#$%&*+/:;<=>?@[\\]^_`{|}~¡¢£¤¥¦§¨©ª«¬\u00ad®¯±²³\u00b4µ-m¶·\u00b8¹º»¼½¾¿ÃãÅåÆæÐðÑñÕõ\u00d7ØøÞþẞß\u00f7')).toEqual(false);
   });
 });

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -35,3 +35,13 @@ export const padWithZero = (value: number, maxLength: number) => {
   if (value.toString().length >= maxLength) return value.toString();
   return value.toString().padStart(maxLength, '0');
 };
+
+/**
+ *
+ * @param input - The string value of the input field to be validated
+ * @returns Boolean indicating whether the input contains all valid characters
+ */
+export function isAllValidInputCharacters(input: string): boolean {
+  const validCharactersRegex = /^[a-zA-Z0-9'(),\-.ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ\u00a0 ]+$/;
+  return validCharactersRegex.test(input);
+}


### PR DESCRIPTION
### Description
Inputs fields need to be validated against a character set.  

The intended use of this utility is for zod validation on certain input fields (like first name, last name, address ,etc).  Inserting this utility into the zod validation schemas will happen at a later time, ideally when new error messages have been supplied to us by business.
