### PR TITLE
Removing unnecessary invariant calls and fixing incorrect logging message

### DIFF
--- a/frontend/app/routes/$lang/_protected/alerts/manage/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/manage/index.tsx
@@ -112,8 +112,6 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
-
   const alertSubscription = await subscriptionService.getSubscription(userInfoToken.sub);
   invariant(alertSubscription, 'Expected alertSubscription to be defined');
 

--- a/frontend/app/routes/$lang/_protected/alerts/subscribe/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/subscribe/index.tsx
@@ -108,9 +108,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
-
-  const alertSubscription = await subscriptionService.getSubscription(userInfoToken.sin);
+  const alertSubscription = await subscriptionService.getSubscription(userInfoToken.sub);
   invariant(alertSubscription, 'Expected alertSubscription to be defined');
 
   //TODO: update it in the next PR

--- a/frontend/app/routes/$lang/_protected/alerts/unsubscribe/index.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/unsubscribe/index.tsx
@@ -60,8 +60,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const meta = { title: t('gcweb:meta.title.template', { title: t('alerts:unsubscribe.page-title') }) };
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
-
   const alertSubscription = await subscriptionService.getSubscription(userInfoToken.sub);
   if (!alertSubscription) {
     instrumentationService.countHttpStatus('alerts.unsubscribe', 302);
@@ -106,8 +104,6 @@ export async function action({ context: { session }, params, request }: ActionFu
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
-
   const alertSubscription = await subscriptionService.getSubscription(userInfoToken.sub);
   invariant(alertSubscription, 'Expected alertSubscription to be defined');
 

--- a/frontend/app/routes/$lang/_protected/alerts/unsubscribe/success.tsx
+++ b/frontend/app/routes/$lang/_protected/alerts/unsubscribe/success.tsx
@@ -3,7 +3,6 @@ import { json } from '@remix-run/node';
 import { useParams } from '@remix-run/react';
 
 import { Trans, useTranslation } from 'react-i18next';
-import invariant from 'tiny-invariant';
 
 import pageIds from '../../../page-ids.json';
 import { ButtonLink } from '~/components/buttons';
@@ -14,7 +13,7 @@ import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
+import { IdToken } from '~/utils/raoidc-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { useUserOrigin } from '~/utils/user-origin-utils';
@@ -39,9 +38,6 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('alerts:success.page-title') }) };
-
-  const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
   const idToken: IdToken = session.get('idToken');
   auditService.audit('page-view.unsubscribe-alerts-success', { userId: idToken.sub });

--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -449,7 +449,7 @@ function createLookupService() {
   }
 
   function getAllClientFriendlyStatuses() {
-    log.debug('Fetching all marital statuses');
+    log.debug('Fetching all client friendly statuses');
 
     const clientFriendlyStatuses = clientFriendlyStatusesJson.value.map((clientFriendlyStatus) => ({
       id: clientFriendlyStatus.esdc_clientfriendlystatusid,
@@ -457,7 +457,7 @@ function createLookupService() {
       nameFr: clientFriendlyStatus.esdc_descriptionfrench,
     }));
 
-    log.trace('Returning marital statuses: [%j]', clientFriendlyStatuses);
+    log.trace('Returning client friendly statuses: [%j]', clientFriendlyStatuses);
     return clientFriendlyStatuses;
   }
 


### PR DESCRIPTION
### Description
The `userInfoToken.sin`, which can be undefined, is not being used to call various subscription services. Instead, the `userInfoToken.sub`, which must be defined, is being used. 

As a result, the `invariant(..)` calls involving the `userInfoToken.sin` have been removed. There's no need to check for its presence (even though it should exist) as it's not being used for any subscription service calls.

Also sneaked in a fix correcting a logging message for getting all client friendly statuses (used by the Status Checker).

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`