### PR TITLE
[gitops] Bump CPU and memory for frontend

### DIFF
--- a/gitops/base/frontend/deployments.yaml
+++ b/gitops/base/frontend/deployments.yaml
@@ -29,10 +29,10 @@ spec:
               port: http
           resources:
             requests:
-              cpu: 250m
-              memory: 256Mi
-            limits:
               cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
               memory: 1024Mi
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
### Increase frontend resources

- increase frontend CPU to `500m`
- increase frontend memory to `512Mi`

Performance testing showed that under load, `250m` causes the application to scale up too quickly, and the application consistently uses more than `256Mi` of memory.