### PR TITLE
refactor(frontend): Add useErrorSummary custom hook

### DIFF
--- a/frontend/app/routes/$lang/_public/status/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/index.tsx
@@ -1,5 +1,4 @@
 import type { FormEvent } from 'react';
-import { useEffect, useMemo } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
@@ -14,11 +13,10 @@ import { z } from 'zod';
 import pageIds from '../../page-ids.json';
 import { Button } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
-import { ErrorSummary, createErrorSummaryItems, hasErrors, scrollAndFocusToErrorSummary } from '~/components/error-summary';
+import { useErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
 import { InputRadios } from '~/components/input-radios';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
-import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { featureEnabled, getEnv } from '~/utils/env.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -107,29 +105,9 @@ export default function StatusChecker() {
   const isSubmitting = fetcher.state !== 'idle';
   const { t } = useTranslation(handle.i18nNamespaces);
   const { captchaRef } = useHCaptcha();
-  const errorSummaryId = 'error-summary';
+
   const errors = fetcher.data?.errors;
-
-  const errorMessages = useMemo(() => {
-    // Optional chaining '?.' is not use to ensure useMemo has errors object as dependency
-    if (!errors) return {};
-    return {
-      'input-radio-status-check-option-0': errors.checkFor,
-    };
-  }, [errors]);
-
-  const errorSummaryItems = createErrorSummaryItems(errorMessages);
-
-  useEffect(() => {
-    if (hasErrors(errorMessages)) {
-      scrollAndFocusToErrorSummary(errorSummaryId);
-
-      if (adobeAnalytics.isConfigured()) {
-        const fieldIds = createErrorSummaryItems(errorMessages).map(({ fieldId }) => fieldId);
-        adobeAnalytics.pushValidationErrorEvent(fieldIds);
-      }
-    }
-  }, [errorMessages]);
+  const errorSummary = useErrorSummary(errors, { checkFor: 'input-radio-status-check-option-0' });
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -212,7 +190,7 @@ export default function StatusChecker() {
         </div>
       </Collapsible>
       <p className="mb-4 italic">{t('status:form.complete-fields')}</p>
-      {errorSummaryItems.length > 0 && <ErrorSummary id={errorSummaryId} errors={errorSummaryItems} />}
+      <errorSummary.ErrorSummary />
       <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
         <input type="hidden" name="_csrf" value={csrfToken} />
         {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,6 +61,7 @@
         "tiny-invariant": "^1.3.3",
         "tsx": "^4.16.2",
         "undici": "^6.19.2",
+        "use-deep-compare": "^1.2.1",
         "validator": "^13.12.0",
         "web-streams-node": "^0.4.0",
         "winston": "^3.13.1",
@@ -6269,7 +6270,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -15238,6 +15238,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-deep-compare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.2.1.tgz",
+      "integrity": "sha512-JTnOZAr0fq1ix6CQ4XANoWIh03xAiMFlP/lVAYDdAOZwur6nqBSdATn1/Q9PLIGIW+C7xmFZBCcaA4KLDcQJtg==",
+      "dependencies": {
+        "dequal": "2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "tiny-invariant": "^1.3.3",
     "tsx": "^4.16.2",
     "undici": "^6.19.2",
+    "use-deep-compare": "^1.2.1",
     "validator": "^13.12.0",
     "web-streams-node": "^0.4.0",
     "winston": "^3.13.1",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Introduce `useErrorSummary`, a custom hook designed to streamline error handling by consolidating common tasks. This includes displaying error summaries, scrolling and focusing on errors, and logging error metrics to Adobe Analytics.

- The first argument, `errors`, captures errors generated during page actions, if any.
- The second argument, `errorFieldMap`, maps error field names to corresponding input field IDs on the page. This mapping is crucial for linking errors to specific input IDs in URLs.
- The third argument, `errorSummaryId`, defaults to `'error-summary'` but can be customized as needed.

It's been implemented and tested in Status Checker.

<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

Test the keyboard navigation... if any error is display on submit the focu should go to the error summary wrapper even if the errors are the same. Test that the error links focus to the proper inputs on click.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->