### PR TITLE
Add JSON merge patch and JSON patch message converters

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
@@ -1,0 +1,50 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+import jakarta.json.Json;
+import jakarta.json.JsonMergePatch;
+
+@Component
+public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonMergePatch> {
+
+	public JsonMergePatchHttpMessageConverter() {
+		super(MediaType.APPLICATION_JSON, JsonPatchMediaTypes.JSON_MERGE_PATCH);
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		return JsonMergePatch.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	protected JsonMergePatch readInternal(Class<? extends JsonMergePatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
+		try {
+			return Json.createMergePatch(Json.createReader(httpInputMessage.getBody()).readValue());
+		}
+		catch (final Exception exception) {
+			final var message = "Could not read JSON merge-patch: %s".formatted(exception.getMessage());
+			throw new HttpMessageNotReadableException(message, exception, httpInputMessage);
+		}
+	}
+
+	@Override
+	protected void writeInternal(JsonMergePatch jsonMergePatch, HttpOutputMessage httpOutputMessage) throws IOException, HttpMessageNotWritableException {
+		try {
+			Json.createWriter(httpOutputMessage.getBody()).write(jsonMergePatch.toJsonValue());
+		}
+		catch (final Exception exception) {
+			final var message = "Could not write JSON merge-patch: %s".formatted(exception.getMessage());
+			throw new HttpMessageNotWritableException(message, exception);
+		}
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
@@ -1,0 +1,50 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+
+@Component
+public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonPatch> {
+
+	public JsonPatchHttpMessageConverter() {
+		super(MediaType.APPLICATION_JSON, JsonPatchMediaTypes.JSON_PATCH);
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		return JsonPatch.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
+		try {
+			return Json.createPatch(Json.createReader(httpInputMessage.getBody()).readArray());
+		}
+		catch (final Exception exception) {
+			final var message = "Could not read JSON patch: %s".formatted(exception.getMessage());
+			throw new HttpMessageNotReadableException(message, exception, httpInputMessage);
+		}
+	}
+
+	@Override
+	protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage httpOutputMessage) {
+		try {
+			Json.createWriter(httpOutputMessage.getBody()).write(jsonPatch.toJsonArray());
+		}
+		catch (final Exception exception) {
+			final var message = "Could not write JSON patch: %s".formatted(exception.getMessage());
+			throw new HttpMessageNotWritableException(message, exception);
+		}
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
@@ -1,0 +1,15 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import org.springframework.http.MediaType;
+
+public class JsonPatchMediaTypes {
+
+	public static final String JSON_MERGE_PATCH_VALUE = "application/merge-patch+json";
+
+	public static final MediaType JSON_MERGE_PATCH = MediaType.valueOf(JSON_MERGE_PATCH_VALUE);
+
+	public static final String JSON_PATCH_VALUE = "application/json-patch+json";
+
+	public static final MediaType JSON_PATCH = MediaType.valueOf(JSON_PATCH_VALUE);
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverterTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverterTests.java
@@ -1,0 +1,65 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+
+import jakarta.json.Json;
+import jakarta.json.JsonMergePatch;
+
+@ExtendWith({ MockitoExtension.class })
+class JsonMergePatchHttpMessageConverterTests {
+
+	JsonMergePatchHttpMessageConverter jsonMergePatchHttpMessageConverter;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		this.jsonMergePatchHttpMessageConverter = new JsonMergePatchHttpMessageConverter();
+	}
+
+	@Test
+	@DisplayName("Test supports(..)")
+	void testSupportsClass() {
+		assertThat(jsonMergePatchHttpMessageConverter.supports(JsonMergePatch.class)).isTrue();
+		assertThat(jsonMergePatchHttpMessageConverter.supports(Object.class)).isFalse();
+	}
+
+	@Test
+	@DisplayName("Test readInternal(..)")
+	void testReadInternal() throws Exception {
+		final var httpInputMessage = mock(HttpInputMessage.class);
+
+		when(httpInputMessage.getBody()).thenReturn(new ByteArrayInputStream("{ \"key\":\"value\" }".getBytes()));
+
+		final var jsonValue = jsonMergePatchHttpMessageConverter.readInternal(JsonMergePatch.class, httpInputMessage).toJsonValue();
+
+		assertThat(jsonValue.asJsonObject().getString("key")).isEqualTo("value");
+	}
+
+	@Test
+	@DisplayName("Test writeInternal(..)")
+	void testWriteInternal() throws Exception {
+		final var httpOutputMessage = mock(HttpOutputMessage.class);
+		final var byteArrayOutputStream = new ByteArrayOutputStream();
+
+		when(httpOutputMessage.getBody()).thenReturn(byteArrayOutputStream);
+
+		final var jsonPatchObject = Json.createObjectBuilder(Map.of("key", "value")).build();
+		jsonMergePatchHttpMessageConverter.writeInternal(Json.createMergePatch(jsonPatchObject), httpOutputMessage);
+
+		assertThat(byteArrayOutputStream).hasToString("{\"key\":\"value\"}");
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverterTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverterTests.java
@@ -1,0 +1,69 @@
+package ca.gov.dtsstn.cdcp.api.web.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+
+@ExtendWith({ MockitoExtension.class })
+class JsonPatchHttpMessageConverterTests {
+
+	JsonPatchHttpMessageConverter jsonPatchHttpMessageConverter;
+
+	@BeforeEach
+	void beforeEach() {
+		this.jsonPatchHttpMessageConverter = new JsonPatchHttpMessageConverter();
+	}
+
+	@Test
+	@DisplayName("Test supports(..)")
+	void testSupportsClass() {
+		assertThat(jsonPatchHttpMessageConverter.supports(JsonPatch.class)).isTrue();
+		assertThat(jsonPatchHttpMessageConverter.supports(Object.class)).isFalse();
+	}
+
+	@Test
+	@DisplayName("Test readInternal(..)")
+	void testReadInternal() throws Exception {
+		final var httpInputMessage = mock(HttpInputMessage.class);
+
+		when(httpInputMessage.getBody()).thenReturn(new ByteArrayInputStream("[{ \"op\":\"replace\", \"path\":\"/id\", \"value\":\"value\" }]".getBytes()));
+
+		final var jsonObject = jsonPatchHttpMessageConverter.readInternal(JsonPatch.class, httpInputMessage).toJsonArray().get(0).asJsonObject();
+
+		assertThat(jsonObject.getString("op")).isEqualTo("replace");
+		assertThat(jsonObject.getString("path")).isEqualTo("/id");
+		assertThat(jsonObject.getString("value")).isEqualTo("value");
+	}
+
+	@Test
+	@DisplayName("Test writeInternal(..)")
+	void testWriteInternal() throws Exception {
+		final var httpOutputMessage = mock(HttpOutputMessage.class);
+		final var byteArrayOutputStream = new ByteArrayOutputStream();
+
+		when(httpOutputMessage.getBody()).thenReturn(byteArrayOutputStream);
+
+		final var map = Map.of("op", "replace", "path", "/id", "value", "value");
+		final var jsonPatchObject = Json.createArrayBuilder(List.of(map)).build();
+		jsonPatchHttpMessageConverter.writeInternal(Json.createPatch(jsonPatchObject), httpOutputMessage);
+
+		assertThat(byteArrayOutputStream).hasToString("[{\"op\":\"replace\",\"path\":\"/id\",\"value\":\"value\"}]");
+	}
+
+}


### PR DESCRIPTION
This pull request introduces two new Spring MVC converters:

- `JsonMergePatchHttpMessageConverter`: this converter handles reading and writing [JSON merge patches](https://datatracker.ietf.org/doc/rfc7386/) from HTTP requests and responses.
- `JsonPatchHttpMessageConverter`: this converter handles reading and writing [JSON patches](https://datatracker.ietf.org/doc/rfc6902/) from HTTP requests and responses.

Unit tests are included to ensure the functionality of both converters.

This addition allows the API to seamlessly handle JSON patch operations for partial object updates within requests and responses.