### PR TITLE
Remove vitest hack

### DIFF
--- a/frontend/__tests__/setup-test-env.ts
+++ b/frontend/__tests__/setup-test-env.ts
@@ -1,14 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 
-import { JSDOM } from 'jsdom';
 import { afterEach } from 'vitest';
-
-// Workaround: For some reason FormData is not set to jsdom's by default
-const jsdom = new JSDOM(`<!doctype html>`);
-const { FormData } = jsdom.window;
-window.FormData = FormData;
-global.FormData = FormData;
 
 /**
  * Jest has their globals API enabled by default. Vitest does not. We can either enable globals via the globals

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,13 @@
 /// <reference types="vitest" />
+import { installGlobals } from '@remix-run/node';
+
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults, defineConfig } from 'vitest/config';
+
+// install global node polyfills
+// see: https://remix.run/docs/en/main/other-api/node#polyfills
+installGlobals();
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],


### PR DESCRIPTION
### Remove vitest hack

This PR removes a workaround/hack from `setup-test-env.ts` in preparation for #2009.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
