### PR TITLE
(gitops) AB#4216 -- Adding Postgres Operator (from Crunchy Data) base resources

### DIFF
--- a/gitops/base/postgres-operator/kustomization.yaml
+++ b/gitops/base/postgres-operator/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/name: postgres-operator
+      # The version below should match the version on the PostgresCluster CRD
+      app.kubernetes.io/version: 5.6.0
+      postgres-operator.crunchydata.com/control-plane: postgres-operator
+
+resources:
+  - manager.yaml
+  - role_binding.yaml
+  - role.yaml
+  - service_account.yaml
+
+images:
+  - name: postgres-operator
+    newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
+    newTag: ubi8-5.6.0-0
+
+patches:
+  - path: manager-target.yaml

--- a/gitops/base/postgres-operator/manager-target.yaml
+++ b/gitops/base/postgres-operator/manager-target.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: operator
+          env:
+            - name: PGO_TARGET_NAMESPACE
+              valueFrom:
+                { fieldRef: { apiVersion: v1, fieldPath: metadata.namespace } }

--- a/gitops/base/postgres-operator/manager.yaml
+++ b/gitops/base/postgres-operator/manager.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-operator
+  labels:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels:
+      postgres-operator.crunchydata.com/control-plane: postgres-operator
+  template:
+    metadata:
+      labels:
+        postgres-operator.crunchydata.com/control-plane: postgres-operator
+    spec:
+      containers:
+        - name: operator
+          image: postgres-operator
+          env:
+            - name: PGO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CRUNCHY_DEBUG
+              value: "true"
+            - name: RELATED_IMAGE_POSTGRES_15
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.7-1"
+            - name: RELATED_IMAGE_POSTGRES_15_GIS_3.3
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.7-3.3-1"
+            - name: RELATED_IMAGE_POSTGRES_16
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1"
+            - name: RELATED_IMAGE_POSTGRES_16_GIS_3.3
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.3-3.3-1"
+            - name: RELATED_IMAGE_POSTGRES_16_GIS_3.4
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.3-3.4-1"
+            - name: RELATED_IMAGE_PGADMIN
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-26"
+            - name: RELATED_IMAGE_PGBACKREST
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1"
+            - name: RELATED_IMAGE_PGBOUNCER
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.22-1"
+            - name: RELATED_IMAGE_PGEXPORTER
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-0.15.0-7"
+            - name: RELATED_IMAGE_PGUPGRADE
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.6.0-0"
+            - name: RELATED_IMAGE_STANDALONE_PGADMIN
+              value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-8.6-1"
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      serviceAccountName: postgres-operator

--- a/gitops/base/postgres-operator/role.yaml
+++ b/gitops/base/postgres-operator/role.yaml
@@ -1,0 +1,163 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: postgres-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - secrets
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints/restricted
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - crunchybridgeclusters
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - crunchybridgeclusters/finalizers
+      - crunchybridgeclusters/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - pgadmins
+      - pgupgrades
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - pgadmins/finalizers
+      - pgupgrades/finalizers
+      - postgresclusters/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - pgadmins/status
+      - pgupgrades/status
+      - postgresclusters/status
+    verbs:
+      - patch
+  - apiGroups:
+      - postgres-operator.crunchydata.com
+    resources:
+      - postgresclusters
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch

--- a/gitops/base/postgres-operator/role_binding.yaml
+++ b/gitops/base/postgres-operator/role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postgres-operator
+  labels:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: postgres-operator
+subjects:
+  - kind: ServiceAccount
+    name: postgres-operator

--- a/gitops/base/postgres-operator/service_account.yaml
+++ b/gitops/base/postgres-operator/service_account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgres-operator
+  labels:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator


### PR DESCRIPTION
### Description
Kustomization files were taken from [Crunchy Data's PGO examples GitHub](https://github.com/CrunchyData/postgres-operator-examples/tree/main/kustomize/install) with namespace-limited mode as per [their documentation](https://access.crunchydata.com/documentation/postgres-operator/latest/installation/kustomize).

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c0efa7ad-e8ea-46e8-a938-bc5376dde385)

### Test Instructions
From the `gitops` project, run `kubectl apply -k base/postgres-operator`. Then run `kubectl get pods`. Verify that the PGO has been created.