### PR TITLE
Add TS stricter Omit helper type

### DIFF
--- a/frontend/app/components/anchor-link.tsx
+++ b/frontend/app/components/anchor-link.tsx
@@ -7,7 +7,7 @@ import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
  * It extends the ComponentProps<'a'> type, omitting the 'href' property,
  * and adds the required 'anchorElementId' property.
  */
-export interface AnchorLinkProps extends Omit<ComponentProps<'a'>, 'href'> {
+export interface AnchorLinkProps extends OmitStrict<ComponentProps<'a'>, 'href'> {
   anchorElementId: string;
 }
 

--- a/frontend/app/components/app-link.tsx
+++ b/frontend/app/components/app-link.tsx
@@ -11,7 +11,7 @@ import { getPathById } from '~/utils/route-utils';
 /**
  * Props for the AppLink component.
  */
-export interface AppLinkProps extends Omit<ComponentProps<typeof Link>, 'to'> {
+export interface AppLinkProps extends OmitStrict<ComponentProps<typeof Link>, 'to'> {
   newTabIndicator?: boolean;
   params?: Params;
   routeId?: string;

--- a/frontend/app/components/input-checkbox.tsx
+++ b/frontend/app/components/input-checkbox.tsx
@@ -8,7 +8,7 @@ const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-7
 const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
 const inputReadOnlyClassName = 'pointer-events-none cursor-not-allowed opacity-70';
 
-export interface InputCheckboxProps extends Omit<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
+export interface InputCheckboxProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
   append?: ReactNode;
   appendClassName?: string;
   children: ReactNode;

--- a/frontend/app/components/input-checkboxes.tsx
+++ b/frontend/app/components/input-checkboxes.tsx
@@ -13,7 +13,7 @@ export interface InputCheckboxesProps {
   helpMessageSecondary?: React.ReactNode;
   helpMessageSecondaryClassName?: string;
   id: string;
-  options: Omit<ComponentProps<typeof InputCheckbox>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-required' | 'id' | 'name' | 'required'>[];
+  options: OmitStrict<ComponentProps<typeof InputCheckbox>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-required' | 'id' | 'name' | 'required'>[];
   legend: ReactNode;
   name: string;
   required?: boolean;

--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -10,7 +10,7 @@ const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-non
 const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputFieldProps extends Omit<React.ComponentProps<'input'>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children'> {
+export interface InputFieldProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children'> {
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;
   helpMessagePrimaryClassName?: string;

--- a/frontend/app/components/input-phone-field.tsx
+++ b/frontend/app/components/input-phone-field.tsx
@@ -13,7 +13,7 @@ const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-non
 const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputPhoneFieldProps extends Omit<React.ComponentProps<typeof PhoneInput>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children'> {
+export interface InputPhoneFieldProps extends OmitStrict<React.ComponentProps<typeof PhoneInput>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value'> {
   defaultValue?: string;
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;

--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -7,7 +7,7 @@ const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-7
 const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
 const inputReadOnlyClassName = 'pointer-events-none cursor-not-allowed opacity-70';
 
-export interface InputRadioProps extends Omit<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
+export interface InputRadioProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
   append?: ReactNode;
   appendClassName?: string;
   children: ReactNode;

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -13,7 +13,7 @@ export interface InputRadiosProps {
   helpMessageSecondary?: React.ReactNode;
   helpMessageSecondaryClassName?: string;
   id: string;
-  options: Omit<ComponentProps<typeof InputRadio>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-required' | 'id' | 'name' | 'required'>[];
+  options: OmitStrict<ComponentProps<typeof InputRadio>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-required' | 'id' | 'name' | 'required'>[];
   legend: ReactNode;
   name: string;
   required?: boolean;

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -12,10 +12,7 @@ const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-n
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
 export interface InputSanitizeFieldProps
-  extends Omit<
-    React.ComponentProps<typeof NumberFormatBase>,
-    'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value' | 'onChange' | 'format' | 'type' | 'removeFormatting' | 'isValidInputCharacter' | 'getCaretBoundary'
-  > {
+  extends OmitStrict<React.ComponentProps<typeof NumberFormatBase>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'value' | 'onChange' | 'format' | 'type' | 'removeFormatting' | 'isValidInputCharacter' | 'getCaretBoundary'> {
   defaultValue: string;
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -11,13 +11,13 @@ const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-5
 const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputSelectProps extends Omit<ComponentProps<'select'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
+export interface InputSelectProps extends OmitStrict<ComponentProps<'select'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
   errorMessage?: string;
   helpMessage?: ReactNode;
   id: string;
   label: string;
   name: string;
-  options: Omit<ComponentProps<typeof InputOption>, 'id'>[];
+  options: OmitStrict<ComponentProps<typeof InputOption>, 'id'>[];
 }
 
 const InputSelect = forwardRef<HTMLSelectElement, InputSelectProps>((props, ref) => {

--- a/frontend/app/components/input-sin-field.tsx
+++ b/frontend/app/components/input-sin-field.tsx
@@ -10,7 +10,7 @@ const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-non
 const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputSinFieldProps extends Omit<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value' | 'onChange' | 'format'> {
+export interface InputSinFieldProps extends OmitStrict<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'value' | 'onChange' | 'format'> {
   defaultValue: string;
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -10,7 +10,7 @@ const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-non
 const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputTextareaProps extends Omit<React.ComponentProps<'textarea'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
+export interface InputTextareaProps extends OmitStrict<React.ComponentProps<'textarea'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
   errorMessage?: string;
   helpMessage?: React.ReactNode;
   id: string;

--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -4,7 +4,7 @@ import type { InlineLinkProps } from '~/components/inline-link';
 import { InlineLink } from '~/components/inline-link';
 import { getAltLanguage } from '~/utils/locale-utils';
 
-export type LanguageSwitcherProps = Omit<InlineLinkProps, 'to' | 'reloadDocument'>;
+export type LanguageSwitcherProps = OmitStrict<InlineLinkProps, 'to' | 'reloadDocument'>;
 
 /**
  * Component that can be used to switch from one language to another.

--- a/frontend/app/components/new-tab-indicator.tsx
+++ b/frontend/app/components/new-tab-indicator.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '~/utils/tw-utils';
 
-export function NewTabIndicator({ className, ...props }: Omit<ComponentProps<'span'>, 'children'>) {
+export function NewTabIndicator({ className, ...props }: OmitStrict<ComponentProps<'span'>, 'children'>) {
   const { t } = useTranslation('gcweb');
   // Following whitespace is important to ensure the content's text is seperated for the screen-reader text
   return (

--- a/frontend/app/components/page-title.tsx
+++ b/frontend/app/components/page-title.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from 'react';
 
 import { cn } from '~/utils/tw-utils';
 
-export function PageTitle({ children, className, ...restProps }: Omit<ComponentProps<'h1'>, 'id' | 'property'>) {
+export function PageTitle({ children, className, ...restProps }: OmitStrict<ComponentProps<'h1'>, 'id' | 'property'>) {
   return (
     <h1 id="wb-cont" tabIndex={-1} className={cn('font-lato text-3xl font-bold focus-visible:ring', className)} property="name" {...restProps}>
       {children}

--- a/frontend/app/route-helpers/apply-route-helpers.server.ts
+++ b/frontend/app/route-helpers/apply-route-helpers.server.ts
@@ -172,8 +172,8 @@ export function loadApplyState({ params, session }: LoadStateArgs) {
 interface SaveStateArgs {
   params: Params;
   session: Session;
-  state: Partial<Omit<ApplyState, 'id' | 'lastUpdatedOn'>>;
-  remove?: keyof Omit<ApplyState, 'id' | 'lastUpdatedOn'>;
+  state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn'>>;
+  remove?: keyof OmitStrict<ApplyState, 'id' | 'lastUpdatedOn'>;
 }
 
 /**

--- a/frontend/app/routes/$lang/_protected/home.tsx
+++ b/frontend/app/routes/$lang/_protected/home.tsx
@@ -98,7 +98,7 @@ export default function Index() {
   );
 }
 
-interface CardLinkProps extends Omit<AppLinkProps, 'className' | 'title'> {
+interface CardLinkProps extends OmitStrict<AppLinkProps, 'className' | 'title'> {
   children: ReactNode;
   inProgress?: boolean;
   title: ReactNode;

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -134,7 +134,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         ...val,
         dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
       };
-    }) satisfies z.ZodType<Omit<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
+    }) satisfies z.ZodType<OmitStrict<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
 
   const childSinSchema = z
     .object({

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -134,7 +134,7 @@ export async function action({ context: { session }, params, request }: ActionFu
         ...val,
         dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
       };
-    }) satisfies z.ZodType<Omit<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
+    }) satisfies z.ZodType<OmitStrict<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
 
   const childSinSchema = z
     .object({

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -29,6 +29,14 @@ declare global {
   interface Window {
     env: PublicEnv;
   }
+
+  /**
+   * Drop keys `K` from `T`, where `K` must exist in `T`.
+   *
+   * @see https://github.com/pelotom/type-zoo?tab=readme-ov-file#omitstrictt-k-extends-keyof-t
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type OmitStrict<T, K extends keyof T> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 }
 
 declare module 'i18next' {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add TS stricter Omit helper type.

Here a post on SO from a little bit of context: [Why does TypeScript's Omit not enforce the value of the omitted properties?](https://stackoverflow.com/questions/73164042/why-does-typescripts-omit-not-enforce-the-value-of-the-omitted-properties)

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

When used it provides the type keys with intellisense which the original Omit doesn't provide.

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/c7d8b198-f1fe-4f85-852b-7eb9702ac84c)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->