### PR TITLE
Adobe Analytics properties added to personal information flow

### DIFF
--- a/frontend/app/routes/$lang/_protected/personal-information/email-address/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/email-address/edit.tsx
@@ -180,11 +180,11 @@ export default function EmailAddressEdit() {
           />
         </div>
         <div className="flex flex-wrap items-center gap-3">
-          <Button id="submit" variant="primary" disabled={isSubmitting}>
+          <Button id="submit" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Email address click">
             {t('personal-information:email-address.edit.button.save')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>
-          <ButtonLink id="cancel" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="cancel" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Cancel - Email address click">
             {t('personal-information:email-address.edit.button.cancel')}
           </ButtonLink>
         </div>

--- a/frontend/app/routes/$lang/_protected/personal-information/home-address/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/home-address/edit.tsx
@@ -327,10 +327,10 @@ export default function PersonalInformationHomeAddressEdit() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="back-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Home address click">
             {t('personal-information:home-address.edit.button.back')}
           </ButtonLink>
-          <Button id="save-button" variant="primary" disabled={isSubmitting}>
+          <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Home address click">
             {t('personal-information:home-address.edit.button.save')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>

--- a/frontend/app/routes/$lang/_protected/personal-information/index.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/index.tsx
@@ -117,7 +117,7 @@ export default function PersonalInformationIndex() {
               )}
               {useFeature('edit-personal-info') && (
                 <p className="mt-4">
-                  <InlineLink id="change-home-address-button" routeId="$lang/_protected/personal-information/home-address/edit" params={params}>
+                  <InlineLink id="change-home-address-button" routeId="$lang/_protected/personal-information/home-address/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change home address - Personal Information click">
                     {t('personal-information:index.change-home-address')}
                   </InlineLink>
                 </p>
@@ -141,7 +141,7 @@ export default function PersonalInformationIndex() {
               )}
               {useFeature('edit-personal-info') && (
                 <p className="mt-4">
-                  <InlineLink id="change-mailing-address-button" routeId="$lang/_protected/personal-information/mailing-address/edit" params={params}>
+                  <InlineLink id="change-mailing-address-button" routeId="$lang/_protected/personal-information/mailing-address/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change mailing address - Personal Information click">
                     {t('personal-information:index.change-mailing-address')}
                   </InlineLink>
                 </p>
@@ -157,7 +157,7 @@ export default function PersonalInformationIndex() {
 
               {useFeature('edit-personal-info') && (
                 <p className="mt-4">
-                  <InlineLink id="change-phone-number-button" routeId="$lang/_protected/personal-information/phone-number/edit" params={params}>
+                  <InlineLink id="change-phone-number-button" routeId="$lang/_protected/personal-information/phone-number/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change phone number - Personal Information click">
                     {t('personal-information:index.change-phone-number')}
                   </InlineLink>
                 </p>
@@ -171,7 +171,7 @@ export default function PersonalInformationIndex() {
 
               {useFeature('edit-personal-info') && (
                 <p className="mt-4">
-                  <InlineLink id="change-phone-number-button" routeId="$lang/_protected/personal-information/phone-number/edit" params={params}>
+                  <InlineLink id="change-phone-number-button" routeId="$lang/_protected/personal-information/phone-number/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change phone number - Personal Information click">
                     {t('personal-information:index.change-phone-number')}
                   </InlineLink>
                 </p>
@@ -183,7 +183,7 @@ export default function PersonalInformationIndex() {
           <p>{personalInformation.emailAddress}</p>
           {useFeature('edit-personal-info') && (
             <p>
-              <InlineLink id="change-email-address-button" routeId="$lang/_protected/personal-information/email-address/edit" params={params}>
+              <InlineLink id="change-email-address-button" routeId="$lang/_protected/personal-information/email-address/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change email address - Personal Information click">
                 {t('personal-information:index.change-email-address')}
               </InlineLink>
             </p>
@@ -193,7 +193,7 @@ export default function PersonalInformationIndex() {
           <p>{preferredLanguage ? getNameByLanguage(i18n.language, preferredLanguage) : t('personal-information:index.no-preferred-language-on-file')}</p>
           {useFeature('edit-personal-info') && (
             <p>
-              <InlineLink id="change-preferred-language-button" routeId="$lang/_protected/personal-information/preferred-language/edit" params={params}>
+              <InlineLink id="change-preferred-language-button" routeId="$lang/_protected/personal-information/preferred-language/edit" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Change preferred language - Personal Information click">
                 {t('personal-information:index.change-preferred-language')}
               </InlineLink>
             </p>
@@ -205,7 +205,7 @@ export default function PersonalInformationIndex() {
 
       {userOrigin && (
         <div className="mt-6 flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" to={userOrigin.to}>
+          <ButtonLink id="back-button" to={userOrigin.to} data-gc-analytics-customclick="ESDC-EDSC:CDCP:Return to dashboard - Personal Information click">
             {t('personal-information:index.dashboard-text')}
           </ButtonLink>
         </div>

--- a/frontend/app/routes/$lang/_protected/personal-information/mailing-address/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/mailing-address/edit.tsx
@@ -325,10 +325,10 @@ export default function PersonalInformationMailingAddressEdit() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="back-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="back-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Mailing address click">
             {t('personal-information:mailing-address.edit.button.back')}
           </ButtonLink>
-          <Button id="save-button" variant="primary" disabled={isSubmitting}>
+          <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Mailing address click">
             {t('personal-information:mailing-address.edit.button.save')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>

--- a/frontend/app/routes/$lang/_protected/personal-information/phone-number/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/phone-number/edit.tsx
@@ -189,10 +189,10 @@ export default function PhoneNumberEdit() {
           />
         </div>
         <div className="flex flex-wrap items-center gap-6 sm:my-4">
-          <ButtonLink id="cancel" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="cancel" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Cancel - Phone number click">
             {t('personal-information:phone-number.edit.button.cancel')}
           </ButtonLink>
-          <Button id="submit" variant="primary" disabled={isSubmitting}>
+          <Button id="submit" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Phone number click">
             {t('personal-information:phone-number.edit.button.save')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>

--- a/frontend/app/routes/$lang/_protected/personal-information/preferred-language/edit.tsx
+++ b/frontend/app/routes/$lang/_protected/personal-information/preferred-language/edit.tsx
@@ -164,10 +164,10 @@ export default function PreferredLanguageEdit() {
           )}
         </div>
         <div className="flex flex-wrap items-center gap-3">
-          <ButtonLink id="cancel-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting}>
+          <ButtonLink id="cancel-button" routeId="$lang/_protected/personal-information/index" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Preferred Language click">
             {t('personal-information:preferred-language.edit.back')}
           </ButtonLink>
-          <Button id="change-button" variant="primary" disabled={isSubmitting}>
+          <Button id="change-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Save - Preferred Language click">
             {t('personal-information:preferred-language.edit.save')}
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </Button>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Adobe Analytics properties added to buttons and links in the personal information flow.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4036](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4036)
[AB#4074](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4074)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`