### PR TITLE
AB#4077 added the code/endpoint to create a user on the api project

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -237,5 +237,4 @@ public class UserService {
 		Assert.notNull(instant, "instant is required; it must not be null");
 		return confirmationCode -> confirmationCode.getExpiryDate().isAfter(instant);
 	}
-	
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -1,6 +1,10 @@
 package ca.gov.dtsstn.cdcp.api.service;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -21,6 +25,8 @@ import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.LanguageEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.UserEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.repository.AlertTypeRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.LanguageRepository;
@@ -31,7 +37,7 @@ import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.ConfirmationCodeMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.SubscriptionMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserMapper;
-
+import ca.gov.dtsstn.cdcp.api.web.v1.model.UserAttributeModel;
 
 @Service
 @Transactional
@@ -199,10 +205,17 @@ public class UserService {
 		return true;
 	}
 
-	public User createUser(String userEmail, String raoidcUserId){
-		//Lets assume the email has already been checked to make sure its a valid one...
+	public User createUser(String userEmail, List<UserAttributeModel> userAttributesModel){
+		//Verify Email
 		Assert.hasText(userEmail, "userEmail is required; it must not be null or blank");
-		return userMapper.toUser(userRepository.save(new UserEntityBuilder().email(userEmail).id(raoidcUserId).build()));
+
+		Collection<UserAttributeEntity> userAttributesCollection = new ArrayList<UserAttributeEntity>();
+		
+		for(UserAttributeModel e : userAttributesModel){
+			userAttributesCollection.add(new UserAttributeEntityBuilder().name(e.getName()).value(e.getValue()).build());
+		}
+		return userMapper.toUser(userRepository.save(new UserEntityBuilder().email(userEmail)
+			.userAttributes(userAttributesCollection).build()));
 	}
 
 	private Predicate<SubscriptionEntity> byAlertTypeId(String alertTypeId) {
@@ -224,5 +237,5 @@ public class UserService {
 		Assert.notNull(instant, "instant is required; it must not be null");
 		return confirmationCode -> confirmationCode.getExpiryDate().isAfter(instant);
 	}
-
+	
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -21,6 +21,7 @@ import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.LanguageEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.repository.AlertTypeRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.LanguageRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.UserRepository;
@@ -30,6 +31,7 @@ import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.ConfirmationCodeMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.SubscriptionMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserMapper;
+
 
 @Service
 @Transactional
@@ -195,6 +197,12 @@ public class UserService {
 		userRepository.save(user);
 
 		return true;
+	}
+
+	public User createUser(String userEmail, String raoidcUserId){
+		//Lets assume the email has already been checked to make sure its a valid one...
+		Assert.hasText(userEmail, "userEmail is required; it must not be null or blank");
+		return userMapper.toUser(userRepository.save(new UserEntityBuilder().email(userEmail).id(raoidcUserId).build()));
 	}
 
 	private Predicate<SubscriptionEntity> byAlertTypeId(String alertTypeId) {

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -1,13 +1,8 @@
 package ca.gov.dtsstn.cdcp.api.service;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.factory.Mappers;
@@ -17,7 +12,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
-
 import ca.gov.dtsstn.cdcp.api.config.properties.ApplicationProperties;
 import ca.gov.dtsstn.cdcp.api.data.entity.AlertTypeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
@@ -25,9 +19,6 @@ import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.LanguageEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntity;
 import ca.gov.dtsstn.cdcp.api.data.entity.SubscriptionEntityBuilder;
-import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntity;
-import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntityBuilder;
-import ca.gov.dtsstn.cdcp.api.data.entity.UserEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.repository.AlertTypeRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.LanguageRepository;
 import ca.gov.dtsstn.cdcp.api.data.repository.UserRepository;
@@ -37,7 +28,6 @@ import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.ConfirmationCodeMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.SubscriptionMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserMapper;
-import ca.gov.dtsstn.cdcp.api.web.v1.model.UserAttributeModel;
 
 @Service
 @Transactional
@@ -55,7 +45,7 @@ public class UserService {
 	private final SubscriptionMapper subscriptionMapper = Mappers.getMapper(SubscriptionMapper.class);
 
 	private final UserMapper userMapper = Mappers.getMapper(UserMapper.class);
-
+	
 	public UserService(
 			ApplicationProperties applicationProperties,
 			AlertTypeRepository alertTypeRepository,
@@ -203,19 +193,6 @@ public class UserService {
 		userRepository.save(user);
 
 		return true;
-	}
-
-	public User createUser(String userEmail, List<UserAttributeModel> userAttributesModel){
-		//Verify Email
-		Assert.hasText(userEmail, "userEmail is required; it must not be null or blank");
-
-		Collection<UserAttributeEntity> userAttributesCollection = new ArrayList<UserAttributeEntity>();
-		
-		for(UserAttributeModel e : userAttributesModel){
-			userAttributesCollection.add(new UserAttributeEntityBuilder().name(e.getName()).value(e.getValue()).build());
-		}
-		return userMapper.toUser(userRepository.save(new UserEntityBuilder().email(userEmail)
-			.userAttributes(userAttributesCollection).build()));
 	}
 
 	private Predicate<SubscriptionEntity> byAlertTypeId(String alertTypeId) {

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -3,6 +3,7 @@ package ca.gov.dtsstn.cdcp.api.service;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Predicate;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.factory.Mappers;
@@ -12,6 +13,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+
 import ca.gov.dtsstn.cdcp.api.config.properties.ApplicationProperties;
 import ca.gov.dtsstn.cdcp.api.data.entity.AlertTypeEntityBuilder;
 import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
@@ -45,7 +47,7 @@ public class UserService {
 	private final SubscriptionMapper subscriptionMapper = Mappers.getMapper(SubscriptionMapper.class);
 
 	private final UserMapper userMapper = Mappers.getMapper(UserMapper.class);
-	
+
 	public UserService(
 			ApplicationProperties applicationProperties,
 			AlertTypeRepository alertTypeRepository,
@@ -214,4 +216,5 @@ public class UserService {
 		Assert.notNull(instant, "instant is required; it must not be null");
 		return confirmationCode -> confirmationCode.getExpiryDate().isAfter(instant);
 	}
+
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -7,14 +7,15 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
+import ca.gov.dtsstn.cdcp.api.web.v1.model.UserCreateModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.mapper.UserModelMapper;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonPatch;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotBlank;
+
 
 @Validated
 @RestController
@@ -86,4 +88,20 @@ public class UsersController {
 		}
 	}
 
+	@PostMapping({"/{userId}"})
+	@Operation(summary = "Create a new user ")
+	public void createUserByRaoidcUserIdAndEmail(
+		@NotBlank(message = "userId must not be null or blank")
+		@Parameter(description = "The id of the user.", example = "00000000-0000-0000-0000-000000000000", required = true)
+			@PathVariable String userId,
+
+		@Validated @RequestBody UserCreateModel user) {
+
+			userService.createUser(user.getEmail(), userId);
+	}
+	
+	public void createUserByEmail(){
+
+
+	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
-import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserAttributeMapper;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserCreateModel;
@@ -38,8 +37,6 @@ import jakarta.validation.constraints.NotBlank;
 public class UsersController {
 
 	private final UserModelMapper userModelMapper = Mappers.getMapper(UserModelMapper.class);
-	private final UserAttributeMapper userAttributeMapper = Mappers.getMapper(UserAttributeMapper.class);
-
 	private final UserService userService;
 
 	private final JsonPatchProcessor jsonPatchProcessor;
@@ -96,11 +93,7 @@ public class UsersController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@Operation(summary = "Create a new user")
 	public void createUserByEmailAndUserAttributes(@Validated @RequestBody UserCreateModel userCreateModel) 
-	{
-		UserModel userModel = new UserModel();
-		userModel.setUserAttributes(userCreateModel.getUserAttributes());
-		userModel.setEmail(userCreateModel.getEmail());
-		
-		userService.createUser(userModelMapper.toDomainObject(userModel));
+	{		
+		userService.createUser(userModelMapper.toDomain(userCreateModel));
 	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -1,7 +1,7 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.controller;
 
-import java.util.List;
 import org.mapstruct.factory.Mappers;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
 import org.springframework.validation.BindException;
 import org.springframework.validation.annotation.Validated;
@@ -11,12 +11,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
+import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserAttributeMapper;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
-import ca.gov.dtsstn.cdcp.api.web.v1.model.UserAttributeModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserCreateModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.mapper.UserModelMapper;
@@ -37,6 +38,7 @@ import jakarta.validation.constraints.NotBlank;
 public class UsersController {
 
 	private final UserModelMapper userModelMapper = Mappers.getMapper(UserModelMapper.class);
+	private final UserAttributeMapper userAttributeMapper = Mappers.getMapper(UserAttributeMapper.class);
 
 	private final UserService userService;
 
@@ -91,12 +93,14 @@ public class UsersController {
 	}
 
 	@PostMapping
-	@Operation(summary = "Create a new user ")
-	public void createUserByEmailAndUserAttributes(
-
-		@Validated @RequestBody UserCreateModel user) {
-			List<UserAttributeModel> userAttributesModels = user.getUserAttributeModel();
-
-			userService.createUser(user.getEmail(), userAttributesModels);
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Operation(summary = "Create a new user")
+	public void createUserByEmailAndUserAttributes(@Validated @RequestBody UserCreateModel userCreateModel) 
+	{
+		UserModel userModel = new UserModel();
+		userModel.setUserAttributes(userCreateModel.getUserAttributes());
+		userModel.setEmail(userCreateModel.getEmail());
+		
+		userService.createUser(userModelMapper.toDomainObject(userModel));
 	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
 import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
@@ -27,7 +28,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonPatch;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotBlank;
-
 
 @Validated
 @RestController
@@ -92,8 +92,7 @@ public class UsersController {
 	@PostMapping
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@Operation(summary = "Create a new user")
-	public void createUserByEmailAndUserAttributes(@Validated @RequestBody UserCreateModel userCreateModel) 
-	{		
+	public void createUserByEmailAndUserAttributes(@Validated @RequestBody UserCreateModel userCreateModel) {
 		userService.createUser(userModelMapper.toDomain(userCreateModel));
 	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersController.java
@@ -1,5 +1,6 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.controller;
 
+import java.util.List;
 import org.mapstruct.factory.Mappers;
 import org.springframework.util.Assert;
 import org.springframework.validation.BindException;
@@ -15,6 +16,7 @@ import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
+import ca.gov.dtsstn.cdcp.api.web.v1.model.UserAttributeModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserCreateModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.mapper.UserModelMapper;
@@ -88,20 +90,13 @@ public class UsersController {
 		}
 	}
 
-	@PostMapping({"/{userId}"})
+	@PostMapping
 	@Operation(summary = "Create a new user ")
-	public void createUserByRaoidcUserIdAndEmail(
-		@NotBlank(message = "userId must not be null or blank")
-		@Parameter(description = "The id of the user.", example = "00000000-0000-0000-0000-000000000000", required = true)
-			@PathVariable String userId,
+	public void createUserByEmailAndUserAttributes(
 
 		@Validated @RequestBody UserCreateModel user) {
+			List<UserAttributeModel> userAttributesModels = user.getUserAttributeModel();
 
-			userService.createUser(user.getEmail(), userId);
-	}
-	
-	public void createUserByEmail(){
-
-
+			userService.createUser(user.getEmail(), userAttributesModels);
 	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
@@ -1,47 +1,18 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.model;
 
-import org.springframework.core.style.ToStringCreator;
-import org.springframework.hateoas.server.core.Relation;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.immutables.value.Value.Immutable;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-
+@Immutable
 @Schema(name = "userAttribute")
-@Relation(collectionRelation = "userAttributes", itemRelation = "userAttribute")
-@JsonPropertyOrder({ "id", "name", "value", "createdBy", "createdDate", "lastModifiedBy", "lastModifiedDate" })
-public class UserAttributeCreateModel {
-	
-	private String name;
-
-	private String value;
+@JsonDeserialize(as = ImmutableUserAttributeCreateModel.class)
+public interface UserAttributeCreateModel {
 
 	@NotBlank
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
+	public String getName(); 
 
 	@NotBlank
-	public String getValue() {
-		return value;
-	}
-
-
-	public void setValue(String value) {
-		this.value = value;
-	}
-
-
-	@Override
-	public String toString() {
-		return new ToStringCreator(this)
-			.append("super", super.toString())
-			.append("name", name)
-			.append("value", value)
-			.toString();
-	}
+	public String getValue();
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
@@ -1,0 +1,47 @@
+package ca.gov.dtsstn.cdcp.api.web.v1.model;
+
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.hateoas.server.core.Relation;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+
+@Schema(name = "userAttribute")
+@Relation(collectionRelation = "userAttributes", itemRelation = "userAttribute")
+@JsonPropertyOrder({ "id", "name", "value", "createdBy", "createdDate", "lastModifiedBy", "lastModifiedDate" })
+public class UserAttributeCreateModel {
+	
+	private String name;
+
+	private String value;
+
+	@NotBlank
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@NotBlank
+	public String getValue() {
+		return value;
+	}
+
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+			.append("super", super.toString())
+			.append("name", name)
+			.append("value", value)
+			.toString();
+	}
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
@@ -1,7 +1,9 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.model;
 
 import org.immutables.value.Value.Immutable;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -15,4 +17,5 @@ public interface UserAttributeCreateModel {
 
 	@NotBlank
 	public String getValue();
+
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
@@ -14,6 +14,6 @@ public interface UserCreateModel {
 	@Email
 	String getEmail();
 
-	List<UserAttributeModel> getUserAttributeModel();
+	List<UserAttributeModel> getUserAttributes();
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
@@ -1,15 +1,19 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.model;
 
+import java.util.List;
 import org.immutables.value.Value.Immutable;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
 
 @Immutable
 @Schema(name = "UserCreate")
 @JsonDeserialize(as = ImmutableUserCreateModel.class)
 public interface UserCreateModel {
 	
-	@NotBlank
+	@Email
 	String getEmail();
+
+	List<UserAttributeModel> getUserAttributeModel();
+
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
@@ -1,0 +1,15 @@
+package ca.gov.dtsstn.cdcp.api.web.v1.model;
+
+import org.immutables.value.Value.Immutable;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Immutable
+@Schema(name = "UserCreate")
+@JsonDeserialize(as = ImmutableUserCreateModel.class)
+public interface UserCreateModel {
+	
+	@NotBlank
+	String getEmail();
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserCreateModel.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.immutables.value.Value.Immutable;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 
 @Immutable
@@ -14,6 +15,7 @@ public interface UserCreateModel {
 	@Email
 	String getEmail();
 
-	List<UserAttributeModel> getUserAttributes();
+	@Valid
+	List<UserAttributeCreateModel> getUserAttributes();
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
@@ -2,12 +2,14 @@ package ca.gov.dtsstn.cdcp.api.web.v1.model.mapper;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 import org.mapstruct.AfterMapping;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
+
 import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.ConfirmationCodesController;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.EmailValidationsController;
@@ -32,7 +34,6 @@ public interface UserModelMapper {
 			.add(linkTo(methodOn(ConfirmationCodesController.class).getConfirmationCodesByUserId(user.getId())).withRel("confirmationCodes"));
 	}
 
-
 	@Nullable	
 	UserPatchModel toPatchModel(@Nullable User user);
 
@@ -41,12 +42,12 @@ public interface UserModelMapper {
 	@BeanMapping(ignoreByDefault = true, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 	User toDomain(@Nullable UserPatchModel userModel);	
 
+	@Nullable
 	@Mapping(target = "id", ignore = true)
 	@Mapping(target = "createdBy", ignore = true)
 	@Mapping(target = "createdDate", ignore = true)
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
-	@Nullable
 	User toDomain(@Nullable UserCreateModel userCreateModel);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
@@ -47,14 +47,6 @@ public interface UserModelMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Nullable
-	User toDomain(@Nullable UserModel userModel);
-
-	@Mapping(target = "id", ignore = true)
-	@Mapping(target = "createdBy", ignore = true)
-	@Mapping(target = "createdDate", ignore = true)
-	@Mapping(target = "lastModifiedBy", ignore = true)
-	@Mapping(target = "lastModifiedDate", ignore = true)
-	@Nullable
 	User toDomain(@Nullable UserCreateModel userCreateModel);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
@@ -2,14 +2,12 @@ package ca.gov.dtsstn.cdcp.api.web.v1.model.mapper;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.mapstruct.AfterMapping;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
-
 import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.ConfirmationCodesController;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.EmailValidationsController;
@@ -33,6 +31,7 @@ public interface UserModelMapper {
 			.add(linkTo(methodOn(ConfirmationCodesController.class).getConfirmationCodesByUserId(user.getId())).withRel("confirmationCodes"));
 	}
 
+
 	@Nullable	
 	UserPatchModel toPatchModel(@Nullable User user);
 
@@ -40,4 +39,13 @@ public interface UserModelMapper {
 	@Mapping(target = "email", ignore = false)
 	@BeanMapping(ignoreByDefault = true, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 	User toDomain(@Nullable UserPatchModel userModel);	
+
+	@Mapping(target = "id", ignore = true)
+	@Mapping(target = "createdBy", ignore = true)
+	@Mapping(target = "createdDate", ignore = true)
+	@Mapping(target = "lastModifiedBy", ignore = true)
+	@Mapping(target = "lastModifiedDate", ignore = true)
+	@Nullable
+	User toDomainObject(@Nullable UserModel userModel);
+
 }

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/mapper/UserModelMapper.java
@@ -13,6 +13,7 @@ import ca.gov.dtsstn.cdcp.api.web.v1.controller.ConfirmationCodesController;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.EmailValidationsController;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.SubscriptionsController;
 import ca.gov.dtsstn.cdcp.api.web.v1.controller.UsersController;
+import ca.gov.dtsstn.cdcp.api.web.v1.model.UserCreateModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserModel;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.UserPatchModel;
 import jakarta.annotation.Nullable;
@@ -46,6 +47,14 @@ public interface UserModelMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Nullable
-	User toDomainObject(@Nullable UserModel userModel);
+	User toDomain(@Nullable UserModel userModel);
+
+	@Mapping(target = "id", ignore = true)
+	@Mapping(target = "createdBy", ignore = true)
+	@Mapping(target = "createdDate", ignore = true)
+	@Mapping(target = "lastModifiedBy", ignore = true)
+	@Mapping(target = "lastModifiedDate", ignore = true)
+	@Nullable
+	User toDomain(@Nullable UserCreateModel userCreateModel);
 
 }


### PR DESCRIPTION
### Description
added the code/endpoint to create a user on the api project.
The endpoint is exposed and now we can add a user with its raoidc user Id and the email address with it.

### Related Azure Boards Work Items
[AB#4077](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4077)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
