### PR TITLE
4348 Add validation on postal codes for Addresses

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -249,6 +249,47 @@ APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY=775170002
 # id for 'Canada'
 # (optional; default: 0cf5389e-97ae-eb11-8236-000d3af4bfc3)
 CANADA_COUNTRY_ID=0cf5389e-97ae-eb11-8236-000d3af4bfc3
+
+# id for 'Alberta'
+# (optional; default: 3b17d494-35b3-eb11-8236-0022486d8d5f)
+ALBERTA_PROVINCE_ID=3b17d494-35b3-eb11-8236-0022486d8d5f
+# id for 'British Columbia'
+# (optional; default: 9c440baa-35b3-eb11-8236-0022486d8d5f)
+BRITISH_COLUMBIA_PROVINCE_ID=9c440baa-35b3-eb11-8236-0022486d8d5f
+# id for 'Manitoba'
+# (optional; default: 6d861c55-36b3-eb11-8236-0022486d8d5f)
+MANITOBA_PROVINCE_ID=6d861c55-36b3-eb11-8236-0022486d8d5f
+# id for 'New Brunswick'
+# (optional; default: 323dc27a2-36b3-eb11-8236-0022486d8d5f)
+NEW_BRUNSWICK_PROVINCE_ID=23dc27a2-36b3-eb11-8236-0022486d8d5f
+# id for 'Nova Scotia'
+# (optional; default: fc2243c9-36b3-eb11-8236-0022486d8d5f)
+NOVA_SCOTIA_PROVINCE_ID=fc2243c9-36b3-eb11-8236-0022486d8d5f
+# id for 'Ontario'
+# (optional; default: daf4d05b-37b3-eb11-8236-0022486d8d5f)
+ONTARIO_PROVINCE_ID=daf4d05b-37b3-eb11-8236-0022486d8d5f
+# id for 'Quebec'
+# (optional; default: 39449f70-37b3-eb11-8236-0022486d8d5f)
+QUEBEC_PROVINCE_ID=39449f70-37b3-eb11-8236-0022486d8d5f
+# id for 'Sasketchewan'
+# (optional; default: 5bc09caf-38b3-eb11-8236-0022486d8d5f)
+SASKATCHEWAN_PROVINCE_ID=5bc09caf-38b3-eb11-8236-0022486d8d5f
+# id for 'Newfoundland'
+# (optional; default: 5abc28c9-38b3-eb11-8236-0022486d8d5f)
+NEWFOUNDLAND_PROVINCE_ID=5abc28c9-38b3-eb11-8236-0022486d8d5f
+# id for 'Prince Edward Island'
+# (optional; default: 3b8110df-38b3-eb11-8236-0022486d8d5f)
+PRINCE_EDWARD_ISLAND_PROVINCE_ID=3b8110df-38b3-eb11-8236-0022486d8d5f
+# id for 'Nunavut'
+# (optional; default: 9936c08e-39b3-eb11-8236-0022486d8d5f)
+NUNAVUT_PROVINCE_ID=9936c08e-39b3-eb11-8236-0022486d8d5f
+# id for 'Northwest Territories'
+# (optional; default: 026aca2-39b3-eb11-8236-0022486d8d5f)
+NORTHWEST_TERRITORIES_PROVINCE_ID=026aca2-39b3-eb11-8236-0022486d8d5f
+# id for 'Yukon'
+# (optional; default: 8fef32b7-39b3-eb11-8236-0022486d8d5f)
+YUKON_PROVINCE_ID=8fef32b7-39b3-eb11-8236-0022486d8d5f
+
 # id for 'Email' communication method
 # (optional; default: 775170000)
 COMMUNICATION_METHOD_EMAIL_ID=775170000

--- a/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
+++ b/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
@@ -1,11 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 
 vi.mock('~/utils/env-utils.server', () => ({
   getEnv: vi.fn().mockReturnValue({
     CANADA_COUNTRY_ID: 'CA',
     USA_COUNTRY_ID: 'US',
+    ALBERTA_PROVINCE_ID: 'AB',
+    BRITISH_COLUMBIA_PROVINCE_ID: 'BC',
+    MANITOBA_PROVINCE_ID: 'MB',
+    NEW_BRUNSWICK_PROVINCE_ID: 'NB',
+    NOVA_SCOTIA_PROVINCE_ID: 'NS',
+    ONTARIO_PROVINCE_ID: 'ON',
+    QUEBEC_PROVINCE_ID: 'QC',
+    SASKATCHEWAN_PROVINCE_ID: 'SK',
+    NEWFOUNDLAND_PROVINCE_ID: 'NL',
+    PRINCE_EDWARD_ISLAND_PROVINCE_ID: 'PE',
+    NUNAVUT_PROVINCE_ID: 'NU',
+    NORTHWEST_TERRITORIES_PROVINCE_ID: 'NW',
+    YUKON_PROVINCE_ID: 'YU',
   }),
 }));
 
@@ -51,6 +64,54 @@ describe('~/utils/postal-zip-code-utils.server.ts', () => {
 
     it('should return true for country codes that are not Canadian or American codes', () => {
       expect(isValidPostalCode('XYZ', 'ABC 123')).toEqual(true);
+    });
+  });
+
+  describe('isValidCanadianPostalCode', () => {
+    const testParams = [
+      ['BC', 'v0h0h0', true],
+      ['AB', 't0h0h0', true],
+      ['SK', 's0h0h0', true],
+      ['MB', 'r0h0h0', true],
+      ['ON', 'k0h0h0', true],
+      ['ON', 'l0h0h0', true],
+      ['ON', 'm0h0h0', true],
+      ['ON', 'n0h0h0', true],
+      ['ON', 'p0h0h0', true],
+      ['QC', 'g0h0h0', true],
+      ['QC', 'j0h0h0', true],
+      ['NB', 'e0h0h0', true],
+      ['NS', 'b0h0h0', true],
+      ['PE', 'c0h0h0', true],
+      ['NL', 'a0h0h0', true],
+      ['YU', 'y0h0h0', true],
+      ['NW', 'x0h0h0', true],
+      ['BC', 'i0h0h0', false],
+      ['AB', 'i0h0h0', false],
+      ['SK', 'i0h0h0', false],
+      ['MB', 'i0h0h0', false],
+      ['ON', 'i0h0h0', false],
+      ['ON', 'i0h0h0', false],
+      ['ON', 'i0h0h0', false],
+      ['ON', 'i0h0h0', false],
+      ['ON', 'i0h0h0', false],
+      ['QC', 'i0h0h0', false],
+      ['QC', 'i0h0h0', false],
+      ['NB', 'i0h0h0', false],
+      ['NS', 'i0h0h0', false],
+      ['PE', 'i0h0h0', false],
+      ['NL', 'i0h0h0', false],
+      ['YU', 'i0h0h0', false],
+      ['XX', 'h0h0h0', false],
+      ['AB', 't0h 0h0', true],
+      ['AB', 't0h  0h0', false],
+      ['AB', 'T0h  0H0', false],
+      ['AB', 'T0h 0H0', true],
+      ['AB', '  T0h 0H0 ', false],
+    ] as const;
+
+    it.each(testParams)('isValidCanadianPostalCode(%j,%j) should return "%s"', (provinceCode, postalCode, expected) => {
+      expect(isValidCanadianPostalCode(provinceCode, postalCode)).toEqual(expected);
     });
   });
 

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/contact-information.tsx
@@ -32,7 +32,7 @@ import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { localizeAndSortCountries, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -142,6 +142,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         } else if (!isValidPostalCode(val.mailingCountry, val.mailingPostalCode)) {
           const message = val.mailingCountry === CANADA_COUNTRY_ID ? t('apply-adult-child:contact-information.error-message.mailing-address.postal-code-valid') : t('apply-adult-child:contact-information.error-message.mailing-address.zip-code-valid');
           ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['mailingPostalCode'] });
+        } else if (val.mailingCountry === CANADA_COUNTRY_ID && val.mailingProvince && !isValidCanadianPostalCode(val.mailingProvince, val.mailingPostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.mailing-address.invalid-postal-code-for-province'), path: ['mailingPostalCode'] });
         }
       }
 
@@ -172,6 +174,8 @@ export async function action({ context: { session }, params, request }: ActionFu
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-adult-child:contact-information.error-message.home-address.postal-code-valid') : t('apply-adult-child:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+          } else if (val.homeCountry === CANADA_COUNTRY_ID && val.homeProvince && !isValidCanadianPostalCode(val.homeProvince, val.homePostalCode)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:contact-information.error-message.home-address.invalid-postal-code-for-province'), path: ['homePostalCode'] });
           }
 
           if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/contact-information.tsx
@@ -32,7 +32,7 @@ import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { localizeAndSortCountries, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -136,12 +136,13 @@ export async function action({ context: { session }, params, request }: ActionFu
         if (!val.mailingProvince || validator.isEmpty(val.mailingProvince)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.mailing-address.province-required'), path: ['mailingProvince'] });
         }
-
         if (!val.mailingPostalCode || validator.isEmpty(val.mailingPostalCode)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.mailing-address.postal-code-required'), path: ['mailingPostalCode'] });
         } else if (!isValidPostalCode(val.mailingCountry, val.mailingPostalCode)) {
           const message = val.mailingCountry === CANADA_COUNTRY_ID ? t('apply-adult:contact-information.error-message.mailing-address.postal-code-valid') : t('apply-adult:contact-information.error-message.mailing-address.zip-code-valid');
           ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['mailingPostalCode'] });
+        } else if (val.mailingCountry === CANADA_COUNTRY_ID && val.mailingProvince && !isValidCanadianPostalCode(val.mailingProvince, val.mailingPostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.mailing-address.invalid-postal-code-for-province'), path: ['mailingPostalCode'] });
         }
       }
 
@@ -166,12 +167,13 @@ export async function action({ context: { session }, params, request }: ActionFu
           if (!val.homeProvince || validator.isEmpty(val.homeProvince)) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.home-address.province-required'), path: ['homeProvince'] });
           }
-
           if (!val.homePostalCode || validator.isEmpty(val.homePostalCode)) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.home-address.postal-code-required'), path: ['homePostalCode'] });
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-adult:contact-information.error-message.home-address.postal-code-valid') : t('apply-adult:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+          } else if (val.homeCountry === CANADA_COUNTRY_ID && val.homeProvince && !isValidCanadianPostalCode(val.homeProvince, val.homePostalCode)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:contact-information.error-message.home-address.invalid-postal-code-for-province'), path: ['homePostalCode'] });
           }
         }
 

--- a/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/contact-information.tsx
@@ -32,7 +32,7 @@ import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { localizeAndSortCountries, localizeAndSortRegions } from '~/utils/lookup-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -142,6 +142,8 @@ export async function action({ context: { session }, params, request }: ActionFu
         } else if (!isValidPostalCode(val.mailingCountry, val.mailingPostalCode)) {
           const message = val.mailingCountry === CANADA_COUNTRY_ID ? t('apply-child:contact-information.error-message.mailing-address.postal-code-valid') : t('apply-child:contact-information.error-message.mailing-address.zip-code-valid');
           ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['mailingPostalCode'] });
+        } else if (val.mailingCountry === CANADA_COUNTRY_ID && val.mailingProvince && !isValidCanadianPostalCode(val.mailingProvince, val.mailingPostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.mailing-address.invalid-postal-code-for-province'), path: ['mailingPostalCode'] });
         }
       }
 
@@ -172,6 +174,8 @@ export async function action({ context: { session }, params, request }: ActionFu
           } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
             const message = val.homeCountry === CANADA_COUNTRY_ID ? t('apply-child:contact-information.error-message.home-address.postal-code-valid') : t('apply-child:contact-information.error-message.home-address.zip-code-valid');
             ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+          } else if (val.homeCountry === CANADA_COUNTRY_ID && val.homeProvince && !isValidCanadianPostalCode(val.homeProvince, val.homePostalCode)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:contact-information.error-message.home-address.invalid-postal-code-for-province'), path: ['homePostalCode'] });
           }
 
           if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -67,13 +67,28 @@ const serverEnv = z.object({
 
   // lookup identifiers
   CANADA_COUNTRY_ID: z.string().trim().min(1).default('0cf5389e-97ae-eb11-8236-000d3af4bfc3'),
+  USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
   COMMUNICATION_METHOD_EMAIL_ID: z.string().trim().min(1).default('775170000'),
   FIRST_NATIONS_YES_TYPE_ID: z.string().trim().min(1).default('first-nations-yes'),
   OTHER_EQUITY_TYPE_ID: z.string().trim().min(1).default('equity-other'),
   OTHER_GENDER_TYPE_ID: z.string().trim().min(1).default('gender-other'),
-  USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
   CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
   INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
+
+  // province/territory lookup identifiers
+  ALBERTA_PROVINCE_ID: z.string().trim().min(1).default("3b17d494-35b3-eb11-8236-0022486d8d5f"),
+  BRITISH_COLUMBIA_PROVINCE_ID: z.string().trim().min(1).default("9c440baa-35b3-eb11-8236-0022486d8d5f"),
+  MANITOBA_PROVINCE_ID: z.string().trim().min(1).default("6d861c55-36b3-eb11-8236-0022486d8d5f"),
+  NEW_BRUNSWICK_PROVINCE_ID: z.string().trim().min(1).default("23dc27a2-36b3-eb11-8236-0022486d8d5f"),
+  NOVA_SCOTIA_PROVINCE_ID: z.string().trim().min(1).default("fc2243c9-36b3-eb11-8236-0022486d8d5f"),
+  ONTARIO_PROVINCE_ID: z.string().trim().min(1).default("daf4d05b-37b3-eb11-8236-0022486d8d5f"),
+  QUEBEC_PROVINCE_ID: z.string().trim().min(1).default("39449f70-37b3-eb11-8236-0022486d8d5f"),
+  SASKATCHEWAN_PROVINCE_ID: z.string().trim().min(1).default("5bc09caf-38b3-eb11-8236-0022486d8d5f"),
+  NEWFOUNDLAND_PROVINCE_ID: z.string().trim().min(1).default("5abc28c9-38b3-eb11-8236-0022486d8d5f"),
+  PRINCE_EDWARD_ISLAND_PROVINCE_ID: z.string().trim().min(1).default("3b8110df-38b3-eb11-8236-0022486d8d5f"),
+  NUNAVUT_PROVINCE_ID: z.string().trim().min(1).default("9936c08e-39b3-eb11-8236-0022486d8d5f"),
+  NORTHWEST_TERRITORIES_PROVINCE_ID: z.string().trim().min(1).default("026aca2-39b3-eb11-8236-0022486d8d5f"),
+  YUKON_PROVINCE_ID: z.string().trim().min(1).default("8fef32b7-39b3-eb11-8236-0022486d8d5f"),
 
   // language codes
   ENGLISH_LANGUAGE_CODE: z.coerce.number().default(1033),

--- a/frontend/app/utils/postal-zip-code-utils.server.ts
+++ b/frontend/app/utils/postal-zip-code-utils.server.ts
@@ -16,6 +16,59 @@ export const isValidPostalCode = (countryCode: string, postalCode: string) => {
   }
 };
 
+export function isValidCanadianPostalCode(provinceCode: string, postalCode: string) {
+  const {
+    CANADA_COUNTRY_ID,
+    ALBERTA_PROVINCE_ID,
+    BRITISH_COLUMBIA_PROVINCE_ID,
+    MANITOBA_PROVINCE_ID,
+    NEW_BRUNSWICK_PROVINCE_ID,
+    NOVA_SCOTIA_PROVINCE_ID,
+    ONTARIO_PROVINCE_ID,
+    QUEBEC_PROVINCE_ID,
+    SASKATCHEWAN_PROVINCE_ID,
+    NEWFOUNDLAND_PROVINCE_ID,
+    PRINCE_EDWARD_ISLAND_PROVINCE_ID,
+    NUNAVUT_PROVINCE_ID,
+    NORTHWEST_TERRITORIES_PROVINCE_ID,
+    YUKON_PROVINCE_ID,
+  } = getEnv();
+  if (!isValidPostalCode(CANADA_COUNTRY_ID, postalCode)) {
+    return false;
+  }
+  const upperCasePostalCode = postalCode.toUpperCase();
+  switch (provinceCode) {
+    case BRITISH_COLUMBIA_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('V');
+    case ALBERTA_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('T');
+    case SASKATCHEWAN_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('S');
+    case MANITOBA_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('R');
+    case ONTARIO_PROVINCE_ID:
+      return /^[KLNMP]/.test(upperCasePostalCode);
+    case QUEBEC_PROVINCE_ID:
+      return /^[GJ]/.test(upperCasePostalCode);
+    case NEW_BRUNSWICK_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('E');
+    case NOVA_SCOTIA_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('B');
+    case PRINCE_EDWARD_ISLAND_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('C');
+    case NEWFOUNDLAND_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('A');
+    case YUKON_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('Y');
+    case NORTHWEST_TERRITORIES_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('X');
+    case NUNAVUT_PROVINCE_ID:
+      return upperCasePostalCode.startsWith('X');
+    default:
+      return false;
+  }
+}
+
 export function formatPostalCode(countryCode: string, postalCode: string) {
   if (!isValidPostalCode(countryCode, postalCode)) {
     throw new Error(`Invalid postal or zip code; countryCode: ${countryCode}, postalCode: ${postalCode}`);

--- a/frontend/e2e/$lang+/_public/apply/adult-child/adult-child-flow.spec.ts
+++ b/frontend/e2e/$lang+/_public/apply/adult-child/adult-child-flow.spec.ts
@@ -176,10 +176,10 @@ async function contactInformation(page: Page) {
   await page.getByRole('group', { name: 'Email' }).getByRole('textbox', { name: 'Confirm email address (optional)', exact: true }).fill('123@mail.com');
 
   //fillout mailing address
-  await fillOutAddress({ page, group: 'Mailing address', address: '123 street', unit: '404', country: 'Canada', province: 'Ontario', city: 'Ottawa', postalCode: 'H0H0H0' });
+  await fillOutAddress({ page, group: 'Mailing address', address: '123 street', unit: '404', country: 'Canada', province: 'Ontario', city: 'Ottawa', postalCode: 'K0H0H0' });
 
   //fillout home address
-  await fillOutAddress({ page, group: 'Home address', address: '555 street', unit: '', country: 'Canada', province: 'Quebec', city: 'Montreal', postalCode: 'K1K1K1' });
+  await fillOutAddress({ page, group: 'Home address', address: '555 street', unit: '', country: 'Canada', province: 'Quebec', city: 'Montreal', postalCode: 'G1K1K1' });
 
   await page.getByRole('button', { name: 'Continue' }).click();
 }

--- a/frontend/e2e/$lang+/_public/apply/adult/adult-flow.spec.ts
+++ b/frontend/e2e/$lang+/_public/apply/adult/adult-flow.spec.ts
@@ -166,10 +166,10 @@ async function contactInformation(page: Page) {
   await page.getByRole('group', { name: 'Email' }).getByRole('textbox', { name: 'Confirm email address (optional)', exact: true }).fill('123@mail.com');
 
   //fillout mailing address
-  await fillOutAddress({ page, group: 'Mailing address', address: '123 street', unit: '404', country: 'Canada', province: 'Ontario', city: 'Ottawa', postalCode: 'H0H0H0' });
+  await fillOutAddress({ page, group: 'Mailing address', address: '123 street', unit: '404', country: 'Canada', province: 'Ontario', city: 'Ottawa', postalCode: 'K0H0H0' });
 
   //fillout home address
-  await fillOutAddress({ page, group: 'Home address', address: '555 street', unit: '', country: 'Canada', province: 'Quebec', city: 'Montreal', postalCode: 'K1K1K1' });
+  await fillOutAddress({ page, group: 'Home address', address: '555 street', unit: '', country: 'Canada', province: 'Quebec', city: 'Montreal', postalCode: 'G1K1K1' });
 
   await page.getByRole('button', { name: 'Continue' }).click();
 }

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -316,7 +316,8 @@
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
         "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -326,7 +327,8 @@
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
         "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -327,7 +327,8 @@
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
         "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -337,7 +338,8 @@
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
         "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -407,7 +407,8 @@
         "postal-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your mailing address",
         "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "home-address": {
         "address-required": "Enter home address, typically number and street",
@@ -417,7 +418,8 @@
         "postal-code-valid": "Enter home address postal code in the correct format, such as A1A 1A1",
         "province-required": "Select a province, territory, state or region for your home address",
         "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789",
-        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code"
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
       },
       "phone-number-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",
       "phone-number-alt-valid": "Phone number does not exist. If it's an international phone number, add '+' in front",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -315,7 +315,8 @@
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -325,7 +326,8 @@
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -327,7 +327,8 @@
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -337,7 +338,8 @@
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -407,7 +407,8 @@
         "postal-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "home-address": {
         "address-required": "Entrez l'adresse du domicile, normalement le numéro et le nom de la rue",
@@ -417,7 +418,8 @@
         "postal-code-valid": "Entrez un code postal pour  l'adresse du domicile dans le bon format, par exemple A1A 1A1",
         "province-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
         "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789",
-        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal"
+        "invalid-postal-code-for-country": "Un code postal canadien a été entré dans l'adresse du domicile mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
       },
       "phone-number-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
       "phone-number-alt-valid": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",


### PR DESCRIPTION
### Description
adds Canadian postal code validation for provinces/territories.

### Related Azure Boards Work Items
[AB#4348](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4348)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/a69c6925-9dfd-4293-94f8-8c6319f70f2a)

![image](https://github.com/user-attachments/assets/73dc527e-2eb4-49ae-85a6-99515b2b6136)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`