### PR TITLE
use InputSinField in status checker

### DIFF
--- a/frontend/app/routes/$lang/_public/status/child/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/child/index.tsx
@@ -18,6 +18,7 @@ import { DatePickerField } from '~/components/date-picker-field';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { InputRadios } from '~/components/input-radios';
+import { InputSinField } from '~/components/input-sin-field';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
@@ -341,7 +342,7 @@ export default function StatusCheckerChild() {
                   errorMessage={errorMessages['input-radio-child-has-sin-option-0']}
                   required
                 />
-                {childHasSinState === true && <InputField id="sin" name="sin" label={t('status:child.form.sin-label')} helpMessagePrimary={t('status:child.form.sin-description')} required errorMessage={errorMessages.sin} />}
+                {childHasSinState === true && <InputSinField id="sin" name="sin" label={t('status:child.form.sin-label')} helpMessagePrimary={t('status:child.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />}
                 {childHasSinState === false && (
                   <>
                     <Collapsible summary={t('status:child.form.if-child-summary')} className="mt-8">

--- a/frontend/app/routes/$lang/_public/status/myself/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/myself/index.tsx
@@ -15,6 +15,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
+import { InputSinField } from '~/components/input-sin-field';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
@@ -207,7 +208,7 @@ export default function StatusCheckerMyself() {
               {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
               <div className="mb-8 space-y-6">
                 <InputField id="code" name="code" label={t('status:myself.form.application-code-label')} helpMessagePrimary={t('status:myself.form.application-code-description')} required errorMessage={errorMessages.code} />
-                <InputField id="sin" name="sin" label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errorMessages.sin} />
+                <InputSinField id="sin" name="sin" label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />
               </div>
               <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit">
                 {t('status:myself.form.submit')}


### PR DESCRIPTION
### Description
opt in to using `InputSinField` in the status checker.

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/ff218d88-ca41-4a07-8c34-6264cda6b0f8)