### PR TITLE
i18n.language checks replaced with getNameByLanguage calls

### DIFF
--- a/frontend/__tests__/routes/_protected/access-to-governmental-benefits/view.test.tsx
+++ b/frontend/__tests__/routes/_protected/access-to-governmental-benefits/view.test.tsx
@@ -58,13 +58,13 @@ vi.mock('~/services/lookup-service.server', () => ({
         provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f'
       },
       {
-        id: 'b5f25fea-a7a9-ee11-a569-000d3af4f898',
+        id: 'b5f25fea-a7a9-ee11-a569-000d3af4f897',
         nameEn: 'BC Employment and Assistance (BCEA) Program',
         nameFr: "Programme d'emploi et d'assistance de la Colombie-Britannique",
         provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f'
       },
       {
-        id: 'b7f25fea-a7a9-ee11-a569-000d3af4f898',
+        id: 'b7f25fea-a7a9-ee11-a569-000d3af4f896',
         nameEn: 'Children in Care and Youth Agreements - Post Majority (MCFD)',
         nameFr: "Accords sur les enfants pris en charge et les jeunes - Après l'âge de majorité (MDEF)",
         provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f'
@@ -83,6 +83,47 @@ vi.mock('~/utils/env.server', () => ({
 
 vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
+  getLocale: vi.fn().mockReturnValue('en'),
+}));
+
+vi.mock('~/services/personal-information-service.server', () => ({
+  getPersonalInformationService: vi.fn().mockReturnValue({
+    getPersonalInformation: vi
+      .fn()
+      .mockResolvedValueOnce({
+        clientNumber: '999999999',
+        preferredLanguageId: '1033',
+        firstName: 'John',
+        homeAddress: '123 Home Street',
+        lastName: 'Maverick',
+        mailingAddress: '123 Mailing Street',
+        phoneNumber: '(555) 555-5555',
+        privateDentalPlanId: '222222222',
+        federalDentalPlanId: '1788f1db-25c5-ee11-9079-000d3a09d640',
+        provincialTerritorialDentalPlanId: 'b3f25fea-a7a9-ee11-a569-000d3af4f898',
+      })
+      .mockResolvedValueOnce({
+        clientNumber: '999999999',
+        preferredLanguageId: '1033',
+        firstName: 'John',
+        homeAddress: '123 Home Street',
+        lastName: 'Maverick',
+        mailingAddress: '123 Mailing Street',
+        phoneNumber: '(555) 555-5555',
+        privateDentalPlanId: '222222222',
+      })
+      .mockResolvedValueOnce({
+        clientNumber: '999999999',
+        preferredLanguageId: '1033',
+        firstName: 'John',
+        homeAddress: '123 Home Street',
+        lastName: 'Maverick',
+        mailingAddress: '123 Mailing Street',
+        phoneNumber: '(555) 555-5555',
+        privateDentalPlanId: '222222222',
+        federalDentalPlanId: '1788f1db-25c5-ee11-9079-000d3a09d640',
+      }),
+  }),
 }));
 
 describe('Access View Governmental Page', () => {
@@ -99,24 +140,6 @@ describe('Access View Governmental Page', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
       session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
       session.set('userInfoToken', { sin: '999999999' });
-
-      vi.mock('~/services/personal-information-service.server', () => ({
-        getPersonalInformationService: vi.fn().mockReturnValue({
-          getPersonalInformation: vi.fn().mockResolvedValue({
-            clientNumber: '999999999',
-            preferredLanguageId: '1033',
-            firstName: 'John',
-            homeAddress: '123 Home Street',
-            lastName: 'Maverick',
-            mailingAddress: '123 Mailing Street',
-            phoneNumber: '(555) 555-5555',
-            privateDentalPlanId: '222222222',
-            federalDentalPlanId: '1788f1db-25c5-ee11-9079-000d3a09d640',
-            provincialTerritorialDentalPlanId: 'b3f25fea-a7a9-ee11-a569-000d3af4f898',
-          }),
-        }),
-      }));
-
       const response = await loader({
         request: new Request('http://localhost:3000/en/access-to-governmental-benefits/view'),
         context: { session },
@@ -128,44 +151,9 @@ describe('Access View Governmental Page', () => {
       const data = await response.json();
 
       expect(data).toMatchObject({
-        federalSocialProgramsList: [
-          {
-            id: '1788f1db-25c5-ee11-9079-000d3a09d640',
-            nameEn: 'Non-Insured Health Benefits Program by Indigenous Services Canada',
-            nameFr: 'Programme des services de santé non assurés par Services aux Autochtones Canada',
-          },
-          {
-            id: 'e174250d-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Veterans Affairs Canada - Basic dental coverage',
-            nameFr: 'Anciens Combattants Canada - Couverture des soins dentaires de base',
-          },
-          {
-            id: '758bb862-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Interim Federal Health Program for asylum seekers or refugee claimants',
-            nameFr: "Programme fédéral de santé intérimaire pour les personnes demandant l'asile ou les personnes revendiquant le statut de réfugié",
-          },
-        ],
+        federalSocialProgramName: 'Non-Insured Health Benefits Program by Indigenous Services Canada',
         meta: {},
-        provincialAndTerritorialProgramsList: [
-          {
-            id: 'b3f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Healthy Kids Program',
-            nameFr: "Programme d'enfants en santé",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b5f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'BC Employment and Assistance (BCEA) Program',
-            nameFr: "Programme d'emploi et d'assistance de la Colombie-Britannique",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b7f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Children in Care and Youth Agreements - Post Majority (MCFD)',
-            nameFr: "Accords sur les enfants pris en charge et les jeunes - Après l'âge de majorité (MDEF)",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-        ],
+        provincialAndTerritorialProgramName: 'Healthy Kids Program',
       });
     });
     it('should return Governmental Access Benefit with no programs page', async () => {
@@ -173,21 +161,6 @@ describe('Access View Governmental Page', () => {
       session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
       session.set('userInfoToken', { sin: '999999999' });
 
-      vi.mock('~/services/personal-information-service.server', () => ({
-        getPersonalInformationService: vi.fn().mockReturnValue({
-          getPersonalInformation: vi.fn().mockResolvedValue({
-            clientNumber: '999999999',
-            preferredLanguageId: '1033',
-            firstName: 'John',
-            homeAddress: '123 Home Street',
-            lastName: 'Maverick',
-            mailingAddress: '123 Mailing Street',
-            phoneNumber: '(555) 555-5555',
-            privateDentalPlanId: '222222222',
-          }),
-        }),
-      }));
-
       const response = await loader({
         request: new Request('http://localhost:3000/en/access-to-governmental-benefits/view'),
         context: { session },
@@ -199,44 +172,7 @@ describe('Access View Governmental Page', () => {
       const data = await response.json();
 
       expect(data).toMatchObject({
-        federalSocialProgramsList: [
-          {
-            id: '1788f1db-25c5-ee11-9079-000d3a09d640',
-            nameEn: 'Non-Insured Health Benefits Program by Indigenous Services Canada',
-            nameFr: 'Programme des services de santé non assurés par Services aux Autochtones Canada',
-          },
-          {
-            id: 'e174250d-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Veterans Affairs Canada - Basic dental coverage',
-            nameFr: 'Anciens Combattants Canada - Couverture des soins dentaires de base',
-          },
-          {
-            id: '758bb862-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Interim Federal Health Program for asylum seekers or refugee claimants',
-            nameFr: "Programme fédéral de santé intérimaire pour les personnes demandant l'asile ou les personnes revendiquant le statut de réfugié",
-          },
-        ],
         meta: {},
-        provincialAndTerritorialProgramsList: [
-          {
-            id: 'b3f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Healthy Kids Program',
-            nameFr: "Programme d'enfants en santé",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b5f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'BC Employment and Assistance (BCEA) Program',
-            nameFr: "Programme d'emploi et d'assistance de la Colombie-Britannique",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b7f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Children in Care and Youth Agreements - Post Majority (MCFD)',
-            nameFr: "Accords sur les enfants pris en charge et les jeunes - Après l'âge de majorité (MDEF)",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-        ],
       });
       expect(data).not.toContain({
         personalInformation: {
@@ -293,22 +229,6 @@ describe('Access View Governmental Page', () => {
         }),
       }));
 
-      vi.mock('~/services/personal-information-service.server', () => ({
-        getPersonalInformationService: vi.fn().mockReturnValue({
-          getPersonalInformation: vi.fn().mockResolvedValue({
-            clientNumber: '999999999',
-            preferredLanguageId: '1033',
-            firstName: 'John',
-            homeAddress: '123 Home Street',
-            lastName: 'Maverick',
-            mailingAddress: '123 Mailing Street',
-            phoneNumber: '(555) 555-5555',
-            privateDentalPlanId: '222222222',
-            federalDentalPlanId: '1788f1db-25c5-ee11-9079-000d3a09d640',
-          }),
-        }),
-      }));
-
       const response = await loader({
         request: new Request('http://localhost:3000/en/access-to-governmental-benefits/view'),
         context: { session },
@@ -320,44 +240,8 @@ describe('Access View Governmental Page', () => {
       const data = await response.json();
 
       expect(data).toMatchObject({
-        federalSocialProgramsList: [
-          {
-            id: '1788f1db-25c5-ee11-9079-000d3a09d640',
-            nameEn: 'Non-Insured Health Benefits Program by Indigenous Services Canada',
-            nameFr: 'Programme des services de santé non assurés par Services aux Autochtones Canada',
-          },
-          {
-            id: 'e174250d-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Veterans Affairs Canada - Basic dental coverage',
-            nameFr: 'Anciens Combattants Canada - Couverture des soins dentaires de base',
-          },
-          {
-            id: '758bb862-26c5-ee11-9079-000d3a09d640',
-            nameEn: 'Interim Federal Health Program for asylum seekers or refugee claimants',
-            nameFr: "Programme fédéral de santé intérimaire pour les personnes demandant l'asile ou les personnes revendiquant le statut de réfugié",
-          },
-        ],
+        federalSocialProgramName: 'Non-Insured Health Benefits Program by Indigenous Services Canada',
         meta: {},
-        provincialAndTerritorialProgramsList: [
-          {
-            id: 'b3f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Healthy Kids Program',
-            nameFr: "Programme d'enfants en santé",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b5f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'BC Employment and Assistance (BCEA) Program',
-            nameFr: "Programme d'emploi et d'assistance de la Colombie-Britannique",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-          {
-            id: 'b7f25fea-a7a9-ee11-a569-000d3af4f898',
-            nameEn: 'Children in Care and Youth Agreements - Post Majority (MCFD)',
-            nameFr: "Accords sur les enfants pris en charge et les jeunes - Après l'âge de majorité (MDEF)",
-            provinceTerritoryStateId: '9c440baa-35b3-eb11-8236-0022486d8d5f',
-          },
-        ],
         personalInformation: {
           federalDentalPlanId: '1788f1db-25c5-ee11-9079-000d3a09d640',
         },

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -13,7 +13,7 @@ import { getInstrumentationService } from '~/services/instrumentation-service.se
 import { getLookupService } from '~/services/lookup-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { featureEnabled } from '~/utils/env.server';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -88,6 +88,12 @@ export default function AccessToGovernmentalsBenefitsView() {
   const hasDentalPlans = personalInformation.federalDentalPlanId ?? personalInformation.provincialTerritorialDentalPlanId;
 
   if (hasDentalPlans) {
+    const federalSocialProgramName =
+      federalSocialProgramsList.filter((federalSocialProgram) => federalSocialProgram.id === personalInformation.provincialTerritorialDentalPlanId).map((federalSocialProgram) => getNameByLanguage(i18n.language, federalSocialProgram))[0] ?? ' ';
+    const provincialAndTerritorialProgramName =
+      provincialAndTerritorialProgramsList
+        .filter((provincialAndTerritorialProgram) => provincialAndTerritorialProgram.id === personalInformation.provincialTerritorialDentalPlanId)
+        .map((provincialAndTerritorialProgram) => getNameByLanguage(i18n.language, provincialAndTerritorialProgram))[0] ?? ' ';
     return (
       <div className="max-w-prose">
         <div className="mb-5 space-y-4">
@@ -100,7 +106,7 @@ export default function AccessToGovernmentalsBenefitsView() {
             <div className="mb-5 space-y-4">
               <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
               <ul className="list-disc space-y-6 pl-7">
-                <li>{provincialAndTerritorialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.provincialTerritorialDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
+                <li>{provincialAndTerritorialProgramName}</li>
               </ul>
             </div>
           ) : (
@@ -115,7 +121,7 @@ export default function AccessToGovernmentalsBenefitsView() {
               <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
 
               <ul className="list-disc space-y-6 pl-7">
-                <li>{federalSocialProgramsList.find((federalSocialProgram) => federalSocialProgram.id === personalInformation.federalDentalPlanId)?.[i18n.language === 'fr' ? 'nameFr' : 'nameEn'] ?? ' '} </li>
+                <li>{federalSocialProgramName} </li>
               </ul>
             </div>
           ) : (


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Checks against the `i18n.language` in the access governmental benefits view page have now been replaced with calls to the `getNameByLanguage` function from `locale-utils`.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4087](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4087)
[AB#4116](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4116)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Bring up the access governmental benefits view page with governmental benefits having been selected.