### PR TITLE
Removing unneeded promise handling lint rule in `hcaptcha-utils`

### DIFF
--- a/frontend/app/utils/hcaptcha-utils.ts
+++ b/frontend/app/utils/hcaptcha-utils.ts
@@ -9,11 +9,9 @@ export function useHCaptcha() {
     let timeoutId: ReturnType<typeof setTimeout>;
 
     if (captchaRef.current?.isReady()) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       captchaRef.current.execute();
     } else {
       timeoutId = setTimeout(() => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         captchaRef.current?.execute();
       }, 500);
     }


### PR DESCRIPTION
### Description
#2037 bumped `react-hcaptcha` to `1.10.3`, which fixed a typing issue dealing with `execute(..)` introduced in the previous version `1.10.2`. Therefore, we don't need to ignore ESLint's promise handling rule for `execute(..)`.

See https://github.com/hCaptcha/react-hcaptcha/releases/tag/1.10.3

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`