### PR TITLE
Adjusted spacing in access to gov benefits view

### DIFF
--- a/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
+++ b/frontend/app/routes/$lang/_protected/access-to-governmental-benefits/view.tsx
@@ -103,9 +103,11 @@ export default function AccessToGovernmentalsBenefitsView() {
   return (
     <div className="max-w-prose">
       {updatedInfo && (
-        <ContextualAlert type="success">
-          <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
-        </ContextualAlert>
+        <div className="mb-5 space-y-4">
+          <ContextualAlert type="success">
+            <h2 className="text-xl font-semibold">{t('access-to-governmental-benefits:access-to-governmental-benefits.view.info-updated.your-info-has-been-updated')}</h2>
+          </ContextualAlert>
+        </div>
       )}
       {hasDentalPlans ? (
         <>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The default function of the access to gov benefits view has been updated to add additional spacing around the contextual alert.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4087](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4087)
[AB#4114](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4114)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![Screenshot from 2024-06-21 15-35-35](https://github.com/DTS-STN/canadian-dental-care-plan/assets/154452024/6233a059-3a64-4c9e-9271-b61263bbbb27)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

1. Bring up the access governmental benefits view page from the update page.
2. Observe the spacing.
