### PR TITLE
Returning 405 for GET `/users/{userId}/email-validations`

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsController.java
@@ -1,10 +1,7 @@
 package ca.gov.dtsstn.cdcp.api.web.v1.controller;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -21,7 +18,6 @@ import ca.gov.dtsstn.cdcp.api.config.SpringDocConfig.OAuthSecurityRequirement;
 import ca.gov.dtsstn.cdcp.api.service.UserService;
 import ca.gov.dtsstn.cdcp.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.cdcp.api.web.v1.model.EmailValidationModel;
-import ca.gov.dtsstn.cdcp.api.web.v1.model.mapper.AbstractModelMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,16 +39,13 @@ public class EmailValidationsController {
 	}
 
 	@GetMapping
+	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
 	@Operation(summary = "List all email validations for a user")
-	public CollectionModel<EmailValidationModel> getEmailValidationByUserId(
+	public ResponseEntity<Void> getEmailValidationByUserId(
 			@NotBlank(message = "userId must not be null or blank")
 			@Parameter(description = "The ID of the user.", example = "00000000-0000-0000-0000-000000000000")
 			@PathVariable String userId) {
-		userService.getUserById(userId)
-			.orElseThrow(() -> new ResourceNotFoundException("No user with id=[%s] was found".formatted(userId)));
-
-		return AbstractModelMapper.wrapCollection(CollectionModel.empty(), EmailValidationModel.class)
-			.add(linkTo(methodOn(getClass()).getEmailValidationByUserId(userId)).withSelfRel());
+		return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
 	}
 
 	@PostMapping

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/EmailValidationsController.java
@@ -46,7 +46,7 @@ public class EmailValidationsController {
 	@Operation(summary = "List all email validations for a user")
 	public CollectionModel<EmailValidationModel> getEmailValidationByUserId(
 			@NotBlank(message = "userId must not be null or blank")
-			@Parameter(description = "The ID of the user.", required = true)
+			@Parameter(description = "The ID of the user.", example = "00000000-0000-0000-0000-000000000000")
 			@PathVariable String userId) {
 		userService.getUserById(userId)
 			.orElseThrow(() -> new ResourceNotFoundException("No user with id=[%s] was found".formatted(userId)));
@@ -60,7 +60,7 @@ public class EmailValidationsController {
 	@Operation(summary = "Create a new email validation for a user")
 	public void verifyConfirmationCodeStatus(
 			@NotBlank(message = "userId must not be null or blank")
-			@Parameter(description = "The ID of the user.", required = true)
+			@Parameter(description = "The ID of the user.", example = "00000000-0000-0000-0000-000000000000")
 			@PathVariable String userId,
 
 			@Validated @RequestBody EmailValidationModel emailValidationModel,

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/SubscriptionsController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/controller/SubscriptionsController.java
@@ -117,7 +117,7 @@ public class SubscriptionsController {
 	}
 
 	@GetMapping({ "/{subscriptionId}" })
-	@Operation(summary = "Get a subscriptions by ID")
+	@Operation(summary = "Get a subscription by ID")
 	public SubscriptionModel getSubscriptionById(
 			@NotBlank(message = "userId must not be null or blank")
 			@Parameter(description = "The id of the user.", example = "00000000-0000-0000-0000-000000000000")

--- a/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/cdcp/api/web/v1/model/UserAttributeCreateModel.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Immutable
-@Schema(name = "userAttribute")
+@Schema(name = "UserAttributeCreate")
 @JsonDeserialize(as = ImmutableUserAttributeCreateModel.class)
 public interface UserAttributeCreateModel {
 
 	@NotBlank
-	public String getName(); 
+	public String getName();
 
 	@NotBlank
 	public String getValue();


### PR DESCRIPTION
### Description
...and some refactoring of annotation attributes.

GET `/users/{userId}/email-validations` was originally exposed to create a HATEOAS `link` from the user resource and would return a 200 with an empty collection. The response has been changed to return a 405 - Method not allowed, which is more suitable.

Also removed `required` attribute from `@Parameter` because `@PathVariable`s are required by default.

### Screenshots (if applicable)
**Before:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/02757eda-71f7-4681-8fd4-3a6703633fbf)

**After:**
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/55502055/552c2052-5307-4b41-860c-0bad8432c814)

### Test Instructions
Run application locally and try a request to GET `/users/{userId}/email-validations`. A 405 should be returned.
