### PR TITLE
Adding TimeoutSession to status-checker

### DIFF
--- a/frontend/app/routes/$lang/_public/status/_route.tsx
+++ b/frontend/app/routes/$lang/_public/status/_route.tsx
@@ -1,20 +1,41 @@
-import { Outlet } from '@remix-run/react';
+import type { LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
 
-import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import SessionTimeout from '~/components/session-timeout';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getLocale } from '~/utils/locale-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
 } as const satisfies RouteHandleData;
 
-/**
- * Do-nothing parent route.
- * (placeholder for future code)
- */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+  const lang = getLocale(request);
+  return { lang };
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    switch (error.status) {
+      case 404: {
+        return <NotFoundError error={error} />;
+      }
+    }
+  }
+
+  return <ServerError error={error} />;
+}
+
 export default function Route() {
+  const { lang } = useLoaderData<typeof loader>();
   return (
     <PublicLayout>
+      <SessionTimeout navigateTo={`/${lang}/status`} promptBeforeIdle={5 * 60 * 1000} timeout={15 * 60 * 1000} />
       <Outlet />
     </PublicLayout>
   );


### PR DESCRIPTION
### Description
Adding Session Timeout to apply/status.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Locally: modify the `5` and the `15` for a shorter time (1 = 1 minute)
![image](https://github.com/user-attachments/assets/970527a9-f9a1-42c3-9a44-8b6cf43ab9e1)


Navigate to /public/status
playa round  with the landing page and all sub pages (`myself` and `child`)