### PR TITLE
[gitops] Add maintenance page application (nginx)

### DIFF
--- a/gitops/base/maintenance/configs/503.html
+++ b/gitops/base/maintenance/configs/503.html
@@ -1,0 +1,135 @@
+<!--
+  Maintenance page copied (and slightly modified) from: https://www.canada.ca/errors/503.html
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Service Unavailable - Canada.ca</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+      integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4="
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="icon" type="image/x-icon"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico"
+      crossorigin="anonymous"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://www.canada.ca/etc/designs/canada/wet-boew/css/noscript.min.css"
+        crossorigin="anonymous"
+      />
+    </noscript>
+  </head>
+  <body>
+    <header>
+      <div id="wb-bnr" class="container">
+        <div class="row">
+          <div class="brand col-xs-8 col-sm-9 col-md-6">
+            <img
+              src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg"
+              alt="Government of Canada / Gouvernement du Canada"
+              crossorigin="anonymous"
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+    <main property="mainContentOfPage" resource="#wb-main" class="container">
+      <h1 id="wb-cont" class="wb-inv">Service Unavailable</h1>
+      <div class="row mrgn-tp-lg mrgn-bttm-lg">
+        <div class="col-md-12">
+          <div class="row">
+            <section>
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">This service is currently not available</h2>
+                      <p class="pagetag"><b>Error 503</b></p>
+                    </div>
+                  </div>
+                  <p>
+                    The web server that provides this service is currently down
+                    for maintenance.
+                  </p>
+                </div>
+              </div>
+            </section>
+            <section lang="fr">
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">Le service est actuellement indisponible</h2>
+                      <p class="pagetag"><b>Erreur 503</b></p>
+                    </div>
+                  </div>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p>
+                        Le serveur Web auquel vous tentez d'accéder est
+                        actuellement hors service à des fins d'entretien.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer role="contentinfo" id="wb-info">
+      <div class="brand">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-6 visible-sm visible-xs tofpg">
+              <a href="#wb-cont">
+                <span lang="en">Top of page</span> / <span lang="fr">Haut de la page</span>
+                <span class="glyphicon glyphicon-chevron-up"></span>
+              </a>
+            </div>
+            <div class="col-xs-6 col-md-12 text-right">
+              <img
+                src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg"
+                alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
+                crossorigin="anonymous"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script
+      src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"
+      integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/gitops/base/maintenance/configs/config.conf
+++ b/gitops/base/maintenance/configs/config.conf
@@ -1,0 +1,14 @@
+server {
+  listen      80;
+  server_name localhost;
+
+  location / {
+    error_page 503 /503.html;
+    return 503;
+  }
+
+  location = /503.html {
+    root /usr/share/nginx/html;
+    internal;
+  }
+}

--- a/gitops/base/maintenance/deployments.yaml
+++ b/gitops/base/maintenance/deployments.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maintenance
+  labels:
+    app.kubernetes.io/name: maintenance
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: maintenance
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: maintenance
+    spec:
+      containers:
+        - name: nginx
+          # Note: image tag should be pinned to a specific version in overlays
+          image: docker.io/nginx:latest
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: maintenance-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: config.conf
+            - name: maintenance-conf
+              mountPath: /usr/share/nginx/html/503.html
+              subPath: 503.html
+      volumes:
+        - name: maintenance-conf
+          configMap:
+            name: maintenance

--- a/gitops/base/maintenance/kustomization.yaml
+++ b/gitops/base/maintenance/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+resources:
+  - ./deployments.yaml
+  - ./services.yaml
+configMapGenerator:
+  - name: maintenance
+    files:
+      - ./configs/503.html
+      - ./configs/config.conf

--- a/gitops/base/maintenance/services.yaml
+++ b/gitops/base/maintenance/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maintenance
+  labels:
+    app.kubernetes.io/name: maintenance
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: maintenance


### PR DESCRIPTION
### Add kustomize base for *under maintenance* nginx pod

This pull request introduces a new `base/maintenance/` folder within the gitops subproject. This folder contains YAML files for deploying an nginx pod specifically designed for displaying an "under maintenance" message during system maintenance events.

The deployed pod utilizes the `nginx:latest` image and serves a static html page indicating the system is undergoing maintenance for all incoming requests.

#### Screenshot

![localhost_33287_](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/a4bd70fc-6fa0-4a89-b393-bdef79c36da0)

#### Additional Information

- this pull request only provides the base configuration for the "under maintenance" pod
- a future PR will be submitted to deploy this pod and its associated service to each environment
