### PR TITLE
4152 add localize prov/fed/terr benefits to look-up service

### DIFF
--- a/frontend/__tests__/utils/lookup-utils.server.test.ts
+++ b/frontend/__tests__/utils/lookup-utils.server.test.ts
@@ -2,14 +2,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   localizeAndSortCountries,
+  localizeAndSortFederalSocialPrograms,
   localizeAndSortMaritalStatuses,
   localizeAndSortPreferredLanguages,
+  localizeAndSortProvincialTerritorialSocialPrograms,
   localizeAndSortRegions,
   localizeCountries,
   localizeCountry,
+  localizeFederalSocialProgram,
   localizeLanguage,
   localizeMaritalStatus,
   localizeMaritalStatuses,
+  localizeProvincialTerritorialSocialProgram,
   localizeRegion,
   localizeRegions,
 } from '~/utils/lookup-utils.server';
@@ -36,6 +40,18 @@ const mockLanguages = [
   { id: '001', nameEn: 'englishLanguageOne', nameFr: 'frenchLanguageOne' },
   { id: '002', nameEn: 'englishLanguageTwo', nameFr: 'frenchLanguageTwo' },
   { id: '003', nameEn: 'englishLanguageThree', nameFr: 'frenchLanguageThree' },
+];
+
+const mockFederalSocialPrograms = [
+  { id: '001', nameEn: 'englishProgramOne', nameFr: 'frenchProgramOne' },
+  { id: '002', nameEn: 'englishProgramTwo', nameFr: 'frenchProgramTwo' },
+  { id: '003', nameEn: 'englishProgramThree', nameFr: 'frenchProgramThree' },
+];
+
+const mockProvincialTerritorialSocialPrograms = [
+  { id: '001', provinceTerritoryStateId: '001', nameEn: 'englishProgramOne', nameFr: 'frenchProgramOne' },
+  { id: '002', provinceTerritoryStateId: '002', nameEn: 'englishProgramTwo', nameFr: 'frenchProgramTwo' },
+  { id: '003', provinceTerritoryStateId: '003', nameEn: 'englishProgramThree', nameFr: 'frenchProgramThree' },
 ];
 
 describe('localizeCountry', () => {
@@ -334,6 +350,118 @@ describe('localizeAndSortPreferredLanguages', () => {
       {
         id: '002',
         name: 'frenchLanguageTwo',
+      },
+    ]);
+  });
+});
+
+describe('localizeFederalSocialProgram', () => {
+  it('should return the federal social program id and english name', () => {
+    expect(localizeFederalSocialProgram(mockFederalSocialPrograms[0], 'en')).toEqual({
+      id: '001',
+      name: 'englishProgramOne',
+    });
+  });
+
+  it('should return the federal social program id and french name', () => {
+    expect(localizeFederalSocialProgram(mockFederalSocialPrograms[0], 'fr')).toEqual({
+      id: '001',
+      name: 'frenchProgramOne',
+    });
+  });
+});
+
+describe('localizeAndSortFederalSocialPrograms', () => {
+  it('should return an array of localized federal social program ids and english names', () => {
+    expect(localizeAndSortFederalSocialPrograms(mockFederalSocialPrograms, 'en')).toEqual([
+      {
+        id: '001',
+        name: 'englishProgramOne',
+      },
+      {
+        id: '003',
+        name: 'englishProgramThree',
+      },
+      {
+        id: '002',
+        name: 'englishProgramTwo',
+      },
+    ]);
+  });
+
+  it('should return an array of localized federal social program ids and french names', () => {
+    expect(localizeAndSortFederalSocialPrograms(mockFederalSocialPrograms, 'fr')).toEqual([
+      {
+        id: '001',
+        name: 'frenchProgramOne',
+      },
+      {
+        id: '003',
+        name: 'frenchProgramThree',
+      },
+      {
+        id: '002',
+        name: 'frenchProgramTwo',
+      },
+    ]);
+  });
+});
+
+describe('localizeProvincialTerritorialSocialProgram', () => {
+  it('should return the provincial/territorial social program id and english name', () => {
+    expect(localizeProvincialTerritorialSocialProgram(mockProvincialTerritorialSocialPrograms[0], 'en')).toEqual({
+      id: '001',
+      provinceTerritoryStateId: '001',
+      name: 'englishProgramOne',
+    });
+  });
+
+  it('should return the provincial/territorial social program id and french name', () => {
+    expect(localizeProvincialTerritorialSocialProgram(mockProvincialTerritorialSocialPrograms[0], 'fr')).toEqual({
+      id: '001',
+      provinceTerritoryStateId: '001',
+      name: 'frenchProgramOne',
+    });
+  });
+});
+
+describe('localizeAndSortProvincialTerritorialSocialPrograms', () => {
+  it('should return an array of localized provincial/territorial social program ids and english names', () => {
+    expect(localizeAndSortProvincialTerritorialSocialPrograms(mockProvincialTerritorialSocialPrograms, 'en')).toEqual([
+      {
+        id: '001',
+        name: 'englishProgramOne',
+        provinceTerritoryStateId: '001',
+      },
+      {
+        id: '003',
+        name: 'englishProgramThree',
+        provinceTerritoryStateId: '003',
+      },
+      {
+        id: '002',
+        name: 'englishProgramTwo',
+        provinceTerritoryStateId: '002',
+      },
+    ]);
+  });
+
+  it('should return an array of localized provincial/territorial social program ids and french names', () => {
+    expect(localizeAndSortProvincialTerritorialSocialPrograms(mockProvincialTerritorialSocialPrograms, 'fr')).toEqual([
+      {
+        id: '001',
+        name: 'frenchProgramOne',
+        provinceTerritoryStateId: '001',
+      },
+      {
+        id: '003',
+        name: 'frenchProgramThree',
+        provinceTerritoryStateId: '003',
+      },
+      {
+        id: '002',
+        name: 'frenchProgramTwo',
+        provinceTerritoryStateId: '002',
       },
     ]);
   });

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -20,10 +20,10 @@ import { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, s
 import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getEnv } from '~/utils/env.server';
-import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
-import { localizeAndSortRegions } from '~/utils/lookup-utils.server';
+import { localizeAndSortFederalSocialPrograms, localizeAndSortProvincialTerritorialSocialPrograms, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -57,8 +57,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const { CANADA_COUNTRY_ID } = getEnv();
   const lookupService = getLookupService();
-  const federalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const provincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
+  const federalSocialPrograms = localizeAndSortFederalSocialPrograms(lookupService.getAllFederalSocialPrograms(), locale);
+  const provincialTerritorialSocialPrograms = localizeAndSortProvincialTerritorialSocialPrograms(lookupService.getAllProvincialTerritorialSocialPrograms(), locale);
   const allRegions = localizeAndSortRegions(lookupService.getAllRegions(), locale);
   const regions = allRegions.filter((region) => region.countryId === CANADA_COUNTRY_ID);
 
@@ -184,7 +184,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 }
 
 export default function AccessToDentalInsuranceQuestion() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode, childName } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -280,7 +280,7 @@ export default function AccessToDentalInsuranceQuestion() {
                       name="federalSocialProgram"
                       legend={t('apply-adult-child:children.dental-benefits.federal-benefits.social-programs.legend')}
                       options={federalSocialPrograms.map((option) => ({
-                        children: getNameByLanguage(i18n.language, option),
+                        children: option.name,
                         defaultChecked: defaultState?.federalSocialProgram === option.id,
                         value: option.id,
                       }))}
@@ -341,7 +341,7 @@ export default function AccessToDentalInsuranceQuestion() {
                           options={provincialTerritorialSocialPrograms
                             .filter((program) => program.provinceTerritoryStateId === provinceValue)
                             .map((option) => ({
-                              children: getNameByLanguage(i18n.language, option),
+                              children: option.name,
                               value: option.id,
                               checked: provincialTerritorialSocialProgramValue === option.id,
                               onChange: handleOnProvincialTerritorialSocialProgramChanged,

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -22,10 +22,10 @@ import { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, s
 import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getEnv } from '~/utils/env.server';
-import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
-import { localizeAndSortRegions } from '~/utils/lookup-utils.server';
+import { localizeAndSortFederalSocialPrograms, localizeAndSortProvincialTerritorialSocialPrograms, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -58,8 +58,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const federalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const provincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
+  const federalSocialPrograms = localizeAndSortFederalSocialPrograms(lookupService.getAllFederalSocialPrograms(), locale);
+  const provincialTerritorialSocialPrograms = localizeAndSortProvincialTerritorialSocialPrograms(lookupService.getAllProvincialTerritorialSocialPrograms(), locale);
   const allRegions = localizeAndSortRegions(lookupService.getAllRegions(), locale);
   const regions = allRegions.filter((region) => region.countryId === CANADA_COUNTRY_ID);
 
@@ -176,7 +176,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 }
 
 export default function AccessToDentalInsuranceQuestion() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -277,7 +277,7 @@ export default function AccessToDentalInsuranceQuestion() {
                       legend={t('apply-adult-child:dental-benefits.federal-benefits.social-programs.legend')}
                       legendClassName="font-normal"
                       options={federalSocialPrograms.map((option) => ({
-                        children: getNameByLanguage(i18n.language, option),
+                        children: option.name,
                         defaultChecked: defaultState?.federalSocialProgram === option.id,
                         value: option.id,
                       }))}
@@ -339,7 +339,7 @@ export default function AccessToDentalInsuranceQuestion() {
                           options={provincialTerritorialSocialPrograms
                             .filter((program) => program.provinceTerritoryStateId === provinceValue)
                             .map((option) => ({
-                              children: getNameByLanguage(i18n.language, option),
+                              children: option.name,
                               value: option.id,
                               checked: provincialTerritorialSocialProgramValue === option.id,
                               onChange: handleOnProvincialTerritorialSocialProgramChanged,

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
@@ -27,7 +27,7 @@ import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
-import { localizeCountries, localizeMaritalStatuses, localizeRegions } from '~/utils/lookup-utils.server';
+import { localizeCountries, localizeFederalSocialProgram, localizeMaritalStatuses, localizeProvincialTerritorialSocialProgram, localizeRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -126,26 +126,19 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const dentalInsurance = state.dentalInsurance;
 
-  const allFederalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const allProvincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
-  const selectedFederalBenefits = allFederalSocialPrograms
-    .filter((obj) => obj.id === state.dentalBenefits.federalSocialProgram)
-    .map((obj) => getNameByLanguage(locale, obj))
-    .join(', ');
-  const selectedProvincialBenefits = allProvincialTerritorialSocialPrograms
-    .filter((obj) => obj.id === state.dentalBenefits.provincialTerritorialSocialProgram)
-    .map((obj) => getNameByLanguage(locale, obj))
-    .join(', ');
+  const selectedFederalBenefit = state.dentalBenefits.federalSocialProgram && localizeFederalSocialProgram(lookupService.getFederalSocialProgramById(state.dentalBenefits.federalSocialProgram), locale);
+  const selectedProvincialBenefit =
+    state.dentalBenefits.provincialTerritorialSocialProgram && localizeProvincialTerritorialSocialProgram(lookupService.getProvincialTerritorialSocialProgramById(state.dentalBenefits.provincialTerritorialSocialProgram), locale);
 
   const dentalBenefit = {
     federalBenefit: {
       access: state.dentalBenefits.hasFederalBenefits,
-      benefit: selectedFederalBenefits,
+      benefit: selectedFederalBenefit && selectedFederalBenefit.name,
     },
     provTerrBenefit: {
       access: state.dentalBenefits.hasProvincialTerritorialBenefits,
       province: state.dentalBenefits.province,
-      benefit: selectedProvincialBenefits,
+      benefit: selectedProvincialBenefit && selectedProvincialBenefit.name,
     },
   };
 

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -21,10 +21,10 @@ import { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, s
 import { getLookupService } from '~/services/lookup-service.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getEnv } from '~/utils/env.server';
-import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
-import { localizeAndSortRegions } from '~/utils/lookup-utils.server';
+import { localizeAndSortFederalSocialPrograms, localizeAndSortProvincialTerritorialSocialPrograms, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -58,8 +58,8 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const federalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const provincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
+  const federalSocialPrograms = localizeAndSortFederalSocialPrograms(lookupService.getAllFederalSocialPrograms(), locale);
+  const provincialTerritorialSocialPrograms = localizeAndSortProvincialTerritorialSocialPrograms(lookupService.getAllProvincialTerritorialSocialPrograms(), locale);
   const allRegions = localizeAndSortRegions(lookupService.getAllRegions(), locale);
   const regions = allRegions.filter((region) => region.countryId === CANADA_COUNTRY_ID);
 
@@ -172,7 +172,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 }
 
 export default function AccessToDentalInsuranceQuestion() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -272,7 +272,7 @@ export default function AccessToDentalInsuranceQuestion() {
                       legend={t('apply-adult:dental-benefits.federal-benefits.social-programs.legend')}
                       legendClassName="font-normal"
                       options={federalSocialPrograms.map((option) => ({
-                        children: getNameByLanguage(i18n.language, option),
+                        children: option.name,
                         defaultChecked: defaultState?.federalSocialProgram === option.id,
                         value: option.id,
                       }))}
@@ -334,7 +334,7 @@ export default function AccessToDentalInsuranceQuestion() {
                           options={provincialTerritorialSocialPrograms
                             .filter((program) => program.provinceTerritoryStateId === provinceValue)
                             .map((option) => ({
-                              children: getNameByLanguage(i18n.language, option),
+                              children: option.name,
                               value: option.id,
                               checked: provincialTerritorialSocialProgramValue === option.id,
                               onChange: handleOnProvincialTerritorialSocialProgramChanged,

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
@@ -31,7 +31,7 @@ import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
-import { localizeCountries, localizeMaritalStatuses, localizeRegions } from '~/utils/lookup-utils.server';
+import { localizeCountries, localizeFederalSocialProgram, localizeMaritalStatuses, localizeProvincialTerritorialSocialProgram, localizeRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -130,26 +130,19 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 
   const dentalInsurance = state.dentalInsurance;
 
-  const allFederalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const allProvincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
-  const selectedFederalBenefits = allFederalSocialPrograms
-    .filter((obj) => obj.id === state.dentalBenefits.federalSocialProgram)
-    .map((obj) => getNameByLanguage(locale, obj))
-    .join(', ');
-  const selectedProvincialBenefits = allProvincialTerritorialSocialPrograms
-    .filter((obj) => obj.id === state.dentalBenefits.provincialTerritorialSocialProgram)
-    .map((obj) => getNameByLanguage(locale, obj))
-    .join(', ');
+  const selectedFederalBenefit = state.dentalBenefits.federalSocialProgram && localizeFederalSocialProgram(lookupService.getFederalSocialProgramById(state.dentalBenefits.federalSocialProgram), locale);
+  const selectedProvincialBenefit =
+    state.dentalBenefits.provincialTerritorialSocialProgram && localizeProvincialTerritorialSocialProgram(lookupService.getProvincialTerritorialSocialProgramById(state.dentalBenefits.provincialTerritorialSocialProgram), locale);
 
   const dentalBenefit = {
     federalBenefit: {
       access: state.dentalBenefits.hasFederalBenefits,
-      benefit: selectedFederalBenefits,
+      benefit: selectedFederalBenefit ? selectedFederalBenefit.name : '',
     },
     provTerrBenefit: {
       access: state.dentalBenefits.hasProvincialTerritorialBenefits,
       province: state.dentalBenefits.province,
-      benefit: selectedProvincialBenefits,
+      benefit: selectedProvincialBenefit && selectedProvincialBenefit.name,
     },
   };
 

--- a/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
@@ -22,9 +22,10 @@ import { getLookupService } from '~/services/lookup-service.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getEnv } from '~/utils/env.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
-import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
+import { localizeFederalSocialProgram, localizeProvincialTerritorialSocialProgram } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import { RouteHandleData, getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -56,15 +57,16 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   const locale = getLocale(request);
   const lookupService = getLookupService();
 
-  const allFederalSocialPrograms = lookupService.getAllFederalSocialPrograms();
-  const allProvincialTerritorialSocialPrograms = lookupService.getAllProvincialTerritorialSocialPrograms();
-
   const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:review-child-information.page-title') }) };
 
   const children = state.children.map((child) => {
+    const selectedFederalBenefit = child.dentalBenefits.federalSocialProgram && localizeFederalSocialProgram(lookupService.getFederalSocialProgramById(child.dentalBenefits.federalSocialProgram), locale);
+    const selectedProvincialBenefit =
+      child.dentalBenefits.provincialTerritorialSocialProgram && localizeProvincialTerritorialSocialProgram(lookupService.getProvincialTerritorialSocialProgramById(child.dentalBenefits.provincialTerritorialSocialProgram), locale);
+
     return {
       id: child.id,
       firstName: child.information.firstName,
@@ -76,18 +78,12 @@ export async function loader({ context: { session }, params, request }: LoaderFu
         acessToDentalInsurance: child.dentalInsurance,
         federalBenefit: {
           access: child.dentalBenefits.hasFederalBenefits,
-          benefit: allFederalSocialPrograms
-            .filter((obj) => obj.id === child.dentalBenefits.federalSocialProgram)
-            .map((obj) => getNameByLanguage(locale, obj))
-            .join(', '),
+          benefit: selectedFederalBenefit && selectedFederalBenefit.name,
         },
         provTerrBenefit: {
           access: child.dentalBenefits.hasProvincialTerritorialBenefits,
           province: child.dentalBenefits.province,
-          benefit: allProvincialTerritorialSocialPrograms
-            .filter((obj) => obj.id === child.dentalBenefits.provincialTerritorialSocialProgram)
-            .map((obj) => getNameByLanguage(locale, obj))
-            .join(', '),
+          benefit: selectedProvincialBenefit && selectedProvincialBenefit.name,
         },
       },
     };

--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -376,6 +376,19 @@ function createLookupService() {
     return federalSocialPrograms;
   }
 
+  function getFederalSocialProgramsById(id: string) {
+    log.debug('Fetching federal social program with id: [%s]', id);
+
+    const federalSocialProgram = getAllFederalSocialPrograms().find((program) => program.id === id);
+
+    if (!federalSocialProgram) {
+      throw new Error(`Failed to find federal social program; id: ${id}`);
+    }
+
+    log.trace('Returning federal social program: [%j]', federalSocialProgram);
+    return federalSocialProgram;
+  }
+
   function getAllProvincialTerritorialSocialPrograms() {
     log.debug('Fetching all provincial/territorial social programs');
 
@@ -388,6 +401,19 @@ function createLookupService() {
 
     log.trace('Returning provincial/territorial social programs: [%j]', provincialTerritorialSocialPrograms);
     return provincialTerritorialSocialPrograms;
+  }
+
+  function getProvincialTerritorialSocialProgramById(id: string) {
+    log.debug('Fetching provincial/territorial social program with id: [%s]', id);
+
+    const provincialTerritorialSocialProgram = getAllProvincialTerritorialSocialPrograms().find((program) => program.id === id);
+
+    if (!provincialTerritorialSocialProgram) {
+      throw new Error(`Failed to find provincial/territorial social program; id: ${id}`);
+    }
+
+    log.trace('Returning provincial/territorial social program: [%j]', provincialTerritorialSocialProgram);
+    return provincialTerritorialSocialProgram;
   }
 
   function getAllCountries() {
@@ -474,6 +500,7 @@ function createLookupService() {
     getAllDisabilityTypes: moize.promise(getAllDisabilityTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_DISABILITY_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllDisabilityTypes memo') }),
     getAllEquityTypes: moize.promise(getAllEquityTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_EQUITY_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllEquityTypes memo') }),
     getAllFederalSocialPrograms: moize(getAllFederalSocialPrograms, { maxAge: 1000 * LOOKUP_SVC_ALL_FEDERAL_SOCIAL_PROGRAMS_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllFederalSocialPrograms memo') }),
+    getFederalSocialProgramById: moize(getFederalSocialProgramsById, { maxAge: 1000 * LOOKUP_SVC_ALL_FEDERAL_SOCIAL_PROGRAMS_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new FederalSocialProgramById memo') }),
     getAllGenderTypes: moize.promise(getAllGenderTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_GENDER_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllGenderTypes memo') }),
     getAllIndigenousGroupTypes: moize.promise(getAllIndigenousGroupTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_INDIGENOUS_GROUP_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllIndigenousGroupTypes memo') }),
     getAllIndigenousTypes: moize.promise(getAllIndigenousTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_INDIGENOUS_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllIndigenousTypes memo') }),
@@ -485,6 +512,10 @@ function createLookupService() {
     getAllProvincialTerritorialSocialPrograms: moize(getAllProvincialTerritorialSocialPrograms, {
       maxAge: 1000 * LOOKUP_SVC_ALL_PROVINCIAL_TERRITORIAL_SOCIAL_PROGRAMS_CACHE_TTL_SECONDS,
       onCacheAdd: () => log.info('Creating new AllProvincialTerritorialSocialPrograms memo'),
+    }),
+    getProvincialTerritorialSocialProgramById: moize(getProvincialTerritorialSocialProgramById, {
+      maxAge: 1000 * LOOKUP_SVC_ALL_PROVINCIAL_TERRITORIAL_SOCIAL_PROGRAMS_CACHE_TTL_SECONDS,
+      onCacheAdd: () => log.info('Creating new ProvincialTerritorialSocialProgramById memo'),
     }),
     getAllRegions: moize(getAllRegions, { maxAge: 1000 * LOOKUP_SVC_ALL_REGIONS_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllRegions memo') }),
     getAllSexAtBirthTypes: moize.promise(getAllSexAtBirthTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_SEX_AT_BIRTH_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllSexAtBirthTypes memo') }),
@@ -506,3 +537,9 @@ export type Region = ReturnType<GetAllRegions>[number];
 export type GetAllPreferredLanguages = Pick<ReturnType<typeof getLookupService>, 'getAllPreferredLanguages'>['getAllPreferredLanguages'];
 export type GetAllPreferredLanguagesReturnType = ReturnType<GetAllPreferredLanguages>;
 export type Language = GetAllPreferredLanguagesReturnType[number];
+
+export type GetAllFederalSocialPrograms = Pick<ReturnType<typeof getLookupService>, 'getAllFederalSocialPrograms'>['getAllFederalSocialPrograms'];
+export type FederalSocialProgram = ReturnType<GetAllFederalSocialPrograms>[number];
+
+export type GetAllProvincialTerritorialSocialPrograms = Pick<ReturnType<typeof getLookupService>, 'getAllProvincialTerritorialSocialPrograms'>['getAllProvincialTerritorialSocialPrograms'];
+export type ProvincialTerritorialSocialProgram = ReturnType<GetAllProvincialTerritorialSocialPrograms>[number];

--- a/frontend/app/utils/lookup-utils.server.ts
+++ b/frontend/app/utils/lookup-utils.server.ts
@@ -1,5 +1,5 @@
 import { getEnv } from './env.server';
-import { Country, Language, MaritalStatus, Region } from '~/services/lookup-service.server';
+import { Country, FederalSocialProgram, Language, MaritalStatus, ProvincialTerritorialSocialProgram, Region } from '~/services/lookup-service.server';
 
 /**
  * Localizes a single country object by adding a localized name.
@@ -149,4 +149,58 @@ export function localizeAndSortPreferredLanguages(languages: Language[], locale:
     if (firstLanguageId && b.id === firstLanguageId.toString()) return 1;
     return a.name.localeCompare(b.name, locale);
   });
+}
+
+/**
+ * Localizes a single federal social program object by adding a localized name.
+ *
+ * @param program - The federal social program object to localize.
+ * @param locale - The locale code for localization.
+ * @returns The localized federal social program object with a localized name.
+ */
+export function localizeFederalSocialProgram(program: FederalSocialProgram, locale: string) {
+  const { nameEn, nameFr, ...rest } = program;
+  return {
+    ...rest,
+    name: locale === 'fr' ? nameFr : nameEn,
+  };
+}
+
+/**
+ * Localizes an array of federal social program objects by adding localized names and sorting them.
+ *
+ * @param program - The array of federal social program objects to localize.
+ * @param locale - The locale code for localization.
+ * @returns The localized and sorted array of federal social program objects.
+ */
+export function localizeAndSortFederalSocialPrograms(programs: FederalSocialProgram[], locale: string) {
+  const mappedFederalSocialPrograms = programs.map((program) => localizeFederalSocialProgram(program, locale));
+  return mappedFederalSocialPrograms.toSorted((a, b) => a.name.localeCompare(b.name, locale));
+}
+
+/**
+ * Localizes a single provincial/territorial social program object by adding a localized name.
+ *
+ * @param program - The provincial/territorial social program object to localize.
+ * @param locale - The locale code for localization.
+ * @returns The localized provincial/territorial social program object with a localized name.
+ */
+export function localizeProvincialTerritorialSocialProgram(program: ProvincialTerritorialSocialProgram, locale: string) {
+  const { nameEn, nameFr, ...rest } = program;
+  return {
+    ...rest,
+    name: locale === 'fr' ? nameFr : nameEn,
+  };
+}
+
+/**
+ * Localizes an array of provincial/territorial social program objects by adding localized names and sorting them.
+ *
+ * @param program - The array of provincial/territorial social program objects to localize.
+ * @param locale - The locale code for localization.
+ * @returns The localized and sorted array of provincial/territorial social program objects.
+ */
+export function localizeAndSortProvincialTerritorialSocialPrograms(programs: ProvincialTerritorialSocialProgram[], locale: string) {
+  const mappedProvincialTerritorialSocialPrograms = programs.map((program) => localizeProvincialTerritorialSocialProgram(program, locale));
+  return mappedProvincialTerritorialSocialPrograms.toSorted((a, b) => a.name.localeCompare(b.name, locale));
 }


### PR DESCRIPTION
### Description
This PR moves the (duplicated) logic of localizing, filtering, and joining federal/provincial/territorial benefits on the review-information screens to the lookup-utils.  

The rationale for keeping a combination of `filter/map/join` instead of `find` is that in my mind, it may be possible in the future to select multiple benefits as a checkbox instead of radio buttons.  

### Related Azure Boards Work Items
[AB#4152](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4152)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`