### PR TITLE
Fixes for ErrorSummary and DatePickerField

### DIFF
--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -133,41 +133,56 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
     [disabled, getAriaDescribedBy, getAriaErrorMessageDay, id, names.day, required, t, value.day],
   );
 
+  const datePickerErrorMessages = useMemo(() => {
+    return {
+      all:
+        typeof errorMessages?.all === 'string' ? (
+          <InputError id={inputErrorIdAll} data-testid="date-picker-error-all">
+            {errorMessages.all}
+          </InputError>
+        ) : undefined,
+      month:
+        typeof errorMessages?.month === 'string' ? (
+          <InputError id={inputErrorIdMonth} data-testid="date-picker-error-month">
+            {errorMessages.month}
+          </InputError>
+        ) : undefined,
+      day:
+        typeof errorMessages?.day === 'string' ? (
+          <InputError id={inputErrorIdDay} data-testid="date-picker-error-day">
+            {errorMessages.day}
+          </InputError>
+        ) : undefined,
+      year:
+        typeof errorMessages?.year === 'string' ? (
+          <InputError id={inputErrorIdYear} data-testid="date-picker-error-year">
+            {errorMessages.year}
+          </InputError>
+        ) : undefined,
+    };
+  }, [errorMessages?.all, errorMessages?.day, errorMessages?.month, errorMessages?.year, inputErrorIdAll, inputErrorIdDay, inputErrorIdMonth, inputErrorIdYear]);
+
   return (
     <div id={inputWrapperId} data-testid="date-picker-field">
       <fieldset>
         <InputLegend id={inputLegendId} className="mb-2">
           {legend}
         </InputLegend>
-        {errorMessages && (
+        {(datePickerErrorMessages.all !== undefined || datePickerErrorMessages.year !== undefined || datePickerErrorMessages.month !== undefined || datePickerErrorMessages.day !== undefined) && (
           <div className="mb-2 space-y-2">
-            {errorMessages.all && (
-              <p>
-                <InputError id={inputErrorIdAll} data-testid="date-picker-error-all">
-                  {errorMessages.all}
-                </InputError>
-              </p>
-            )}
-            {errorMessages.month && (
-              <p>
-                <InputError id={inputErrorIdMonth} data-testid="date-picker-error-month">
-                  {errorMessages.month}
-                </InputError>
-              </p>
-            )}
-            {errorMessages.day && (
-              <p>
-                <InputError id={inputErrorIdDay} data-testid="date-picker-error-day">
-                  {errorMessages.day}
-                </InputError>
-              </p>
-            )}
-            {errorMessages.year && (
-              <p>
-                <InputError id={inputErrorIdYear} data-testid="date-picker-error-year">
-                  {errorMessages.year}
-                </InputError>
-              </p>
+            {datePickerErrorMessages.all && <p>{datePickerErrorMessages.all}</p>}
+            {i18n.language === 'fr' ? (
+              <>
+                {datePickerErrorMessages.day && <p>{datePickerErrorMessages.day}</p>}
+                {datePickerErrorMessages.month && <p>{datePickerErrorMessages.month}</p>}
+                {datePickerErrorMessages.year && <p>{datePickerErrorMessages.year}</p>}
+              </>
+            ) : (
+              <>
+                {datePickerErrorMessages.month && <p>{datePickerErrorMessages.month}</p>}
+                {datePickerErrorMessages.day && <p>{datePickerErrorMessages.day}</p>}
+                {datePickerErrorMessages.year && <p>{datePickerErrorMessages.year}</p>}
+              </>
             )}
           </div>
         )}

--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -96,7 +96,7 @@ export function ErrorSummary({ errors, id }: ErrorSummaryProps) {
       {errors.length > 0 && (
         <ul className="mt-1.5 list-disc space-y-2 pl-7">
           {errors.map(({ fieldId, errorMessage }) => (
-            <li key={fieldId}>
+            <li key={`${fieldId}-${errorMessage}`}>
               <AnchorLink className="text-red-700 underline hover:decoration-2 focus:decoration-2" anchorElementId={fieldId}>
                 {errorMessage}
               </AnchorLink>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

- fix(frontend): issue when same fieldId is used as key
- fix(frontend): DatePickerField error messages order based on current UI language

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4283](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4283)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

English
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/9e89f9ac-befa-4100-8208-ebf0521d9c5b)

French
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/114004123/4a6c7fa9-86fb-45e9-9989-df9291b6a1ad)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->