### PR TITLE
fix(frontend): valid sin cannot consist entirely of zeros

### DIFF
--- a/frontend/__tests__/utils/sin-utils.test.ts
+++ b/frontend/__tests__/utils/sin-utils.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
 
 describe('isValidSin', () => {
-  it.each([['130692544'], ['178302576'], ['549831204'], ['130 692 544'], ['178 302 576'], ['549 831 204'], ['130-692-544'], ['178-302-576'], ['549-831-204']])('should return true for valid SIN "%s"', (sin) => {
+  it.each([['000000042'], ['000 000 042'], ['000-000-042'], ['800000002'], ['800 000 002'], ['800-000-002']])('should return true for valid SIN "%s"', (sin) => {
     expect(isValidSin(sin)).toEqual(true);
   });
 
-  it.each([['000000000'], ['451987368'], ['736194850'], ['000 000 000'], ['451 987 368'], ['736 194 850'], ['000-000-000'], ['451-987-368'], ['736-194-850']])('should return false for invalid SIN "%s"', (sin) => {
+  it.each([['000000000'], ['000 000 000'], ['000-000-000'], ['800000003'], ['800 000 003'], ['800-000-003']])('should return false for invalid SIN "%s"', (sin) => {
     expect(isValidSin(sin)).toEqual(false);
   });
 

--- a/frontend/app/utils/sin-utils.ts
+++ b/frontend/app/utils/sin-utils.ts
@@ -1,4 +1,25 @@
-const sinRegex = /^[1-9]\d{2}[ -]?\d{3}[ -]?\d{3}$/;
+/**
+ * Regular expression to validate Canadian SIN (Social Insurance Number) format.
+ *
+ * The SIN must follow the format XXXXXXXXX or XXX XXX XXX or XXX-XXX-XXX.
+ * The SIN number cannot consist entirely of zeros (e.g., 000000000 or 000 000 000 or 000-000-000 is not valid).
+ *
+ * Note: This regular expression only validates the format of the SIN.
+ * Consumers must validate the SIN against the Luhn algorithm separately.
+ *
+ * Examples of valid SIN formats:
+ * - 123-456-789
+ * - 123 456 789
+ * - 123456789
+ * - 000-000-010
+ *
+ * Examples of invalid SIN formats:
+ * - 000-000-000
+ * - 000000000
+ * - 123-45-6789
+ * - ABC-DEF-GHI
+ */
+const sinFormatRegex = /^(?!0{3}[ -]?0{3}[ -]?0{3})\d{3}[ -]?\d{3}[ -]?\d{3}$/;
 
 /**
  *
@@ -17,7 +38,7 @@ const sinRegex = /^[1-9]\d{2}[ -]?\d{3}[ -]?\d{3}$/;
  *
  */
 export function isValidSin(sin: string): boolean {
-  if (!sinRegex.test(sin)) return false;
+  if (!sinFormatRegex.test(sin)) return false;
   const multDigitString = [...sin.replace(/\D/g, '')].map((digit, index) => Number(digit) * (index % 2 === 0 ? 1 : 2)).join('');
   const digitSum = [...multDigitString].reduce((acc, cur) => acc + Number(cur), 0);
   return digitSum % 10 === 0;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Change SIN validation to accepts number starting by 0 but cannot consist entirely of zeros.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4241](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4241)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Invalid with only zeros
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/2554d887-04c8-4034-9acd-10f2562411da)

Valid when it starts with zero
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/74368072-dc8e-43cc-995c-1b52353dc1a3)

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->