### PR TITLE
Add `vitest.explorer` to `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "ms-playwright.playwright",
+        "vitest.explorer",
         "vscjava.vscode-java-pack",
         "yoavbls.pretty-ts-errors"
       ],


### PR DESCRIPTION
Per title.. Prevents Github Codespaces from asking to install it every time you start a new codespace.