### PR TITLE
AB#4216 -- Adding Postgres support for backend project

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -75,6 +75,10 @@
 			<artifactId>flyway-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>${mapstruct.version}</version>
@@ -82,6 +86,10 @@
 		<dependency>
 			<groupId>io.opentelemetry.instrumentation</groupId>
 			<artifactId>opentelemetry-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/backend/src/main/resources/application-local.yml.sample
+++ b/backend/src/main/resources/application-local.yml.sample
@@ -11,6 +11,10 @@ logging:
 ---
 
 spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: password
   security:
     oauth2:
       resourceserver:

--- a/backend/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
+++ b/backend/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
@@ -1,146 +1,146 @@
-CREATE TABLE `event_log` (
-	`id` VARCHAR(64) NOT NULL,
+CREATE TABLE "event_log" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`actor` VARCHAR(128),
-	`description` VARCHAR(256) NOT NULL,
-	`details` VARCHAR(65536) NOT NULL,
-	`event_type` VARCHAR(32) NOT NULL,
-	`source` VARCHAR(256),
+	"actor" VARCHAR(128),
+	"description" VARCHAR(256) NOT NULL,
+	"details" VARCHAR(65536) NOT NULL,
+	"event_type" VARCHAR(32) NOT NULL,
+	"source" VARCHAR(256),
 
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_event_log` PRIMARY KEY (id)
+	CONSTRAINT "pk_event_log" PRIMARY KEY (id)
 );
 
 
 
-CREATE TABLE `user` (
-	`id` VARCHAR(64) NOT NULL,
+CREATE TABLE "user" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`email` VARCHAR(256),
-	`email_verified` BOOLEAN,
-
-	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
-
-	CONSTRAINT `pk_user` PRIMARY KEY (`id`)
-);
-
-CREATE INDEX `ix_user_email` ON `user` (`email`);
-
-
-
-create TABLE `user_attribute` (
-	`id` VARCHAR(64) NOT NULL,
-
-	`name` VARCHAR(256) NOT NULL,
-	`value` VARCHAR(2048),
-	`user_id` VARCHAR(64) NOT NULL,
+	"email" VARCHAR(256),
+	"email_verified" BOOLEAN,
 
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_user_attribute` PRIMARY KEY (`id`),
-	CONSTRAINT `fk_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
-	CONSTRAINT `uq_user_attribute` UNIQUE (`name`, `user_id`)
+	CONSTRAINT "pk_user" PRIMARY KEY ("id")
 );
 
-CREATE INDEX `ix_user_attribute_user_id` on `user_attribute` (`user_id`);
-CREATE INDEX `ix_user_attribute_name_value` ON `user_attribute` (`name`, `value`);
+CREATE INDEX "ix_user_email" ON "user" ("email");
 
 
 
-CREATE TABLE `alert_type` (
-	`id` VARCHAR(64) NOT NULL,
+create TABLE "user_attribute" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`code` VARCHAR(16) NOT NULL,
-	`description` VARCHAR(256),
+	"name" VARCHAR(256) NOT NULL,
+	"value" VARCHAR(2048),
+	"user_id" VARCHAR(64) NOT NULL,
 
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_alert_type` PRIMARY KEY (`id`)
+	CONSTRAINT "pk_user_attribute" PRIMARY KEY ("id"),
+	CONSTRAINT "fk_user" FOREIGN KEY ("user_id") REFERENCES "user" ("id"),
+	CONSTRAINT "uq_user_attribute" UNIQUE ("name", "user_id")
 );
 
-CREATE INDEX `ix_alert_type_code` on `alert_type` (`code`);
+CREATE INDEX "ix_user_attribute_user_id" on "user_attribute" ("user_id");
+CREATE INDEX "ix_user_attribute_name_value" ON "user_attribute" ("name", "value");
 
 
 
-CREATE TABLE `language` (
-	`id` VARCHAR(64) NOT NULL,
+CREATE TABLE "alert_type" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`code` VARCHAR(16) NOT NULL,
-	`description` VARCHAR(256),
-	`iso_code` VARCHAR(16),
-	`ms_locale_code` VARCHAR(16),
+	"code" VARCHAR(16) NOT NULL,
+	"description" VARCHAR(256),
 
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_language` PRIMARY KEY (`id`)
+	CONSTRAINT "pk_alert_type" PRIMARY KEY ("id")
 );
 
-CREATE INDEX `ix_language_code` on `language` (`code`);
-CREATE INDEX `ix_language_iso_code` on `language` (`iso_code`);
-CREATE INDEX `ix_language_ms_locale_code` on `language` (`ms_locale_code`);
+CREATE INDEX "ix_alert_type_code" on "alert_type" ("code");
 
 
 
-CREATE TABLE `subscription` (
-	`id` VARCHAR(64) NOT NULL,
+CREATE TABLE "language" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`user_id` VARCHAR(64) NOT NULL,
-	`language_id` VARCHAR(64) NOT NULL,
-	`alert_type_id` VARCHAR(64) NOT NULL,
+	"code" VARCHAR(16) NOT NULL,
+	"description" VARCHAR(256),
+	"iso_code" VARCHAR(16),
+	"ms_locale_code" VARCHAR(16),
 
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_subscription` PRIMARY KEY (`id`),
-	CONSTRAINT `fk_subscription_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
-	CONSTRAINT `fk_subscription_alert_type` FOREIGN KEY (`alert_type_id`) REFERENCES `alert_type` (`id`),
-	CONSTRAINT `fk_subscription_language` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`)
+	CONSTRAINT "pk_language" PRIMARY KEY ("id")
 );
 
-CREATE INDEX `ix_subscription_alert_type_id` on `subscription` (`alert_type_id`);
-CREATE INDEX `ix_subscription_user_id` on `subscription` (`user_id`);
+CREATE INDEX "ix_language_code" on "language" ("code");
+CREATE INDEX "ix_language_iso_code" on "language" ("iso_code");
+CREATE INDEX "ix_language_ms_locale_code" on "language" ("ms_locale_code");
 
 
 
-CREATE TABLE `confirmation_code` (
-	`id` VARCHAR(64) NOT NULL,
+CREATE TABLE "subscription" (
+	"id" VARCHAR(64) NOT NULL,
 
-	`code` VARCHAR(8) NOT NULL,
-	`expiry_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`user_id` VARCHAR(64) NOT NULL,
+	"user_id" VARCHAR(64) NOT NULL,
+	"language_id" VARCHAR(64) NOT NULL,
+	"alert_type_id" VARCHAR(64) NOT NULL,
+
+	-- audit fields
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
+
+	CONSTRAINT "pk_subscription" PRIMARY KEY ("id"),
+	CONSTRAINT "fk_subscription_user" FOREIGN KEY ("user_id") REFERENCES "user" ("id"),
+	CONSTRAINT "fk_subscription_alert_type" FOREIGN KEY ("alert_type_id") REFERENCES "alert_type" ("id"),
+	CONSTRAINT "fk_subscription_language" FOREIGN KEY ("language_id") REFERENCES "language" ("id")
+);
+
+CREATE INDEX "ix_subscription_alert_type_id" on "subscription" ("alert_type_id");
+CREATE INDEX "ix_subscription_user_id" on "subscription" ("user_id");
+
+
+
+CREATE TABLE "confirmation_code" (
+	"id" VARCHAR(64) NOT NULL,
+
+	"code" VARCHAR(8) NOT NULL,
+	"expiry_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"user_id" VARCHAR(64) NOT NULL,
 	
 	-- audit fields
-	`created_by` VARCHAR(64) NOT NULL,
-	`created_date` TIMESTAMP WITH TIME ZONE NOT NULL,
-	`last_modified_by` VARCHAR(64),
-	`last_modified_date` TIMESTAMP WITH TIME ZONE,
+	"created_by" VARCHAR(64) NOT NULL,
+	"created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+	"last_modified_by" VARCHAR(64),
+	"last_modified_date" TIMESTAMP WITH TIME ZONE,
 
-	CONSTRAINT `pk_confirmation_code `PRIMARY KEY (`id`),
-	CONSTRAINT `fk_confirmation_code_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+	CONSTRAINT "pk_confirmation_code"PRIMARY KEY ("id"),
+	CONSTRAINT "fk_confirmation_code_user" FOREIGN KEY ("user_id") REFERENCES "user" ("id")
 );
 
-CREATE INDEX `ix_confirmation_code_user_id` on `confirmation_code` (`user_id`);
+CREATE INDEX "ix_confirmation_code_user_id" on "confirmation_code" ("user_id");


### PR DESCRIPTION
### Description
Somewhat depends on #1916 (see "Test Instructions" below)

- Adding Flyway/Postgres dependencies to `pom.xml`
- Updating `common/v0-[common]-schema-init.sql` for Postgres compatibility - backtick replaced with quotation marks. Quotation marks are needed because `user` is a [reserved keyword](https://www.postgresql.org/docs/current/sql-keywords-appendix.html)
- Adding sample Postgres configuration in `application-local.yml.sample`.

### Related Azure Boards Work Items
[AB#4216](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4216)

### Test Instructions
- Run a local Postgres instance (`docker-compose up -d`)
- Update `application-local.yml` to use Postgres instance (see, `spring.datasource` configuration in `application-local.yml.sample`)
- Launch the backend application locally
- Run some requests against the API (eg. `POST /users` then `GET /users/{id}` with the user that was just posted)
- Verify you can't see the data coming from `/data-migrations/h2`

### Additional Notes
Data migration scripts should still run as expected when using h2 database.