### PR TITLE
Updated "adult" flow progress bars value

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -196,7 +196,7 @@ export default function ApplyFlowApplicationInformation() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={40} size="lg" />
+        <Progress aria-labelledby="progress-label" value={44} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-4">{t('applicant-information.form-instructions-sin')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/communication-preference.tsx
@@ -236,7 +236,7 @@ export default function ApplyFlowCommunicationPreferencePage() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={70} size="lg" />
+        <Progress aria-labelledby="progress-label" value={66} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-6">{t('apply-adult:communication-preference.note')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
@@ -361,7 +361,7 @@ export default function ApplyFlowPersonalInformation() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={60} size="lg" />
+        <Progress aria-labelledby="progress-label" value={55} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-4 italic">{t('apply:optional-label')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/date-of-birth.tsx
@@ -198,7 +198,7 @@ export default function ApplyFlowDateOfBirth() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={30} size="lg" />
+        <Progress aria-labelledby="progress-label" value={33} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-6">{t('apply-adult:eligibility.date-of-birth.description')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/dental-insurance.tsx
@@ -143,7 +143,7 @@ export default function AccessToDentalInsuranceQuestion() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={80} size="lg" />
+        <Progress aria-labelledby="progress-label" value={77} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-4 italic">{t('apply:required-label')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/disability-tax-credit.tsx
@@ -133,7 +133,7 @@ export default function ApplyFlowDisabilityTaxCredit() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={35} size="lg" />
+        <Progress aria-labelledby="progress-label" value={39} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-5">{t('apply-adult:disability-tax-credit.non-refundable')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -241,7 +241,7 @@ export default function AccessToDentalInsuranceQuestion() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={90} size="lg" />
+        <Progress aria-labelledby="progress-label" value={88} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-4">{t('apply-adult:dental-benefits.access-to-dental')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/living-independently.tsx
@@ -124,7 +124,7 @@ export default function ApplyFlowLivingIndependently() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={10} size="lg" />
+        <Progress aria-labelledby="progress-label" value={39} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-6">{t('apply-adult:living-independently.description')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
@@ -255,7 +255,7 @@ export default function ReviewInformation() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={100} size="lg" />
+        <Progress aria-labelledby="progress-label" value={99} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-8 text-lg">{t('apply-adult:review-information.read-carefully')}</p>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/tax-filing.tsx
@@ -118,7 +118,7 @@ export default function ApplyFlowTaxFiling() {
         <p id="progress-label" className="sr-only mb-2">
           {t('apply:progress.label')}
         </p>
-        <Progress aria-labelledby="progress-label" value={20} size="lg" />
+        <Progress aria-labelledby="progress-label" value={22} size="lg" />
       </div>
       <div className="max-w-prose">
         <p className="mb-4 italic">{t('apply:required-label')}</p>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Updated "adult" flow progress bars value based on the [Excel sheet](https://014gc.sharepoint.com/:x:/r/sites/BU6282451/Shared%20Documents/CDCP/Designs/Progress%20bar%20percentages.xlsx?d=wd754bc0d302b4cce823c9b5abbae8f45&csf=1&web=1&e=FgcuO5)

Note: Type of application shouldn't be different between "flows" since no flow has been selected at this point.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->