### PR TITLE
add input sanitization to address related fields

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
@@ -17,6 +17,7 @@ import { InputCheckbox } from '~/components/input-checkbox';
 import { InputField } from '~/components/input-field';
 import { InputOptionProps } from '~/components/input-option';
 import { InputPhoneField } from '~/components/input-phone-field';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
@@ -31,6 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -94,19 +96,19 @@ export async function action({ context: { session }, params, request }: ActionFu
         .optional(),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
-      mailingAddress: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.address-required')).max(30),
-      mailingApartment: z.string().trim().max(30).optional(),
+      mailingAddress: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.address-required')).max(30).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')),
+      mailingApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.country-required')),
       mailingProvince: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.province-required')).optional(),
-      mailingCity: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.city-required')).max(100),
-      mailingPostalCode: z.string().trim().max(100).optional(),
+      mailingCity: z.string().trim().min(1, t('apply-adult-child:contact-information.error-message.mailing-address.city-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')),
+      mailingPostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
       copyMailingAddress: z.boolean(),
-      homeAddress: z.string().trim().max(30).optional(),
-      homeApartment: z.string().trim().max(30).optional(),
+      homeAddress: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
+      homeApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
       homeCountry: z.string().trim().optional(),
       homeProvince: z.string().trim().optional(),
-      homeCity: z.string().trim().max(100).optional(),
-      homePostalCode: z.string().trim().max(100).optional(),
+      homeCity: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
+      homePostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult-child:contact-information.error-message.characters-valid')).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.email ?? val.confirmEmail) {
@@ -442,7 +444,7 @@ export default function ApplyFlowPersonalInformation() {
           <fieldset className="mb-6">
             <legend className="mb-4 font-lato text-2xl font-bold">{t('apply-adult-child:contact-information.mailing-address.header')}</legend>
             <div className="space-y-6">
-              <InputField
+              <InputSanitizeField
                 id="mailing-address"
                 name="mailingAddress"
                 className="w-full"
@@ -455,7 +457,7 @@ export default function ApplyFlowPersonalInformation() {
                 errorMessage={errorMessages['mailing-address']}
                 required
               />
-              <InputField
+              <InputSanitizeField
                 id="mailing-apartment"
                 name="mailingApartment"
                 className="w-full"
@@ -490,7 +492,7 @@ export default function ApplyFlowPersonalInformation() {
                 />
               )}
               <div className="grid items-end gap-6 md:grid-cols-2">
-                <InputField
+                <InputSanitizeField
                   id="mailing-city"
                   name="mailingCity"
                   className="w-full"
@@ -501,14 +503,14 @@ export default function ApplyFlowPersonalInformation() {
                   errorMessage={errorMessages['mailing-city']}
                   required
                 />
-                <InputField
+                <InputSanitizeField
                   id="mailing-postal-code"
                   name="mailingPostalCode"
                   className="w-full"
                   label={mailingPostalCodeRequired ? t('apply-adult-child:contact-information.address-field.postal-code') : t('apply-adult-child:contact-information.address-field.postal-code-optional')}
                   maxLength={100}
                   autoComplete="postal-code"
-                  defaultValue={defaultState?.mailingPostalCode}
+                  defaultValue={defaultState?.mailingPostalCode ?? ''}
                   errorMessage={errorMessages['mailing-postal-code']}
                   required={mailingPostalCodeRequired}
                 />
@@ -523,7 +525,7 @@ export default function ApplyFlowPersonalInformation() {
               </InputCheckbox>
               {!copyAddressChecked && (
                 <>
-                  <InputField
+                  <InputSanitizeField
                     id="home-address"
                     name="homeAddress"
                     className="w-full"
@@ -536,7 +538,7 @@ export default function ApplyFlowPersonalInformation() {
                     errorMessage={errorMessages['home-address']}
                     required
                   />
-                  <InputField
+                  <InputSanitizeField
                     id="home-apartment"
                     name="homeApartment"
                     className="w-full"
@@ -571,7 +573,7 @@ export default function ApplyFlowPersonalInformation() {
                     />
                   )}
                   <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                    <InputField
+                    <InputSanitizeField
                       id="home-city"
                       name="homeCity"
                       className="w-full"
@@ -582,7 +584,7 @@ export default function ApplyFlowPersonalInformation() {
                       errorMessage={errorMessages['home-city']}
                       required
                     />
-                    <InputField
+                    <InputSanitizeField
                       id="home-postal-code"
                       name="homePostalCode"
                       className="w-full"

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
@@ -17,6 +17,7 @@ import { InputCheckbox } from '~/components/input-checkbox';
 import { InputField } from '~/components/input-field';
 import { InputOptionProps } from '~/components/input-option';
 import { InputPhoneField } from '~/components/input-phone-field';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
@@ -31,6 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -94,19 +96,19 @@ export async function action({ context: { session }, params, request }: ActionFu
         .optional(),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
-      mailingAddress: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.address-required')).max(30),
-      mailingApartment: z.string().trim().max(30).optional(),
+      mailingAddress: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.address-required')).max(30).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')),
+      mailingApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.country-required')),
       mailingProvince: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.province-required')).optional(),
-      mailingCity: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.city-required')).max(100),
-      mailingPostalCode: z.string().trim().max(100).optional(),
+      mailingCity: z.string().trim().min(1, t('apply-adult:contact-information.error-message.mailing-address.city-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')),
+      mailingPostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
       copyMailingAddress: z.boolean(),
-      homeAddress: z.string().trim().max(30).optional(),
-      homeApartment: z.string().trim().max(30).optional(),
+      homeAddress: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
+      homeApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
       homeCountry: z.string().trim().optional(),
       homeProvince: z.string().trim().optional(),
-      homeCity: z.string().trim().max(100).optional(),
-      homePostalCode: z.string().trim().max(100).optional(),
+      homeCity: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
+      homePostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-adult:contact-information.error-message.characters-valid')).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.email ?? val.confirmEmail) {
@@ -442,7 +444,7 @@ export default function ApplyFlowPersonalInformation() {
           <fieldset className="mb-6">
             <legend className="mb-4 font-lato text-2xl font-bold">{t('apply-adult:contact-information.mailing-address.header')}</legend>
             <div className="space-y-6">
-              <InputField
+              <InputSanitizeField
                 id="mailing-address"
                 name="mailingAddress"
                 className="w-full"
@@ -455,7 +457,7 @@ export default function ApplyFlowPersonalInformation() {
                 errorMessage={errorMessages['mailing-address']}
                 required
               />
-              <InputField
+              <InputSanitizeField
                 id="mailing-apartment"
                 name="mailingApartment"
                 className="w-full"
@@ -490,7 +492,7 @@ export default function ApplyFlowPersonalInformation() {
                 />
               )}
               <div className="grid items-end gap-6 md:grid-cols-2">
-                <InputField
+                <InputSanitizeField
                   id="mailing-city"
                   name="mailingCity"
                   className="w-full"
@@ -501,14 +503,14 @@ export default function ApplyFlowPersonalInformation() {
                   errorMessage={errorMessages['mailing-city']}
                   required
                 />
-                <InputField
+                <InputSanitizeField
                   id="mailing-postal-code"
                   name="mailingPostalCode"
                   className="w-full"
                   label={mailingPostalCodeRequired ? t('apply-adult:contact-information.address-field.postal-code') : t('apply-adult:contact-information.address-field.postal-code-optional')}
                   maxLength={100}
                   autoComplete="postal-code"
-                  defaultValue={defaultState?.mailingPostalCode}
+                  defaultValue={defaultState?.mailingPostalCode ?? ''}
                   errorMessage={errorMessages['mailing-postal-code']}
                   required={mailingPostalCodeRequired}
                 />
@@ -523,7 +525,7 @@ export default function ApplyFlowPersonalInformation() {
               </InputCheckbox>
               {!copyAddressChecked && (
                 <>
-                  <InputField
+                  <InputSanitizeField
                     id="home-address"
                     name="homeAddress"
                     className="w-full"
@@ -536,7 +538,7 @@ export default function ApplyFlowPersonalInformation() {
                     errorMessage={errorMessages['home-address']}
                     required
                   />
-                  <InputField
+                  <InputSanitizeField
                     id="home-apartment"
                     name="homeApartment"
                     className="w-full"
@@ -571,7 +573,7 @@ export default function ApplyFlowPersonalInformation() {
                     />
                   )}
                   <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                    <InputField
+                    <InputSanitizeField
                       id="home-city"
                       name="homeCity"
                       className="w-full"
@@ -582,7 +584,7 @@ export default function ApplyFlowPersonalInformation() {
                       errorMessage={errorMessages['home-city']}
                       required
                     />
-                    <InputField
+                    <InputSanitizeField
                       id="home-postal-code"
                       name="homePostalCode"
                       className="w-full"
@@ -615,7 +617,7 @@ export default function ApplyFlowPersonalInformation() {
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId={[MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED].includes(Number(maritalStatus)) ? '$lang/_public/apply/$id/adult/partner-information' : '$lang/_public/apply/$id/adult/applicant-information'}
+                routeId={[MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED].includes(Number(maritalStatus)) ? '$lang/_public/apply/$id/adult/partner-information' : '$lang/_public/apply/$id/adult/contact-information'}
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Contact information click"

--- a/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
@@ -17,6 +17,7 @@ import { InputCheckbox } from '~/components/input-checkbox';
 import { InputField } from '~/components/input-field';
 import { InputOptionProps } from '~/components/input-option';
 import { InputPhoneField } from '~/components/input-phone-field';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
@@ -31,6 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -94,19 +96,19 @@ export async function action({ context: { session }, params, request }: ActionFu
         .optional(),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
-      mailingAddress: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.address-required')).max(30),
-      mailingApartment: z.string().trim().max(30).optional(),
+      mailingAddress: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.address-required')).max(30).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')),
+      mailingApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
       mailingCountry: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.country-required')),
       mailingProvince: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.province-required')).optional(),
-      mailingCity: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.city-required')).max(100),
-      mailingPostalCode: z.string().trim().max(100).optional(),
+      mailingCity: z.string().trim().min(1, t('apply-child:contact-information.error-message.mailing-address.city-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')),
+      mailingPostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
       copyMailingAddress: z.boolean(),
-      homeAddress: z.string().trim().max(30).optional(),
-      homeApartment: z.string().trim().max(30).optional(),
+      homeAddress: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
+      homeApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
       homeCountry: z.string().trim().optional(),
       homeProvince: z.string().trim().optional(),
-      homeCity: z.string().trim().max(100).optional(),
-      homePostalCode: z.string().trim().max(100).optional(),
+      homeCity: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
+      homePostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('apply-child:contact-information.error-message.characters-valid')).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.email ?? val.confirmEmail) {
@@ -442,7 +444,7 @@ export default function ApplyFlowPersonalInformation() {
           <fieldset className="mb-6">
             <legend className="mb-4 font-lato text-2xl font-bold">{t('apply-child:contact-information.mailing-address.header')}</legend>
             <div className="space-y-6">
-              <InputField
+              <InputSanitizeField
                 id="mailing-address"
                 name="mailingAddress"
                 className="w-full"
@@ -455,7 +457,7 @@ export default function ApplyFlowPersonalInformation() {
                 errorMessage={errorMessages['mailing-address']}
                 required
               />
-              <InputField
+              <InputSanitizeField
                 id="mailing-apartment"
                 name="mailingApartment"
                 className="w-full"
@@ -490,7 +492,7 @@ export default function ApplyFlowPersonalInformation() {
                 />
               )}
               <div className="grid items-end gap-6 md:grid-cols-2">
-                <InputField
+                <InputSanitizeField
                   id="mailing-city"
                   name="mailingCity"
                   className="w-full"
@@ -501,14 +503,14 @@ export default function ApplyFlowPersonalInformation() {
                   errorMessage={errorMessages['mailing-city']}
                   required
                 />
-                <InputField
+                <InputSanitizeField
                   id="mailing-postal-code"
                   name="mailingPostalCode"
                   className="w-full"
                   label={mailingPostalCodeRequired ? t('apply-child:contact-information.address-field.postal-code') : t('apply-child:contact-information.address-field.postal-code-optional')}
                   maxLength={100}
                   autoComplete="postal-code"
-                  defaultValue={defaultState?.mailingPostalCode}
+                  defaultValue={defaultState?.mailingPostalCode ?? ''}
                   errorMessage={errorMessages['mailing-postal-code']}
                   required={mailingPostalCodeRequired}
                 />
@@ -523,7 +525,7 @@ export default function ApplyFlowPersonalInformation() {
               </InputCheckbox>
               {!copyAddressChecked && (
                 <>
-                  <InputField
+                  <InputSanitizeField
                     id="home-address"
                     name="homeAddress"
                     className="w-full"
@@ -536,7 +538,7 @@ export default function ApplyFlowPersonalInformation() {
                     errorMessage={errorMessages['home-address']}
                     required
                   />
-                  <InputField
+                  <InputSanitizeField
                     id="home-apartment"
                     name="homeApartment"
                     className="w-full"
@@ -571,7 +573,7 @@ export default function ApplyFlowPersonalInformation() {
                     />
                   )}
                   <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                    <InputField
+                    <InputSanitizeField
                       id="home-city"
                       name="homeCity"
                       className="w-full"
@@ -582,7 +584,7 @@ export default function ApplyFlowPersonalInformation() {
                       errorMessage={errorMessages['home-city']}
                       required
                     />
-                    <InputField
+                    <InputSanitizeField
                       id="home-postal-code"
                       name="homePostalCode"
                       className="w-full"

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -333,7 +333,8 @@
       "confirm-email-required": "Confirm email address",
       "email-required": "Enter email address",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "dental-benefits": {

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -343,7 +343,8 @@
       "confirm-email-required": "Confirm email address",
       "email-required": "Enter email address",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "review-information": {

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -424,7 +424,8 @@
       "confirm-email-required": "Confirm email address",
       "email-required": "Enter email address",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
   },
   "review-adult-information": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -333,7 +333,8 @@
       "email-required": "Entrez l'adresse courriel",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@exemple.com",
-      "preferred-language-required": "Sélectionnez la langue de communication préférée"
+      "preferred-language-required": "Sélectionnez la langue de communication préférée",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "dental-benefits": {

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -344,7 +344,8 @@
       "email-required": "Entrez l'adresse courriel",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@exemple.com",
-      "preferred-language-required": "Sélectionnez la langue de communication préférée"
+      "preferred-language-required": "Sélectionnez la langue de communication préférée",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "review-information": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -425,7 +425,8 @@
       "email-required": "Entrez l'adresse courriel",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@exemple.com",
-      "preferred-language-required": "Sélectionnez la langue de communication préférée"
+      "preferred-language-required": "Sélectionnez la langue de communication préférée",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()"
     }
   },
   "review-adult-information": {


### PR DESCRIPTION
### Description
adds input sanitization client/server-side for address related fields in `/contact-information` across all flows

### Related Azure Boards Work Items
[AB#4062](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4062)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
