### PR TITLE
add H prefix for Quebec in postal code validation

### DIFF
--- a/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
+++ b/frontend/__tests__/utils/postal-zip-code-utils.server.test.ts
@@ -79,6 +79,7 @@ describe('~/utils/postal-zip-code-utils.server.ts', () => {
       ['ON', 'n0h0h0', true],
       ['ON', 'p0h0h0', true],
       ['QC', 'g0h0h0', true],
+      ['QC', 'h0h0h0', true],
       ['QC', 'j0h0h0', true],
       ['NB', 'e0h0h0', true],
       ['NS', 'b0h0h0', true],

--- a/frontend/app/utils/postal-zip-code-utils.server.ts
+++ b/frontend/app/utils/postal-zip-code-utils.server.ts
@@ -49,7 +49,7 @@ export function isValidCanadianPostalCode(provinceCode: string, postalCode: stri
     case ONTARIO_PROVINCE_ID:
       return /^[KLNMP]/.test(upperCasePostalCode);
     case QUEBEC_PROVINCE_ID:
-      return /^[GJ]/.test(upperCasePostalCode);
+      return /^[GHJ]/.test(upperCasePostalCode);
     case NEW_BRUNSWICK_PROVINCE_ID:
       return upperCasePostalCode.startsWith('E');
     case NOVA_SCOTIA_PROVINCE_ID:


### PR DESCRIPTION
### Description
adds missing prefix for Montreal region