### PR TITLE
h1 heading max-width

### DIFF
--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -46,9 +46,11 @@ export function PublicLayout({ children }: PropsWithChildren) {
 export function AppPageTitle({ children }: PropsWithChildren) {
   const { t } = useTranslation(i18nNamespaces);
   return (
-    <div className="my-8 max-w-prose border-b border-red-800">
-      <h2 className="font-lato text-lg text-stone-500 sm:text-xl">{t('gcweb:header.application-title')}</h2>
-      <PageTitle>{children}</PageTitle>
+    <div className="my-8 border-b border-red-800">
+      <div className="max-w-prose">
+        <h2 className="font-lato text-lg text-stone-500 sm:text-xl">{t('gcweb:header.application-title')}</h2>
+        <PageTitle>{children}</PageTitle>
+      </div>
     </div>
   );
 }

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -46,7 +46,7 @@ export function PublicLayout({ children }: PropsWithChildren) {
 export function AppPageTitle({ children }: PropsWithChildren) {
   const { t } = useTranslation(i18nNamespaces);
   return (
-    <div className="my-8 border-b border-red-800">
+    <div className="my-8 max-w-prose border-b border-red-800">
       <h2 className="font-lato text-lg text-stone-500 sm:text-xl">{t('gcweb:header.application-title')}</h2>
       <PageTitle>{children}</PageTitle>
     </div>


### PR DESCRIPTION
### Description
Pages such as the federal-provincial-territorial has very long title, heading should have the same width as the content according to Figma. Added max-width to h1 heading.

### Screenshots (if applicable)
<img width="760" alt="Screenshot 2024-07-02 at 12 17 27 PM" src="https://github.com/DTS-STN/canadian-dental-care-plan/assets/64853947/fe66c09c-e253-4e65-9179-472482861b77">
<img width="945" alt="Screenshot 2024-07-02 at 12 17 12 PM" src="https://github.com/DTS-STN/canadian-dental-care-plan/assets/64853947/ee266a0c-b709-41fa-a45a-25b35d04c05d">


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->