### PR TITLE
refactor status checker

### DIFF
--- a/frontend/app/services/lookup-service.server.ts
+++ b/frontend/app/services/lookup-service.server.ts
@@ -492,10 +492,24 @@ function createLookupService() {
     return clientFriendlyStatuses;
   }
 
+  function getClientFriendlyStatusById(id: string) {
+    log.debug('Fetching client friendly status');
+
+    const clientFriendlyStatus = getAllClientFriendlyStatuses().find((status) => status.id === id);
+
+    if (!clientFriendlyStatus) {
+      throw new Error(`Failed to find client friendly status; id: ${id}`);
+    }
+
+    log.trace('Returning client friendly statuse: [%j]', clientFriendlyStatus);
+    return clientFriendlyStatus;
+  }
+
   return {
     getAllAvoidedDentalCostTypes: moize.promise(getAllAvoidedDentalCostTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_AVOIDED_DENTAL_COST_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllAvoidedDentalCostTypes memo') }),
     getAllBornTypes: moize.promise(getAllBornTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_BORN_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllBornTypes memo') }),
     getAllClientFriendlyStatuses: moize(getAllClientFriendlyStatuses, { maxAge: 1000 * LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllClientFriendlyStatuses memo') }),
+    getClientFriendlyStatusById: moize(getClientFriendlyStatusById, { maxAge: 1000 * LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new ClientFriendlyStatusById memo') }),
     getAllCountries: moize(getAllCountries, { maxAge: 1000 * LOOKUP_SVC_ALL_COUNTRIES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllCountries memo') }),
     getAllDisabilityTypes: moize.promise(getAllDisabilityTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_DISABILITY_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllDisabilityTypes memo') }),
     getAllEquityTypes: moize.promise(getAllEquityTypes, { maxAge: 1000 * LOOKUP_SVC_ALL_EQUITY_TYPES_CACHE_TTL_SECONDS, onCacheAdd: () => log.info('Creating new AllEquityTypes memo') }),
@@ -543,3 +557,6 @@ export type FederalSocialProgram = ReturnType<GetAllFederalSocialPrograms>[numbe
 
 export type GetAllProvincialTerritorialSocialPrograms = Pick<ReturnType<typeof getLookupService>, 'getAllProvincialTerritorialSocialPrograms'>['getAllProvincialTerritorialSocialPrograms'];
 export type ProvincialTerritorialSocialProgram = ReturnType<GetAllProvincialTerritorialSocialPrograms>[number];
+
+export type GetAllClientFriendlyStatuses = Pick<ReturnType<typeof getLookupService>, 'getAllClientFriendlyStatuses'>['getAllClientFriendlyStatuses'];
+export type ClientFriendlyStatus = ReturnType<GetAllClientFriendlyStatuses>[number];

--- a/frontend/app/utils/lookup-utils.server.ts
+++ b/frontend/app/utils/lookup-utils.server.ts
@@ -1,5 +1,5 @@
 import { getEnv } from './env.server';
-import type { Country, FederalSocialProgram, Language, MaritalStatus, ProvincialTerritorialSocialProgram, Region } from '~/services/lookup-service.server';
+import type { ClientFriendlyStatus, Country, FederalSocialProgram, Language, MaritalStatus, ProvincialTerritorialSocialProgram, Region } from '~/services/lookup-service.server';
 
 /**
  * Localizes a single country object by adding a localized name.
@@ -203,4 +203,12 @@ export function localizeProvincialTerritorialSocialProgram(program: ProvincialTe
 export function localizeAndSortProvincialTerritorialSocialPrograms(programs: ProvincialTerritorialSocialProgram[], locale: string) {
   const mappedProvincialTerritorialSocialPrograms = programs.map((program) => localizeProvincialTerritorialSocialProgram(program, locale));
   return mappedProvincialTerritorialSocialPrograms.toSorted((a, b) => a.name.localeCompare(b.name, locale));
+}
+
+export function localizeClientFriendlyStatus(clientFriendlyStatus: ClientFriendlyStatus, locale: string) {
+  const { nameEn, nameFr, ...rest } = clientFriendlyStatus;
+  return {
+    ...rest,
+    name: locale === 'fr' ? nameFr : nameEn,
+  };
 }


### PR DESCRIPTION
### Description
- adds new service method `getClientFriendlyStatusById` 
- adds new lookup util to localize a client friendly status

I'll add unit tests in a separate PR.  I'm also planning to move `getAlertType` to a util to avoid duplication and will do so in a separate PR.

### Related Azure Boards Work Items
[AB#4261](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4261)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`