### PR TITLE
4325 Change address validation on all the /contact-information pages

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
@@ -145,6 +145,10 @@ export async function action({ context: { session }, params, request }: ActionFu
         }
       }
 
+      if (val.mailingCountry && val.mailingCountry !== CANADA_COUNTRY_ID && val.mailingPostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.mailingPostalCode)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.mailing-address.invalid-postal-code-for-country'), path: ['mailingCountry'] });
+      }
+
       if (val.copyMailingAddress === false) {
         if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.home-address.address-required'), path: ['homeAddress'] });
@@ -168,6 +172,10 @@ export async function action({ context: { session }, params, request }: ActionFu
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-adult-child:contact-information.error-message.home-address.postal-code-valid') : t('apply-adult-child:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+          }
+
+          if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.home-address.invalid-postal-code-for-country'), path: ['homeCountry'] });
           }
         }
       }

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
@@ -145,6 +145,10 @@ export async function action({ context: { session }, params, request }: ActionFu
         }
       }
 
+      if (val.mailingCountry && val.mailingCountry !== CANADA_COUNTRY_ID && val.mailingPostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.mailingPostalCode)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.mailing-address.invalid-postal-code-for-country'), path: ['mailingCountry'] });
+      }
+
       if (val.copyMailingAddress === false) {
         if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.home-address.address-required'), path: ['homeAddress'] });
@@ -169,6 +173,10 @@ export async function action({ context: { session }, params, request }: ActionFu
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-adult:contact-information.error-message.home-address.postal-code-valid') : t('apply-adult:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
           }
+        }
+
+        if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.home-address.invalid-postal-code-for-country'), path: ['homeCountry'] });
         }
       }
     })

--- a/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
@@ -145,6 +145,10 @@ export async function action({ context: { session }, params, request }: ActionFu
         }
       }
 
+      if (val.mailingCountry && val.mailingCountry !== CANADA_COUNTRY_ID && val.mailingPostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.mailingPostalCode)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.mailing-address.invalid-postal-code-for-country'), path: ['mailingCountry'] });
+      }
+
       if (val.copyMailingAddress === false) {
         if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.home-address.address-required'), path: ['homeAddress'] });
@@ -168,6 +172,10 @@ export async function action({ context: { session }, params, request }: ActionFu
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-child:contact-information.error-message.home-address.postal-code-valid') : t('apply-child:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+          }
+
+          if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.home-address.invalid-postal-code-for-country'), path: ['homeCountry'] });
           }
         }
       }

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -315,7 +315,8 @@
         "postal-code-required": "Enter postal code or zip code for your mailing address",
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
-        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -324,7 +325,8 @@
         "postal-code-required": "Enter postal code or zip code for your home address",
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
-        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -326,7 +326,8 @@
         "postal-code-required": "Enter postal code or zip code for your mailing address",
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
-        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -335,7 +336,8 @@
         "postal-code-required": "Enter postal code or zip code for your home address",
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
-        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -406,7 +406,8 @@
         "postal-code-required": "Enter postal code or zip code for your mailing address",
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
-        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -415,7 +416,8 @@
         "postal-code-required": "Enter postal code or zip code for your home address",
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
-        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789"
+        "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -314,7 +314,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse postale",
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -323,7 +324,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse du domicile",
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -326,7 +326,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse postale",
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -335,7 +336,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse du domicile",
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -406,7 +406,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse postale",
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -415,7 +416,8 @@
         "postal-code-required": "Entrez un code postal ou un code postal américain pour votre adresse du domicile",
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
-        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789"
+        "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",


### PR DESCRIPTION
### Description
Adds validation against Canadian-like postal codes when the country selected isn't Canada.

per user story:

In the /contact-information pages, for both home and mailing :

    If country != Canada && postal code != empty
        If postal code matches Canadian format
            Generate validation error



### Related Azure Boards Work Items
[AB#4325](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4325)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f82a32d1-a310-41df-b9f4-daa50826c644)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`