### PR TITLE
Addressing Status Checker bug 4312.

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -267,6 +267,9 @@ USA_COUNTRY_ID=fcf7389e-97ae-eb11-8236-000d3af4bfc3
 ## id for client successful status
 CLIENT_STATUS_SUCCESS_ID=51af5170-614e-ee11-be6f-000d3a09d640
 
+# Invalid statusId that can be returned when using status checker; must be treated like a null statusId
+INVALID_CLIENT_FRIENDLY_STATUS=504fba6e-604e-ee11-be6f-000d3a09d640
+
 # lanuage code for English type
 # (optional; default: 1033)
 ENGLISH_LANGUAGE_CODE=1033

--- a/frontend/app/routes/$lang/_public/status/child.tsx
+++ b/frontend/app/routes/$lang/_public/status/child.tsx
@@ -72,7 +72,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/child/index');
-  const { CLIENT_STATUS_SUCCESS_ID, ENABLED_FEATURES } = getEnv();
+  const { CLIENT_STATUS_SUCCESS_ID, ENABLED_FEATURES, INVALID_CLIENT_FRIENDLY_STATUS } = getEnv();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -202,7 +202,7 @@ export async function action({ context: { session }, params, request }: ActionFu
   const applicationStatusService = getApplicationStatusService();
   const lookupService = getLookupService();
 
-  const statusId = parsedSinResult
+  let statusId = parsedSinResult
     ? await applicationStatusService.getStatusIdWithSin({
         sin: parsedSinResult.data.sin,
         applicationCode: parsedCodeResult.data.code,
@@ -213,6 +213,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         lastName: parsedChildInfoResult?.data.lastName ?? '',
         dateOfBirth: parsedChildInfoResult?.data.dateOfBirth ?? '',
       });
+
+  statusId = statusId === INVALID_CLIENT_FRIENDLY_STATUS ? null : statusId;
 
   const clientFriendlyStatus = statusId ? lookupService.getClientFriendlyStatusById(statusId) : null;
 

--- a/frontend/app/routes/$lang/_public/status/myself.tsx
+++ b/frontend/app/routes/$lang/_public/status/myself.tsx
@@ -62,7 +62,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/myself/index');
-  const { CLIENT_STATUS_SUCCESS_ID, ENABLED_FEATURES } = getEnv();
+  const { CLIENT_STATUS_SUCCESS_ID, ENABLED_FEATURES, INVALID_CLIENT_FRIENDLY_STATUS } = getEnv();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -115,7 +115,8 @@ export async function action({ context: { session }, params, request }: ActionFu
   const applicationStatusService = getApplicationStatusService();
   const lookupService = getLookupService();
   const { sin, code } = parsedDataResult.data;
-  const statusId = await applicationStatusService.getStatusIdWithSin({ sin, applicationCode: code });
+  let statusId = await applicationStatusService.getStatusIdWithSin({ sin, applicationCode: code });
+  statusId = statusId === INVALID_CLIENT_FRIENDLY_STATUS ? null : statusId;
   const clientFriendlyStatus = statusId ? lookupService.getClientFriendlyStatusById(statusId) : null;
 
   function getAlertType() {

--- a/frontend/app/utils/env.server.ts
+++ b/frontend/app/utils/env.server.ts
@@ -73,6 +73,7 @@ const serverEnv = z.object({
   OTHER_GENDER_TYPE_ID: z.string().trim().min(1).default('gender-other'),
   USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
   CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
+  INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
 
   // language codes
   ENGLISH_LANGUAGE_CODE: z.coerce.number().default(1033),


### PR DESCRIPTION
### Description
The "esdc_clientfriendlystatusid": "504fba6e-604e-ee11-be6f-000d3a09d640" should be treated the same way as if the API returns a No Data.

I don't know why the API still responds with this `clientfriendlystatusid` in the first place...

### Related Azure Boards Work Items
[AB#4312](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4312)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Update your `.env` file with what is in the `.env.example` file.

![image](https://github.com/user-attachments/assets/d88729aa-6254-4839-84e5-f625e38e7781)
Change line 101 to `return '504fba6e-604e-ee11-be6f-000d3a09d640'` to force this statusId as a response.

Then navigate to `http://localhost:3000/en/status/myself` and enter any valid SIN and Code. (example: code: 661635 and SIN: 498108802