### PR TITLE
(gitops) AB#4216 -- Adding base configuration for Postgres cluster

### DIFF
--- a/gitops/base/postgres/kustomization.yaml
+++ b/gitops/base/postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./postgres-clusters.yaml

--- a/gitops/base/postgres/postgres-clusters.yaml
+++ b/gitops/base/postgres/postgres-clusters.yaml
@@ -1,0 +1,62 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: canada-dental-care-plan-db
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
+  postgresVersion: 16
+  instances:
+    - name: pgha1
+      replicas: 3
+      dataVolumeClaimSpec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 265Gi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: canada-dental-care-plan-db
+                    postgres-operator.crunchydata.com/instance-set: pgha1
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
+      global:
+        repo1-retention-full: "3"
+        repo1-retention-full-type: count
+      repos:
+        - name: repo1
+          schedules:
+            full: "0 0/8 * * *"
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 265Gi
+  proxy:
+    pgBouncer:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.22-1
+      replicas: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: canada-dental-care-plan-db
+                    postgres-operator.crunchydata.com/role: pgbouncer
+  users:
+    - name: postgres
+    - name: canadian-dental-care-plan
+      databases:
+        - canadian-dental-care-plan


### PR DESCRIPTION
### Description
Base configuration includes:
- [connection pooling](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/connection-pooling)
- [user/database management](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management)
- [backup configuration](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/backups) and [backup management](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/backups-disaster-recovery/backup-management)
- [high-availability](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/day-two/high-availability)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/bffc5deb-e79f-4fc2-8c4d-cc883f3b3763)

### Test Instructions
(Note: I performed the test instructions on my local k8s environment with `minikube`)
- In the `gitops` project/directory, run `kubectl apply -k base/postgres-operator` to create the Postgres Operator (PGO) required to create the Postgres cluster
- Install the PGO's CRDs with the following commands:
```
curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml | kubectl create --filename -
curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml | kubectl create --filename -
curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml | kubectl create --filename -
curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml | kubectl create --filename -
```
- Run `kubectl apply -k postgres` to create the Postgres cluster
- Run `kubectl get pods` to verify that the cluster has been created
