### PR TITLE
AB#4215 Add the repository for confirmation code with a delete function

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/ConfirmationCodeRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/repository/ConfirmationCodeRepository.java
@@ -1,0 +1,12 @@
+package ca.gov.dtsstn.cdcp.api.data.repository;
+import java.time.Instant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
+
+
+@Repository
+public interface ConfirmationCodeRepository extends JpaRepository<ConfirmationCodeEntity, String> {
+
+	int deleteByExpiryDateLessThan(Instant instant);
+}

--- a/backend/src/main/resources/db-migrations/h2/v0.1-[vendor]-data-init.sql
+++ b/backend/src/main/resources/db-migrations/h2/v0.1-[vendor]-data-init.sql
@@ -25,9 +25,3 @@ INSERT INTO `subscription` (`id`, `user_id`, `language_id`, `alert_type_id`, `cr
 VALUES
 	('a6ea4925-f813-493e-80ec-a5b90ca28b6c', '76c48130-e1d4-4c2f-8dd0-1c17f9bbb4f6', '3a91d740-facf-48c2-bd9e-9ab46a8f6200', 'cf185099-8a17-4086-a890-c456250822a3', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
 	('d3419bcb-5e46-4678-831b-c9211d479429', '76c48130-e1d4-4c2f-8dd0-1c17f9bbb4f6', '3a91d740-facf-48c2-bd9e-9ab46a8f6200', 'daf8b8d9-95f4-4f38-9ee3-17ac7826c1e7', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
-
-
-INSERT INTO `confirmation_code` (`id`, `code`, `expiry_date`, `user_id`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`)
-VALUES
-	('a6ea4925-f813-493e-80ec-a5b90ca28b6c', '12345', CURRENT_TIMESTAMP, 'f9f33652-0ebd-46bc-8d93-04cef538a689', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
-	('a6ea4925-f813-493e-80ec-a5b90ca28b6d', '54321', CURRENT_TIMESTAMP + 20000000, 'f9f33652-0ebd-46bc-8d93-04cef538a689', 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/ConfirmationCodeRepositoryIT.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/repository/ConfirmationCodeRepositoryIT.java
@@ -1,0 +1,60 @@
+package ca.gov.dtsstn.cdcp.api.data.repository;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import ca.gov.dtsstn.cdcp.api.config.DataSourceConfig;
+import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.ConfirmationCodeEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserAttributeEntityBuilder;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserEntity;
+import ca.gov.dtsstn.cdcp.api.data.entity.UserEntityBuilder;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({ DataSourceConfig.class })
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class ConfirmationCodeRepositoryIT {
+
+	@Autowired ConfirmationCodeRepository confirmationCodeRepository;
+	@Autowired UserRepository userRepository;
+
+	@Test
+	@DisplayName("Test confirmationCodeRepository.deleteByExpiryDateLessThan(..)")
+	void testDeleteByExpiryDateLessThan() {
+
+		ConfirmationCodeEntity confirmationCode = new ConfirmationCodeEntityBuilder()
+		.expiryDate(LocalDate.of(2024, 5, 15).atStartOfDay(ZoneId.systemDefault()).toInstant())
+		.code("98765")
+		.build();
+
+		Collection<ConfirmationCodeEntity> confirmationCodes = new ArrayList<ConfirmationCodeEntity>();
+		confirmationCodes.add(confirmationCode);
+
+		UserEntity newUser = userRepository.save(new UserEntityBuilder()
+		.userAttributes(List.of(new UserAttributeEntityBuilder()
+			.name("RAOIDC_USER_ID")
+			.value("1234-5678-90")
+			.build()))
+			.confirmationCodes(confirmationCodes)
+		.build());
+
+		assertThat(userRepository.findById(newUser.getId())).isNotEmpty();
+		assertThat(userRepository.findById(newUser.getId()).get().getConfirmationCodes()).isNotEmpty();
+		int deletedRows = confirmationCodeRepository.deleteByExpiryDateLessThan(Instant.now());
+		confirmationCodeRepository.flush();
+		assertThat(deletedRows).isEqualTo(1);
+		assertThat(userRepository.findById(newUser.getId()).get().getConfirmationCodes()).isEmpty();
+	}
+}


### PR DESCRIPTION
### Description
Add the repository for confirmation code with a delete function. This will delete all confirmation codes that have their expiry date less than the inserted time.

### Related Azure Boards Work Items
[AB#4215](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4215) 


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
