### PR TITLE
move sr-only alt text into Link

### DIFF
--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -114,8 +114,8 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
             <div property="publisher" typeof="GovernmentOrganization">
               <Link to="https://canada.ca/" property="url">
                 <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
+                <span className="sr-only">/ {altLogoContent}</span>
               </Link>
-              <span className="sr-only">/ {altLogoContent}</span>
               <meta property="name" content={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} />
               <meta property="areaServed" typeof="Country" content="Canada" />
               <link property="logo" href="/assets/wmms-blk.svg" />

--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -17,8 +17,8 @@ export function PageHeaderBrand() {
         <div property="publisher" typeof="GovernmentOrganization">
           <Link to={t('gcweb:header.govt-of-canada.href')} property="url">
             <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
+            <span className="sr-only">/ {altLogoContent}</span>
           </Link>
-          <span className="sr-only">/ {altLogoContent}</span>
           <meta property="name" content={t('gcweb:header.govt-of-canada.text')} />
           <meta property="areaServed" typeof="Country" content="Canada" />
           <link property="logo" href="/assets/wmms-blk.svg" />

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -48,10 +48,10 @@ export default function RootIndex() {
           <div className="w-11/12 lg:w-8/12">
             <Link to="https://www.canada.ca/en.html" property="url">
               <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt="Government of Canada" property="logo" width="300" height="28" decoding="async" />
+              <span className="sr-only">
+                / <span lang="fr">Gouvernement du Canada</span>
+              </span>
             </Link>
-            <span className="sr-only">
-              / <span lang="fr">Gouvernement du Canada</span>
-            </span>
           </div>
           <div className="mb-2 mt-9 grid grid-cols-2 gap-8 md:mx-4 lg:mx-8">
             <section lang="en">


### PR DESCRIPTION
### Description
Subsequent to the previous PR of changing the alt text for the Government of Canada logo, the ITAO responded that the sr-only text wasn't being read by screenreaders. I've moved the span inside the Link component for it to be picked up.