### PR TITLE
Access View Governmental Page refactored to reduce code repetition

### DIFF
--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -110,31 +110,23 @@ export default function AccessToGovernmentalsBenefitsView() {
       {hasDentalPlans ? (
         <>
           <div className="mb-5 space-y-4">
-            {personalInformation.provincialTerritorialDentalPlanId ? (
+            {personalInformation.provincialTerritorialDentalPlanId && (
               <div className="mb-5 space-y-4">
                 <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
                 <ul className="list-disc space-y-6 pl-7">
                   <li>{provincialAndTerritorialProgramName}</li>
                 </ul>
               </div>
-            ) : (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
-              </div>
             )}
           </div>
           <div className="mb-5 space-y-4">
-            {personalInformation.federalDentalPlanId ? (
+            {personalInformation.federalDentalPlanId && (
               <div className="mb-5 space-y-4">
                 <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
 
                 <ul className="list-disc space-y-6 pl-7">
                   <li>{federalSocialProgramName} </li>
                 </ul>
-              </div>
-            ) : (
-              <div className="mb-5 space-y-4">
-                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
               </div>
             )}
           </div>

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -100,93 +100,70 @@ export default function AccessToGovernmentalsBenefitsView() {
   const params = useParams();
   const hasDentalPlans = personalInformation.federalDentalPlanId ?? personalInformation.provincialTerritorialDentalPlanId;
 
-  if (hasDentalPlans) {
-    return (
-      <div className="max-w-prose">
-        <div className="mb-5 space-y-4">
-          {updatedInfo && (
-            <ContextualAlert type="success">
-              <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
-            </ContextualAlert>
-          )}
-          {personalInformation.provincialTerritorialDentalPlanId ? (
-            <div className="mb-5 space-y-4">
-              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
-              <ul className="list-disc space-y-6 pl-7">
-                <li>{provincialAndTerritorialProgramName}</li>
-              </ul>
-            </div>
-          ) : (
-            <div className="mb-5 space-y-4">
-              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
-            </div>
-          )}
-        </div>
-        <div className="mb-5 space-y-4">
-          {personalInformation.federalDentalPlanId ? (
-            <div className="mb-5 space-y-4">
-              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
-
-              <ul className="list-disc space-y-6 pl-7">
-                <li>{federalSocialProgramName} </li>
-              </ul>
-            </div>
-          ) : (
-            <div className="mb-5 space-y-4">
-              <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
-            </div>
-          )}
-        </div>
-        <div className="mb-5 space-y-4">
-          <InlineLink
-            routeId="$lang/_protected/access-to-governmental-benefits/edit"
-            params={{ ...params }}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Access to governmental benefits click"
-          >
-            {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
-          </InlineLink>
-        </div>
-
-        <fetcher.Form method="post" noValidate>
-          <input type="hidden" name="_csrf" value={csrfToken} />
-          <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to governmental benefits click">
-              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
-            </ButtonLink>
+  return (
+    <div className="max-w-prose">
+      {updatedInfo && (
+        <ContextualAlert type="success">
+          <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
+        </ContextualAlert>
+      )}
+      if {hasDentalPlans}
+      {
+        <>
+          <div className="mb-5 space-y-4">
+            {personalInformation.provincialTerritorialDentalPlanId ? (
+              <div className="mb-5 space-y-4">
+                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
+                <ul className="list-disc space-y-6 pl-7">
+                  <li>{provincialAndTerritorialProgramName}</li>
+                </ul>
+              </div>
+            ) : (
+              <div className="mb-5 space-y-4">
+                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.provincial-or-territorial-dental-benefit')}</h2>
+              </div>
+            )}
           </div>
-        </fetcher.Form>
-      </div>
-    );
-  } else {
-    return (
-      <div className="max-w-prose">
-        {updatedInfo && (
-          <ContextualAlert type="success">
-            <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
-          </ContextualAlert>
-        )}
+          <div className="mb-5 space-y-4">
+            {personalInformation.federalDentalPlanId ? (
+              <div className="mb-5 space-y-4">
+                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
+
+                <ul className="list-disc space-y-6 pl-7">
+                  <li>{federalSocialProgramName} </li>
+                </ul>
+              </div>
+            ) : (
+              <div className="mb-5 space-y-4">
+                <h2 className="font-bold"> {t('access-to-governmental-benefits:access-to-governmental-benefits.view.federal-benefits-dental-benefits')}</h2>
+              </div>
+            )}
+          </div>
+        </>
+      }
+      :
+      {
         <div className="mb-5 space-y-4">
           <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.view.no-government-benefits')}</p>
         </div>
-        <div className="mb-5 space-y-4">
-          <InlineLink
-            routeId="$lang/_protected/access-to-governmental-benefits/edit"
-            params={{ ...params }}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Access to governmental benefits click"
-          >
-            {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
-          </InlineLink>
-        </div>
-
-        <fetcher.Form method="post" noValidate>
-          <input type="hidden" name="_csrf" value={csrfToken} />
-          <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to governmental benefits click">
-              {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
+      }
+      <div className="mb-5 space-y-4">
+        <InlineLink
+          routeId="$lang/_protected/access-to-governmental-benefits/edit"
+          params={{ ...params }}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Update your access to governmental benefits - Access to governmental benefits click"
+        >
+          {t('access-to-governmental-benefits:access-to-governmental-benefits.view.update-your-access-text')}
+        </InlineLink>
       </div>
-    );
-  }
+      <fetcher.Form method="post" noValidate>
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <div className="flex flex-wrap items-center gap-3">
+          <ButtonLink id="back-button" routeId="$lang/_protected/access-to-governmental-benefits/index" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Personal Information:Back - Access to governmental benefits click">
+            {t('access-to-governmental-benefits:access-to-governmental-benefits.view.back')}
+          </ButtonLink>
+        </div>
+      </fetcher.Form>
+    </div>
+  );
 }

--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -107,8 +107,7 @@ export default function AccessToGovernmentalsBenefitsView() {
           <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
         </ContextualAlert>
       )}
-      if {hasDentalPlans}
-      {
+      {hasDentalPlans ? (
         <>
           <div className="mb-5 space-y-4">
             {personalInformation.provincialTerritorialDentalPlanId ? (
@@ -140,13 +139,11 @@ export default function AccessToGovernmentalsBenefitsView() {
             )}
           </div>
         </>
-      }
-      :
-      {
+      ) : (
         <div className="mb-5 space-y-4">
           <p>{t('access-to-governmental-benefits:access-to-governmental-benefits.view.no-government-benefits')}</p>
         </div>
-      }
+      )}
       <div className="mb-5 space-y-4">
         <InlineLink
           routeId="$lang/_protected/access-to-governmental-benefits/edit"


### PR DESCRIPTION
### Description

The default function has been refactored to reduce code repetition between the branches where dental plan information is present and is not present.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4087](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4087)
[AB#4113](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4113)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

1. Bring up the access governmental benefits view page with governmental benefits having been selected.
2. Repeat with governmental benefits not having been selected.