### PR TITLE
add conditional redirect if edit mode is enabled

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -79,7 +79,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/federal-provincial-territorial');
-  loadApplyAdultChildState({ params, request, session });
+  const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // NOTE: state validation schemas are independent otherwise user have to anwser
@@ -165,6 +165,10 @@ export async function action({ context: { session }, params, request }: ActionFu
       },
     },
   });
+
+  if (state.editMode) {
+    return redirect(getPathById('$lang/_public/apply/$id/adult-child/review-adult-information', params));
+  }
 
   return redirect(getPathById('$lang/_public/apply/$id/adult-child/children/index', params));
 }


### PR DESCRIPTION
### Description
Add missing conditional redirect to `/adult-child/federal-provincial-territorial-benefits` back to the review-information page if `editMode` is enabled in state.

### Related Azure Boards Work Items
[AB#4083](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4083)