### PR TITLE
Add `SubscriptionsController.deleteSubscriptionById(..)` tests

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/SubscriptionsController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/SubscriptionsController.java
@@ -166,6 +166,7 @@ public class SubscriptionsController {
 	}
 
 	@DeleteMapping({ "/{subscriptionId}" })
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@Operation(summary = "Delete a subscription by ID")
 	@ApiResponse(responseCode = "204", description = "The request has been successfully processed.")
 	public void deleteSubscriptionById(


### PR DESCRIPTION
(drafting until #1766 is merged)

This PR increases test coverage for `SubscriptionsController` by adding tests for `SubscriptionsController.deleteSubscriptionById(..)`

Test coverage for `SubscriptionsController` is now at 100%:

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/4c53f003-1fc7-4b33-ae67-c653df673a1d)
