### PR TITLE
fix nbsp char in child dental insurance page heading

### DIFF
--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -134,7 +134,7 @@
       }
     },
     "dental-benefits": {
-      "title": "{{childName}}\u0a00: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "select-one": "Choisissez une option",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -142,7 +142,7 @@
       }
     },
     "dental-benefits": {
-      "title": "{{childName}}\u0a00: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "select-one": "Choisissez une option",


### PR DESCRIPTION
### Description
Fixed incorrect unicode character for nbsp.

### Related Azure Boards Work Items
[AB#4082](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4082)