### PR TITLE
fix(frontend): change InputSanitizerField inputMode to "text"

### DIFF
--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -69,6 +69,7 @@ export function InputSanitizeField(props: InputSanitizeFieldProps) {
         {...restProps}
         defaultValue={defaultValue}
         type="text"
+        inputMode="text"
         format={(value) => normalizeHyphens(removeInvalidInputCharacters(value))}
         removeFormatting={(value) => normalizeHyphens(removeInvalidInputCharacters(value))}
         isValidInputCharacter={(char) => isAllValidInputCharacters(char)}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Default inputmode attribute with [React number format](https://s-yadav.github.io/react-number-format/) is `numeric`. The InputSanitizeField allows not only numeric characters. We received complains that users cannot use regular input keyboard on with their phone.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

AB#4285

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->