### PR TITLE
AB#4010 -- Minor refactoring of `toPersonalInformation(..)`

### DIFF
--- a/frontend/app/schemas/personal-informaton-service-schemas.server.ts
+++ b/frontend/app/schemas/personal-informaton-service-schemas.server.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+// TODO some fields in this schema aren't being used as personal information and can be removed
 export const getApplicantResponseSchema = z.object({
   BenefitApplication: z.object({
     Applicant: z


### PR DESCRIPTION
### Description
Reordered function declaration, added a `toAddress(..)` helper mapper function, and replacing use of `filter(..)` + `at(0)` with `find(..)` where necessary.

### Related Azure Boards Work Items
[AB#4010](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4010)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/en/personal-information`. Verify that the page renders with all personal info.