### PR TITLE
Chained assertions in JsonPatchProcessorTests class.

### DIFF
--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
@@ -39,7 +39,10 @@ class JsonPatchProcessorTests {
 		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
 		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonMergePatch);
 
-		assertThat(patchedEntity).isNotSameAs(entity).hasFieldOrPropertyWithValue("id", "id").hasFieldOrPropertyWithValue("name", "updated name");
+		assertThat(patchedEntity)
+			.isNotSameAs(entity)
+			.hasFieldOrPropertyWithValue("id", "id")
+			.hasFieldOrPropertyWithValue("name", "updated name");
 	}
 
 	@Test
@@ -70,7 +73,10 @@ class JsonPatchProcessorTests {
 		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
 		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonPatch);
 
-		assertThat(patchedEntity).isNotSameAs(entity).hasFieldOrPropertyWithValue("id", "id").hasFieldOrPropertyWithValue("name", "updated name");
+		assertThat(patchedEntity)
+			.isNotSameAs(entity)
+			.hasFieldOrPropertyWithValue("id", "id")
+			.hasFieldOrPropertyWithValue("name", "updated name");
 	}
 
 	@Test

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/web/json/JsonPatchProcessorTests.java
@@ -39,9 +39,7 @@ class JsonPatchProcessorTests {
 		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
 		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonMergePatch);
 
-		assertThat(patchedEntity).isNotSameAs(entity);
-		assertThat(patchedEntity).hasFieldOrPropertyWithValue("id", "id");
-		assertThat(patchedEntity).hasFieldOrPropertyWithValue("name", "updated name");
+		assertThat(patchedEntity).isNotSameAs(entity).hasFieldOrPropertyWithValue("id", "id").hasFieldOrPropertyWithValue("name", "updated name");
 	}
 
 	@Test
@@ -72,9 +70,7 @@ class JsonPatchProcessorTests {
 		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
 		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonPatch);
 
-		assertThat(patchedEntity).isNotSameAs(entity);
-		assertThat(patchedEntity).hasFieldOrPropertyWithValue("id", "id");
-		assertThat(patchedEntity).hasFieldOrPropertyWithValue("name", "updated name");
+		assertThat(patchedEntity).isNotSameAs(entity).hasFieldOrPropertyWithValue("id", "id").hasFieldOrPropertyWithValue("name", "updated name");
 	}
 
 	@Test


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Where applicable, assertions have been chained in the `JsonPatchProcessorTests` class. This addresses sonarlint warnings.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4185](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4185)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
