### PR TITLE
Sonarlint update to JsonMergePatchHttpMessageConvertor

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Component;
 
 import jakarta.json.Json;
 import jakarta.json.JsonMergePatch;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonWriter;
 
 @Component
 public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonMergePatch> {
@@ -29,7 +27,7 @@ public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConve
 
 	@Override
 	protected JsonMergePatch readInternal(Class<? extends JsonMergePatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
-		try (JsonReader jsonReader = Json.createReader(httpInputMessage.getBody())) {
+		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
 			return Json.createMergePatch(jsonReader.readValue());
 		}
 		catch (final Exception exception) {
@@ -40,7 +38,7 @@ public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConve
 
 	@Override
 	protected void writeInternal(JsonMergePatch jsonMergePatch, HttpOutputMessage httpOutputMessage) throws IOException, HttpMessageNotWritableException {
-		try (JsonWriter jsonWriter = Json.createWriter(httpOutputMessage.getBody())){
+		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())){
 			jsonWriter.write(jsonMergePatch.toJsonValue());
 		}
 		catch (final Exception exception) {

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonMergePatchHttpMessageConverter.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 
 import jakarta.json.Json;
 import jakarta.json.JsonMergePatch;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonWriter;
 
 @Component
 public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonMergePatch> {
@@ -27,8 +29,8 @@ public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConve
 
 	@Override
 	protected JsonMergePatch readInternal(Class<? extends JsonMergePatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
-		try {
-			return Json.createMergePatch(Json.createReader(httpInputMessage.getBody()).readValue());
+		try (JsonReader jsonReader = Json.createReader(httpInputMessage.getBody())) {
+			return Json.createMergePatch(jsonReader.readValue());
 		}
 		catch (final Exception exception) {
 			final var message = "Could not read JSON merge-patch: %s".formatted(exception.getMessage());
@@ -38,8 +40,8 @@ public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConve
 
 	@Override
 	protected void writeInternal(JsonMergePatch jsonMergePatch, HttpOutputMessage httpOutputMessage) throws IOException, HttpMessageNotWritableException {
-		try {
-			Json.createWriter(httpOutputMessage.getBody()).write(jsonMergePatch.toJsonValue());
+		try (JsonWriter jsonWriter = Json.createWriter(httpOutputMessage.getBody())){
+			jsonWriter.write(jsonMergePatch.toJsonValue());
 		}
 		catch (final Exception exception) {
 			final var message = "Could not write JSON merge-patch: %s".formatted(exception.getMessage());


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Updated `JsonMergePatchHttpMessageConvertor` based on sonarlint warnings.

- Added try-with-resources to close `JsonReader` after use.
- Added try-with-resources to close `JsonWriter` after use.
- Relevant test updates made.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4180](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4180)
[AB#4181](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4181)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
