### PR TITLE
Remove unused annotations

### DIFF
--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsControllerIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsControllerIT.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -34,7 +33,6 @@ import ca.gov.dtsstn.cdcp.api.web.v1.model.ImmutableEmailValidationModel;
 @ActiveProfiles("test")
 @Import({ WebSecurityConfig.class })
 @WebMvcTest({ EmailValidationsController.class })
-@ComponentScan({ "ca.gov.dtsstn.cdcp.api.web.v1.model.mapper" })
 class EmailValidationsControllerIT {
 
 	@MockBean UserService userService;

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersControllerIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersControllerIT.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
 @ActiveProfiles("test")
 @Import({ WebSecurityConfig.class })
 @WebMvcTest({ UsersController.class })
-@ComponentScan({ "ca.gov.dtsstn.cdcp.api.web.v1.model.mapper" })
 class UsersControllerIT {
 
 	@MockBean JsonPatchProcessor jsonPatchProcessor;

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersControllerIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/UsersControllerIT.java
@@ -30,12 +30,15 @@ import ca.gov.dtsstn.cdcp.api.config.WebSecurityConfig;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
 import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableUser;
 import ca.gov.dtsstn.cdcp.api.service.domain.ImmutableUserAttribute;
+import ca.gov.dtsstn.cdcp.api.web.json.JsonPatchProcessor;
 
 @ActiveProfiles("test")
 @Import({ WebSecurityConfig.class })
 @WebMvcTest({ UsersController.class })
 @ComponentScan({ "ca.gov.dtsstn.cdcp.api.web.v1.model.mapper" })
 class UsersControllerIT {
+
+	@MockBean JsonPatchProcessor jsonPatchProcessor;
 
 	@MockBean UserService userService;
 


### PR DESCRIPTION
Remove unused `@ComponentScan` in tests.
Depends on #1751; marking as draft until that is merged.