### PR TITLE
Add JsonPatchProcessor for applying JSON patches to objects

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,6 +43,7 @@
 
 		<immutables.version>2.10.1</immutables.version>
 		<jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+		<johnzon.version>2.0.1</johnzon.version>
 		<mapstruct.version>1.5.5.Final</mapstruct.version>
 		<spring-boot.version>3.3.0</spring-boot.version>
 		<springdoc.version>2.5.0</springdoc.version>
@@ -57,6 +58,15 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.json</groupId>
+			<artifactId>jakarta.json-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.johnzon</groupId>
+			<artifactId>johnzon-core</artifactId>
+			<version>${johnzon.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessor.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessor.java
@@ -1,0 +1,80 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.json.Json;
+import jakarta.json.JsonMergePatch;
+import jakarta.json.JsonPatch;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+@Component
+public class JsonPatchProcessor {
+
+	private static final Logger log = LoggerFactory.getLogger(JsonPatchProcessor.class);
+
+	private final ObjectMapper objectMapper = new ObjectMapper()
+		.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+		.findAndRegisterModules();
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	/**
+	 * Applies a JSON merge patch to the specified object. The object is not modified by the patch.
+	 *
+	 * @param object the object to apply the JSON merge patch
+	 * @param jsonMergePatch the JSON merge patch to apply
+	 * @return the transformed object after the patch
+	 */
+	public <T> T patch(T object, JsonMergePatch jsonMergePatch) {
+		return patch(object, jsonMergePatch::apply);
+	}
+
+	/**
+	 * Applies JSON patch operations to the specified object. The object is not modified by the patch.
+	 *
+	 * @param object the object to apply the JSON patch
+	 * @param jsonPatch the JSON patch to apply
+	 * @return the transformed target after the patch
+	 */
+	public <T> T patch(T object, JsonPatch jsonPatch) {
+		return patch(object, jsonPatch::apply);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	protected <T> T patch(T object, Function<? super JsonStructure, ? extends JsonValue> patchFn) {
+		Assert.notNull(object, "object is required; it must not be null");
+		Assert.notNull(patchFn, "patchFn is required; it must not be null");
+
+		try {
+			log.debug("Patching object of type {}", object.getClass().getSimpleName());
+			final var valueMap = objectMapper.convertValue(object, Map.class);
+			final var jsonObject = Json.createObjectBuilder(valueMap).build();
+			final var patchedObject = objectMapper.readValue(patchFn.apply(jsonObject).toString(), object.getClass());
+
+			log.debug("Performing JSON patch validation");
+			final var constraintViolations = validator.validate(patchedObject);
+			if (constraintViolations.isEmpty() == false) { throw new ConstraintViolationException(constraintViolations); }
+			log.debug("No validation errors for {}", object.getClass().getSimpleName());
+
+			return (T) patchedObject;
+		}
+		catch (final JsonProcessingException jsonProcessingException) {
+			throw new RuntimeException(jsonProcessingException);
+		}
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
@@ -1,0 +1,91 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.json.Json;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotBlank;
+
+@ExtendWith({ MockitoExtension.class })
+class JsonPatchProcessorTests {
+
+	JsonPatchProcessor jsonPatchProcessor;
+
+	@BeforeEach
+	void beforeEach() {
+		this.jsonPatchProcessor = new JsonPatchProcessor();
+	}
+
+	@Test
+	@DisplayName("Test patch(..) w/ JSON merge patch")
+	void testPatchJsonMergePatch() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("name", "updated name").build();
+		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
+		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonMergePatch);
+
+		assertThat(patchedEntity).isNotSameAs(entity);
+		assertThat(patchedEntity).hasFieldOrPropertyWithValue("id", "id");
+		assertThat(patchedEntity).hasFieldOrPropertyWithValue("name", "updated name");
+	}
+
+	@Test
+	@DisplayName("Test patch(..) w/ invalid JSON merge patch")
+	void testPatchJsonMergePatch_validationError_throws() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("name", "").build();
+		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
+
+		assertThatExceptionOfType(ConstraintViolationException.class)
+			.isThrownBy(() -> jsonPatchProcessor.patch(entity, jsonMergePatch))
+			.withMessage("name: must not be blank");
+	}
+
+	@Test
+	@DisplayName("Test patch(..) w/ JSON patch")
+	void testPatchJsonPatch() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("op", "replace").add("path", "/name").add("value", "updated name").build();
+		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
+		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonPatch);
+
+		assertThat(patchedEntity).isNotSameAs(entity);
+		assertThat(patchedEntity).hasFieldOrPropertyWithValue("id", "id");
+		assertThat(patchedEntity).hasFieldOrPropertyWithValue("name", "updated name");
+	}
+
+	@Test
+	@DisplayName("Test patch(..) w/ invalid JSON patch")
+	void testPatchJsonPatch_validationError_throws() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("op", "replace").add("path", "/name").add("value", "").build();
+		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
+
+		assertThatExceptionOfType(ConstraintViolationException.class)
+			.isThrownBy(() -> jsonPatchProcessor.patch(entity, jsonPatch))
+			.withMessage("name: must not be blank");
+	}
+
+	static class MyEntity {
+
+		@NotBlank
+		public String id;
+
+		@NotBlank
+		public String name;
+
+		public MyEntity(String id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This pull request introduces a new class `JsonPatchProcessor` to the API which provides functionality to apply [JSON patches](https://datatracker.ietf.org/doc/rfc7386/) to data objects. The `patch` methods accept an object and either a *JSON merge patch* or *JSON patch* as input and returns a new object with the applied changes. The original object is not modified.

Key features:

- supports applying both JSON merge patches and JSON patches
- handles unknown properties during deserialization
- validates the patched object using JSR 380 Bean Validation
- includes unit tests for the functionality

This functionality allows developers to partially update objects within the API using JSON patches.