### PR TITLE
chore(frontend): bump minor dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "fast-xml-parser": "^4.4.1",
         "i18next": "^23.12.2",
         "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-fs-backend": "^2.3.1",
+        "i18next-fs-backend": "^2.3.2",
         "i18next-http-backend": "^2.5.2",
         "ioredis": "^5.4.1",
         "isbot": "^5.1.13",
@@ -59,8 +59,8 @@
         "source-map-support": "^0.5.21",
         "tailwind-merge": "^2.4.0",
         "tiny-invariant": "^1.3.3",
-        "tsx": "^4.16.2",
-        "undici": "^6.19.4",
+        "tsx": "^4.16.3",
+        "undici": "^6.19.5",
         "use-deep-compare": "^1.3.0",
         "validator": "^13.12.0",
         "web-streams-node": "^0.4.0",
@@ -87,8 +87,8 @@
         "@types/validator": "^13.12.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@vitejs/plugin-react": "^4.3.1",
-        "@vitest/coverage-v8": "^2.0.4",
-        "@vitest/ui": "^2.0.4",
+        "@vitest/coverage-v8": "^2.0.5",
+        "@vitest/ui": "^2.0.5",
         "chokidar": "^3.6.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -105,7 +105,7 @@
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.5.4",
         "vite-tsconfig-paths": "^4.3.2",
-        "vitest": "^2.0.4"
+        "vitest": "^2.0.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4499,9 +4499,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.0.4.tgz",
-      "integrity": "sha512-i4lx/Wpg5zF1h2op7j0wdwuEQxaL/YTwwQaKuKMHYj7MMh8c7I4W7PNfOptZBCSBZI0z1qwn64o0pM/pA8Tz1g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.0.5.tgz",
+      "integrity": "sha512-qeFcySCg5FLO2bHHSa0tAZAOnAUbp4L6/A5JDuj9+bt53JREl8hpLjLHEWF0e/gWc8INVpJaqA7+Ene2rclpZg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -4521,17 +4521,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.0.4"
+        "vitest": "2.0.5"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.4.tgz",
-      "integrity": "sha512-39jr5EguIoanChvBqe34I8m1hJFI4+jxvdOpD7gslZrVQBKhh8H9eD7J/LJX4zakrw23W+dITQTDqdt43xVcJw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.0.4",
-        "@vitest/utils": "2.0.4",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
         "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -4540,9 +4540,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.4.tgz",
-      "integrity": "sha512-RYZl31STbNGqf4l2eQM1nvKPXE0NhC6Eq0suTTePc4mtMQ1Fn8qZmjV4emZdEdG2NOWGKSCrHZjmTqDCDoeFBw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -4552,12 +4552,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.4.tgz",
-      "integrity": "sha512-Gk+9Su/2H2zNfNdeJR124gZckd5st4YoSuhF1Rebi37qTXKnqYyFCd9KP4vl2cQHbtuVKjfEKrNJxHHCW8thbQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
+      "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.0.4",
+        "@vitest/utils": "2.0.5",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -4565,12 +4565,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.4.tgz",
-      "integrity": "sha512-or6Mzoz/pD7xTvuJMFYEtso1vJo1S5u6zBTinfl+7smGUhqybn6VjzCDMhmTyVOFWwkCMuNjmNNxnyXPgKDoPw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
+      "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.4",
+        "@vitest/pretty-format": "2.0.5",
         "magic-string": "^0.30.10",
         "pathe": "^1.1.2"
       },
@@ -4579,9 +4579,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.4.tgz",
-      "integrity": "sha512-uTXU56TNoYrTohb+6CseP8IqNwlNdtPwEO0AWl+5j7NelS6x0xZZtP0bDWaLvOfUbaYwhhWp1guzXUxkC7mW7Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^3.0.0"
@@ -4591,12 +4591,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.0.4.tgz",
-      "integrity": "sha512-9SNE9ve3kgDkVTxJsY7BjqSwyqDVRJbq/AHVHZs+V0vmr/0cCX6yGT6nOahSXEsXFtKAsvRtBXKlTgr+5njzZQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.0.5.tgz",
+      "integrity": "sha512-m+ZpVt/PVi/nbeRKEjdiYeoh0aOfI9zr3Ria9LO7V2PlMETtAXJS3uETEZkc8Be2oOl8mhd7Ew+5SRBXRYncNw==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.0.4",
+        "@vitest/utils": "2.0.5",
         "fast-glob": "^3.3.2",
         "fflate": "^0.8.2",
         "flatted": "^3.3.1",
@@ -4608,16 +4608,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.0.4"
+        "vitest": "2.0.5"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.4.tgz",
-      "integrity": "sha512-Zc75QuuoJhOBnlo99ZVUkJIuq4Oj0zAkrQ2VzCqNCx6wAwViHEh5Fnp4fiJTE9rA+sAoXRf00Z9xGgfEzV6fzQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.4",
+        "@vitest/pretty-format": "2.0.5",
         "estree-walker": "^3.0.3",
         "loupe": "^3.1.1",
         "tinyrainbow": "^1.2.0"
@@ -8368,9 +8368,9 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.1.tgz",
-      "integrity": "sha512-tvfXskmG/9o+TJ5Fxu54sSO5OkY6d+uMn+K6JiUGLJrwxAVfer+8V3nU8jq3ts9Pe5lXJv4b1N7foIjJ8Iy2Gg=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.2.tgz",
+      "integrity": "sha512-LIwUlkqDZnUI8lnUxBnEj8K/FrHQTT/Sc+1rvDm9E8YvvY5YxzoEAASNx+W5M9DfD5s77lI5vSAFWeTp26B/3Q=="
     },
     "node_modules/i18next-http-backend": {
       "version": "2.5.2",
@@ -9649,12 +9649,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/magicast": {
@@ -14368,9 +14368,9 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/tsx": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.16.2.tgz",
-      "integrity": "sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.16.3.tgz",
+      "integrity": "sha512-MP8AEUxVnboD2rCC6kDLxnpDBNWN9k3BSVU/0/nNxgm70bPBnfn+yCKcnOsIVPQwdkbKYoFOlKjjWZWJ2XCXUg==",
       "dependencies": {
         "esbuild": "~0.21.5",
         "get-tsconfig": "^4.7.5"
@@ -14900,9 +14900,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.4.tgz",
-      "integrity": "sha512-i3uaEUwNdkRq2qtTRRJb13moW5HWqviu7Vl7oYRYz++uPtGHJj+x7TGjcEuwS5Mt2P4nA0U9dhIX3DdB6JGY0g==",
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg==",
       "engines": {
         "node": ">=18.17"
       }
@@ -15843,18 +15843,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.4.tgz",
-      "integrity": "sha512-luNLDpfsnxw5QSW4bISPe6tkxVvv5wn2BBs/PuDRkhXZ319doZyLOBr1sjfB5yCEpTiU7xCAdViM8TNVGPwoog==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
+      "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@vitest/expect": "2.0.4",
-        "@vitest/pretty-format": "^2.0.4",
-        "@vitest/runner": "2.0.4",
-        "@vitest/snapshot": "2.0.4",
-        "@vitest/spy": "2.0.4",
-        "@vitest/utils": "2.0.4",
+        "@vitest/expect": "2.0.5",
+        "@vitest/pretty-format": "^2.0.5",
+        "@vitest/runner": "2.0.5",
+        "@vitest/snapshot": "2.0.5",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
         "chai": "^5.1.1",
         "debug": "^4.3.5",
         "execa": "^8.0.1",
@@ -15865,7 +15865,7 @@
         "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.0.4",
+        "vite-node": "2.0.5",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -15880,8 +15880,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.0.4",
-        "@vitest/ui": "2.0.4",
+        "@vitest/browser": "2.0.5",
+        "@vitest/ui": "2.0.5",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -16041,9 +16041,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.4.tgz",
-      "integrity": "sha512-ZpJVkxcakYtig5iakNeL7N3trufe3M6vGuzYAr4GsbCTwobDeyPJpE4cjDhhPluv8OvQCFzu2LWp6GkoKRITXA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "fast-xml-parser": "^4.4.1",
     "i18next": "^23.12.2",
     "i18next-browser-languagedetector": "^8.0.0",
-    "i18next-fs-backend": "^2.3.1",
+    "i18next-fs-backend": "^2.3.2",
     "i18next-http-backend": "^2.5.2",
     "ioredis": "^5.4.1",
     "isbot": "^5.1.13",
@@ -74,8 +74,8 @@
     "source-map-support": "^0.5.21",
     "tailwind-merge": "^2.4.0",
     "tiny-invariant": "^1.3.3",
-    "tsx": "^4.16.2",
-    "undici": "^6.19.4",
+    "tsx": "^4.16.3",
+    "undici": "^6.19.5",
     "use-deep-compare": "^1.3.0",
     "validator": "^13.12.0",
     "web-streams-node": "^0.4.0",
@@ -102,8 +102,8 @@
     "@types/validator": "^13.12.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "@vitest/coverage-v8": "^2.0.4",
-    "@vitest/ui": "^2.0.4",
+    "@vitest/coverage-v8": "^2.0.5",
+    "@vitest/ui": "^2.0.5",
     "chokidar": "^3.6.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -120,7 +120,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.4",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^2.0.4"
+    "vitest": "^2.0.5"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

```
@vitest/coverage-v8   ^2.0.4  →   ^2.0.5
@vitest/ui            ^2.0.4  →   ^2.0.5
i18next-fs-backend    ^2.3.1  →   ^2.3.2
tsx                  ^4.16.2  →  ^4.16.3
undici               ^6.19.4  →  ^6.19.5
vitest                ^2.0.4  →   ^2.0.5
```