### PR TITLE
refactor(frontend): Add button start and end icon props

### DIFF
--- a/frontend/__tests__/components/button-icons.test.tsx
+++ b/frontend/__tests__/components/button-icons.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ButtonEndIcon, ButtonStartIcon } from '~/components/button-icons';
+
+// Mock FontAwesomeIcon to avoid rendering actual icons in tests
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FontAwesomeIcon: ({ className, icon, ...props }: any) => (
+    <div className={className} {...props}>
+      {JSON.stringify(icon)}
+    </div>
+  ),
+}));
+
+describe('ButtonStartIcon', () => {
+  it('should render FontAwesomeIcon with the correct classes', () => {
+    const { container } = render(<ButtonStartIcon icon="spinner" className="custom-class" />);
+    const icon = container.querySelector('div');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('me-3 block size-4 custom-class');
+    expect(icon).toHaveTextContent('spinner');
+  });
+
+  it('should pass additional props to FontAwesomeIcon', () => {
+    const { container } = render(<ButtonStartIcon icon="spinner" aria-label="start-icon" />);
+    const icon = container.querySelector('div');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('aria-label', 'start-icon');
+    expect(icon).toHaveTextContent('spinner');
+  });
+});
+
+describe('ButtonEndIcon', () => {
+  it('should render FontAwesomeIcon with the correct classes', () => {
+    const { container } = render(<ButtonEndIcon icon="spinner" className="custom-class" />);
+    const icon = container.querySelector('div');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('ms-3 block size-4 custom-class');
+    expect(icon).toHaveTextContent('spinner');
+  });
+
+  it('should pass additional props to FontAwesomeIcon', () => {
+    const { container } = render(<ButtonEndIcon icon="spinner" aria-label="end-icon" />);
+    const icon = container.querySelector('div');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('aria-label', 'end-icon');
+    expect(icon).toHaveTextContent('spinner');
+  });
+});

--- a/frontend/app/components/button-icons.tsx
+++ b/frontend/app/components/button-icons.tsx
@@ -1,0 +1,12 @@
+import type { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { cn } from '~/utils/tw-utils';
+
+export function ButtonStartIcon({ className, ...restProps }: FontAwesomeIconProps) {
+  return <FontAwesomeIcon className={cn('me-3 block size-4', className)} {...restProps} />;
+}
+
+export function ButtonEndIcon({ className, ...restProps }: FontAwesomeIconProps) {
+  return <FontAwesomeIcon className={cn('ms-3 block size-4', className)} {...restProps} />;
+}

--- a/frontend/app/components/buttons.tsx
+++ b/frontend/app/components/buttons.tsx
@@ -1,8 +1,12 @@
 import type { ComponentProps } from 'react';
 import { forwardRef } from 'react';
 
+import { ButtonEndIcon, ButtonStartIcon } from './button-icons';
 import { AppLink } from '~/components/app-link';
 import { cn } from '~/utils/tw-utils';
+
+type ButtonEndIconProps = ComponentProps<typeof ButtonEndIcon>;
+type ButtonStartIconProps = ComponentProps<typeof ButtonStartIcon>;
 
 const sizes = {
   xs: 'px-3 py-2 text-xs',
@@ -24,27 +28,41 @@ const variants = {
 const baseClassName = 'inline-flex items-center justify-center rounded border align-middle font-lato outline-offset-4';
 
 export interface ButtonProps extends ComponentProps<'button'> {
-  size?: keyof typeof sizes;
-  variant?: keyof typeof variants;
+  endIcon?: ButtonEndIconProps['icon'];
+  endIconProps?: OmitStrict<ButtonEndIconProps, 'icon'>;
   pill?: boolean;
+  size?: keyof typeof sizes;
+  startIcon?: ButtonStartIconProps['icon'];
+  startIconProps?: OmitStrict<ButtonStartIconProps, 'icon'>;
+  variant?: keyof typeof variants;
 }
 
 /**
  * Tailwind CSS Buttons from Flowbite
  * @see https://flowbite.com/docs/components/buttons/
  */
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ className, pill, size = 'base', variant = 'default', ...props }, ref) => {
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ children, className, endIcon, endIconProps, pill, size = 'base', startIcon, startIconProps, variant = 'default', ...props }, ref) => {
   const disabledClassName = 'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
   const buttonClassName = cn(baseClassName, sizes[size], variants[variant], disabledClassName, pill && 'rounded-full', className);
-  return <button className={buttonClassName} {...props} ref={ref} />;
+  return (
+    <button className={buttonClassName} {...props} ref={ref}>
+      {startIcon && <ButtonStartIcon {...(startIconProps ?? {})} icon={startIcon} />}
+      {children}
+      {endIcon && <ButtonEndIcon {...(endIconProps ?? {})} icon={endIcon} />}
+    </button>
+  );
 });
 
 Button.displayName = 'Button';
 
 export interface ButtonLinkProps extends ComponentProps<typeof AppLink> {
   disabled?: boolean;
+  endIcon?: ButtonEndIconProps['icon'];
+  endIconProps?: OmitStrict<ButtonEndIconProps, 'icon'>;
   size?: keyof typeof sizes;
   variant?: keyof typeof variants;
+  startIcon?: ButtonStartIconProps['icon'];
+  startIconProps?: OmitStrict<ButtonStartIconProps, 'icon'>;
   pill?: boolean;
 }
 
@@ -55,21 +73,29 @@ export interface ButtonLinkProps extends ComponentProps<typeof AppLink> {
  * Disabling a link
  * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
  */
-const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(({ children, className, disabled, pill, size = 'base', routeId, to, variant = 'default', ...props }, ref) => {
+const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(({ children, className, disabled, endIcon, endIconProps, pill, size = 'base', routeId, startIcon, startIconProps, to, variant = 'default', ...props }, ref) => {
   const disabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
   const buttonLinkClassName = cn(baseClassName, sizes[size], variants[variant], pill && 'rounded-full', className);
+
+  const actualChildren = (
+    <>
+      {startIcon && <ButtonStartIcon {...(startIconProps ?? {})} icon={startIcon} />}
+      {children}
+      {endIcon && <ButtonEndIcon {...(endIconProps ?? {})} icon={endIcon} />}
+    </>
+  );
 
   if (disabled) {
     return (
       <a className={cn(buttonLinkClassName, disabledClassName)} role="link" aria-disabled="true" {...props} ref={ref}>
-        {children}
+        {actualChildren}
       </a>
     );
   }
 
   return (
     <AppLink className={buttonLinkClassName} routeId={routeId} to={to} {...props} ref={ref}>
-      {children}
+      {actualChildren}
     </AppLink>
   );
 });

--- a/frontend/app/routes/$lang/_public/status/child.tsx
+++ b/frontend/app/routes/$lang/_public/status/child.tsx
@@ -6,7 +6,6 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -38,7 +37,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { extractDigits, isAllValidInputCharacters } from '~/utils/string-utils';
-import { cn } from '~/utils/tw-utils';
 import { transformFlattenedError } from '~/utils/zod-utils.server';
 
 enum ChildHasSin {
@@ -298,9 +296,8 @@ export default function StatusCheckerChild() {
               {fetcher.data.status.name && <ClientFriendlyStatusMarkdown content={fetcher.data.status.name} />}
             </div>
           </ContextualAlert>
-          <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang/_public/status/index" params={params} className="mt-12">
+          <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang/_public/status/index" params={params} className="mt-12" endIcon={faChevronRight}>
             {t('status:child.check-another')}
-            <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </ButtonLink>
         </>
       ) : (
@@ -376,9 +373,8 @@ export default function StatusCheckerChild() {
                 </>
               )}
             </div>
-            <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit">
+            <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={isSubmitting ? faSpinner : faChevronRight} endIconProps={{ spin: isSubmitting }}>
               {t('status:child.form.submit')}
-              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
           </fetcher.Form>
         </>

--- a/frontend/app/routes/$lang/_public/status/index.tsx
+++ b/frontend/app/routes/$lang/_public/status/index.tsx
@@ -5,7 +5,6 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -26,7 +25,6 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { cn } from '~/utils/tw-utils';
 import { transformFlattenedError } from '~/utils/zod-utils.server';
 
 enum CheckFor {
@@ -211,9 +209,8 @@ export default function StatusChecker() {
           required
           errorMessage={errors?.checkFor}
         />
-        <Button variant="primary" id="submit" disabled={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit">
+        <Button variant="primary" id="submit" disabled={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit" endIcon={isSubmitting ? faSpinner : faChevronRight} endIconProps={{ spin: isSubmitting }}>
           {t('status:form.continue')}
-          <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
         </Button>
       </fetcher.Form>
     </div>

--- a/frontend/app/routes/$lang/_public/status/myself.tsx
+++ b/frontend/app/routes/$lang/_public/status/myself.tsx
@@ -6,7 +6,6 @@ import { json, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronRight, faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -33,7 +32,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { extractDigits } from '~/utils/string-utils';
-import { cn } from '~/utils/tw-utils';
 import { transformFlattenedError } from '~/utils/zod-utils.server';
 
 export const handle = {
@@ -185,9 +183,8 @@ export default function StatusCheckerMyself() {
               {fetcher.data.status.name && <ClientFriendlyStatusMarkdown content={fetcher.data.status.name} />}
             </div>
           </ContextualAlert>
-          <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang/_public/status/index" params={params} className="mt-12">
+          <ButtonLink id="cancel-button" variant="primary" type="button" routeId="$lang/_public/status/index" params={params} className="mt-12" endIcon={faChevronRight}>
             {t('status:myself.check-another')}
-            <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
           </ButtonLink>
         </>
       ) : (
@@ -212,9 +209,8 @@ export default function StatusCheckerMyself() {
               />
               <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t('status:myself.form.sin-label')} helpMessagePrimary={t('status:myself.form.sin-description')} required errorMessage={errors?.sin} defaultValue="" />
             </div>
-            <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit">
+            <Button variant="primary" id="submit" disabled={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={isSubmitting ? faSpinner : faChevronRight} endIconProps={{ spin: isSubmitting }}>
               {t('status:myself.form.submit')}
-              <FontAwesomeIcon icon={isSubmitting ? faSpinner : faChevronRight} className={cn('ms-3 block size-4', isSubmitting && 'animate-spin')} />
             </Button>
           </fetcher.Form>
         </>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add button start and end icon props to help with positioning and cleanup the codebas from repetitive code. This pull request implement the `startIcon` and `endIcon` in status checker pages. Those properties are similar to [MUI Buttons with icons and label example](https://mui.com/material-ui/react-button/#buttons-with-icons-and-label).

Note: Next PR will be to  introduce `LoadingButton` component.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->