### PR TITLE
update government of canada logo alt text

### DIFF
--- a/frontend/__tests__/components/page-header-brand.test.tsx
+++ b/frontend/__tests__/components/page-header-brand.test.tsx
@@ -6,8 +6,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PageHeaderBrand } from '~/components/page-header-brand';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      getFixedT: (lang: string) => (key: string) => key,
+    },
+  }),
+}));
+
 vi.mock('~/components/language-switcher', () => ({
   LanguageSwitcher: vi.fn().mockImplementation(({ children }) => <div>{children}</div>),
+}));
+
+vi.mock('~/utils/locale-utils.ts', () => ({
+  getAltLanguage: (lang: string) => lang,
 }));
 
 describe('PageHeaderBrand', () => {

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -15,7 +15,7 @@ import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getAltLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useI18nNamespaces, usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
@@ -90,9 +90,12 @@ export interface BilingualNotFoundErrorProps {
  * A 404 page that renders both languages, for when the user's language cannot be detected
  */
 export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
-  const { i18n } = useTranslation(['gcweb']);
+  const { i18n, t } = useTranslation(['gcweb']);
   const en = i18n.getFixedT('en');
   const fr = i18n.getFixedT('fr');
+
+  const altLanguage = getAltLanguage(i18n.language);
+  const altLogoContent = <span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>;
 
   const englishCdcpLink = <InlineLink to={en('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" />;
   const frenchCdcpLink = <InlineLink to={fr('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" />;
@@ -110,8 +113,9 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
           <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
             <div property="publisher" typeof="GovernmentOrganization">
               <Link to="https://canada.ca/" property="url">
-                <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} property="logo" width="300" height="28" decoding="async" />
+                <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
               </Link>
+              <span className="sr-only">/ {altLogoContent}</span>
               <meta property="name" content={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} />
               <meta property="areaServed" typeof="Country" content="Canada" />
               <link property="logo" href="/assets/wmms-blk.svg" />

--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -3,9 +3,14 @@ import { Link } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
+import { getAltLanguage } from '~/utils/locale-utils';
 
 export function PageHeaderBrand() {
   const { i18n, t } = useTranslation(['gcweb']);
+
+  const altLanguage = getAltLanguage(i18n.language);
+  const altLogoContent = <span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>;
+
   return (
     <div id="wb-bnr">
       <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">
@@ -13,6 +18,7 @@ export function PageHeaderBrand() {
           <Link to={t('gcweb:header.govt-of-canada.href')} property="url">
             <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
           </Link>
+          <span className="sr-only">/ {altLogoContent}</span>
           <meta property="name" content={t('gcweb:header.govt-of-canada.text')} />
           <meta property="areaServed" typeof="Country" content="Canada" />
           <link property="logo" href="/assets/wmms-blk.svg" />


### PR DESCRIPTION
### Description
This PR implements the recommendation from the ITAO for the Government of Canada logo's alt text.  I resubmitted the Status Checker for a reassessment and this is what they want us to change to before they give us a 100% completion.  I guess Canada.ca also has this implementation.  We're using this on the index page as well, so I don't know when it was changed by canada.ca, but it's existed for a few months at least :shrug: 

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->
![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/685f9c88-dc6b-49dc-86c6-3b1466359677)

![image](https://github.com/DTS-STN/canadian-dental-care-plan/assets/48450599/300dbe21-4e20-4e5c-9a70-2be0dc240a09)