### PR TITLE
Changing `/fr/statut` to `/fr/etat`

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -647,7 +647,7 @@
             "file": "routes/$lang/_public/status/_route.tsx",
             "paths": {
               "en": "/:lang/status",
-              "fr": "/:lang/statut"
+              "fr": "/:lang/etat"
             },
             "children": [
               {
@@ -656,7 +656,7 @@
                 "index": true,
                 "paths": {
                   "en": "/:lang/status",
-                  "fr": "/:lang/statut"
+                  "fr": "/:lang/etat"
                 }
               },
               {
@@ -664,7 +664,7 @@
                 "file": "routes/$lang/_public/status/myself.tsx",
                 "paths": {
                   "en": "/:lang/status/myself",
-                  "fr": "/:lang/statut/moi-meme"
+                  "fr": "/:lang/etat/moi-meme"
                 }
               },
               {
@@ -672,7 +672,7 @@
                 "file": "routes/$lang/_public/status/child.tsx",
                 "paths": {
                   "en": "/:lang/status/child",
-                  "fr": "/:lang/statut/enfant"
+                  "fr": "/:lang/etat/enfant"
                 }
               }
             ]


### PR DESCRIPTION
### Description
As per title

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d60e43f2-96c0-4c5f-9fdd-f0b97a1aa256)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/fr/etat`. 