### PR TITLE
order preferred languages by locale

### DIFF
--- a/frontend/__tests__/routes/_public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/_public/communication-preference.test.tsx
@@ -47,11 +47,14 @@ vi.mock('~/services/lookup-service.server', () => ({
 vi.mock('~/utils/env.server', () => ({
   getEnv: vi.fn().mockReturnValue({
     COMMUNICATION_METHOD_EMAIL_ID: 'email',
+    ENGLISH_LANGUAGE_CODE: 'en',
+    FRENCH_LANGUAGE_CODE: 'fr',
   }),
 }));
 
 vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
+  getLocale: vi.fn().mockResolvedValue('en'),
 }));
 
 describe('_public.apply.id.communication-preference', () => {
@@ -93,14 +96,12 @@ describe('_public.apply.id.communication-preference', () => {
         ],
         preferredLanguages: [
           {
-            id: 'en',
-            nameEn: 'English',
-            nameFr: 'Anglais',
+            id: 'fr',
+            name: 'French',
           },
           {
-            id: 'fr',
-            nameEn: 'French',
-            nameFr: 'Français',
+            id: 'en',
+            name: 'English',
           },
         ],
       });

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/communication-preference.tsx
@@ -22,8 +22,9 @@ import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
+import { localizeAndSortPreferredLanguages } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -41,12 +42,14 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID, ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = getEnv();
 
   const lookupService = getLookupService();
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
   const preferredLanguages = lookupService.getAllPreferredLanguages();
+  const localizedAndSortedPreferredLanguages = localizeAndSortPreferredLanguages(preferredLanguages, locale, locale === 'en' ? ENGLISH_LANGUAGE_CODE : FRENCH_LANGUAGE_CODE);
   const preferredCommunicationMethods = lookupService.getAllPreferredCommunicationMethods();
 
   const communicationMethodEmail = preferredCommunicationMethods.find((method) => method.id === COMMUNICATION_METHOD_EMAIL_ID);
@@ -63,7 +66,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     csrfToken,
     meta,
     preferredCommunicationMethods,
-    preferredLanguages,
+    preferredLanguages: localizedAndSortedPreferredLanguages,
     defaultState: {
       ...(state.communicationPreferences ?? {}),
       email: state.communicationPreferences?.email ?? state.contactInformation?.email,
@@ -249,7 +252,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 legend={t('apply-adult-child:communication-preference.preferred-language')}
                 options={preferredLanguages.map((language) => ({
                   defaultChecked: defaultState.preferredLanguage === language.id,
-                  children: getNameByLanguage(i18n.language, language),
+                  children: language.name,
                   value: language.id,
                 }))}
                 errorMessage={errorMessages['input-radio-preferred-language-option-0']}

--- a/frontend/app/routes/$lang/_public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/communication-preference.tsx
@@ -22,8 +22,9 @@ import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getEnv } from '~/utils/env.server';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { getFixedT } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
+import { localizeAndSortPreferredLanguages } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -41,12 +42,14 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID, ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = getEnv();
 
   const lookupService = getLookupService();
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
   const preferredLanguages = lookupService.getAllPreferredLanguages();
+  const localizedAndSortedPreferredLanguages = localizeAndSortPreferredLanguages(preferredLanguages, locale, locale === 'en' ? ENGLISH_LANGUAGE_CODE : FRENCH_LANGUAGE_CODE);
   const preferredCommunicationMethods = lookupService.getAllPreferredCommunicationMethods();
 
   const communicationMethodEmail = preferredCommunicationMethods.find((method) => method.id === COMMUNICATION_METHOD_EMAIL_ID);
@@ -63,7 +66,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     csrfToken,
     meta,
     preferredCommunicationMethods,
-    preferredLanguages,
+    preferredLanguages: localizedAndSortedPreferredLanguages,
     defaultState: {
       ...(state.communicationPreferences ?? {}),
       email: state.communicationPreferences?.email ?? state.contactInformation?.email,
@@ -256,7 +259,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
                 legend={t('apply-child:communication-preference.preferred-language')}
                 options={preferredLanguages.map((language) => ({
                   defaultChecked: defaultState.preferredLanguage === language.id,
-                  children: getNameByLanguage(i18n.language, language),
+                  children: language.name,
                   value: language.id,
                 }))}
                 errorMessage={errorMessages['input-radio-preferred-language-option-0']}

--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -108,11 +108,16 @@ function createLookupService() {
   function getAllPreferredLanguages() {
     log.debug('Fetching all preferred languages');
 
-    const preferredLanguages = preferredLanguageJson.value[0].OptionSet.Options.map((o) => ({
-      id: o.Value.toString(),
-      nameEn: o.Label.LocalizedLabels.find((label) => label.LanguageCode === ENGLISH_LANGUAGE_CODE)?.Label,
-      nameFr: o.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label,
-    }));
+    const preferredLanguages = [];
+    for (const o of preferredLanguageJson.value[0].OptionSet.Options) {
+      const id = o.Value.toString();
+      const nameEn = o.Label.LocalizedLabels.find((label) => label.LanguageCode === ENGLISH_LANGUAGE_CODE)?.Label;
+      const nameFr = o.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label;
+      if (nameEn === undefined || nameFr === undefined) {
+        throw new Error('Missing English or French name in power platform data for all preferred languages');
+      }
+      preferredLanguages.push({ id, nameEn, nameFr });
+    }
 
     log.trace('Returning preferred languages: [%j]', preferredLanguages);
     return preferredLanguages;
@@ -497,3 +502,7 @@ export type MaritalStatus = ReturnType<GetAllMaritalStatuses>[number];
 
 export type GetAllRegions = Pick<ReturnType<typeof getLookupService>, 'getAllRegions'>['getAllRegions'];
 export type Region = ReturnType<GetAllRegions>[number];
+
+export type GetAllPreferredLanguages = Pick<ReturnType<typeof getLookupService>, 'getAllPreferredLanguages'>['getAllPreferredLanguages'];
+export type GetAllPreferredLanguagesReturnType = ReturnType<GetAllPreferredLanguages>;
+export type Language = GetAllPreferredLanguagesReturnType[number];

--- a/frontend/app/utils/lookup-utils.server.ts
+++ b/frontend/app/utils/lookup-utils.server.ts
@@ -1,5 +1,5 @@
 import { getEnv } from './env.server';
-import { Country, MaritalStatus, Region } from '~/services/lookup-service.server';
+import { Country, Language, MaritalStatus, Region } from '~/services/lookup-service.server';
 
 /**
  * Localizes a single country object by adding a localized name.
@@ -117,4 +117,36 @@ export function localizeRegions(regions: ReadonlyArray<Region>, locale: AppLocal
  */
 export function localizeAndSortRegions(regions: ReadonlyArray<Region>, locale: AppLocale) {
   return localizeRegions(regions, locale).toSorted((a, b) => a.name.localeCompare(b.name, locale));
+}
+
+/**
+ * Localizes a single language object by adding a localized name.
+ *
+ * @param language - The language object to localize.
+ * @param locale - The locale code for localization.
+ * @returns The localized language object with a localized name.
+ */
+export function localizeLanguage(language: Language, locale: string) {
+  const { nameEn, nameFr, ...rest } = language;
+  return {
+    ...rest,
+    name: locale === 'fr' ? nameFr : nameEn,
+  };
+}
+
+/**
+ * Localizes an array of language objects by adding localized names and sorting them.
+ *
+ * @param language - The array of language objects to localize.
+ * @param locale - The locale code for localization.
+ * @param firstLanguageId - The language ID that specifies the language object that should appear first in the sorted array.
+ * @returns The localized and sorted array of language objects.
+ */
+export function localizeAndSortPreferredLanguages(languages: Language[], locale: string, firstLanguageId?: number) {
+  const mappedLanguages = languages.map((language) => localizeLanguage(language, locale));
+  return mappedLanguages.toSorted((a, b) => {
+    if (firstLanguageId && a.id === firstLanguageId.toString()) return -1;
+    if (firstLanguageId && b.id === firstLanguageId.toString()) return 1;
+    return a.name.localeCompare(b.name, locale);
+  });
 }


### PR DESCRIPTION
### Description
Based on Figma, the preferred communication language for a user should be sorted based on their locale. Now, since there are 2 official languages in Canada, the way they have it presented is that if the locale of the application is in French, then `Francais` should come before `Anglais`.  If the locale of the application is English, then `English`comes before `French`.

This could be probably be moved into the newly created `lookup-utils`, but for now I'm holding back until that stabilizes.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/9003

### Screenshots (if applicable)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/fa407ba0-1564-4a18-9257-fc343f828c05)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/0b786247-0b53-4056-9c3a-1910c815c73d)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`