### PR TITLE
4244 add descriptive page title to status checker

### DIFF
--- a/frontend/app/routes/$lang/_public/status/_route.tsx
+++ b/frontend/app/routes/$lang/_public/status/_route.tsx
@@ -1,9 +1,21 @@
 import { Outlet } from '@remix-run/react';
 
+import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
+} as const satisfies RouteHandleData;
+
 /**
  * Do-nothing parent route.
  * (placeholder for future code)
  */
 export default function Route() {
-  return <Outlet />;
+  return (
+    <PublicLayout>
+      <Outlet />
+    </PublicLayout>
+  );
 }

--- a/frontend/app/routes/$lang/_public/status/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/index.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 import { useEffect, useMemo } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
@@ -17,7 +17,6 @@ import { Collapsible } from '~/components/collapsible';
 import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
 import { InputRadios } from '~/components/input-radios';
-import { PublicLayout } from '~/components/layouts/public-layout';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { featureEnabled, getEnv } from '~/utils/env.server';
@@ -25,8 +24,10 @@ import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
 import { cn } from '~/utils/tw-utils';
 
 enum CheckFor {
@@ -39,6 +40,10 @@ export const handle = {
   pageIdentifier: pageIds.public.status.index,
   pageTitleI18nKey: 'status:page-title',
 } as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
 
 export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
@@ -147,91 +152,89 @@ export default function StatusChecker() {
   const canadaTermsConditions = <InlineLink to={t('status:links.canada-terms-conditions')} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <PublicLayout>
-      <div className="max-w-prose">
-        <div>
-          <h2 className="font-bold">{t('status:status-checker-heading')}</h2>
-          <p className="mb-4">{t('status:status-checker-content')}</p>
-          <h2 className="font-bold">{t('status:online-status-heading')}</h2>
-          <p className="mb-4">{t('status:online-status-content')}</p>
-          <p className="mb-4">{t('status:terms-conditions')}</p>
-        </div>
-        <Collapsible summary={t('status:terms-of-use.summary')} className="mt-8">
-          <div className="space-y-4">
-            <h2 className="mb-4 font-bold">{t('status:terms-of-use.heading')}</h2>
-            <p>{t('status:terms-of-use.thank-you')}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.legal-terms" components={{ canadaTermsConditions }} />
-            </p>
-            <p>{t('status:terms-of-use.access-terms')}</p>
-            <p>{t('status:terms-of-use.maintenance')}</p>
-            <p>{t('status:terms-of-use.inactive')}</p>
-            <p>{t('status:terms-of-use.terms-rejection-policy')}</p>
-
-            <p>{t('status:terms-of-use.esdc-definition-clarification')}</p>
-            <p className="font-bold">{t('status:terms-of-use.status-checker.heading')}</p>
-            <ul className="list-disc space-y-1 pl-7">
-              <li>{t('status:terms-of-use.status-checker.self-agreement')}</li>
-              <li>{t('status:terms-of-use.status-checker.on-behalf-of-someone-else')}</li>
-              <li>{t('status:terms-of-use.status-checker.at-your-own-risk')}</li>
-              <li>{t('status:terms-of-use.status-checker.only-use')}</li>
-              <li>
-                <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.status-checker.msdc" components={{ microsoftServiceAgreement }} />
-              </li>
-              <li>
-                <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.status-checker.antibot" components={{ hcaptchaTermsOfService }} />
-              </li>
-            </ul>
-            <h2 className="font-bold">{t('status:terms-of-use.changes-to-these-terms-of-use.heading')}</h2>
-            <p>{t('status:terms-of-use.changes-to-these-terms-of-use.esdc-terms-amendment-policy')}</p>
-          </div>
-        </Collapsible>
-        <Collapsible summary={t('status:privacy-notice-statement.summary')} className="my-8">
-          <div className="space-y-4">
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.collection-of-use" components={{ cite: <cite /> }} />
-            </p>
-            <p>{t('status:privacy-notice-statement.provided-information')}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.third-party-provider" components={{ microsoftDataPrivacyPolicy }} />
-            </p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.personal-information" components={{ cite: <cite /> }} />
-            </p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.report-a-concern" components={{ fileacomplaint }} />
-            </p>
-          </div>
-        </Collapsible>
-        <p className="mb-4 italic">{t('status:form.complete-fields')}</p>
-        {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
-        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
-          <input type="hidden" name="_csrf" value={csrfToken} />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
-          <fieldset>
-            <InputRadios
-              id="status-check-for"
-              name="statusCheckFor"
-              legend={t('status:form.radio-legend')}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.myself" />,
-                  value: CheckFor.Myself,
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.child" />,
-                  value: CheckFor.Child,
-                },
-              ]}
-              required
-            />
-          </fieldset>
-          <Button variant="primary" id="submit" disabled={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit">
-            {t('status:form.continue')}
-            <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
-          </Button>
-        </fetcher.Form>
+    <div className="max-w-prose">
+      <div>
+        <h2 className="font-bold">{t('status:status-checker-heading')}</h2>
+        <p className="mb-4">{t('status:status-checker-content')}</p>
+        <h2 className="font-bold">{t('status:online-status-heading')}</h2>
+        <p className="mb-4">{t('status:online-status-content')}</p>
+        <p className="mb-4">{t('status:terms-conditions')}</p>
       </div>
-    </PublicLayout>
+      <Collapsible summary={t('status:terms-of-use.summary')} className="mt-8">
+        <div className="space-y-4">
+          <h2 className="mb-4 font-bold">{t('status:terms-of-use.heading')}</h2>
+          <p>{t('status:terms-of-use.thank-you')}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.legal-terms" components={{ canadaTermsConditions }} />
+          </p>
+          <p>{t('status:terms-of-use.access-terms')}</p>
+          <p>{t('status:terms-of-use.maintenance')}</p>
+          <p>{t('status:terms-of-use.inactive')}</p>
+          <p>{t('status:terms-of-use.terms-rejection-policy')}</p>
+
+          <p>{t('status:terms-of-use.esdc-definition-clarification')}</p>
+          <p className="font-bold">{t('status:terms-of-use.status-checker.heading')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('status:terms-of-use.status-checker.self-agreement')}</li>
+            <li>{t('status:terms-of-use.status-checker.on-behalf-of-someone-else')}</li>
+            <li>{t('status:terms-of-use.status-checker.at-your-own-risk')}</li>
+            <li>{t('status:terms-of-use.status-checker.only-use')}</li>
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.status-checker.msdc" components={{ microsoftServiceAgreement }} />
+            </li>
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey="status:terms-of-use.status-checker.antibot" components={{ hcaptchaTermsOfService }} />
+            </li>
+          </ul>
+          <h2 className="font-bold">{t('status:terms-of-use.changes-to-these-terms-of-use.heading')}</h2>
+          <p>{t('status:terms-of-use.changes-to-these-terms-of-use.esdc-terms-amendment-policy')}</p>
+        </div>
+      </Collapsible>
+      <Collapsible summary={t('status:privacy-notice-statement.summary')} className="my-8">
+        <div className="space-y-4">
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.collection-of-use" components={{ cite: <cite /> }} />
+          </p>
+          <p>{t('status:privacy-notice-statement.provided-information')}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.third-party-provider" components={{ microsoftDataPrivacyPolicy }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.personal-information" components={{ cite: <cite /> }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey="status:privacy-notice-statement.report-a-concern" components={{ fileacomplaint }} />
+          </p>
+        </div>
+      </Collapsible>
+      <p className="mb-4 italic">{t('status:form.complete-fields')}</p>
+      {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+        <fieldset>
+          <InputRadios
+            id="status-check-for"
+            name="statusCheckFor"
+            legend={t('status:form.radio-legend')}
+            options={[
+              {
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.myself" />,
+                value: CheckFor.Myself,
+              },
+              {
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.child" />,
+                value: CheckFor.Child,
+              },
+            ]}
+            required
+          />
+        </fieldset>
+        <Button variant="primary" id="submit" disabled={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit">
+          {t('status:form.continue')}
+          <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
+        </Button>
+      </fetcher.Form>
+    </div>
   );
 }


### PR DESCRIPTION
### Description
This failed the a11y audit because the status checker lacked a descriptive title. \

- moved the `PublicLayout` component to wrap the `Outlet` in the root `_route.tsx` file so it doesn't have to be duplicated
- added the necessary function to pull the page title out of the locales and have it rendered in the layout

### Related Azure Boards Work Items
[AB#4244](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4244)

### Screenshots (if applicable)
before:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/3c8a11e5-599a-4a55-93bc-7e17ccaffbc4)


after:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/9cb75577-8ab3-4b66-b10c-6a8c162b9e25)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`