### PR TITLE
small refactor of getAlertType in status checker

### DIFF
--- a/frontend/__tests__/utils/application-code-utils.test.ts
+++ b/frontend/__tests__/utils/application-code-utils.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatSubmissionApplicationCode, isValidCodeOrNumber } from '~/utils/application-code-utils';
+import { formatSubmissionApplicationCode, getContextualAlertType, isValidCodeOrNumber } from '~/utils/application-code-utils';
+
+vi.mock('~/utils/env.server', () => ({
+  getEnv: vi.fn().mockReturnValue({
+    CLIENT_STATUS_SUCCESS_ID: '000',
+    INVALID_CLIENT_FRIENDLY_STATUS: '111',
+  }),
+}));
 
 describe('~/utils/application-code-utils.ts', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
   describe('isValidCodeOrNumber()', () => {
     it.each([['123456'], ['123 456'], ['12345678901'], ['123 456 789 01'], ['1234567890123'], ['123 456 789 0123']])('should return true for a valid application code (6, 11 and 13 digits) with %s', (value) => {
       expect(isValidCodeOrNumber(value)).toEqual(true);
@@ -37,6 +48,17 @@ describe('~/utils/application-code-utils.ts', () => {
 
     it('should return the input if the application code is invalid', () => {
       expect(formatSubmissionApplicationCode('123 abc')).toEqual('123 abc');
+    });
+  });
+
+  describe('getContextualAlertType', () => {
+    it.each([
+      ['000', 'danger', 'success'],
+      ['111', 'warning', 'danger'],
+      ['222', undefined, 'info'],
+      [null, 'danger', 'danger'],
+    ])('getContextualAlertType(%j,%j) should return "%s"', (statusId, nullStatusMapping, expected) => {
+      expect(getContextualAlertType(statusId, nullStatusMapping)).toEqual(expected);
     });
   });
 });

--- a/frontend/app/utils/application-code-utils.ts
+++ b/frontend/app/utils/application-code-utils.ts
@@ -1,3 +1,5 @@
+import { getEnv } from './env.server';
+
 export const applicationCodeInputPatternFormat = '### ### ### ####';
 const applicationCodeFormatRegex = /^\d{3}[ ]?\d{3}$/;
 const clientNumberFormatRegex = /^\d{3}[ ]?\d{3}[ ]?\d{3}[ ]?\d{2}$/;
@@ -54,4 +56,24 @@ export function formatSubmissionApplicationCode(applicationCode: string): string
   const strippedCode = applicationCode.replace(/ /g, '');
   if (!/^\d{13}$/.test(strippedCode)) return applicationCode;
   return (strippedCode.match(/....$|.../g) ?? []).join(' ');
+}
+
+/**
+ *
+ * @param statusId - the statusId of the application to check
+ * @param nullStatusMapping- the type to return if a null statusId is supplied; defaults to 'info'
+ * @returns the "info" | "success" | "danger" | "warning" which is consumed by the ContextualAlert component
+ */
+export function getContextualAlertType(statusId: string | null, nullStatusMapping = 'info') {
+  const { CLIENT_STATUS_SUCCESS_ID, INVALID_CLIENT_FRIENDLY_STATUS } = getEnv();
+  switch (statusId) {
+    case null:
+      return nullStatusMapping as 'info' | 'success' | 'danger' | 'warning';
+    case INVALID_CLIENT_FRIENDLY_STATUS:
+      return 'danger';
+    case CLIENT_STATUS_SUCCESS_ID:
+      return 'success';
+    default:
+      return 'info';
+  }
 }


### PR DESCRIPTION
### Description
moves `getAlertType` into a utility file.  Previously this function was operating on a global variable which has since been changed to accept the `statusId` as the only argument.  

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
