### PR TITLE
Added equals and hashCode methods to AlertTypeEntity class

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/AlertTypeEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/entity/AlertTypeEntity.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.cdcp.api.data.entity;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -62,5 +63,26 @@ public class AlertTypeEntity extends AbstractEntity {
 			.append("description", description)
 			.toString();
 	}
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		if (this == obj) { return true; }
+		if (obj == null || !super.equals(obj)) { return false; }
+		if (getClass() != obj.getClass()) { return false; }
 
+		final var other = (AlertTypeEntity) obj;
+
+		return Objects.equals(isNew, other.isNew)
+				&& Objects.equals(id, other.id)
+				&& Objects.equals(createdBy, other.createdBy)
+				&& Objects.equals(createdDate, other.createdDate)
+				&& Objects.equals(lastModifiedBy, other.lastModifiedBy)
+				&& Objects.equals(lastModifiedDate, other.lastModifiedDate)
+				&& Objects.equals(code, other.code)
+				&& Objects.equals(description, other.description)
+;
+	}
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), isNew, id, createdBy, createdDate, lastModifiedBy, lastModifiedDate, code, description);
+	}
 }

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/entity/AlertTypeEntityTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/entity/AlertTypeEntityTest.java
@@ -1,0 +1,50 @@
+package ca.gov.dtsstn.cdcp.api.data.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("serial")
+@ExtendWith({ MockitoExtension.class })
+class AlertTypeEntityTest extends AlertTypeEntity {
+
+	AlertTypeEntity alertTypeEntity;
+
+	@BeforeEach
+	void beforeEach() {
+		this.alertTypeEntity = new AlertTypeEntity();
+	}
+
+	@Test
+	final void testHashCode() {
+		alertTypeEntity.setCode("0000");
+		AlertTypeEntity otherAlertTypeEntity = new AlertTypeEntity();
+		otherAlertTypeEntity.setCode("0000");
+		assertThat(alertTypeEntity).hasSameHashCodeAs(otherAlertTypeEntity);
+	}
+
+	@Test
+	final void testEqualsObjectNull() {
+		assertThat(alertTypeEntity.equals(null)).isFalse();
+	}
+
+	@Test
+	final void testEqualsObjectDoesNotMatch() {
+		alertTypeEntity.setCode("0000");
+		AlertTypeEntity otherAlertTypeEntity = new AlertTypeEntity();
+		otherAlertTypeEntity.setCode("1111");
+		assertThat(alertTypeEntity.equals(otherAlertTypeEntity)).isFalse();
+	}
+
+	@Test
+	final void testEqualsObjectDoesMatch() {
+		alertTypeEntity.setCode("0000");
+		AlertTypeEntity otherAlertTypeEntity = new AlertTypeEntity();
+		otherAlertTypeEntity.setCode("0000");
+		assertThat(alertTypeEntity.equals(otherAlertTypeEntity)).isTrue();
+	}
+
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

- The `equals` and `hashCode` methods have been overridden to account for added fields.
- Addresses Sonar Lint warnings.
- Made relevant test updates.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4175](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4175)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`

