### PR TITLE
refactor(frontend): Add zod utility func to transform flattened error

### DIFF
--- a/frontend/__tests__/utils/zod-utils.server.test.ts
+++ b/frontend/__tests__/utils/zod-utils.server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+describe('transformFlattenedError', () => {
+  it('should transform a flattened error object with multiple fields and multiple error messages', () => {
+    const flattenedError = {
+      fieldErrors: {
+        name: ['Name is required', 'Name is too short'],
+        age: ['Age must be a number'],
+      },
+    };
+    const expectedResult = {
+      name: 'Name is required',
+      age: 'Age must be a number',
+    };
+    const result = transformFlattenedError(flattenedError);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should transform a flattened error object with fields that have a single error message', () => {
+    const flattenedError = {
+      fieldErrors: {
+        name: ['Name is required'],
+        age: ['Age must be a number'],
+      },
+    };
+    const expectedResult = {
+      name: 'Name is required',
+      age: 'Age must be a number',
+    };
+    const result = transformFlattenedError(flattenedError);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should transform a flattened error object with fields that have no error messages', () => {
+    const flattenedError = {
+      fieldErrors: {
+        name: [],
+        age: [],
+      },
+    };
+    const expectedResult = {
+      name: undefined,
+      age: undefined,
+    };
+    const result = transformFlattenedError(flattenedError);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should transform an empty flattened error object', () => {
+    const flattenedError = {
+      fieldErrors: {},
+    };
+    const expectedResult = {};
+    const result = transformFlattenedError(flattenedError);
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/frontend/app/utils/zod-utils.server.ts
+++ b/frontend/app/utils/zod-utils.server.ts
@@ -1,0 +1,34 @@
+/**
+ * Transforms a flattened error object by mapping each field to its first error message.
+ *
+ * @param flattenedError - An object containing `fieldErrors`, which is a record of field names to an array of error messages.
+ * @returns An object where each field is mapped to its first error message, or `undefined` if no error message is present.
+ *
+ * @example
+ * // Input:
+ * // {
+ * //   fieldErrors: {
+ * //     name: ["Name is required", "Name is too short"],
+ * //     age: ["Age must be a number"]
+ * //   }
+ * // }
+ * // Output:
+ * // {
+ * //   name: "Name is required",
+ * //   age: "Age must be a number"
+ * // }
+ *
+ * const flattenedError = {
+ *   fieldErrors: {
+ *     name: ["Name is required", "Name is too short"],
+ *     age: ["Age must be a number"]
+ *   }
+ * };
+ * const result = transformFlattenedError(flattenedError);
+ * console.log(result);
+ * // Output: { name: "Name is required", age: "Age must be a number" }
+ */
+export function transformFlattenedError<T extends { fieldErrors: Record<string, string[]> }>(flattenedError: T): { [K in keyof T['fieldErrors']]: string | undefined } {
+  const transformedEntries = Object.entries(flattenedError.fieldErrors).map(([key, value]) => [key, value.at(0)]);
+  return Object.fromEntries(transformedEntries);
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request introduces the `transformFlattenedError` utility function from Zod to transform flattened errors. Since our object schemas are only one level deep, using [.flatten()](https://zod.dev/ERROR_HANDLING?id=flattening-errors) is more convenient. The `fieldErrors` properties contain arrays of error strings (string[]), but we only use the first element of each array. This utility has been implemented in the status checker.

Usage example:

```ts
const flattenedError = {
  fieldErrors: {
    name: ["Name is required", "Name is too short"],
    age: ["Age must be a number"]
  }
};
const result = transformFlattenedError(flattenedError);
console.log(result);
// Output: { name: "Name is required", age: "Age must be a number" }
```

The next feature to be introduced is the `useErrorSummary` custom hook, which will leverage this change.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->