### PR TITLE
chore(gitops): bump 'prod' to v2.4.0

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:2.3.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:2.4.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title, I'm bumping 'prod' to version 2.4.0 as an emergency release. The schedule release time is Today at 12:00 PM EST.