### PR TITLE
Adobe Analytics properties added to adult application flow

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/apply-yourself.tsx
@@ -73,7 +73,13 @@ export default function ApplyForYourself() {
         <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-info')}</p>
         <p>{t('apply-adult-child:eligibility.apply-yourself.eligibility-2025')}</p>
         <p>
-          <InlineLink to={t('apply-adult-child:eligibility.apply-yourself.when-to-apply-href')} className="external-link" newTabIndicator target="_blank">
+          <InlineLink
+            to={t('apply-adult-child:eligibility.apply-yourself.when-to-apply-href')}
+            className="external-link"
+            newTabIndicator
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Find out when you can apply for the Canadian Dental Care Plan - Apply for yourself click"
+            target="_blank"
+          >
             {t('apply-adult-child:eligibility.apply-yourself.when-to-apply')}
           </InlineLink>
         </p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/dob-eligibility.tsx
@@ -65,7 +65,15 @@ export default function ApplyFlowDobEligibility() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const eligibilityInfo = <InlineLink to={t('apply-adult:eligibility.dob-eligibility.eligibility-info-href')} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityInfo = (
+    <InlineLink
+      to={t('apply-adult:eligibility.dob-eligibility.eligibility-info-href')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Find out when you can apply for the Canadian Dental Care Plan - Find out when you can apply click"
+      target="_blank"
+    />
+  );
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/file-taxes.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/file-taxes.tsx
@@ -65,7 +65,15 @@ export default function ApplyFlowFileYourTaxes() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const taxInfo = <InlineLink to={t('apply-adult:eligibility.file-your-taxes.tax-info-href')} className="external-link" newTabIndicator target="_blank" />;
+  const taxInfo = (
+    <InlineLink
+      to={t('apply-adult:eligibility.file-your-taxes.tax-info-href')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Get ready to do your taxes - File your taxes click"
+      target="_blank"
+    />
+  );
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
@@ -265,7 +265,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.full-name-title')}>
                 <p>{`${userInfo.firstName} ${userInfo.lastName}`}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-full-name" routeId="$lang/_public/apply/$id/adult/applicant-information" params={params}>
+                  <InlineLink id="change-full-name" routeId="$lang/_public/apply/$id/adult/applicant-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change full name - Review your information click">
                     {t('apply-adult:review-information.full-name-change')}
                   </InlineLink>
                 </div>
@@ -273,7 +273,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.dob-title')}>
                 <p>{userInfo.birthday}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-date-of-birth" routeId="$lang/_public/apply/$id/adult/date-of-birth" params={params}>
+                  <InlineLink id="change-date-of-birth" routeId="$lang/_public/apply/$id/adult/date-of-birth" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change date of birth - Review your information click">
                     {t('apply-adult:review-information.dob-change')}
                   </InlineLink>
                 </div>
@@ -281,7 +281,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.sin-title')}>
                 <p>{formatSin(userInfo.sin)}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-sin" routeId="$lang/_public/apply/$id/adult/applicant-information" params={params}>
+                  <InlineLink id="change-sin" routeId="$lang/_public/apply/$id/adult/applicant-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change SIN - Review your information click">
                     {t('apply-adult:review-information.sin-change')}
                   </InlineLink>
                 </div>
@@ -289,7 +289,12 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.marital-title')}>
                 <p>{userInfo.maritalStatus}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-martial-status" routeId="$lang/_public/apply/$id/adult/applicant-information" params={params}>
+                  <InlineLink
+                    id="change-martial-status"
+                    routeId="$lang/_public/apply/$id/adult/applicant-information"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change marital status - Review your information click"
+                  >
                     {t('apply-adult:review-information.marital-change')}
                   </InlineLink>
                 </div>
@@ -303,7 +308,12 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply-adult:review-information.full-name-title')}>
                   <p>{`${spouseInfo.firstName} ${spouseInfo.lastName}`}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-spouse-full-name" routeId="$lang/_public/apply/$id/adult/partner-information" params={params}>
+                    <InlineLink
+                      id="change-spouse-full-name"
+                      routeId="$lang/_public/apply/$id/adult/partner-information"
+                      params={params}
+                      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change full name - Review your information click"
+                    >
                       {t('apply-adult:review-information.full-name-change')}
                     </InlineLink>
                   </div>
@@ -311,7 +321,12 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply-adult:review-information.dob-title')}>
                   <p>{spouseInfo.birthday}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" routeId="$lang/_public/apply/$id/adult/partner-information" params={params}>
+                    <InlineLink
+                      id="change-spouse-date-of-birth"
+                      routeId="$lang/_public/apply/$id/adult/partner-information"
+                      params={params}
+                      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change date of birth - Review your information click"
+                    >
                       {t('apply-adult:review-information.dob-change')}
                     </InlineLink>
                   </div>
@@ -319,7 +334,7 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply-adult:review-information.sin-title')}>
                   <p>{formatSin(spouseInfo.sin)}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-spouse-sin" routeId="$lang/_public/apply/$id/adult/partner-information" params={params}>
+                    <InlineLink id="change-spouse-sin" routeId="$lang/_public/apply/$id/adult/partner-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change SIN - Review your information click">
                       {t('apply-adult:review-information.sin-change')}
                     </InlineLink>
                   </div>
@@ -334,7 +349,12 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.phone-title')}>
                 <p>{userInfo.phoneNumber}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-phone-number" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
+                  <InlineLink
+                    id="change-phone-number"
+                    routeId="$lang/_public/apply/$id/adult/contact-information"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change phone number - Review your information click"
+                  >
                     {t('apply-adult:review-information.phone-change')}
                   </InlineLink>
                 </div>
@@ -342,7 +362,12 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.alt-phone-title')}>
                 <p>{userInfo.altPhoneNumber}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-alternate-phone-number" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
+                  <InlineLink
+                    id="change-alternate-phone-number"
+                    routeId="$lang/_public/apply/$id/adult/contact-information"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change alternate phone number - Review your information click"
+                  >
                     {t('apply-adult:review-information.alt-phone-change')}
                   </InlineLink>
                 </div>
@@ -350,7 +375,7 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.email')}>
                 <p>{userInfo.contactInformationEmail}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-email" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
+                  <InlineLink id="change-email" routeId="$lang/_public/apply/$id/adult/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change email address - Review your information click">
                     {t('apply-adult:review-information.email-change')}
                   </InlineLink>
                 </div>
@@ -365,7 +390,12 @@ export default function ReviewInformation() {
                   apartment={mailingAddressInfo.apartment}
                 />
                 <div className="mt-4">
-                  <InlineLink id="change-mailing-address" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
+                  <InlineLink
+                    id="change-mailing-address"
+                    routeId="$lang/_public/apply/$id/adult/contact-information"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change mailing address - Review your information click"
+                  >
                     {t('apply-adult:review-information.mailing-change')}
                   </InlineLink>
                 </div>
@@ -380,7 +410,12 @@ export default function ReviewInformation() {
                   apartment={homeAddressInfo.apartment}
                 />
                 <div className="mt-4">
-                  <InlineLink id="change-home-address" routeId="$lang/_public/apply/$id/adult/contact-information" params={params}>
+                  <InlineLink
+                    id="change-home-address"
+                    routeId="$lang/_public/apply/$id/adult/contact-information"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change home address - Review your information click"
+                  >
                     {t('apply-adult:review-information.home-change')}
                   </InlineLink>
                 </div>
@@ -394,7 +429,12 @@ export default function ReviewInformation() {
                 <p>{userInfo.communicationPreference}</p>
                 {userInfo.communicationPreferenceEmail && <p>{userInfo.communicationPreferenceEmail}</p>}
                 <p>
-                  <InlineLink id="change-communication-preference" routeId="$lang/_public/apply/$id/adult/communication-preference" params={params}>
+                  <InlineLink
+                    id="change-communication-preference"
+                    routeId="$lang/_public/apply/$id/adult/communication-preference"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change communication preference - Review your information click"
+                  >
                     {t('apply-adult:review-information.comm-pref-change')}
                   </InlineLink>
                 </p>
@@ -403,7 +443,12 @@ export default function ReviewInformation() {
                 <DescriptionListItem term={t('apply-adult:review-information.lang-pref-title')}>
                   <p>{getNameByLanguage(i18n.language, preferredLanguage)}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-language-preference" routeId="$lang/_public/apply/$id/adult/communication-preference" params={params}>
+                    <InlineLink
+                      id="change-language-preference"
+                      routeId="$lang/_public/apply/$id/adult/communication-preference"
+                      params={params}
+                      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change language preference - Review your information click"
+                    >
                       {t('apply-adult:review-information.lang-pref-change')}
                     </InlineLink>
                   </div>
@@ -417,7 +462,12 @@ export default function ReviewInformation() {
               <DescriptionListItem term={t('apply-adult:review-information.dental-insurance-title')}>
                 <p>{dentalInsurance ? t('apply-adult:review-information.yes') : t('apply-adult:review-information.no')}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-access-dental" routeId="$lang/_public/apply/$id/adult/dental-insurance" params={params}>
+                  <InlineLink
+                    id="change-access-dental"
+                    routeId="$lang/_public/apply/$id/adult/dental-insurance"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change answer to dental insurance - Review your information click"
+                  >
                     {t('apply-adult:review-information.dental-insurance-change')}
                   </InlineLink>
                 </div>
@@ -436,7 +486,12 @@ export default function ReviewInformation() {
                   <p>{t('apply-adult:review-information.no')}</p>
                 )}
                 <div className="mt-4">
-                  <InlineLink id="change-dental-benefits" routeId="$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits" params={params}>
+                  <InlineLink
+                    id="change-dental-benefits"
+                    routeId="$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Change answer to government dental benefits - Review your information click"
+                  >
                     {t('apply-adult:review-information.dental-benefit-change')}
                   </InlineLink>
                 </div>
@@ -453,16 +508,21 @@ export default function ReviewInformation() {
         <fetcher.Form onSubmit={handleSubmit} method="post" className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <input type="hidden" name="_csrf" value={csrfToken} />
           {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
-          <Button id="confirm-button" name="_action" value={FormAction.Submit} variant="green" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Submit - Review your information click">
+          <Button id="confirm-button" name="_action" value={FormAction.Submit} variant="green" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Submit application - Review your information click">
             {t('apply-adult:review-information.submit-button')}
             {isSubmitting && submitAction === FormAction.Submit && <FontAwesomeIcon icon={faSpinner} className="ms-3 block size-4 animate-spin" />}
           </Button>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Exit - Review your information click">
+          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Review your information click">
             <FontAwesomeIcon icon={faChevronLeft} className="me-3 block size-4" />
             {t('apply-adult:review-information.back-button')}
           </Button>
         </fetcher.Form>
-        <InlineLink routeId="$lang/_public/apply/$id/adult/exit-application" params={params} className="mt-6 block font-lato font-semibold">
+        <InlineLink
+          routeId="$lang/_public/apply/$id/adult/exit-application"
+          params={params}
+          className="mt-6 block font-lato font-semibold"
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Exit application - Review your information click"
+        >
           {t('apply-adult:review-information.exit-button')}
         </InlineLink>
       </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/application-delegate.tsx
@@ -65,8 +65,24 @@ export default function ApplyFlowApplicationDelegate() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const contactServiceCanada = <InlineLink to={t('apply:application-delegate.contact-service-canada-href')} className="external-link" newTabIndicator target="_blank" />;
-  const preparingToApply = <InlineLink to={t('apply:application-delegate.preparing-to-apply-href')} className="external-link" newTabIndicator target="_blank" />;
+  const contactServiceCanada = (
+    <InlineLink
+      to={t('apply:application-delegate.contact-service-canada-href')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Service Canada Centre - Applying on behalf of someone click"
+      target="_blank"
+    />
+  );
+  const preparingToApply = (
+    <InlineLink
+      to={t('apply:application-delegate.preparing-to-apply-href')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Preparing to apply on behalf of someone - Applying on behalf of someone click"
+      target="_blank"
+    />
+  );
   const noWrap = <span className="whitespace-nowrap" />;
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {

--- a/frontend/app/routes/$lang/_public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/terms-and-conditions.tsx
@@ -61,11 +61,33 @@ export default function ApplyIndex() {
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const canadaTermsConditions = <InlineLink to={t('apply:terms-and-conditions.links.canada-ca-terms-and-conditions')} className="external-link" newTabIndicator target="_blank" />;
-  const fileacomplaint = <InlineLink to={t('apply:terms-and-conditions.links.file-complaint')} className="external-link" newTabIndicator target="_blank" />;
-  const hcaptchaTermsOfService = <InlineLink to={t('apply:terms-and-conditions.links.hcaptcha')} className="external-link" newTabIndicator target="_blank" />;
-  const infosource = <InlineLink to={t('apply:terms-and-conditions.links.info-source')} className="external-link" newTabIndicator target="_blank" />;
-  const microsoftDataPrivacyPolicy = <InlineLink to={t('apply:terms-and-conditions.links.microsoft-data-privacy-policy')} className="external-link" newTabIndicator target="_blank" />;
+  const canadaTermsConditions = (
+    <InlineLink
+      to={t('apply:terms-and-conditions.links.canada-ca-terms-and-conditions')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Canada.ca website Terms and Conditions - Terms and Conditions click"
+      target="_blank"
+    />
+  );
+  const fileacomplaint = (
+    <InlineLink to={t('apply:terms-and-conditions.links.file-complaint')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:file a complaint - Terms and Conditions click" target="_blank" />
+  );
+  const hcaptchaTermsOfService = (
+    <InlineLink to={t('apply:terms-and-conditions.links.hcaptcha')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Terms of Service - Terms and Conditions click" target="_blank" />
+  );
+  const infosource = (
+    <InlineLink to={t('apply:terms-and-conditions.links.info-source')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Info Source - Terms and Conditions click" target="_blank" />
+  );
+  const microsoftDataPrivacyPolicy = (
+    <InlineLink
+      to={t('apply:terms-and-conditions.links.microsoft-data-privacy-policy')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Microsoft Data Privacy Policy & Privacy Principles - Terms and Conditions click"
+      target="_blank"
+    />
+  );
 
   return (
     <div className="max-w-prose">

--- a/frontend/app/routes/$lang/_public/status/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/index.tsx
@@ -138,11 +138,29 @@ export default function StatusChecker() {
     fetcher.submit(formData, { method: 'POST' });
   }
 
-  const hcaptchaTermsOfService = <InlineLink to={t('status:links.hcaptcha')} className="external-link" newTabIndicator target="_blank" />;
-  const microsoftDataPrivacyPolicy = <InlineLink to={t('status:links.microsoft-data-privacy-policy')} className="external-link" newTabIndicator target="_blank" />;
-  const microsoftServiceAgreement = <InlineLink to={t('status:links.microsoft-service-agreement')} className="external-link" newTabIndicator target="_blank" />;
-  const fileacomplaint = <InlineLink to={t('status:links.file-complaint')} className="external-link" newTabIndicator target="_blank" />;
-  const canadaTermsConditions = <InlineLink to={t('status:links.canada-terms-conditions')} className="external-link" newTabIndicator target="_blank" />;
+  const hcaptchaTermsOfService = <InlineLink to={t('status:links.hcaptcha')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan:Terms of Service - Status Checker click" target="_blank" />;
+  const microsoftDataPrivacyPolicy = (
+    <InlineLink
+      to={t('status:links.microsoft-data-privacy-policy')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan:Microsoft Data Privacy Policy & Privacy Principles - Status Checker click"
+      target="_blank"
+    />
+  );
+  const microsoftServiceAgreement = (
+    <InlineLink
+      to={t('status:links.microsoft-service-agreement')}
+      className="external-link"
+      newTabIndicator
+      data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan:Microsoft Corporation's Terms of Service Agreement - Status Checker click"
+      target="_blank"
+    />
+  );
+  const fileacomplaint = <InlineLink to={t('status:links.file-complaint')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan:Report a concern - Status Checker click" target="_blank" />;
+  const canadaTermsConditions = (
+    <InlineLink to={t('status:links.canada-terms-conditions')} className="external-link" newTabIndicator data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan:Canada.ca website Terms and Conditions - Status Checker click" target="_blank" />
+  );
 
   return (
     <PublicLayout>

--- a/frontend/app/routes/$lang/_public/status/myself/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/myself/index.tsx
@@ -193,7 +193,15 @@ export default function StatusCheckerMyself() {
                 {fetcher.data.status.id ? getNameByLanguage(i18n.language, fetcher.data.status) : t('status:myself.empty-status')}
               </div>
             </ContextualAlert>
-            <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang/_public/status/index" params={params} className="mt-12">
+            <ButtonLink
+              id="cancel-button"
+              variant="primary"
+              type="button"
+              routeId="$lang/_public/status/index"
+              params={params}
+              className="mt-12"
+              data-gc-analytics-customclick="ESDC-EDSC: Canadian Dental Care Plan: Check another status - Status Checker click"
+            >
               {t('status:myself.check-another')}
               <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </ButtonLink>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Adobe Analytics properties added to buttons and links in the adult application flow.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4036](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4036)
[AB#4070](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4070)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`