### PR TITLE
chore(frontend): bump dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "i18next-fs-backend": "^2.3.1",
         "i18next-http-backend": "^2.5.2",
         "ioredis": "^5.4.1",
-        "isbot": "^5.1.12",
+        "isbot": "^5.1.13",
         "jose": "^5.6.3",
         "libphonenumber-js": "^1.11.4",
         "markdown-to-jsx": "^7.4.7",
@@ -51,7 +51,7 @@
         "oauth4webapi": "^2.11.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-i18next": "^14.1.2",
+        "react-i18next": "^14.1.3",
         "react-idle-timer": "^5.7.2",
         "react-number-format": "^5.4.0",
         "react-phone-number-input": "^3.4.3",
@@ -69,7 +69,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@playwright/test": "^1.45.1",
+        "@playwright/test": "^1.45.2",
         "@remix-run/dev": "^2.10.2",
         "@remix-run/testing": "^2.10.2",
         "@testing-library/jest-dom": "^6.4.6",
@@ -84,10 +84,10 @@
         "@types/react-dom": "^18.3.0",
         "@types/source-map-support": "^0.5.10",
         "@types/validator": "^13.12.0",
-        "@typescript-eslint/eslint-plugin": "^7.16.0",
+        "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@vitejs/plugin-react": "^4.3.1",
-        "@vitest/coverage-v8": "^2.0.2",
-        "@vitest/ui": "^2.0.2",
+        "@vitest/coverage-v8": "^2.0.3",
+        "@vitest/ui": "^2.0.3",
         "chokidar": "^3.6.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -100,11 +100,11 @@
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.5",
-        "tailwindcss": "^3.4.4",
+        "tailwindcss": "^3.4.5",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.5.3",
         "vite-tsconfig-paths": "^4.3.2",
-        "vitest": "^2.0.2"
+        "vitest": "^2.0.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2335,12 +2335,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
-      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.2.tgz",
+      "integrity": "sha512-JxG9eq92ET75EbVi3s+4sYbcG7q72ECeZNbdBlaMkGcNbiDQ4cAi8U2QP5oKkOx+1gpaiL1LDStmzCaEM1Z6fQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.45.1"
+        "playwright": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4063,16 +4063,16 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.0.tgz",
-      "integrity": "sha512-py1miT6iQpJcs1BiJjm54AMzeuMPBSPuKPlnT8HlfudbcS5rYeX5jajpLf3mrdRh9dA/Ec2FVUY0ifeVNDIhZw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.1.tgz",
+      "integrity": "sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.16.0",
-        "@typescript-eslint/type-utils": "7.16.0",
-        "@typescript-eslint/utils": "7.16.0",
-        "@typescript-eslint/visitor-keys": "7.16.0",
+        "@typescript-eslint/scope-manager": "7.16.1",
+        "@typescript-eslint/type-utils": "7.16.1",
+        "@typescript-eslint/utils": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -4096,13 +4096,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.0.tgz",
-      "integrity": "sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.1.tgz",
+      "integrity": "sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
-        "@typescript-eslint/visitor-keys": "7.16.0"
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4113,9 +4113,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.1.tgz",
+      "integrity": "sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4126,12 +4126,12 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
-      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
+      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/types": "7.16.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4190,13 +4190,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.0.tgz",
-      "integrity": "sha512-j0fuUswUjDHfqV/UdW6mLtOQQseORqfdmoBNDFOqs9rvNVR2e+cmu6zJu/Ku4SDuqiJko6YnhwcL8x45r8Oqxg==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.1.tgz",
+      "integrity": "sha512-rbu/H2MWXN4SkjIIyWcmYBjlp55VT+1G3duFOIukTNFxr9PI35pLc2ydwAfejCEitCv4uztA07q0QWanOHC7dA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.16.0",
-        "@typescript-eslint/utils": "7.16.0",
+        "@typescript-eslint/typescript-estree": "7.16.1",
+        "@typescript-eslint/utils": "7.16.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -4217,9 +4217,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.1.tgz",
+      "integrity": "sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4230,13 +4230,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.0.tgz",
-      "integrity": "sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.1.tgz",
+      "integrity": "sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
-        "@typescript-eslint/visitor-keys": "7.16.0",
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4258,12 +4258,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
-      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
+      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/types": "7.16.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4318,15 +4318,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.16.0.tgz",
-      "integrity": "sha512-PqP4kP3hb4r7Jav+NiRCntlVzhxBNWq6ZQ+zQwII1y/G/1gdIPeYDCKr2+dH6049yJQsWZiHU6RlwvIFBXXGNA==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.16.1.tgz",
+      "integrity": "sha512-WrFM8nzCowV0he0RlkotGDujx78xudsxnGMBHI88l5J8wEhED6yBwaSLP99ygfrzAjsQvcYQ94quDwI0d7E1fA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.16.0",
-        "@typescript-eslint/types": "7.16.0",
-        "@typescript-eslint/typescript-estree": "7.16.0"
+        "@typescript-eslint/scope-manager": "7.16.1",
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/typescript-estree": "7.16.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4340,13 +4340,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.0.tgz",
-      "integrity": "sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.1.tgz",
+      "integrity": "sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
-        "@typescript-eslint/visitor-keys": "7.16.0"
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.1.tgz",
+      "integrity": "sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -4370,13 +4370,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.0.tgz",
-      "integrity": "sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.1.tgz",
+      "integrity": "sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
-        "@typescript-eslint/visitor-keys": "7.16.0",
+        "@typescript-eslint/types": "7.16.1",
+        "@typescript-eslint/visitor-keys": "7.16.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4398,12 +4398,12 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
-      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.1.tgz",
+      "integrity": "sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/types": "7.16.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4513,9 +4513,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.0.2.tgz",
-      "integrity": "sha512-iA8eb4PMid3bMc++gfQSTvYE1QL//fC8pz+rKsTUDBFjdDiy/gH45hvpqyDu5K7FHhvgG0GNNCJzTMMSFKhoxg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.0.3.tgz",
+      "integrity": "sha512-53d+6jXFdYbasXBmsL6qaGIfcY5eBQq0sP57AjdasOcSiGNj4qxkkpDKIitUNfjxcfAfUfQ8BD0OR2fSey64+g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -4536,17 +4536,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.0.2"
+        "vitest": "2.0.3"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.2.tgz",
-      "integrity": "sha512-nKAvxBYqcDugYZ4nJvnm5OR8eDJdgWjk4XM9owQKUjzW70q0icGV2HVnQOyYsp906xJaBDUXw0+9EHw2T8e0mQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.3.tgz",
+      "integrity": "sha512-X6AepoOYePM0lDNUPsGXTxgXZAl3EXd0GYe/MZyVE4HzkUqyUVC6S3PrY5mClDJ6/7/7vALLMV3+xD/Ko60Hqg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.0.2",
-        "@vitest/utils": "2.0.2",
+        "@vitest/spy": "2.0.3",
+        "@vitest/utils": "2.0.3",
         "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -4555,9 +4555,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.2.tgz",
-      "integrity": "sha512-SBCyOXfGVvddRd9r2PwoVR0fonQjh9BMIcBMlSzbcNwFfGr6ZhOhvBzurjvi2F4ryut2HcqiFhNeDVGwru8tLg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.3.tgz",
+      "integrity": "sha512-URM4GLsB2xD37nnTyvf6kfObFafxmycCL8un3OC9gaCs5cti2u+5rJdIflZ2fUJUen4NbvF6jCufwViAFLvz1g==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -4567,12 +4567,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.2.tgz",
-      "integrity": "sha512-OCh437Vi8Wdbif1e0OvQcbfM3sW4s2lpmOjAE7qfLrpzJX2M7J1IQlNvEcb/fu6kaIB9n9n35wS0G2Q3en5kHg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.3.tgz",
+      "integrity": "sha512-EmSP4mcjYhAcuBWwqgpjR3FYVeiA4ROzRunqKltWjBfLNs1tnMLtF+qtgd5ClTwkDP6/DGlKJTNa6WxNK0bNYQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.0.2",
+        "@vitest/utils": "2.0.3",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -4580,12 +4580,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.2.tgz",
-      "integrity": "sha512-Yc2ewhhZhx+0f9cSUdfzPRcsM6PhIb+S43wxE7OG0kTxqgqzo8tHkXFuFlndXeDMp09G3sY/X5OAo/RfYydf1g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.3.tgz",
+      "integrity": "sha512-6OyA6v65Oe3tTzoSuRPcU6kh9m+mPL1vQ2jDlPdn9IQoUxl8rXhBnfICNOC+vwxWY684Vt5UPgtcA2aPFBb6wg==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.2",
+        "@vitest/pretty-format": "2.0.3",
         "magic-string": "^0.30.10",
         "pathe": "^1.1.2"
       },
@@ -4594,9 +4594,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.2.tgz",
-      "integrity": "sha512-MgwJ4AZtCgqyp2d7WcQVE8aNG5vQ9zu9qMPYQHjsld/QVsrvg78beNrXdO4HYkP0lDahCO3P4F27aagIag+SGQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.3.tgz",
+      "integrity": "sha512-sfqyAw/ypOXlaj4S+w8689qKM1OyPOqnonqOc9T91DsoHbfN5mU7FdifWWv3MtQFf0lEUstEwR9L/q/M390C+A==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^3.0.0"
@@ -4606,12 +4606,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.0.2.tgz",
-      "integrity": "sha512-VwxFTOC2GcNPexQlR9PFb8drWCLA+nLWTWlAS4oba1xbTJYJ8H5vY8OUFOTMb7YQXF0Vsc5IfmLpYkb2dcVgOA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.0.3.tgz",
+      "integrity": "sha512-UAkzHk5veR3NRF7BNUxWlLly7Cw7H+wzP3+eiMIVeKo3Md33Ey20rYsNQn/9McIqOeO02tMzqHhpThmjk1yRzw==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.0.2",
+        "@vitest/utils": "2.0.3",
         "fast-glob": "^3.3.2",
         "fflate": "^0.8.2",
         "flatted": "^3.3.1",
@@ -4623,16 +4623,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.0.2"
+        "vitest": "2.0.3"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.2.tgz",
-      "integrity": "sha512-pxCY1v7kmOCWYWjzc0zfjGTA3Wmn8PKnlPvSrsA643P1NHl1fOyXj2Q9SaNlrlFE+ivCsxM80Ov3AR82RmHCWQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-c/UdELMuHitQbbc/EVctlBaxoYAwQPQdSNwv7z/vHyBKy2edYZaFgptE27BRueZB7eW8po+cllotMNTDpL3HWg==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.2",
+        "@vitest/pretty-format": "2.0.3",
         "estree-walker": "^3.0.3",
         "loupe": "^3.1.1",
         "tinyrainbow": "^1.2.0"
@@ -9134,9 +9134,9 @@
       "dev": true
     },
     "node_modules/isbot": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.12.tgz",
-      "integrity": "sha512-Igy8nbj3Yn/XgYboRFTixH5ccUBvNPA89ek2zx3jCcBYkDkEnuFs0RkT36EPag5OFd2nLlK7u4uzG5AXfXR46w==",
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.13.tgz",
+      "integrity": "sha512-RXtBib4m9zChSb+187EpNQML7Z3u2i34zDdqcRFZnqSJs0xdh91xzJytc5apYVg+9Y4NGnUQ0AIeJvX9FAnCUw==",
       "engines": {
         "node": ">=18"
       }
@@ -11876,12 +11876,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.2.tgz",
+      "integrity": "sha512-ReywF2t/0teRvNBpfIgh5e4wnrI/8Su8ssdo5XsQKpjxJj+jspm00jSoz9BTg91TT0c9HRjXO7LBNVrgYj9X0g==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11894,9 +11894,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
-      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.2.tgz",
+      "integrity": "sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -12527,9 +12527,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.2.tgz",
-      "integrity": "sha512-FSIcJy6oauJbGEXfhUgVeLzvWBhIBIS+/9c6Lj4niwKZyGaGb4V4vUbATXSlsHJDXXB+ociNxqFNiFuV1gmoqg==",
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "html-parse-stringify": "^3.0.1"
@@ -13937,9 +13937,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
-      "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.5.tgz",
+      "integrity": "sha512-DlTxttYcogpDfx3tf/8jfnma1nfAYi2cBUYV2YNoPPecwmO3YGiFlOX9D8tGAu+EDF38ryBzvrDKU/BLMsUwbw==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -15897,18 +15897,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.2.tgz",
-      "integrity": "sha512-WlpZ9neRIjNBIOQwBYfBSr0+of5ZCbxT2TVGKW4Lv0c8+srCFIiRdsP7U009t8mMn821HQ4XKgkx5dVWpyoyLw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.3.tgz",
+      "integrity": "sha512-o3HRvU93q6qZK4rI2JrhKyZMMuxg/JRt30E6qeQs6ueaiz5hr1cPj+Sk2kATgQzMMqsa2DiNI0TIK++1ULx8Jw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@vitest/expect": "2.0.2",
-        "@vitest/pretty-format": "^2.0.2",
-        "@vitest/runner": "2.0.2",
-        "@vitest/snapshot": "2.0.2",
-        "@vitest/spy": "2.0.2",
-        "@vitest/utils": "2.0.2",
+        "@vitest/expect": "2.0.3",
+        "@vitest/pretty-format": "^2.0.3",
+        "@vitest/runner": "2.0.3",
+        "@vitest/snapshot": "2.0.3",
+        "@vitest/spy": "2.0.3",
+        "@vitest/utils": "2.0.3",
         "chai": "^5.1.1",
         "debug": "^4.3.5",
         "execa": "^8.0.1",
@@ -15919,7 +15919,7 @@
         "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.0.2",
+        "vite-node": "2.0.3",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -15934,8 +15934,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.0.2",
-        "@vitest/ui": "2.0.2",
+        "@vitest/browser": "2.0.3",
+        "@vitest/ui": "2.0.3",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -16095,9 +16095,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite-node": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.2.tgz",
-      "integrity": "sha512-w4vkSz1Wo+NIQg8pjlEn0jQbcM/0D+xVaYjhw3cvarTanLLBh54oNiRbsT8PNK5GfuST0IlVXjsNRoNlqvY/fw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.3.tgz",
+      "integrity": "sha512-14jzwMx7XTcMB+9BhGQyoEAmSl0eOr3nrnn+Z12WNERtOvLN+d2scbRUvyni05rT3997Bg+rZb47NyP4IQPKXg==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "i18next-fs-backend": "^2.3.1",
     "i18next-http-backend": "^2.5.2",
     "ioredis": "^5.4.1",
-    "isbot": "^5.1.12",
+    "isbot": "^5.1.13",
     "jose": "^5.6.3",
     "libphonenumber-js": "^1.11.4",
     "markdown-to-jsx": "^7.4.7",
@@ -65,7 +65,7 @@
     "oauth4webapi": "^2.11.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-i18next": "^14.1.2",
+    "react-i18next": "^14.1.3",
     "react-idle-timer": "^5.7.2",
     "react-number-format": "^5.4.0",
     "react-phone-number-input": "^3.4.3",
@@ -83,7 +83,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@playwright/test": "^1.45.1",
+    "@playwright/test": "^1.45.2",
     "@remix-run/dev": "^2.10.2",
     "@remix-run/testing": "^2.10.2",
     "@testing-library/jest-dom": "^6.4.6",
@@ -98,10 +98,10 @@
     "@types/react-dom": "^18.3.0",
     "@types/source-map-support": "^0.5.10",
     "@types/validator": "^13.12.0",
-    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@vitejs/plugin-react": "^4.3.1",
-    "@vitest/coverage-v8": "^2.0.2",
-    "@vitest/ui": "^2.0.2",
+    "@vitest/coverage-v8": "^2.0.3",
+    "@vitest/ui": "^2.0.3",
     "chokidar": "^3.6.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -114,11 +114,11 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.5",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "^3.4.5",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.3",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^2.0.2"
+    "vitest": "^2.0.3"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

```
@playwright/test                  ^1.45.1  →  ^1.45.2
@typescript-eslint/eslint-plugin  ^7.16.0  →  ^7.16.1
@vitest/coverage-v8                ^2.0.2  →   ^2.0.3
@vitest/ui                         ^2.0.2  →   ^2.0.3
isbot                             ^5.1.12  →  ^5.1.13
react-i18next                     ^14.1.2  →  ^14.1.3
tailwindcss                        ^3.4.4  →   ^3.4.5
vitest                             ^2.0.2  →   ^2.0.3
```

**Note:** @playwright/test has been updated in TC