### PR TITLE
fix(frontend): ensure _action value is included in FormData for older browsers

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/index.tsx
@@ -9,6 +9,7 @@ import { faChevronLeft, faChevronRight, faEdit, faPlus, faRemove, faSpinner } fr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { randomUUID } from 'crypto';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../../page-ids.json';
@@ -132,8 +133,14 @@ export default function ApplyFlowChildSummary() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     fetcher.submit(formData, { method: 'POST' });
   }

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-adult-information.tsx
@@ -215,8 +215,14 @@ export default function ReviewInformation() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     if (hCaptchaEnabled && captchaRef.current) {
       try {

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/review-child-information.tsx
@@ -10,6 +10,7 @@ import { faChevronLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
@@ -163,8 +164,14 @@ export default function ReviewInformation() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     if (hCaptchaEnabled && captchaRef.current) {
       try {

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/review-information.tsx
@@ -226,9 +226,14 @@ export default function ReviewInformation() {
 
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
+    const formData = new FormData(event.currentTarget);
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     if (hCaptchaEnabled && captchaRef.current) {
       try {

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/index.tsx
@@ -9,6 +9,7 @@ import { faChevronLeft, faChevronRight, faEdit, faPlus, faRemove, faSpinner } fr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { randomUUID } from 'crypto';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../../page-ids.json';
@@ -125,8 +126,14 @@ export default function ApplyFlowChildSummary() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     fetcher.submit(formData, { method: 'POST' });
   }

--- a/frontend/app/routes/$lang/_public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/review-adult-information.tsx
@@ -204,8 +204,14 @@ export default function ReviewInformation() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     if (hCaptchaEnabled && captchaRef.current) {
       try {

--- a/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/review-child-information.tsx
@@ -9,6 +9,7 @@ import { faChevronLeft, faChevronRight, faSpinner } from '@fortawesome/free-soli
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
@@ -155,8 +156,14 @@ export default function ReviewInformation() {
   function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();
 
-    const formData = new FormData(event.currentTarget, event.nativeEvent.submitter);
-    setSubmitAction(String(formData.get('_action')));
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
 
     if (hCaptchaEnabled && captchaRef.current) {
       try {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Older browsers doesn't support FormData constructer with `submitter` second argument. Some users have issue in production because of it. This pull request's using a different approach to provide the `_action` form data value when submitting.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

FormData Constructor `submitter` browers support
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/c70deb2e-6dc6-45a7-9f08-4762a7ca1596)

Dynatrace
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/12a0dc75-945a-4bda-86a7-f65b12ed1c82)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/0fa3ac44-0b9a-47fe-9782-ac22017ee350)

Dynatrace log
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/3179585a-ac43-45f8-8b6a-8388134ee9ff)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->