### PR TITLE
AB#4211 -- Adding ETag support with `ShallowEtagHeaderFilter`

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/ServletConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/ServletConfig.java
@@ -1,0 +1,36 @@
+package ca.gov.dtsstn.cdcp.api.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+/**
+ * This class configures the servlet container by handling filter bean creation and registration.
+ */
+@Configuration
+public class ServletConfig {
+
+	static final Logger log = LoggerFactory.getLogger(ServletConfig.class);
+
+	@ConfigurationProperties("application.shallow-etag-header-filter")
+	@Bean ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+		log.info("Creating 'shallowEtagHeaderFilter' bean");
+		return new ShallowEtagHeaderFilter();
+	}
+
+	@Bean FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilterRegistration() {
+		log.info("Creating 'shallowEtagHeaderFilterRegistration' bean");
+
+		final var shallowEtagHeaderFilter = shallowEtagHeaderFilter();
+		final var filterRegistrationBean = new FilterRegistrationBean<>(shallowEtagHeaderFilter);
+		filterRegistrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+		return filterRegistrationBean;
+	}
+
+}


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
[AB#4211](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4211)

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/5bcae419-b7f7-4528-8210-f4f3497d1449)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/393840f6-17e5-42fd-b76d-9ea9f2437e3e)

### Test Instructions
- Run backend application locally. 
- Run the following `curl` command:
`curl -v http://localhost:8080/api/v1/users?raoidcUserId=0000`
- You should see the `ETag` response header.