### PR TITLE
Sonarlint update to JsonPatchHttpMessageConvertor

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
@@ -20,11 +20,13 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 		super(MediaType.APPLICATION_JSON, JsonPatchMediaTypes.JSON_PATCH);
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	protected boolean supports(Class<?> clazz) {
 		return JsonPatch.class.isAssignableFrom(clazz);
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
 		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
@@ -36,6 +38,7 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 		}
 	}
 
+	@SuppressWarnings("null")
 	@Override
 	protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage httpOutputMessage) {
 		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())){

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import jakarta.json.Json;
 import jakarta.json.JsonPatch;
 
+@SuppressWarnings("null")
 @Component
 public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonPatch> {
 
@@ -20,13 +21,11 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 		super(MediaType.APPLICATION_JSON, JsonPatchMediaTypes.JSON_PATCH);
 	}
 
-	@SuppressWarnings("null")
 	@Override
 	protected boolean supports(Class<?> clazz) {
 		return JsonPatch.class.isAssignableFrom(clazz);
 	}
 
-	@SuppressWarnings("null")
 	@Override
 	protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
 		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
@@ -38,7 +37,6 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 		}
 	}
 
-	@SuppressWarnings("null")
 	@Override
 	protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage httpOutputMessage) {
 		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())){

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchHttpMessageConverter.java
@@ -27,8 +27,8 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 
 	@Override
 	protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage httpInputMessage) throws IOException, HttpMessageNotReadableException {
-		try {
-			return Json.createPatch(Json.createReader(httpInputMessage.getBody()).readArray());
+		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
+			return Json.createPatch(jsonReader.readArray());
 		}
 		catch (final Exception exception) {
 			final var message = "Could not read JSON patch: %s".formatted(exception.getMessage());
@@ -38,8 +38,8 @@ public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<
 
 	@Override
 	protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage httpOutputMessage) {
-		try {
-			Json.createWriter(httpOutputMessage.getBody()).write(jsonPatch.toJsonArray());
+		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())){
+			jsonWriter.write(jsonPatch.toJsonArray());
 		}
 		catch (final Exception exception) {
 			final var message = "Could not write JSON patch: %s".formatted(exception.getMessage());


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Updated `JsonPatchHttpMessageConvertor` based on sonarlint warnings.

- Added try-with-resources to close `JsonReader` after use.
- Added try-with-resources to close `JsonWriter` after use.
- Relevant test updates made.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4182](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4182)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
