### PR TITLE
 Adobe Analytics properties added to alert flow

### DIFF
--- a/frontend/app/routes/$lang/_protected/alerts/manage/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/manage/index.tsx
@@ -160,7 +160,7 @@ export default function ManageAlerts() {
     }
   }, [errorMessages]);
 
-  const unsubscribelink = <InlineLink routeId="$lang/_protected/alerts/unsubscribe/index" params={params} />;
+  const unsubscribelink = <InlineLink routeId="$lang/_protected/alerts/unsubscribe/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Unsubscribe from CDCP email alerts - Manage CDCP email alerts click" />;
 
   return (
     <>

--- a/frontend/app/routes/$lang/_protected/alerts/subscribe/confirm.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/subscribe/confirm.tsx
@@ -215,13 +215,13 @@ export default function ConfirmSubscription() {
           <InputField id="confirmationCode" label={t('alerts:confirm.confirmation-code-label')} maxLength={100} name="confirmationCode" errorMessage={errorMessages.confirmationCode} />
         </div>
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to={userOrigin?.to} params={params} disabled={isSubmitting}>
+          <ButtonLink id="back-button" to={userOrigin?.to} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Back - Confirmation code click">
             {t('alerts:confirm.back')}
           </ButtonLink>
-          <Button id="new-code-button" name="action" value={ConfirmationCodeAction.NewCode} variant="alternative" disabled={isSubmitting}>
+          <Button id="new-code-button" name="action" value={ConfirmationCodeAction.NewCode} variant="alternative" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Request New Confirmation Code - Confirmation code click">
             {t('alerts:confirm.request-new-code')}
           </Button>
-          <Button id="submit-button" name="action" value={ConfirmationCodeAction.Submit} variant="primary" disabled={isSubmitting}>
+          <Button id="submit-button" name="action" value={ConfirmationCodeAction.Submit} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Submit Confirmation Code - Confirmation code click">
             {t('alerts:confirm.submit-code')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>

--- a/frontend/app/routes/$lang/_protected/alerts/subscribe/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/subscribe/index.tsx
@@ -183,10 +183,10 @@ export default function AlertsSubscribe() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to={userOrigin?.to} params={params} disabled={isSubmitting}>
+          <ButtonLink id="back-button" to={userOrigin?.to} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Back - Subscribe to CDCP email alerts click">
             {t('alerts:subscribe.button.back')}
           </ButtonLink>
-          <Button id="subscribe-button" variant="primary" disabled={isSubmitting}>
+          <Button id="subscribe-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Subscribe - Subscribe to CDCP email alerts click">
             {t('alerts:subscribe.button.subscribe')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>

--- a/frontend/app/routes/$lang/_protected/alerts/subscribe/success.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/subscribe/success.tsx
@@ -53,8 +53,8 @@ export default function SuccessSubscription() {
   const { alertSubscription } = useLoaderData<typeof loader>();
   const params = useParams();
 
-  const personalInformationLink = <InlineLink routeId="$lang/_protected/personal-information/index" params={params} />;
-  const homeLink = <InlineLink routeId="$lang/_protected/home" params={params} />;
+  const personalInformationLink = <InlineLink routeId="$lang/_protected/personal-information/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Manage my Personal Information - Subscription Confirmation click" />;
+  const homeLink = <InlineLink routeId="$lang/_protected/home" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Home - Subscription Confirmation click" />;
   return (
     <>
       <ContextualAlert type="success">

--- a/frontend/app/routes/$lang/_protected/alerts/unsubscribe/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/unsubscribe/index.tsx
@@ -159,11 +159,11 @@ export default function UnsubscribeAlerts() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <Button id="unsubscribe-button" variant="primary" disabled={isSubmitting}>
+          <Button id="unsubscribe-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Unsubscribe from CDCP email alerts - Unsubscribe from CDCP email alerts click">
             {t('alerts:unsubscribe.button.unsubscribe')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>
-          <ButtonLink id="cancel-button" routeId="$lang/_protected/alerts/manage/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="cancel-button" routeId="$lang/_protected/alerts/manage/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Cancel - Unsubscribe from CDCP email alerts click">
             {t('alerts:unsubscribe.button.cancel')}
           </ButtonLink>
         </div>

--- a/frontend/app/routes/$lang/_protected/alerts/unsubscribe/success.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/unsubscribe/success.tsx
@@ -61,10 +61,10 @@ export default function UnsubscribeAlertsSuccess() {
     <div className="max-w-prose">
       <p className="mb-4">{t('alerts:success.unsubscribe-successful')}</p>
       <p className="mb-4">
-        <Trans ns={handle.i18nNamespaces} i18nKey="alerts:success.subscribe-again" components={{ subscribelink }} />
+        <Trans ns={handle.i18nNamespaces} i18nKey="alerts:success.subscribe-again" components={{ subscribelink }} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:completing the subscription process - Unsubscribe Confirmation click" />
       </p>
       {userOrigin && (
-        <ButtonLink id="back-button" to={userOrigin.to}>
+        <ButtonLink id="back-button" to={userOrigin.to} data-gc-analytics-customclick="ESDC-EDSC:CDCP Alerts:Return to dashboard - Unsubscribe Confirmation click">
           {t('alerts:success.return-dashboard')}
         </ButtonLink>
       )}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Adobe Analytics properties added to buttons and links in the alert subscription flow.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4036](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4036)
[AB#4072](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4072)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`