### PR TITLE
Disable CSRF in API

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/WebSecurityConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/WebSecurityConfig.java
@@ -56,6 +56,9 @@ public class WebSecurityConfig {
 		}
 
 		@Bean SecurityFilterChain securityFilterChain() throws Exception {
+			log.info("Disabling CSRF protection (reason: stateless api)");
+			httpSecurity.csrf(csrf -> csrf.disable());
+
 			log.info("Configuring OAuth resource server settings");
 			httpSecurity.oauth2ResourceServer(oauth2 -> oauth2
 				.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -109,7 +109,7 @@ server:
       - text/plain
       - text/xml
   error:
-    include-stacktrace: never 
+    include-stacktrace: never
   shutdown: graceful
 
 ---
@@ -122,7 +122,7 @@ springdoc:
     #
     oauth:
       client-id: api://api.example.com
-      scopes: api://api.example.com/.default 
+      scopes: api://api.example.com/.default
 
 ---
 
@@ -143,7 +143,7 @@ application:
         # cache preferred languages for one minute to
         # reduce excessive database calls
         expire-after-write: 1
-        time-unit: minutes        
+        time-unit: minutes
   email-notifications:
     confirmation-codes:
       expiry:

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsControllerIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsControllerIT.java
@@ -3,7 +3,6 @@ package ca.gov.dtsstn.cdcp.api.web.v1.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -54,7 +53,6 @@ class EmailValidationsControllerIT {
 		when(userService.verifyEmail(anyString(), anyString())).thenReturn(true);
 
 		mockMvc.perform(post("/api/v1/users/00000000-0000-0000-0000-000000000000/email-validations")
-				.with(csrf()).header("origin", "http://localhost")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(ImmutableEmailValidationModel.builder().confirmationCode("code value").build()))
 				.accept(MediaType.APPLICATION_JSON))
@@ -75,7 +73,6 @@ class EmailValidationsControllerIT {
 			when(userService.verifyEmail(anyString(), any())).thenReturn(false);
 
 			mockMvc.perform(post("/api/v1/users/00000000-0000-0000-0000-000000000000/email-validations")
-					.with(csrf()).header("origin", "http://localhost")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(ImmutableEmailValidationModel.builder().confirmationCode("code value").build()))
 					.accept(MediaType.APPLICATION_JSON))
@@ -91,7 +88,6 @@ class EmailValidationsControllerIT {
 		when(userService.verifyEmail(anyString(), any())).thenThrow(new ResourceNotFoundException("No user with id=[%s] was found".formatted("00000000-0000-0000-0000-000000000000")));
 
 		mockMvc.perform(post("/api/v1/users/00000000-0000-0000-0000-000000000000/email-validations")
-				.with(csrf()).header("origin", "http://localhost")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(ImmutableEmailValidationModel.builder().confirmationCode("code value").build()))
 				.accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
### Disable CSRF protection

Stateless APIs are only vulnerable to CSRF attacks under very specific circumstances. We do not need this in our API.