### PR TITLE
AB#4280 -- Fixed aria-descriptions on input textboxes for screenreaders

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -71,6 +71,8 @@ module.exports = {
         '@typescript-eslint/consistent-type-exports': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+        //Note: aria-props for aria-description is only supported in the upcoming WAI-ARIA 1.3 spec
+        'jsx-a11y/aria-props': 'warn',
       },
     },
     {

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -71,7 +71,7 @@ module.exports = {
         '@typescript-eslint/consistent-type-exports': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
-        //Note: aria-props for aria-description is only supported in the upcoming WAI-ARIA 1.3 spec
+        // Note: aria-props for aria-description is only supported in the upcoming WAI-ARIA 1.3 spec
         'jsx-a11y/aria-props': 'warn',
       },
     },

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
@@ -223,7 +223,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
-                aria-describedby="name-instructions"
+                aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errorMessages['first-name']}
                 defaultValue={defaultState?.firstName ?? ''}
@@ -238,7 +238,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errorMessages['last-name']}
-                aria-describedby="name-instructions"
+                aria-description={t('applicant-information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -321,7 +321,7 @@ export default function ApplyFlowChildInformation() {
                 label={t('apply-adult-child:children.information.first-name')}
                 className="w-full"
                 maxLength={100}
-                aria-describedby="name-instructions"
+                aria-description={t('apply-adult-child:children.information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
                 defaultValue={defaultState?.firstName ?? ''}
@@ -336,7 +336,7 @@ export default function ApplyFlowChildInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('apply-adult-child:children.information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
@@ -245,7 +245,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
               <InputSanitizeField
@@ -257,7 +257,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -217,7 +217,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
-                aria-describedby="name-instructions"
+                aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errorMessages['first-name']}
                 defaultValue={defaultState?.firstName ?? ''}
@@ -229,10 +229,10 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.last-name')}
                 className="w-full"
                 maxLength={100}
+                aria-description={t('applicant-information.name-instructions')}
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errorMessages['last-name']}
-                aria-describedby="name-instructions"
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -239,7 +239,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
               <InputSanitizeField
@@ -251,7 +251,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
@@ -314,7 +314,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
-                aria-describedby="name-instructions"
+                aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName?._errors[0]}
                 defaultValue={defaultState?.firstName ?? ''}
@@ -329,7 +329,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('applicant-information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -321,7 +321,7 @@ export default function ApplyFlowChildInformation() {
                 label={t('apply-child:children.information.first-name')}
                 className="w-full"
                 maxLength={100}
-                aria-describedby="name-instructions"
+                aria-description={t('apply-child:children.information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
                 defaultValue={defaultState?.firstName ?? ''}
@@ -336,7 +336,7 @@ export default function ApplyFlowChildInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('apply-child:children.information.name-instructions')}
                 required
               />
             </div>

--- a/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
@@ -244,7 +244,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={fetcher.data?.errors.firstName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
               <InputSanitizeField
@@ -256,7 +256,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={fetcher.data?.errors.lastName?._errors[0]}
-                aria-describedby="name-instructions"
+                aria-description={t('partner-information.name-instructions')}
                 required
               />
             </div>


### PR DESCRIPTION
### Description
Text inputs field such as first/last name had incorrect descriptions set from the collapsible info boxes (aria-describedby). When collapsed the screen reader would only read the title instead of the whole description.

Set the aria-description instead to the infobox text to mitigate this issue.

### Related Azure Boards Work Items
[AB#4280](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4280)

### Screenshots (if applicable)
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/155585182/fff23c6c-d694-4951-8349-6ececb4afe93)


### Additional Notes
ESLint checker set to warn for aria-props due to WAI-ARIA 1.3 unavailability