### PR TITLE
[gitops] AB#4216 -- Adding `canada-dental-care-plan` namespace and renaming PostgresCluster

### DIFF
--- a/gitops/base/postgres-operator/kustomization.yaml
+++ b/gitops/base/postgres-operator/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: canada-dental-care-plan
 labels:
   - includeTemplates: true
     pairs:
@@ -10,10 +10,10 @@ labels:
       postgres-operator.crunchydata.com/control-plane: postgres-operator
 
 resources:
-  - manager.yaml
-  - role_binding.yaml
-  - role.yaml
-  - service_account.yaml
+  - ./manager.yaml
+  - ./role_binding.yaml
+  - ./role.yaml
+  - ./service_account.yaml
 
 images:
   - name: postgres-operator

--- a/gitops/base/postgres/kustomization.yaml
+++ b/gitops/base/postgres/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: canada-dental-care-plan
 resources:
   - ./postgres-clusters.yaml

--- a/gitops/base/postgres/postgres-clusters.yaml
+++ b/gitops/base/postgres/postgres-clusters.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: canada-dental-care-plan-db
+  name: postgres
 spec:
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16


### PR DESCRIPTION
### Description
As per title.

`PostgresCluster` renamed to be consistent with existing naming conventions for pods in `canada-dental-care-plan` namespace.

### Screenshots (if applicable)
**Before (sample cluster):**
![image](https://github.com/user-attachments/assets/b4dde14f-b516-4ac0-bcc8-fa21a4a4dc67)

**After:**
![image](https://github.com/user-attachments/assets/1ab3ffb1-74aa-44f1-b06f-369892f626f5)