### PR TITLE
AB#4010 -- Removing unneeded fields from applicant response schema

### DIFF
--- a/frontend/app/mappers/personal-information-service-mappers.server.ts
+++ b/frontend/app/mappers/personal-information-service-mappers.server.ts
@@ -84,7 +84,7 @@ export function toUpdateApplicantRequest(personalInformation: PersonalInformatio
       },
       BenefitApplicationIdentification: [
         {
-          IdentificationID: personalInformation.benefitApplicationIdentification ?? '',
+          IdentificationID: personalInformation.benefitApplicationId ?? '',
           IdentificationCategoryText: 'Dental Application ID',
         },
       ],
@@ -134,7 +134,6 @@ export function toPersonalInformation(getApplicantResponse: GetApplicantResponse
   const mailingAddress = addresses?.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
 
   return {
-    applicantCategoryCode: applicant?.ApplicantCategoryCode.ReferenceDataID,
     applictantId: applicant?.ClientIdentification?.find((clientInfoDto) => clientInfoDto.IdentificationCategoryText === 'Applicant ID')?.IdentificationID,
     clientId: applicant?.ClientIdentification?.find((clientInfoDto) => clientInfoDto.IdentificationCategoryText === 'Client ID')?.IdentificationID,
     clientNumber: applicant?.ClientIdentification?.find((clientInfoDto) => clientInfoDto.IdentificationCategoryText === 'Client Number')?.IdentificationID,

--- a/frontend/app/schemas/personal-informaton-service-schemas.server.ts
+++ b/frontend/app/schemas/personal-informaton-service-schemas.server.ts
@@ -1,7 +1,88 @@
 import { z } from 'zod';
 
-// TODO some fields in this schema aren't being used as personal information and can be removed
 export const getApplicantResponseSchema = z.object({
+  BenefitApplication: z.object({
+    Applicant: z
+      .object({
+        ClientIdentification: z
+          .object({
+            IdentificationID: z.string().optional(),
+            IdentificationCategoryText: z.string().optional(),
+          })
+          .array()
+          .optional(),
+        PersonBirthDate: z.object({
+          date: z.string().date().optional(),
+        }),
+        PersonContactInformation: z
+          .object({
+            EmailAddress: z
+              .object({
+                EmailAddressID: z.string().optional(),
+              })
+              .array(),
+            TelephoneNumber: z
+              .object({
+                FullTelephoneNumber: z.object({
+                  TelephoneNumberFullID: z.string().optional(),
+                }),
+                TelephoneNumberCategoryCode: z.object({
+                  ReferenceDataName: z.string().optional(),
+                }),
+              })
+              .array(),
+            Address: z
+              .object({
+                AddressCategoryCode: z.object({
+                  ReferenceDataName: z.string().optional(),
+                }),
+                AddressStreet: z.object({
+                  StreetName: z.string().optional(),
+                }),
+                AddressSecondaryUnitText: z.string().optional(),
+                AddressCityName: z.string().optional(),
+                AddressProvince: z.object({
+                  ProvinceCode: z.object({
+                    ReferenceDataID: z.string().optional(),
+                  }),
+                }),
+                AddressCountry: z.object({
+                  CountryCode: z.object({
+                    ReferenceDataID: z.string().optional(),
+                  }),
+                }),
+                AddressPostalCode: z.string().optional(),
+              })
+              .array(),
+          })
+          .optional()
+          .array(),
+        PersonMaritalStatus: z.object({
+          StatusCode: z.object({
+            ReferenceDataID: z.string().optional(),
+          }),
+        }),
+        PersonName: z
+          .object({
+            PersonSurName: z.string().optional(),
+            PersonGivenName: z.string().array().optional(),
+          })
+          .array()
+          .optional(),
+        PreferredMethodCommunicationCode: z
+          .object({
+            ReferenceDataID: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+  }),
+});
+
+export type GetApplicantResponse = z.infer<typeof getApplicantResponseSchema>;
+
+// TODO definition for request to update applicant is not yet available from Interop; Using the full structure of the response for getting applicants for now
+export const updateApplicantRequestSchema = z.object({
   BenefitApplication: z.object({
     Applicant: z
       .object({
@@ -140,11 +221,6 @@ export const getApplicantResponseSchema = z.object({
   }),
 });
 
-export type GetApplicantResponse = z.infer<typeof getApplicantResponseSchema>;
-
-// TODO definition for request to update applicant is not yet available from Interop; Using getApplicantResponseSchema for now
-export const updateApplicantRequestSchema = getApplicantResponseSchema;
-
 export type UpdateApplicantRequest = z.infer<typeof updateApplicantRequestSchema>;
 
 export const personalInformationSchema = z.object({
@@ -185,7 +261,7 @@ export const personalInformationSchema = z.object({
   privateDentalPlanId: z.string().optional(),
   federalDentalPlanId: z.string().optional(),
   provincialTerritorialDentalPlanId: z.string().optional(),
-  benefitApplicationIdentification: z.string().optional(),
+  benefitApplicationId: z.string().optional(),
 });
 
 export type PersonalInformation = z.infer<typeof personalInformationSchema>;


### PR DESCRIPTION
### Description
As per title. 

Note that GitHub changes indicate that `getApplicantResponseSchema` is a new schema but it it's actually a copy of the previous schema with the unused fields (ie. fields not being mapped to our domain model) removed.

Also renamed `benefitApplicationIdentification` to `benefitApplicationId` for consistency.

### Related Azure Boards Work Items
[AB#4010](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4010)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/personal-information`. Verify that you can view and update the info on that page.