### PR TITLE
Memoize @remix-run/router's `compilePath()` function

### DIFF
--- a/frontend/other/patches/@remix-run+router+1.18.0.patch
+++ b/frontend/other/patches/@remix-run+router+1.18.0.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/@remix-run/router/dist/router.cjs.js b/node_modules/@remix-run/router/dist/router.cjs.js
+index 0fbf253..053d307 100644
+--- a/node_modules/@remix-run/router/dist/router.cjs.js
++++ b/node_modules/@remix-run/router/dist/router.cjs.js
+@@ -10,6 +10,12 @@
+  */
+ 'use strict';
+ 
++// XXX :: GjB :: **PERFORMANCE ISSUE MITIGATION**
++//
++// We use moize to memoize the `compilePath()` function to attempt to
++// gain some performance when building regexes for matching incoming requests.
++const moize = require("moize");
++
+ Object.defineProperty(exports, '__esModule', { value: true });
+ 
+ function _extends() {
+@@ -1072,7 +1078,9 @@ function matchPath(pattern, pathname) {
+     pattern
+   };
+ }
+-function compilePath(path, caseSensitive, end) {
++// XXX :: GjB :: **PERFORMANCE ISSUE MITIGATION**
++const compilePath = moize(compilePathOrig, { maxSize: Infinity });
++function compilePathOrig(path, caseSensitive, end) {
+   if (caseSensitive === void 0) {
+     caseSensitive = false;
+   }


### PR DESCRIPTION
### Memoize @remix-run/router's `compilePath()` function

This is a first-attempt at fixing performance issues.

``` shell
❯ npm install

> postinstall
> patch-package --patch-dir other/patches

patch-package 8.0.0
Applying patches...
@remix-run/router@1.18.0 ✔
```

### Checklist

- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
