### PR TITLE
Add `bindHostToBuilder` to enable podman support

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -288,6 +288,13 @@
 					<image>
 						<name>${image.name}:${image.tag}</name>
 					</image>
+					<docker>
+						<!--
+							when true, the value of the DOCKER_HOST environment variable will be provided to the CNB builder
+							see https://docs.spring.io/spring-boot/maven-plugin/build-image.html#build-image.examples.docker.podman
+						-->
+						<bindHostToBuilder>true</bindHostToBuilder>
+					</docker>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
### Enable podman support

When building with podman, the `DOCKER_HOST` environment variable must be set. The `bindHostToBuilder` spring-boot-maven-plugin parameter will expose this `DOCKER_HOST` variable to the CNB builder so that it can use it.

See: <https://docs.spring.io/spring-boot/maven-plugin/build-image.html#build-image.examples.docker.podman>