### PR TITLE
[frontend](string-utils): fix bug when "undefined" is passed by 3rd party library

### DIFF
--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -45,8 +45,8 @@ export const invalidInputCharactersRegex = /[^a-zA-Z0-9(),\-.'\u2019\s\u00a0ÀÁ
  * @returns - Returns true if the input contains only valid characters, otherwise false.
  */
 export function isAllValidInputCharacters(value: string) {
-  const invalidCharacters = value.match(invalidInputCharactersRegex);
-  return invalidCharacters === null;
+  const hasInvalidCharacters = invalidInputCharactersRegex.test(value);
+  return !hasInvalidCharacters;
 }
 
 /**


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Client errors are logged in Dynatrace by RUM, with one issue related to the `InputSanatizeField` component used in various places. The `isValudInputCharater` prop function passes "undefined" when you press `Backspace` on an empty input, despite the function argument type indicating "string." 

This PR addresses the logged issue. Note that passing `undefined` to `invalidInputCharactersRegex` when using the `test` regex function does not cause any problems.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![dynatrace prod-dp admin dts-stn com_e_676a0299-9802-4933-99d4-481318a557db_ui_applications_APPLICATION-4EA9ADEA09B9C11E_analysis_js-error-details_filtr3ftf=custom1719392875467to1719400075467select1719396 (1)](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/2a8b7b20-d369-456d-a272-1463d7143ef4)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->