### PR TITLE
Constructor injection now used in SpringDocConfig class

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/SpringDocConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/config/SpringDocConfig.java
@@ -33,9 +33,15 @@ public class SpringDocConfig {
 
 	static final Logger log = LoggerFactory.getLogger(SpringDocConfig.class);
 
-	@Autowired ApplicationProperties applicationProperties;
+	private final ApplicationProperties applicationProperties;
+	private final GitProperties gitProperties;
 
-	@Autowired GitProperties gitProperties;
+	@Autowired
+	public SpringDocConfig(ApplicationProperties applicationProperties, GitProperties gitProperties) {
+		super();
+		this.applicationProperties = applicationProperties;
+		this.gitProperties = gitProperties;
+	}
 
 	/**
 	 * SpringDoc annotations used to tell Swagger UI that an endpoint is protected by OAuth.


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The `Autowired` field annotations in the `SpringDocConfig` class has been moved to a newly created constructor.
This addresses a sonarlint warning

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4173](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4173)
[AB#4190](https://dev.azure.com/DTS-STN/Canada%20Dental%20Care%20Plan/_workitems/edit/4190)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [X] I have tested the changes locally
- [X] I have checked that my code follows the project's coding style by running `npm run format:check`
- [X] I have checked that my code contains no linting errors by running `npm run lint`
- [X] I have checked that my code contains no type errors by running `npm run typecheck`
- [X] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [X] I have checked that all e2e tests pass by running `npm run test:e2e`
