### PR TITLE
add user-origin-utils unit tests

### DIFF
--- a/frontend/__tests__/utils/user-origin-utils.test.ts
+++ b/frontend/__tests__/utils/user-origin-utils.test.ts
@@ -1,0 +1,56 @@
+import { useRouteLoaderData } from '@remix-run/react';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserOrigin } from '~/utils/user-origin-utils';
+
+vi.mock('@remix-run/react');
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('useUserOrigin', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should return undefined if no data is returned from the root loader', () => {
+    vi.mocked(useRouteLoaderData);
+    expect(useUserOrigin()).toEqual(undefined);
+  });
+
+  it('should return user origin from MSCA', () => {
+    vi.mocked(useRouteLoaderData).mockReturnValue({
+      userOrigin: 'msca',
+      env: 'msca',
+    });
+    expect(useUserOrigin()).toEqual({
+      to: 'gcweb:header.menu-msca-home.href',
+      text: 'gcweb:header.menu-dashboard.text',
+      isFromMSCAD: false,
+    });
+  });
+
+  it('should return user origin from MSCA-D', () => {
+    vi.mocked(useRouteLoaderData).mockReturnValue({
+      userOrigin: 'msca-d',
+      env: 'msca-d',
+    });
+    expect(useUserOrigin()).toEqual({
+      to: 'gcweb:header.menu-dashboard.href',
+      text: 'gcweb:header.menu-dashboard.text',
+      isFromMSCAD: true,
+    });
+  });
+
+  it('should throw an error for origins that are not msca or msca-d', () => {
+    vi.mocked(useRouteLoaderData).mockReturnValue({
+      userOrigin: 'not-msca-or-msca-d',
+      env: 'not-msca-or-msca-d',
+    });
+    expect(() => useUserOrigin()).toThrowError();
+  });
+});


### PR DESCRIPTION
### Description
Add unit tests for `useUserOrigin()` from `'~/utils/user-origin-utils'`

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
