### PR TITLE
Added masking constructor to JsonPatchMediaTypes class

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
@@ -4,6 +4,10 @@ import org.springframework.http.MediaType;
 
 public class JsonPatchMediaTypes {
 
+	private JsonPatchMediaTypes() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
+
 	public static final String JSON_MERGE_PATCH_VALUE = "application/merge-patch+json";
 
 	public static final MediaType JSON_MERGE_PATCH = MediaType.valueOf(JSON_MERGE_PATCH_VALUE);

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchMediaTypes.java
@@ -4,10 +4,6 @@ import org.springframework.http.MediaType;
 
 public class JsonPatchMediaTypes {
 
-	private JsonPatchMediaTypes() {
-		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
-	}
-
 	public static final String JSON_MERGE_PATCH_VALUE = "application/merge-patch+json";
 
 	public static final MediaType JSON_MERGE_PATCH = MediaType.valueOf(JSON_MERGE_PATCH_VALUE);
@@ -15,5 +11,9 @@ public class JsonPatchMediaTypes {
 	public static final String JSON_PATCH_VALUE = "application/json-patch+json";
 
 	public static final MediaType JSON_PATCH = MediaType.valueOf(JSON_PATCH_VALUE);
+
+	private JsonPatchMediaTypes() {
+		throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
 
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Implicit constructor for `JsonPatchMediaTypes` is now blocked by explicit constructor.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4184](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4184)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
