### PR TITLE
Removing extra Zod validation in status checker.

### DIFF
--- a/frontend/app/routes/$lang/_public/status/child.tsx
+++ b/frontend/app/routes/$lang/_public/status/child.tsx
@@ -103,26 +103,17 @@ export async function action({ context: { session }, params, request }: ActionFu
     .object({
       firstName: z.string().trim().max(100, t('status:child.form.error-message.first-name-too-long')).refine(isAllValidInputCharacters, t('status:child.form.error-message.characters-valid')).optional(),
       lastName: z.string().trim().min(1, t('status:child.form.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('status:child.form.error-message.characters-valid')),
-      dateOfBirthYear: z
-        .number({
-          required_error: t('status:child.form.error-message.date-of-birth-year-required'),
-          invalid_type_error: t('status:child.form.error-message.date-of-birth-year-number'),
-        })
-        .int()
-        .positive(),
-      dateOfBirthMonth: z
-        .number({
-          required_error: t('status:child.form.error-message.date-of-birth-month-required'),
-        })
-        .int()
-        .positive(),
-      dateOfBirthDay: z
-        .number({
-          required_error: t('status:child.form.error-message.date-of-birth-day-required'),
-          invalid_type_error: t('status:child.form.error-message.date-of-birth-day-number'),
-        })
-        .int()
-        .positive(),
+      dateOfBirthYear: z.number({
+        required_error: t('status:child.form.error-message.date-of-birth-year-required'),
+        invalid_type_error: t('status:child.form.error-message.date-of-birth-year-number'),
+      }),
+      dateOfBirthMonth: z.number({
+        required_error: t('status:child.form.error-message.date-of-birth-month-required'),
+      }),
+      dateOfBirthDay: z.number({
+        required_error: t('status:child.form.error-message.date-of-birth-day-required'),
+        invalid_type_error: t('status:child.form.error-message.date-of-birth-day-number'),
+      }),
       dateOfBirth: z.string(),
     })
     .superRefine((val, ctx) => {


### PR DESCRIPTION
### Description
Removed `int()` and `positive()` validations as we are covering these in our `superrefine()`

### Related Azure Boards Work Items
[AB#4286](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4286)

### Screenshots (if applicable)
It used to give this default Zod error when entering 0:
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/77116011/631e8a2c-79e1-4843-b079-7a80c5e840fd)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `http://localhost:3000/en/status/child` and `http://localhost:3000/fr/statut/enfant`
Select "Does not have a SIN"
Play around with the dates:
 - Try decimals
 - Try 0
 - Try negative numbers
