### PR TITLE
Refactor InputSinField to generic InputPatternField

### DIFF
--- a/frontend/__tests__/components/input-pattern-field.test.tsx
+++ b/frontend/__tests__/components/input-pattern-field.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { InputSinField } from '~/components/input-sin-field';
+import { InputPatternField } from '~/components/input-pattern-field';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -10,11 +10,13 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-describe('InputSinField', () => {
+describe('InputPatternField', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
   });
+
+  const testFormat = '### ### ###';
 
   it.each([
     ['800000002', '800 000 002'],
@@ -23,10 +25,10 @@ describe('InputSinField', () => {
     ['800 000-002', '800 000 002'],
     ['800000 002', '800 000 002'],
     ['800000-002', '800 000 002'],
-  ])('should render %s -> %s', (sin, expected) => {
-    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} />);
+  ])('should render %s -> %s', (defaultValue, expected) => {
+    render(<InputPatternField id="test-id" name="test" label="label test" defaultValue={defaultValue} format={testFormat} />);
 
-    const actual: HTMLInputElement = screen.getByTestId('input-sin-field');
+    const actual: HTMLInputElement = screen.getByTestId('input-pattern-field');
 
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAccessibleName('label test');
@@ -37,10 +39,9 @@ describe('InputSinField', () => {
   });
 
   it('should render with help message', () => {
-    const sin = '800000002';
-    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} helpMessageSecondary="help message" />);
+    render(<InputPatternField id="test-id" name="test" label="label test" format={testFormat} defaultValue="800000002" helpMessageSecondary="help message" />);
 
-    const actual = screen.getByTestId('input-sin-field');
+    const actual = screen.getByTestId('input-pattern-field');
 
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAccessibleDescription('help message');
@@ -51,10 +52,9 @@ describe('InputSinField', () => {
   });
 
   it('should render with required', () => {
-    const sin = '800000002';
-    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} required />);
+    render(<InputPatternField id="test-id" name="test" label="label test" format={testFormat} defaultValue="800000002" required />);
 
-    const actual = screen.getByTestId('input-sin-field');
+    const actual = screen.getByTestId('input-pattern-field');
 
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAttribute('id', 'test-id');
@@ -64,10 +64,9 @@ describe('InputSinField', () => {
   });
 
   it('should render with error message', () => {
-    const sin = '800000002';
-    render(<InputSinField id="test-id" name="test" label="label test" defaultValue={sin} errorMessage="error message" />);
+    render(<InputPatternField id="test-id" name="test" label="label test" format={testFormat} defaultValue="800000002" errorMessage="error message" />);
 
-    const actual = screen.getByTestId('input-sin-field');
+    const actual = screen.getByTestId('input-pattern-field');
 
     expect(actual).toBeInTheDocument();
     expect(actual).toHaveAccessibleName('label test');

--- a/frontend/__tests__/utils/sin-utils.test.ts
+++ b/frontend/__tests__/utils/sin-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 describe('isValidSin', () => {
   it.each([['000000042'], ['000 000 042'], ['000-000-042'], ['800000002'], ['800 000 002'], ['800-000-002']])('should return true for valid SIN "%s"', (sin) => {
@@ -35,5 +35,11 @@ describe('formatSin', () => {
 
   it('should throw an error for invalid SIN', () => {
     expect(() => formatSin('123456789')).toThrowError();
+  });
+});
+
+describe('sinInputPatternFormat', () => {
+  it('should have correct format', () => {
+    expect(sinInputPatternFormat).toBe('### ### ###');
   });
 });

--- a/frontend/app/components/input-pattern-field.tsx
+++ b/frontend/app/components/input-pattern-field.tsx
@@ -10,9 +10,10 @@ const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-non
 const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
 const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
-export interface InputSinFieldProps extends OmitStrict<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'value' | 'onChange' | 'format'> {
+export interface InputPatternFieldProps extends OmitStrict<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'value' | 'onChange'> {
   defaultValue: string;
   errorMessage?: string;
+  format: string;
   helpMessagePrimary?: React.ReactNode;
   helpMessagePrimaryClassName?: string;
   helpMessageSecondary?: React.ReactNode;
@@ -22,10 +23,10 @@ export interface InputSinFieldProps extends OmitStrict<React.ComponentProps<type
   name: string;
 }
 
-export function InputSinField(props: InputSinFieldProps) {
+export function InputPatternField(props: InputPatternFieldProps) {
   const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
 
-  const inputWrapperId = `input-sin-field-${id}`;
+  const inputWrapperId = `input-pattern-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
   const inputHelpMessagePrimaryId = `${inputWrapperId}-help-primary`;
   const inputHelpMessageSecondaryId = `${inputWrapperId}-help-secondary`;
@@ -50,7 +51,7 @@ export function InputSinField(props: InputSinFieldProps) {
         </p>
       )}
       {helpMessagePrimary && (
-        <InputHelp id={inputHelpMessagePrimaryId} className={cn('mb-2', helpMessagePrimaryClassName)} data-testid="input-sin-field-help-primary">
+        <InputHelp id={inputHelpMessagePrimaryId} className={cn('mb-2', helpMessagePrimaryClassName)} data-testid="input-pattern-field-help-primary">
           {helpMessagePrimary}
         </InputHelp>
       )}
@@ -60,8 +61,7 @@ export function InputSinField(props: InputSinFieldProps) {
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        data-testid="input-sin-field"
-        format="### ### ###"
+        data-testid="input-pattern-field"
         id={id}
         className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
         required={required}
@@ -69,7 +69,7 @@ export function InputSinField(props: InputSinFieldProps) {
         {...restProps}
       />
       {helpMessageSecondary && (
-        <InputHelp id={inputHelpMessageSecondaryId} className={cn('mt-2', helpMessageSecondaryClassName)} data-testid="input-sin-field-help-secondary">
+        <InputHelp id={inputHelpMessageSecondaryId} className={cn('mt-2', helpMessageSecondaryClassName)} data-testid="input-pattern-field-help-secondary">
           {helpMessageSecondary}
         </InputHelp>
       )}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
@@ -14,10 +14,10 @@ import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { ApplicantInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -32,7 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -242,9 +242,10 @@ export default function ApplyFlowApplicationInformation() {
                 required
               />
             </div>
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('applicant-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-adult-child:applicant-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -16,10 +16,10 @@ import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { ChildInformationState, ChildSinState } from '~/route-helpers/apply-route-helpers.server';
@@ -33,7 +33,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -270,9 +270,10 @@ export default function ApplyFlowChildInformation() {
       defaultChecked: defaultState?.hasSocialInsuranceNumber === true,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-          <InputSinField
+          <InputPatternField
             id="social-insurance-number"
             name="socialInsuranceNumber"
+            format={sinInputPatternFormat}
             label={t('apply-adult-child:children.information.sin')}
             inputMode="numeric"
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
@@ -16,8 +16,8 @@ import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -31,7 +31,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -269,9 +269,10 @@ export default function ApplyFlowApplicationInformation() {
               }}
               required
             />
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('apply-adult-child:partner-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-adult-child:partner-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -14,10 +14,10 @@ import pageIds from '../../../../page-ids.json';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { ApplicantInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -32,7 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -236,9 +236,10 @@ export default function ApplyFlowApplicationInformation() {
                 required
               />
             </div>
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('applicant-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-adult:applicant-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -16,8 +16,8 @@ import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -31,7 +31,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -263,9 +263,10 @@ export default function ApplyFlowApplicationInformation() {
               }}
               required
             />
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('apply-adult:partner-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-adult:partner-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
@@ -16,10 +16,10 @@ import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { ApplicantInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -35,7 +35,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -341,9 +341,10 @@ export default function ApplyFlowApplicationInformation() {
               }}
               required
             />
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('applicant-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-child:applicant-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -16,10 +16,10 @@ import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { ChildInformationState, ChildSinState } from '~/route-helpers/apply-route-helpers.server';
@@ -33,7 +33,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -270,9 +270,10 @@ export default function ApplyFlowChildInformation() {
       defaultChecked: defaultState?.hasSocialInsuranceNumber === true,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-          <InputSinField
+          <InputPatternField
             id="social-insurance-number"
             name="socialInsuranceNumber"
+            format={sinInputPatternFormat}
             label={t('apply-child:children.information.sin')}
             inputMode="numeric"
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}

--- a/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
@@ -16,8 +16,8 @@ import { DatePickerField } from '~/components/date-picker-field';
 import type { ErrorSummaryItem } from '~/components/error-summary';
 import { ErrorSummary, createErrorSummaryItem, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -31,7 +31,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -268,9 +268,10 @@ export default function ApplyFlowApplicationInformation() {
               }}
               required
             />
-            <InputSinField
+            <InputPatternField
               id="social-insurance-number"
               name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
               label={t('apply-child:partner-information.sin')}
               inputMode="numeric"
               helpMessagePrimary={t('apply-child:partner-information.help-message.sin')}

--- a/frontend/app/routes/$lang/_public/status/child/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/child/index.tsx
@@ -18,9 +18,9 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { DatePickerField } from '~/components/date-picker-field';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
+import { InputPatternField } from '~/components/input-pattern-field';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { InputSinField } from '~/components/input-sin-field';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
@@ -35,7 +35,7 @@ import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -347,7 +347,9 @@ export default function StatusCheckerChild() {
                   errorMessage={errorMessages['input-radio-child-has-sin-option-0']}
                   required
                 />
-                {childHasSinState === true && <InputSinField id="sin" name="sin" label={t('status:child.form.sin-label')} helpMessagePrimary={t('status:child.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />}
+                {childHasSinState === true && (
+                  <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t('status:child.form.sin-label')} helpMessagePrimary={t('status:child.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />
+                )}
                 {childHasSinState === false && (
                   <>
                     <Collapsible summary={t('status:child.form.if-child-summary')} className="mt-8">

--- a/frontend/app/routes/$lang/_public/status/myself/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/myself/index.tsx
@@ -16,7 +16,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { InputSinField } from '~/components/input-sin-field';
+import { InputPatternField } from '~/components/input-pattern-field';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
@@ -30,7 +30,7 @@ import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
-import { formatSin, isValidSin } from '~/utils/sin-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { cn } from '~/utils/tw-utils';
 
 export const handle = {
@@ -211,7 +211,7 @@ export default function StatusCheckerMyself() {
               {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
               <div className="mb-8 space-y-6">
                 <InputField id="code" name="code" label={t('status:myself.form.application-code-label')} helpMessagePrimary={t('status:myself.form.application-code-description')} required errorMessage={errorMessages.code} />
-                <InputSinField id="sin" name="sin" label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />
+                <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errorMessages.sin} defaultValue="" />
               </div>
               <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit">
                 {t('status:myself.form.submit')}

--- a/frontend/app/utils/sin-utils.ts
+++ b/frontend/app/utils/sin-utils.ts
@@ -22,6 +22,17 @@
 const sinFormatRegex = /^(?!0{3}[ -]?0{3}[ -]?0{3})\d{3}[ -]?\d{3}[ -]?\d{3}$/;
 
 /**
+ * This pattern is intended for use with the `format` property of the `InputPatternField` component.
+ *
+ * Example:
+ * ```typescript
+ * // Usage with InputPatternField
+ * <InputPatternField format={sinInputPatternFormat} />
+ * ```
+ */
+export const sinInputPatternFormat = '### ### ###';
+
+/**
  *
  * @param sin - the Social Insurance Number (SIN)
  * @returns a boolean indicating if a SIN is valid using Luhn's Algorithm


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Refactor `InputSinField` into a generic `InputPatternField` to enhance the component's usability. This refactoring will allow us to reuse the component within the status checker application code.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->