### PR TITLE
Add InputSanitizeField new component

### DIFF
--- a/frontend/__tests__/components/input-sanitize-field.test.tsx
+++ b/frontend/__tests__/components/input-sanitize-field.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('InputSanitizeField', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it.each([
+    ["Hi, my name is Smith's.", "Hi, my name is Smith's."],
+    ['Hi, my name is Smith’s.', 'Hi, my name is Smith’s.'],
+    ['Hello!', 'Hello'],
+    ['Good@Morning', 'GoodMorning'],
+    ['123#456', '123456'],
+    ['Welcome*Home', 'WelcomeHome'],
+    ['800--000-----000', '800-000-000'],
+  ])('should render %s -> %s', (defaultValue, expected) => {
+    render(<InputSanitizeField id="test-id" name="test" label="label test" defaultValue={defaultValue} />);
+
+    const actual: HTMLInputElement = screen.getByTestId('input-sanitize-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue(expected);
+    expect(actual).not.toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with help message', () => {
+    const defaultValue = "Hi, my name is Smith's.";
+    render(<InputSanitizeField id="test-id" name="test" label="label test" defaultValue={defaultValue} helpMessageSecondary="help message" />);
+
+    const actual = screen.getByTestId('input-sanitize-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleDescription('help message');
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue("Hi, my name is Smith's.");
+    expect(actual).not.toBeRequired();
+  });
+
+  it('should render with required', () => {
+    const defaultValue = "Hi, my name is Smith's.";
+    render(<InputSanitizeField id="test-id" name="test" label="label test" defaultValue={defaultValue} required />);
+
+    const actual = screen.getByTestId('input-sanitize-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAttribute('id', 'test-id');
+    expect(actual).toHaveValue("Hi, my name is Smith's.");
+    expect(actual).toBeRequired();
+    expect(actual).not.toHaveAccessibleDescription();
+  });
+
+  it('should render with error message', () => {
+    const defaultValue = "Hi, my name is Smith's.";
+    render(<InputSanitizeField id="test-id" name="test" label="label test" defaultValue={defaultValue} errorMessage="error message" />);
+
+    const actual = screen.getByTestId('input-sanitize-field');
+
+    expect(actual).toBeInTheDocument();
+    expect(actual).toHaveAccessibleName('label test');
+    expect(actual).toBeInvalid();
+    expect(actual).toHaveAccessibleErrorMessage('error message');
+  });
+});

--- a/frontend/__tests__/utils/string-utils.test.ts
+++ b/frontend/__tests__/utils/string-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { expandTemplate, isAllValidInputCharacters, padWithZero, randomHexString, randomString } from '~/utils/string-utils';
+import { expandTemplate, isAllValidInputCharacters, normalizeHyphens, padWithZero, randomHexString, randomString, removeInvalidInputCharacters } from '~/utils/string-utils';
 
 describe('expandTemplate', () => {
   it('should expand a template', () => {
@@ -62,10 +62,35 @@ describe('padWithZero', () => {
 
 describe('isAllValidInputCharacters', () => {
   it('should return true for input containing the entire valid character set', () => {
-    expect(isAllValidInputCharacters("a-zA-Z0-9'(),-.ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ\u00a0 ")).toEqual(true);
+    expect(isAllValidInputCharacters("a-zA-Z0-9'’ \u00a0(),-.ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ")).toEqual(true);
   });
 
   it('should return false for input containing invalid characters', () => {
     expect(isAllValidInputCharacters('!"#$%&*+/:;<=>?@[\\]^_`{|}~¡¢£¤¥¦§¨©ª«¬\u00ad®¯±²³\u00b4µ-m¶·\u00b8¹º»¼½¾¿ÃãÅåÆæÐðÑñÕõ\u00d7ØøÞþẞß\u00f7')).toEqual(false);
+  });
+});
+
+describe('removeInvalidInputCharacters', () => {
+  it.each([
+    ['abc123!@#', 'abc123'],
+    ['abcdef123', 'abcdef123'],
+    ['', ''],
+    ['!@#', ''],
+    ['a b c', 'a b c'],
+    ['a1b!c2@d#e3f', 'a1bc2de3f'],
+  ])('should remove invalid characters from "%s" to "%s"', (input, expectedOutput) => {
+    expect(removeInvalidInputCharacters(input)).toBe(expectedOutput);
+  });
+});
+
+describe('normalizeHyphens', () => {
+  it.each([
+    ['a--b---c', 'a-b-c'],
+    ['a-b-c', 'a-b-c'],
+    ['', ''],
+    ['----', '-'],
+    ['-abc--def-', '-abc-def-'],
+  ])('should normalize hyphens in "%s" to "%s"', (input, expectedOutput) => {
+    expect(normalizeHyphens(input)).toBe(expectedOutput);
   });
 });

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -1,0 +1,91 @@
+import { NumberFormatBase } from 'react-number-format';
+
+import { InputError } from './input-error';
+import { InputHelp } from './input-help';
+import { InputLabel } from '~/components/input-label';
+import { isAllValidInputCharacters, normalizeHyphens, removeInvalidInputCharacters } from '~/utils/string-utils';
+import { cn } from '~/utils/tw-utils';
+
+const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500';
+const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
+const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
+const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
+
+export interface InputSanitizeFieldProps
+  extends Omit<
+    React.ComponentProps<typeof NumberFormatBase>,
+    'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value' | 'onChange' | 'format' | 'type' | 'removeFormatting' | 'isValidInputCharacter' | 'getCaretBoundary'
+  > {
+  defaultValue: string;
+  errorMessage?: string;
+  helpMessagePrimary?: React.ReactNode;
+  helpMessagePrimaryClassName?: string;
+  helpMessageSecondary?: React.ReactNode;
+  helpMessageSecondaryClassName?: string;
+  id: string;
+  label: string;
+  name: string;
+}
+
+export function InputSanitizeField(props: InputSanitizeFieldProps) {
+  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
+
+  const inputWrapperId = `input-sanitize-field-${id}`;
+  const inputErrorId = `${inputWrapperId}-error`;
+  const inputHelpMessagePrimaryId = `${inputWrapperId}-help-primary`;
+  const inputHelpMessageSecondaryId = `${inputWrapperId}-help-secondary`;
+  const inputLabelId = `${inputWrapperId}-label`;
+
+  function getAriaDescribedby() {
+    const describedby = [];
+    if (ariaDescribedby) describedby.push(ariaDescribedby);
+    if (helpMessagePrimary) describedby.push(inputHelpMessagePrimaryId);
+    if (helpMessageSecondary) describedby.push(inputHelpMessageSecondaryId);
+    return describedby.length > 0 ? describedby.join(' ') : undefined;
+  }
+
+  return (
+    <div id={inputWrapperId} data-testid={inputWrapperId}>
+      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2">
+        {label}
+      </InputLabel>
+      {errorMessage && (
+        <p className="mb-2">
+          <InputError id={inputErrorId}>{errorMessage}</InputError>
+        </p>
+      )}
+      {helpMessagePrimary && (
+        <InputHelp id={inputHelpMessagePrimaryId} className={cn('mb-2', helpMessagePrimaryClassName)} data-testid="input-sanitize-field-help-primary">
+          {helpMessagePrimary}
+        </InputHelp>
+      )}
+      <NumberFormatBase
+        aria-describedby={getAriaDescribedby()}
+        aria-errormessage={errorMessage ? inputErrorId : undefined}
+        aria-invalid={!!errorMessage}
+        aria-labelledby={inputLabelId}
+        aria-required={required}
+        data-testid="input-sanitize-field"
+        id={id}
+        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        required={required}
+        {...restProps}
+        defaultValue={defaultValue}
+        type="text"
+        format={(value) => normalizeHyphens(removeInvalidInputCharacters(value))}
+        removeFormatting={(value) => normalizeHyphens(removeInvalidInputCharacters(value))}
+        isValidInputCharacter={(char) => isAllValidInputCharacters(char)}
+        getCaretBoundary={(value) =>
+          Array(value.length + 1)
+            .fill(0)
+            .map((v) => true)
+        }
+      />
+      {helpMessageSecondary && (
+        <InputHelp id={inputHelpMessageSecondaryId} className={cn('mt-2', helpMessageSecondaryClassName)} data-testid="input-sanitize-field-help-secondary">
+          {helpMessageSecondary}
+        </InputHelp>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -13,8 +13,8 @@ import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
-import { InputField } from '~/components/input-field';
 import { InputRadios } from '~/components/input-radios';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
@@ -203,7 +203,7 @@ export default function ApplyFlowApplicationInformation() {
               <p>{t('applicant-information.name-instructions')}</p>
             </Collapsible>
             <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputField
+              <InputSanitizeField
                 id="first-name"
                 name="firstName"
                 label={t('applicant-information.first-name')}
@@ -215,7 +215,7 @@ export default function ApplyFlowApplicationInformation() {
                 defaultValue={defaultState?.firstName ?? ''}
                 required
               />
-              <InputField
+              <InputSanitizeField
                 id="last-name"
                 name="lastName"
                 label={t('applicant-information.last-name')}

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -36,12 +36,35 @@ export const padWithZero = (value: number, maxLength: number) => {
   return value.toString().padStart(maxLength, '0');
 };
 
+export const invalidInputCharactersRegex = /[^a-zA-Z0-9(),\-.'\u2019\s\u00a0ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ]/g;
+
 /**
+ * Checks if the input string contains only valid characters.
  *
- * @param input - The string value of the input field to be validated
- * @returns Boolean indicating whether the input contains all valid characters
+ * @param value - The input string to be checked.
+ * @returns - Returns true if the input contains only valid characters, otherwise false.
  */
-export function isAllValidInputCharacters(input: string): boolean {
-  const validCharactersRegex = /^[a-zA-Z0-9'(),\-.ÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÝàáâäçèéêëìíîïòóôöùúûüýÿ\u00a0 ]+$/;
-  return validCharactersRegex.test(input);
+export function isAllValidInputCharacters(value: string) {
+  const invalidCharacters = value.match(invalidInputCharactersRegex);
+  return invalidCharacters == null;
+}
+
+/**
+ * Removes invalid characters from the input string based on a predefined regular expression.
+ *
+ * @param value - The input string to be filtered.
+ * @returns - The filtered string with invalid characters removed.
+ */
+export function removeInvalidInputCharacters(value: string) {
+  return value.replace(invalidInputCharactersRegex, '');
+}
+
+/**
+ * Normalizes hyphens in the input string by replacing sequences of two or more hyphens with a single hyphen.
+ *
+ * @param str - The input string to normalize.
+ * @returns - The normalized string with sequences of hyphens replaced by a single hyphen.
+ */
+export function normalizeHyphens(str: string) {
+  return str.replace(/-{2,}/g, '-');
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The InputSanitizeField component filters out invalid input characters according to Sunlife specifications. This component is specifically integrated into the applicant information page within the "adult" flow. It enables key players to test it before integrating it into other areas. This continues the work started in #169.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4062](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4062)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Start application "adult" flow and go to the applicant information page. FirstName and LastName fields should filter invalid characters.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

I've used the React Number Format component already used in our application. I tweaked it based on the following example:
https://s-yadav.github.io/react-number-format/docs/customization#iban-account-input-field-with-pattern

