### PR TITLE
[frontend](typescript): Specifies the folder path to the tsserver under a TypeScript install

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,5 +59,6 @@
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
     ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-  ]
+  ],
+  "typescript.tsdk": "./frontend/node_modules/typescript/lib"
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

You may want or have to use the project Typescript version instead of VS Code shipped version.

> Specifies the folder path to the tsserver and lib*.d.ts files under a TypeScript install to use for IntelliSense, for example: ./node_modules/typescript/lib.
> 
> - When specified as a workspace setting, typescript.tsdk allows you to switch to use that workspace version of TypeScript for IntelliSense with the TypeScript: Select TypeScript version command.
> 
> See the [TypeScript documentation](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions) for more detail about managing TypeScript versions.