### PR TITLE
add character validation to firstname and lastname

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
@@ -28,6 +28,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum FormAction {
@@ -110,8 +111,8 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.first-name-required')).max(100),
-    lastName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.last-name-required')).max(100),
+    firstName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:applicant-information.error-message.characters-valid')),
+    lastName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:applicant-information.error-message.characters-valid')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-adult-child:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -29,6 +29,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum YesNoOption {
@@ -76,8 +77,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   // state validation schema
   const childInformationSchema = z
     .object({
-      firstName: z.string().trim().min(1, t('apply-adult-child:children.information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply-adult-child:children.information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('apply-adult-child:children.information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:children.information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('apply-adult-child:children.information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:children.information.error-message.characters-valid')),
       dateOfBirthYear: z
         .number({
           required_error: t('apply-adult-child:children.information.error-message.date-of-birth-year-required'),

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
@@ -28,6 +28,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -86,8 +87,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .int()
         .positive(),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-adult-child:partner-information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply-adult-child:partner-information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('apply-adult-child:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:partner-information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('apply-adult-child:partner-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:partner-information.error-message.characters-valid')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -28,6 +28,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum FormAction {
@@ -104,8 +105,8 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.first-name-required')).max(100),
-    lastName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.last-name-required')).max(100),
+    firstName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:applicant-information.error-message.characters-valid')),
+    lastName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:applicant-information.error-message.characters-valid')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-adult:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -28,6 +28,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -85,8 +86,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .int()
         .positive(),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-adult:partner-information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply-adult:partner-information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('apply-adult:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:partner-information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('apply-adult:partner-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:partner-information.error-message.characters-valid')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
@@ -30,6 +30,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum FormAction {
@@ -152,8 +153,8 @@ export async function action({ context: { session }, params, request }: ActionFu
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-child:applicant-information.error-message.first-name-required')).max(100),
-    lastName: z.string().trim().min(1, t('apply-child:applicant-information.error-message.last-name-required')).max(100),
+    firstName: z.string().trim().min(1, t('apply-child:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:applicant-information.error-message.characters-valid')),
+    lastName: z.string().trim().min(1, t('apply-child:applicant-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:applicant-information.error-message.characters-valid')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-child:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -29,6 +29,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum YesNoOption {
@@ -76,8 +77,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   // state validation schema
   const childInformationSchema = z
     .object({
-      firstName: z.string().trim().min(1, t('apply-child:children.information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply-child:children.information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('apply-child:children.information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:children.information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('apply-child:children.information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:children.information.error-message.characters-valid')),
       dateOfBirthYear: z
         .number({
           required_error: t('apply-child:children.information.error-message.date-of-birth-year-required'),

--- a/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
@@ -28,6 +28,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -85,8 +86,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         .int()
         .positive(),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-child:partner-information.error-message.first-name-required')).max(100),
-      lastName: z.string().trim().min(1, t('apply-child:partner-information.error-message.last-name-required')).max(100),
+      firstName: z.string().trim().min(1, t('apply-child:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:partner-information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('apply-child:partner-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:partner-information.error-message.characters-valid')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -23,7 +23,8 @@
       "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "children": {
@@ -91,7 +92,8 @@
         "date-of-birth-year-number": "Year must be a number, for example 1950",
         "date-of-birth-year-required": "Date of birth must include a year",
         "has-social-insurance-number": "Select whether the child has a SIN",
-        "is-parent": "Select whether you are the parent or legal guardian of the child"
+        "is-parent": "Select whether you are the parent or legal guardian of the child",
+        "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
       }
     },
     "dental-insurance": {
@@ -592,7 +594,8 @@
       "last-name-required": "Enter last name",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "review-adult-information": {

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -23,7 +23,8 @@
       "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "communication-preference": {
@@ -281,7 +282,8 @@
       "last-name-required": "Enter last name",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -32,7 +32,8 @@
       "date-of-birth-month-required": "Date of birth must include a month",
       "date-of-birth-valid": "Day must be valid for the given month and year",
       "date-of-birth-year-number": "Year must be a number, for example 1950",
-      "date-of-birth-year-required": "Date of birth must include a year"
+      "date-of-birth-year-required": "Date of birth must include a year",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "children": {
@@ -99,7 +100,8 @@
         "date-of-birth-year-number": "Year must be a number, for example 1950",
         "date-of-birth-year-required": "Date of birth must include a year",
         "has-social-insurance-number": "Select whether the child has a SIN",
-        "is-parent": "Select whether you are the parent or legal guardian of the child"
+        "is-parent": "Select whether you are the parent or legal guardian of the child",
+        "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
       }
     },
     "dental-insurance": {
@@ -361,7 +363,8 @@
       "last-name-required": "Enter last name",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -23,7 +23,8 @@
       "marital-status-no-partner-information": "Si vous êtes marié ou vivez en conjoint de fait, vous devez saisir leurs informations sur la page suivante. Sélectionnez votre état civil et appuyez sur «\u00a0Enregistrer\u00a0».",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "children": {
@@ -91,7 +92,8 @@
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
         "date-of-birth-year-required": "La date de naissance doit inclure une année",
         "has-social-insurance-number": "Sélectionnez si l'enfant a un NAS",
-        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant"
+        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant",
+        "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
       }
     },
     "dental-insurance": {
@@ -592,7 +594,8 @@
       "last-name-required": "Entrez le nom de famille",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "review-adult-information": {

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -23,7 +23,8 @@
       "marital-status-no-partner-information": "Si vous êtes marié ou vivez en conjoint de fait, vous devez saisir leurs informations sur la page suivante. Sélectionnez votre état civil et appuyez sur «\u00a0Enregistrer\u00a0».",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "communication-preference": {
@@ -281,7 +282,8 @@
       "last-name-required": "Entrez le nom de famille",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -32,7 +32,8 @@
       "date-of-birth-month-required": "La date de naissance doit inclure un mois",
       "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
       "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
-      "date-of-birth-year-required": "La date de naissance doit inclure une année"
+      "date-of-birth-year-required": "La date de naissance doit inclure une année",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "children": {
@@ -99,7 +100,8 @@
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
         "date-of-birth-year-required": "La date de naissance doit inclure une année",
         "has-social-insurance-number": "Sélectionnez si l'enfant a un NAS",
-        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant"
+        "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant",
+        "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
       }
     },
     "dental-insurance": {
@@ -361,7 +363,8 @@
       "last-name-required": "Entrez le nom de famille",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789 ",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "contact-information": {


### PR DESCRIPTION
### Description
Adds server-side character validation to `firstName` and `lastName` fields across all flows in `application-information`, `partner-information`, and `children-information` screen.  More fields to follow once we know exactly what fields need this validation, but for now, names are guaranteed to need it.

### Related Azure Boards Work Items
[AB#4062](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4062)