### PR TITLE
Adding status checker date validation.

### DIFF
--- a/frontend/app/routes/$lang/_public/status/child.tsx
+++ b/frontend/app/routes/$lang/_public/status/child.tsx
@@ -272,6 +272,7 @@ export default function StatusCheckerChild() {
       sin: errors?.sin?._errors[0],
       'first-name': errors?.firstName?._errors[0],
       'last-name': errors?.lastName?._errors[0],
+      'date-picker-date-of-birth': errors?.dateOfBirth?._errors[0],
       'date-picker-date-of-birth-year': errors?.dateOfBirthYear?._errors[0],
       'date-picker-date-of-birth-month': errors?.dateOfBirthMonth?._errors[0],
       'date-picker-date-of-birth-day': errors?.dateOfBirthDay?._errors[0],
@@ -386,6 +387,7 @@ export default function StatusCheckerChild() {
                     legend={t('status:child.form.date-of-birth-label')}
                     required
                     errorMessages={{
+                      all: errorMessages['date-picker-date-of-birth'],
                       year: errorMessages['date-picker-date-of-birth-year'],
                       month: errorMessages['date-picker-date-of-birth-month'],
                       day: errorMessages['date-picker-date-of-birth-day'],


### PR DESCRIPTION
### Description
Implementing date picker validation for status checker. (Child has no SIN route)

### Related Azure Boards Work Items
[AB#4243](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4243)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/status` and select "I am submitting for a child"
Select "Child has no SIN"
Applciation Code: 2461733341149
Play around with the dates. (Make it fail with ridiculous dates, even unreal dates (ex.: Year 33333))