### PR TITLE
feat(frontend): redirect to CDCP website when apply state is not found or has expired

### DIFF
--- a/frontend/__tests__/utils/locale-utils.server.test.ts
+++ b/frontend/__tests__/utils/locale-utils.server.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getEnv } from '~/utils/env-utils.server';
-import { getFixedT, getLocale, initI18n } from '~/utils/locale-utils.server';
+import { getFixedT, getLocale, getLocaleFromParams, initI18n } from '~/utils/locale-utils.server';
 
 vi.mock('~/utils/env-utils.server', () => ({
   getEnv: vi.fn(),
@@ -26,6 +26,28 @@ describe('locale-utils.server', () => {
 
     it('should return the default locale if there is no locale in the URL', () => {
       expect(getLocale(new Request('http://localhost:3000/'))).toEqual('en');
+    });
+  });
+
+  describe('getLocaleFromParams', () => {
+    it('should return "en" when lang is "en"', () => {
+      const params = { lang: 'en' };
+      expect(getLocaleFromParams(params)).toBe('en');
+    });
+
+    it('should return "fr" when lang is "fr"', () => {
+      const params = { lang: 'fr' };
+      expect(getLocaleFromParams(params)).toBe('fr');
+    });
+
+    it('should return "en" when lang is unsupported', () => {
+      const params = { lang: 'es' };
+      expect(getLocaleFromParams(params)).toBe('en');
+    });
+
+    it('should return "en" when lang is undefined', () => {
+      const params = {};
+      expect(getLocaleFromParams(params)).toBe('en');
     });
   });
 

--- a/frontend/app/utils/locale-utils.server.ts
+++ b/frontend/app/utils/locale-utils.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@remix-run/node';
+import type { Params } from '@remix-run/react';
 
 import type { Namespace } from 'i18next';
 import { createInstance } from 'i18next';
@@ -22,22 +23,56 @@ export async function getFixedT<N extends Namespace>(localeOrRequest: 'en' | 'fr
 }
 
 /**
- * Retrieves the locale using a deterministic lookup algorithm (URL → cookies → 🤷).
+ * Extracts and returns the locale from the provided request URL.
+ *
+ * This function analyzes the pathname of the given `request` URL to determine the locale. It supports
+ * English (`'en'`) and French (`'fr'`). If the pathname does not start with `/en` or `/fr`, the function
+ * defaults to English (`'en'`).
+ *
+ * @param request - The HTTP request object containing the URL from which to extract the locale.
+ * @returns The detected locale, either `'en'` or `'fr'`. Defaults to `'en'` if no valid locale is found.
  */
 export function getLocale(request: Request): AppLocale {
-  const url = new URL(request.url);
+  const { pathname } = new URL(request.url);
 
-  if (url.pathname.startsWith('/en')) {
-    log.debug('Locale [en] detected in URL');
+  if (pathname.startsWith('/en')) {
+    log.debug('Locale [en] detected in URL; pathname: [%s]', pathname);
     return 'en';
   }
 
-  if (url.pathname.startsWith('/fr')) {
-    log.debug('Locale [fr] detected in URL');
+  if (pathname.startsWith('/fr')) {
+    log.debug('Locale [fr] detected in URL; pathname: [%s]', pathname);
     return 'fr';
   }
 
-  log.debug('Epic fail: no locale detected in URL search params or cookies; returning default [en]');
+  log.debug('No locale detected in URL; returning default [en]; pathname: [%s]', pathname);
+  return 'en';
+}
+
+/**
+ * Extracts and returns the locale from the provided parameters.
+ *
+ * This function checks the `lang` property in the given `params` object to determine the locale to use.
+ * It supports English (`'en'`) and French (`'fr'`). If the `lang` property is not recognized or is
+ * not provided, the function defaults to English (`'en'`).
+ *
+ * @param params - The parameters object containing the `lang` property.
+ * @returns The detected locale, either `'en'` or `'fr'`. Defaults to `'en'` if no valid locale is found.
+ */
+export function getLocaleFromParams(params: Params): AppLocale {
+  const lang = params.lang;
+
+  if (lang === 'en') {
+    log.debug("Locale [en] detected in 'lang' param; lang: [%s]", lang);
+    return 'en';
+  }
+
+  if (lang === 'fr') {
+    log.debug("Locale [fr] detected in 'lang' param; lang: [%s]", lang);
+    return 'fr';
+  }
+
+  log.debug("No locale detected in 'lang' param; returning default [en]; lang: [%s]", lang);
   return 'en';
 }
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

If the application state is not found or has expired, redirect to the CDCP website. Since the apply routes are dynamic and have a very short lifespan, redirecting to the CDCP website apply page allows the user to start a new application, which is preferable to displaying a 404 page or attempting to create a new application.

1. **Invalid apply state ID format:** Redirect to the CDCP website apply page.
2. **Apply state session ID not found:** Redirect to the CDCP website apply page.
3. **Apply state expired (not touched for over 15 minutes):** Clear the apply state from the session and redirect to the CDCP website apply page.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->