### PR TITLE
Changing logging level for all requests to `DEBUG`

### DIFF
--- a/frontend/express.server.ts
+++ b/frontend/express.server.ts
@@ -71,7 +71,7 @@ async function runServer() {
       return req.url ? ignoredUrls.includes(req.url) : false;
     },
     stream: {
-      write: (str: string) => log.info(str.trim()),
+      write: (str: string) => log.debug(str.trim()),
     },
   });
 


### PR DESCRIPTION
### Description
This change is a result of perf testing logs causing the DHSP cluster logs to exceed the ingestion limit.
Nginx has request logging so there's no need to log requests in Express

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d10234f5-3bc0-4832-9d6c-9241546a9bd0)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and verify that requests are being logged at the `DEBUG` level.