### PR TITLE
[infra] Add internal prod OAuth callback URL

### DIFF
--- a/infrastructure/terragrunt/nonprod/oauth-proxy-aad-application/terragrunt.hcl
+++ b/infrastructure/terragrunt/nonprod/oauth-proxy-aad-application/terragrunt.hcl
@@ -40,8 +40,7 @@ inputs = {
 
     #
     # TODO :: GjB :: remove production URL below after go-live
-    #                (on or around May 01, 2024)
     #
-    "https://srv024.service.canada.ca/oauth/callback",
+    "https://canada-dental-care-plan.prod-dp-internal.dts-stn.com/oauth/callback",
   ]
 }


### PR DESCRIPTION
### Add internal prod OAuth callback URL

This PR adds our internal prod URLs to the AAD OAuth client so we can enable the auth proxy during maintenance.
