### PR TITLE
AB#4225 -- Adding and configuring `opentelemetry-spring-boot-starter`

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -45,6 +45,8 @@
 		<jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 		<johnzon.version>2.0.1</johnzon.version>
 		<mapstruct.version>1.5.5.Final</mapstruct.version>
+		<opentelemetry-bom.version>1.39.0</opentelemetry-bom.version>
+		<opentelemetry-instrumentation-bom.version>2.5.0-alpha</opentelemetry-instrumentation-bom.version>
 		<spring-boot.version>3.3.1</spring-boot.version>
 		<springdoc.version>2.5.0</springdoc.version>
 	</properties>
@@ -76,6 +78,10 @@
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>${mapstruct.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry.instrumentation</groupId>
+			<artifactId>opentelemetry-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
@@ -119,7 +125,7 @@
 		</dependency>
 
 		<!-- optional/provided dependencies -->
-		
+
 		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>builder</artifactId>
@@ -160,6 +166,26 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-bom</artifactId>
+				<version>${opentelemetry-bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.opentelemetry.instrumentation</groupId>
+				<artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+				<version>${opentelemetry-instrumentation-bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 
 	<build>

--- a/backend/src/main/resources/application-local.yml.sample
+++ b/backend/src/main/resources/application-local.yml.sample
@@ -21,6 +21,17 @@ spring:
 
 ---
 
+otel:
+  exporter:
+    otlp:
+      endpoint: https://example.com/e/00000000-0000-0000-0000-000000000000/api/v2/otlp
+  metrics:
+    exporter: otlp
+  traces:
+    exporter: otlp
+
+---
+
 springdoc:
   swagger-ui:
     oauth:
@@ -30,6 +41,8 @@ springdoc:
 ---
 
 application:
+  otel:
+    api-token: dt0c01.xxxxxxxxxxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
   security:
     enabled: true
   swagger-ui:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -95,6 +95,32 @@ management:
 ---
 
 #
+# OpenTelemetry configuration properties, see:
+# https://opentelemetry.io/docs/languages/java/configuration
+#
+
+otel:
+  #
+  # ⚠️ OpenTelemetry exporter settings must be configured externally
+  # when `otel.(logs|metrics|traces).exporter` is set to `otlp`
+  #
+  exporter:
+    otlp:
+      endpoint: https://example.com/e/00000000-0000-0000-0000-000000000000/api/v2/otlp
+      headers:
+        authorization: Api-Token ${application.otel.api-token}
+  logs:
+    exporter: none
+  metrics:
+    exporter: none
+  service:
+    name: Canadian Dental Care Plan API
+  traces:
+    exporter: none
+
+---
+
+#
 # Server configuration properties, see:
 # https://docs.spring.io/spring-boot/docs/3.2.x/reference/html/application-properties.html#appendix.application-properties.server
 #
@@ -155,6 +181,8 @@ application:
         value: 24
         time-unit: hours
       length: 5
+  otel:
+    api-token: dt0c01.xxxxxxxxxxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
   swagger-ui:
     application-name: Canadian Dental Care Plan API
     contact-name: Digital Technology Solutions


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
[AB#4225](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4225)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/590ce5a6-5a95-4ac9-915a-ec80c04fb1d2)

### Test Instructions
1. Copy `application-local.yml.sample` to your `application-local.yml` file to enable exporting of metrics and traces
3. Update the `otel.exporter.otlp.endpoint` config to be our development endpoint: 
`https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp`
4. Update the `application.otel.api-token` to use our development API key (from vault)
5. Run application and make a request. 
6. Login to our Dynatrace development instance and find the Canadian Dental Care Plan API service. Click around and make sense of stuff.