### PR TITLE
Removed empty statement from LanguageCodeValidator class.

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidator.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/validation/LanguageCodeValidator.java
@@ -15,7 +15,7 @@ public class LanguageCodeValidator implements ConstraintValidator<LanguageCode, 
 		INTERNAL_CODE,
 		ISO_CODE,
 		MS_LOCALE_CODE
-	};
+	}
 
 	private CodeType codeType;
 


### PR DESCRIPTION
### Description

Removed an empty statement in the form of a superfluous semi-colon from the `LanguageCodeValidator` class. This addresses a Sonarlint warning.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->
[
AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4186](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4186)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have added/updated tests that prove my fix is effective or that my feature works
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`