### PR TITLE
[gitops] Deploy "under maintenance" pod to nonprod (shared) environment

### DIFF
--- a/gitops/overlays/.gitignore
+++ b/gitops/overlays/.gitignore
@@ -1,5 +1,2 @@
 # ignore secrets (ie: frontend-secrets.conf, redis-secrets.conf)
 **/*secrets.conf
-
-# allow secrets examples (ie: frontend-secrets.conf.example, redis-secrets.conf.example)
-!**/*secrets.conf.example

--- a/gitops/overlays/shared/kustomization.yaml
+++ b/gitops/overlays/shared/kustomization.yaml
@@ -1,0 +1,21 @@
+#
+# This overlay file is intended for deployment of shared resources across all non-production environments.
+# Resources defined here will be available in all pseudo-environments (e.g., dev, staging, etc.) within the non-production namespace.
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+nameSuffix: -shared
+commonLabels:
+  # commonLabels must have at least one unique label
+  # per environment to ensure selectors are applied correctly
+  app.kubernetes.io/instance: shared
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: canada-dental-care-plan
+      app.kubernetes.io/managed-by: teamcity
+      app.kubernetes.io/cluster: dts-dev-sced-rhp-spoke-aks
+      app.kubernetes.io/environment: shared
+      app.kubernetes.io/tier: nonprod
+resources:
+  - ../../base/maintenance/


### PR DESCRIPTION
### Deploy *under maintenance* pod to nonprod (shared) environment

(drafting until #1784 is merged)

This pull request builds upon the previously introduced `base/maintenance/` configurations and  leverages a kustomize overlay to deploy this pod to a nonprod/shared environment.
