### PR TITLE
fix closing angle bracket in translation

### DIFF
--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -113,7 +113,7 @@
         "purchased": "achetée individuellement par un parent ou un tuteur légal ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
         "professional": "par l'intermédiaire d'une organisation professionnelle ou étudiante"
       },
-      "option-yes": "<strong>Oui</strong, l'enfant a accès à une assurance dentaire",
+      "option-yes": "<strong>Oui</strong>, l'enfant a accès à une assurance dentaire",
       "option-no": "<strong>Non</strong>, l'enfant n'a pas accès à une assurance dentaire",
       "button": {
         "back": "Retour",


### PR DESCRIPTION
### Description
missing angle bracket cause `Trans` to not render the text correctly.

### Related Azure Boards Work Items
[AB#4081](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4081)