### PR TITLE
AB#4224 -- Spring Data auditor should use the current user

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/DataSourceConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/DataSourceConfig.java
@@ -1,12 +1,6 @@
 package ca.gov.dtsstn.cdcp.api.config;
 
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 /**
@@ -14,17 +8,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
  */
 @Configuration
 @EnableJpaAuditing
-public class DataSourceConfig {
-
-	static final Logger log = LoggerFactory.getLogger(DataSourceConfig.class);
-
-	/**
-	 * Creates an {@link AuditorAware} bean that provides the name of
-	 * the currentauthentication context for auditing purposes.
-	 */
-	@Bean AuditorAware<String> auditor() {
-		log.info("Creating 'auditor' bean");
-		return () -> Optional.of("Canadian Dental Care Plan API");
-	}
-
-}
+public class DataSourceConfig {}

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/DefaultAuditor.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/data/DefaultAuditor.java
@@ -1,0 +1,48 @@
+package ca.gov.dtsstn.cdcp.api.data;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.core.env.Environment;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class DefaultAuditor implements AuditorAware<String> {
+
+	private final String applicationName;
+
+	public DefaultAuditor(Environment environment) {
+		Assert.notNull(environment, "environment is required; it must not be null");
+		this.applicationName = Optional.ofNullable(environment.getProperty("spring.application.name")).orElse("Canadian Dental Care Plan API");
+	}
+
+	@NonNull
+	@Override
+	public Optional<String> getCurrentAuditor() {
+		final var securityContext = SecurityContextHolder.getContext();
+
+		final var user = Optional.ofNullable(securityContext.getAuthentication())
+			.filter(JwtAuthenticationToken.class::isInstance)
+			.map(JwtAuthenticationToken.class::cast)
+			.map(JwtAuthenticationToken::getToken)
+			.map(toUserString())
+			.orElse(applicationName);
+
+		return Optional.of(user);
+	}
+
+	private Function<Jwt, String> toUserString() {
+		return jwt -> {
+			final var userName = Optional.ofNullable(jwt.getClaimAsString("name")).orElse("Service Principal");
+			final var userId = Optional.ofNullable(jwt.getClaimAsString("sub")).orElse("00000000-0000-0000-0000-000000000000");
+			return "%s (id: %s)".formatted(userName, userId);
+		};
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/DefaultAuditorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/cdcp/api/data/DefaultAuditorTests.java
@@ -1,0 +1,77 @@
+package ca.gov.dtsstn.cdcp.api.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@ExtendWith({ MockitoExtension.class })
+class DefaultAuditorTests {
+
+	@Mock Environment environment;
+
+	DefaultAuditor defaultAuditor;
+
+	@BeforeEach
+	void beforeEach() {
+		this.defaultAuditor = new DefaultAuditor(environment);
+	}
+
+	@Test
+	@DisplayName("Test DefaultAuditor.getCurrentAuditor() w/ no authentication")
+	void testGetCurrentAuditor_NoAuth() {
+		SecurityContextHolder.getContext().setAuthentication(null);
+		final var currentAuditor = defaultAuditor.getCurrentAuditor();
+		assertThat(currentAuditor).contains("Canadian Dental Care Plan API");
+	}
+
+	@Test
+	@DisplayName("Test DefaultAuditor.getCurrentAuditor() w/ invalid authentication type")
+	void testGetCurrentAuditor_InvalidAuth() {
+		SecurityContextHolder.getContext().setAuthentication(mock(TestingAuthenticationToken.class));
+		final var currentAuditor = defaultAuditor.getCurrentAuditor();
+		assertThat(currentAuditor).contains("Canadian Dental Care Plan API");
+	}
+
+	@Test
+	@DisplayName("Test DefaultAuditor.getCurrentAuditor() w/ user principal")
+	void testGetCurrentAuditor_UserPrincipal() {
+		final var authentication = mock(JwtAuthenticationToken.class);
+		final var token = mock(Jwt.class);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		when(authentication.getToken()).thenReturn(token);
+		when(token.getClaimAsString("name")).thenReturn("Haffaf, Nicholas Sébastien [NC]");
+		when(token.getClaimAsString("sub")).thenReturn("00000000-0000-0000-0000-000000000000");
+
+		final var currentAuditor = defaultAuditor.getCurrentAuditor();
+		assertThat(currentAuditor).contains("Haffaf, Nicholas Sébastien [NC] (id: 00000000-0000-0000-0000-000000000000)");
+	}
+
+	@Test
+	@DisplayName("Test DefaultAuditor.getCurrentAuditor() w/ service principal")
+	void testGetCurrentAuditor_ServicePrincipal() {
+		final var authentication = mock(JwtAuthenticationToken.class);
+		final var token = mock(Jwt.class);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		when(authentication.getToken()).thenReturn(token);
+		when(token.getClaimAsString("name")).thenReturn(null);
+		when(token.getClaimAsString("sub")).thenReturn("00000000-0000-0000-0000-000000000000");
+
+		final var currentAuditor = defaultAuditor.getCurrentAuditor();
+		assertThat(currentAuditor).contains("Service Principal (id: 00000000-0000-0000-0000-000000000000)");
+	}
+
+}


### PR DESCRIPTION
### Update Spring Data auditor to use current user

### Related Azure Boards Work Items

- [AB#4224](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4224)

### Screenshots (if applicable)

(from h2 console)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48123208/e25c9761-be0e-4b4a-884e-815e514dd0ad)

### Additional Notes

Test coverage is 100%! 🎉
