### PR TITLE
[gitops] Enable OAuth proxy on staging/internal

### DIFF
--- a/gitops/overlays/staging/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/staging/configs/oauth-proxy/config.conf
@@ -20,7 +20,7 @@ skip_auth_routes = [ "GET=^/api/livez", "GET=^/api/readyz" ]
 api_routes = [ "^/api" ]
 
 ## cookie settings
-cookie_domains = [ "cdcp-staging.dev-dp.dts-stn.com" ]
+cookie_domains = [ "cdcp-staging.dev-dp.dts-stn.com", "cdcp-staging.dev-dp-internal.dts-stn.com" ]
 
 ## html page settings
 banner = "<strong style='display:block'>Authorized personnel only</strong><span>Please sign in to access site.</span>"

--- a/gitops/overlays/staging/ingresses.yaml
+++ b/gitops/overlays/staging/ingresses.yaml
@@ -29,9 +29,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: maintenance-shared
+                name: frontend
                 port:
-                  name: http
-                # name: frontend
-                # port:
+                  name: oauth-proxy
                 #   name: application


### PR DESCRIPTION
This PR enables the OAuth proxy on <https://https://cdcp-staging.dev-dp-internal.dts-stn.com/>