### PR TITLE
[gitops] Bumping staging, training, and perf to `0.0.0-90c8837a-005b2`

### DIFF
--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-5546d19d-005ae
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-90c8837a-005b2
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-5546d19d-005ae
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-90c8837a-005b2
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-5546d19d-005ae
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-90c8837a-005b2
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
As per title.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/aadb161b-da9f-4334-8a02-f3d4989790fd)
