### PR TITLE
OpenAPI schema: customize `JsonPatch` model

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/SpringDocConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/SpringDocConfig.java
@@ -6,6 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.info.GitProperties;
@@ -15,10 +16,14 @@ import org.springframework.context.annotation.Configuration;
 import ca.gov.dtsstn.cdcp.api.config.properties.ApplicationProperties;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import jakarta.json.JsonPatch;
 
 /**
  * This class configures SpringDoc and customizes the OpenAPI documentation.
@@ -42,8 +47,9 @@ public class SpringDocConfig {
 	/**
 	 * Creates an {@link OpenApiCustomizer} bean that customizes the OpenAPI base documentation.
 	 */
-	@Bean OpenApiCustomizer baseOpenApiCustomizer() {
-		log.info("Creating 'baseOpenApiCustomizer' bean");
+	@Bean OpenApiCustomizer openApiCustomizer() {
+		log.info("Creating 'openApiCustomizer' bean");
+
 		return openApi -> openApi.getInfo()
 			.title(applicationProperties.getSwaggerUi().getApplicationName())
 			.contact(new Contact()
@@ -55,11 +61,38 @@ public class SpringDocConfig {
 	}
 
 	/**
+	 * Creates an {@link OpenApiCustomizer} bean that customizes the OpenAPI schemas.
+	 */
+	@Bean OpenApiCustomizer openApiSchemaCustomizer() {
+		log.info("Creating 'openApiSchemaCustomizer' bean");
+
+		final var jsonPatchSchema = new ArraySchema()
+			.items(new Schema<JsonPatch>()
+				.addRequiredItem("op")
+				.addRequiredItem("path")
+				.addProperty("op", new StringSchema()
+					.addEnumItem("add")
+					.addEnumItem("copy")
+					.addEnumItem("move")
+					.addEnumItem("remove")
+					.addEnumItem("replace")
+					.addEnumItem("test"))
+				.addProperty("path", new StringSchema().example("/path"))
+				.addProperty("value", new StringSchema().example("value")));
+
+		SpringDocUtils.getConfig().replaceWithSchema(JsonPatch.class, jsonPatchSchema);
+
+		return openApi -> openApi.getComponents()
+			.addSchemas("JsonPatch", jsonPatchSchema);
+	}
+
+	/**
 	 * Creates an {@link OpenApiCustomizer} bean that customizes the OpenAPI security documentation.
 	 */
 	@ConditionalOnProperty(name = { "application.security.enabled" }, havingValue = "true", matchIfMissing = false)
-	@Bean OpenApiCustomizer securityOpenApiCustomizer() {
-		log.info("Creating 'securityOpenApiCustomizer' bean");
+	@Bean OpenApiCustomizer openApiSecurityCustomizer() {
+		log.info("Creating 'openApiSecurityCustomizer' bean");
+
 		return openApi -> openApi.getComponents()
 			.addSecuritySchemes("Azure AD", new SecurityScheme()
 				.type(Type.OAUTH2)


### PR DESCRIPTION
This pull request introduces a new Spring bean, `openApiSchemaCustomizer`, which enhances the OpenAPI schema definition for the `JsonPatch` class.

Here's a breakdown of the changes:

- defines a custom `JsonPatch` schema with required properties like `op` and `path`
- specifies valid enum values for the "op" property (`add`, `copy`, `move`, `remove`, `replace`, and `test`)
- provides example values for `path` and `value` properties
- globally assigns the new schema to all `JsonPatch` instances using `SpringDocUtils`
- updates the OpenAPI components by adding the customized `JsonPatch` schema

This improvement ensures a more accurate and informative representation of the JsonPatch object within the OpenAPI documentation.

### Screenshot

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/4fefeb21-f59f-4347-8fdb-abb8fbb4b6ca)

### Additional notes

I renamed the existing OpenAPI customizer beans.