### PR TITLE
AB#4225 -- Adding timers to internal service calls

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/MetricsConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/MetricsConfig.java
@@ -1,0 +1,24 @@
+package ca.gov.dtsstn.cdcp.api.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * This class configures metric collection for the application.
+ */
+@Configuration
+public class MetricsConfig {
+
+	static final Logger log = LoggerFactory.getLogger(MetricsConfig.class);
+
+	@Bean TimedAspect timedAspect(MeterRegistry meterRegstry) {
+		log.info("Creating 'timedAspect' bean");
+		return new TimedAspect(meterRegstry);
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/AlertTypeService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/AlertTypeService.java
@@ -11,6 +11,7 @@ import org.springframework.util.Assert;
 import ca.gov.dtsstn.cdcp.api.data.repository.AlertTypeRepository;
 import ca.gov.dtsstn.cdcp.api.service.domain.AlertType;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.AlertTypeMapper;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @CacheConfig(cacheNames = { "alert-types" })
@@ -25,12 +26,14 @@ public class AlertTypeService {
 		this.alertTypeRepository = alertTypeRepository;
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'id', #id }", sync = true)
 	public Optional<AlertType> readById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return alertTypeRepository.findById(id).map(alertTypeMapper::toAlertType);
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'code', #code }", sync = true)
 	public Optional<AlertType> readByCode(String code) {
 		Assert.hasText(code, "code is required; it must not be null or blank");

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/LanguageService.java
@@ -11,6 +11,7 @@ import org.springframework.util.Assert;
 import ca.gov.dtsstn.cdcp.api.data.repository.LanguageRepository;
 import ca.gov.dtsstn.cdcp.api.service.domain.Language;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.LanguageMapper;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @CacheConfig(cacheNames = { "languages" })
@@ -25,24 +26,28 @@ public class LanguageService {
 		this.languageRepository = languageRepository;
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'id', #id }", sync = true)
 	public Optional<Language> readById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return languageRepository.findById(id).map(languageMapper::toLanguage);
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'code', #code }", sync = true)
 	public Optional<Language> readByCode(String code) {
 		Assert.hasText(code, "code is required; it must not be null or blank");
 		return languageRepository.findByCode(code).map(languageMapper::toLanguage);
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'isoCode', #isoCode }", sync = true)
 	public Optional<Language> readByIsoCode(String isoCode) {
 		Assert.hasText(isoCode, "isoCode is required; it must not be null or blank");
 		return languageRepository.findByIsoCode(isoCode).map(languageMapper::toLanguage);
 	}
 
+	@Timed
 	@Cacheable(key = "{ 'msLocaleCode', #msLocaleCode }", sync = true)
 	public Optional<Language> readByMsLocaleCode(String msLocaleCode) {
 		Assert.hasText(msLocaleCode, "msLocaleCode is required; it must not be null or blank");

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/service/UserService.java
@@ -30,6 +30,7 @@ import ca.gov.dtsstn.cdcp.api.service.domain.User;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.ConfirmationCodeMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.SubscriptionMapper;
 import ca.gov.dtsstn.cdcp.api.service.domain.mapper.UserMapper;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @Transactional
@@ -64,6 +65,7 @@ public class UserService {
 		this.userRepository = userRepository;
 	}
 
+	@Timed
 	public User createUser(User user) {
 		Assert.notNull(user, "user is required; it must not be null");
 		Assert.isNull(user.getId(), "user.id must be null when creating new instance");
@@ -71,17 +73,19 @@ public class UserService {
 		return userMapper.toUser(userRepository.save(userMapper.toUserEntity(user)));
 	}
 
+	@Timed
 	public Optional<User> getUserById(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return userRepository.findById(id).map(userMapper::toUser);
 	}
 
-
+	@Timed
 	public Optional<User> getUserByRaoidcUserId(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return userRepository.findByRaoidcUserId(id).map(userMapper::toUser);
 	}
 
+	@Timed
 	public void updateUser(String userId, User userPatch) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
 		Assert.notNull(userPatch, "userPatch is required; it must not be null");
@@ -96,6 +100,7 @@ public class UserService {
 		userRepository.save(userMapper.update(user, userPatch));
 	}
 
+	@Timed
 	public Subscription createSubscriptionForUser(String userId, String alertTypeId, String languageId) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
 		Assert.hasText(alertTypeId, "alertTypeId is required; it must not be null or blank");
@@ -131,6 +136,7 @@ public class UserService {
 			.map(subscriptionMapper::toSubscription).orElseThrow();
 	}
 
+	@Timed
 	public void updateSubscriptionForUser(String userId, String subscriptionId, String languageId) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
 		Assert.hasText(subscriptionId, "subscriptionId is required; it must not be null or blank");
@@ -154,6 +160,7 @@ public class UserService {
 		userRepository.save(user);
 	}
 
+	@Timed
 	public void deleteSubscriptionForUser(String userId, String subscriptionId) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
 		Assert.hasText(subscriptionId, "subscriptionId is required; it must not be null or blank");
@@ -163,6 +170,7 @@ public class UserService {
 		userRepository.save(user);
 	}
 
+	@Timed
 	public boolean verifyEmail(String userId, String code){
 		Assert.hasText(code, "code is required; it must not be null or blank");
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
@@ -186,6 +194,7 @@ public class UserService {
 		return true;
 	}
 
+	@Timed
 	public ConfirmationCode createConfirmationCodeForUser(String userId) {
 		Assert.hasText(userId, "userId is required; it must not be null or blank");
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -86,6 +86,11 @@ management:
         enabled: true
       show-components: always
       show-details: when-authorized
+  endpoints:
+    web:
+      exposure:
+        include:
+        - metrics
 
 ---
 


### PR DESCRIPTION
### Description
As per title

### Related Azure Boards Work Items
[AB#4225](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4225)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/9efb3e37-2a22-4e96-827e-220c70d97df9)

### Test Instructions
1. Run the `backend` application locally and make a request to any API endpoint
2. Navigate to `/actuator/metrics/method.timed`, which has metrics for calls to `@Service` methods
3. Navigate to `/actuator/metrics/http.server.requests`, which has metrics for API requests, including `@Controller` invocations
4. Navigate to `/actuator/metrics/spring.data.repository.invocations`, which has metrics for `@Repository` invocations
