### PR TITLE
adult-child 500 on dtc page in edit mode

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -89,7 +89,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
 
   if (state.editMode) {
-    return redirect(getPathById('$lang/_public/apply/$id/adult-child/review-information', params));
+    return redirect(getPathById('$lang/_public/apply/$id/adult-child/review-adult-information', params));
   }
 
   if (ageCategory !== 'adults') {
@@ -178,7 +178,7 @@ export default function ApplyFlowDisabilityTaxCredit() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="$lang/_public/apply/$id/adult-child/review-information"
+                routeId="$lang/_public/apply/$id/adult-child/review-adult-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult-Child:Cancel - Disability tax credit click"


### PR DESCRIPTION
### Description
In adult-child flow date-of-birth page edit mode, if you change age category from 'youth' to 'adults', you'll get 500 instead of dtc page. Change the path from `review-information` to `review-adult-information` on the DTC page should fix the issue.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->