### PR TITLE
add dropdown-menu unit tests

### DIFF
--- a/frontend/__tests__/components/dropdown-menu.test.tsx
+++ b/frontend/__tests__/components/dropdown-menu.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '~/components/dropdown-menu';
+
+describe('DropdownMenu', () => {
+  it('renders DropdownMenuTrigger and opens DropdownMenuContent on click', async () => {
+    render(
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button>Open Menu</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem asChild>
+            <span>Item 1</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <span>Item 2</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const user = userEvent.setup();
+    const triggerButton = screen.getByText('Open Menu');
+    await user.click(triggerButton);
+
+    expect(screen.getByText('Item 1')).toBeVisible();
+    expect(screen.getByText('Item 2')).toBeVisible();
+  });
+
+  it('renders DropdownMenuCheckboxItem with checked state', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open Menu</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem checked>Checked Item 1</DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem>Checked Item 2</DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const user = userEvent.setup();
+    const triggerButton = screen.getByText('Open Menu');
+    await user.click(triggerButton);
+
+    const checkedItem = screen.getByText('Checked Item 1');
+    expect(checkedItem).toBeInTheDocument();
+    expect(checkedItem).toHaveAttribute('data-state', 'checked');
+
+    const uncheckedItem = screen.getByText('Checked Item 2');
+    expect(uncheckedItem).toBeInTheDocument();
+    expect(uncheckedItem).toHaveAttribute('data-state', 'unchecked');
+  });
+
+  it('renders DropdownMenuRadioItem', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open Menu</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup>
+            <DropdownMenuRadioItem value="item-1">Item 1</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="item-2">Item 2</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const user = userEvent.setup();
+    const triggerButton = screen.getByText('Open Menu');
+    await user.click(triggerButton);
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  it('renders DropdownMenuLabel and DropdownMenuSeparator', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open Menu</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Label</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const user = userEvent.setup();
+    const triggerButton = screen.getByText('Open Menu');
+    await user.click(triggerButton);
+
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+  });
+
+  it('renders DropdownMenuSub with nested items', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open Menu</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Sub Menu</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Sub Item 1</DropdownMenuItem>
+              <DropdownMenuItem>Sub Item 2</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const user = userEvent.setup();
+    const triggerButton = screen.getByText('Open Menu');
+    await user.click(triggerButton);
+
+    const subTrigger = screen.getByText('Sub Menu');
+    await user.click(subTrigger);
+
+    expect(screen.getByText('Sub Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Sub Item 2')).toBeInTheDocument();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
         "@remix-run/testing": "^2.10.3",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/compression": "^1.7.5",
         "@types/express": "^4.17.21",
@@ -3579,6 +3580,19 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "@remix-run/testing": "^2.10.3",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
### Description
- adds unit tests for `DropdownMenu`
- adds dev dependency `@testing-library/user-event`.  We need this because `fireEvent` isn't able to handle side-effects, like clicking on a button and then finding a newly added element in the DOM.  For more info, see the `user-event` [docs](https://testing-library.com/docs/user-event/intro/#differences-from-fireevent)

### Related Azure Boards Work Items
[AB#4309](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4309)