### PR TITLE
add optional text to label on childs first name field

### DIFF
--- a/frontend/public/locales/en/status.json
+++ b/frontend/public/locales/en/status.json
@@ -107,7 +107,7 @@
       "if-child-summary": "If the child has a single legal name",
       "if-child-desc": "If the child goes by a single legal name, leave the first name field blank",
       "last-name": "Child's last name",
-      "first-name": "Child's first name",
+      "first-name": "Child's first name (optional)",
       "date-of-birth-label": "Child's date of birth",
       "submit": "Check status",
       "error-message": {

--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -107,7 +107,7 @@
       "if-child-summary": "Si l'enfant a un seul nom légal",
       "if-child-desc": "Si l'enfant porte un seul nom légal, laissez le champ du prénom vide.",
       "last-name": "Nom de famille de l'enfant",
-      "first-name": "Prénom de l'enfant",
+      "first-name": "Prénom de l'enfant (facultatif)",
       "date-of-birth-label": "Date de naissance de l'enfant",
       "submit": "Vérifier l'état",
       "error-message": {


### PR DESCRIPTION
### Description
This was a failure from the a11y audit.  Because the child's first name can be blank, it needs to explicitly marked as optional in the label.

### Related Azure Boards Work Items
[AB#4244](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4244)
