### PR TITLE
add mock mappings for application codes to application status codes for status checker

### DIFF
--- a/frontend/app/mocks/status-check-api.server.ts
+++ b/frontend/app/mocks/status-check-api.server.ts
@@ -1,9 +1,31 @@
 import { HttpResponse, http } from 'msw';
 import { z } from 'zod';
 
+import { getLookupService } from '~/services/lookup-service.server';
 import { getLogger } from '~/utils/logging.server';
 
 const log = getLogger('status-check-api.server');
+
+/**
+ * Mock mapping for application codes to application status codes
+ * which can then be used to render on the frontend
+ *
+ * Example mapping:
+ *  {
+ *    '111111': '873ac4c6-77c0-ee11-9079-000d3a09d132',
+ *    '222222': 'f752c665-c4e6-ee11-a204-000d3a09d1b8',
+ *    '333333': 'e882086c-c4e6-ee11-a204-000d3a09d1b8',
+ *    '444444': '4d335896-c4e6-ee11-a204-000d3a09d1b8',
+ *    '555555': '504fba6e-604e-ee11-be6f-000d3a09d640',
+ *    '666666': '1e158ec8-604e-ee11-be6f-000d3a09d640',
+ *    '777777': 'c23252fe-604e-ee11-be6f-000d3a09d640',
+ *    '888888': '9687572e-614e-ee11-be6f-000d3a09d640',
+ *    '999999': '51af5170-614e-ee11-be6f-000d3a09d640'
+ *  }
+ */
+const MOCK_APPLICATION_CODES_TO_STATUS_CODES_MAP: Record<string, string> = getLookupService()
+  .getAllClientFriendlyStatuses()
+  .reduce((acc, { id }, i) => ({ ...acc, [(i + 1).toString().repeat(6)]: id }), {});
 
 /**
  * Server-side MSW mocks for the Status Check API
@@ -39,11 +61,13 @@ export function getStatusCheckApiMockHandlers() {
         return new HttpResponse(null, { status: 401 });
       }
 
+      const statusCode = MOCK_APPLICATION_CODES_TO_STATUS_CODES_MAP[statusRequest.data.BenefitApplication.Applicant.ClientIdentification[0].IdentificationID];
+
       return HttpResponse.json({
         BenefitApplication: {
           BenefitApplicationStatus: [
             {
-              ReferenceDataID: 'c23252fe-604e-ee11-be6f-000d3a09d640',
+              ReferenceDataID: statusCode || 'c23252fe-604e-ee11-be6f-000d3a09d640',
               ReferenceDataName: 'Dental Status Code',
             },
           ],
@@ -83,11 +107,13 @@ export function getStatusCheckApiMockHandlers() {
         return new HttpResponse(null, { status: 401 });
       }
 
+      const statusCode = MOCK_APPLICATION_CODES_TO_STATUS_CODES_MAP[statusRequest.data.BenefitApplication.Applicant.ClientIdentification[0].IdentificationID];
+
       return HttpResponse.json({
         BenefitApplication: {
           BenefitApplicationStatus: [
             {
-              ReferenceDataID: 'c23252fe-604e-ee11-be6f-000d3a09d640',
+              ReferenceDataID: statusCode || 'c23252fe-604e-ee11-be6f-000d3a09d640',
               ReferenceDataName: 'Dental Status Code',
             },
           ],


### PR DESCRIPTION
### Description
We should have a way to display the different application status messages.  

This PR creates a mock mapping of application codes to status codes.

### Related Azure Boards Work Items
[AB#4261](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4261)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/c4df554d-27e3-41ec-a144-e31ff28d8969)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/877a844b-6601-447c-a837-1abfee3a5127)




### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`