### PR TITLE
Increasing unit test coverage for `fetch-utils.server`

### DIFF
--- a/frontend/__tests__/utils/fetch-utils.server.test.ts
+++ b/frontend/__tests__/utils/fetch-utils.server.test.ts
@@ -1,0 +1,95 @@
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getInstrumentationService } from '~/services/instrumentation-service.server';
+import { getEnv } from '~/utils/env-utils.server';
+import { getFetchFn, instrumentedFetch } from '~/utils/fetch-utils.server';
+
+describe('fetch-utils.server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getFetchFn', () => {
+    vi.mock('~/utils/env-utils.server', () => ({
+      getEnv: vi.fn(),
+    }));
+
+    vi.mock('~/utils/logging.server', () => ({
+      getLogger: () => ({
+        debug: vi.fn(),
+      }),
+    }));
+
+    vi.mock('undici', () => ({
+      ProxyAgent: vi.fn(),
+      fetch: vi.fn(),
+    }));
+
+    vi.mock('web-streams-node', () => ({
+      toNodeReadable: vi.fn(),
+    }));
+
+    it('should return global fetch when no proxy URL is provided', () => {
+      const fetchFn = getFetchFn();
+      expect(fetchFn).toBe(global.fetch);
+    });
+
+    it('should return custom fetch function when a proxy URL is provided', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ HTTP_PROXY_TLS_TIMEOUT: 1000 });
+      vi.mocked(undiciFetch, { partial: true }).mockResolvedValue({ status: 200 });
+
+      const proxyUrl = 'http://proxy.example.com';
+      const fetchFn = getFetchFn(proxyUrl);
+      expect(fetchFn).not.toBe(global.fetch);
+
+      await fetchFn('https://api.example.com');
+      expect(ProxyAgent).toHaveBeenCalledWith({ uri: proxyUrl, proxyTls: { timeout: 1000 } });
+      expect(undiciFetch).toHaveBeenCalled();
+    });
+
+    it('should return custom fetch function with specified timeout when a proxy URL and timeout value is provided', async () => {
+      vi.mocked(getEnv, { partial: true }).mockReturnValue({ HTTP_PROXY_TLS_TIMEOUT: 1000 });
+      vi.mocked(undiciFetch, { partial: true }).mockResolvedValue({ status: 200 });
+
+      const proxyUrl = 'http://proxy.example.com';
+      const fetchFn = getFetchFn(proxyUrl, 2000);
+      expect(fetchFn).not.toBe(global.fetch);
+
+      await fetchFn('https://api.example.com');
+      expect(ProxyAgent).toHaveBeenCalledWith({ uri: proxyUrl, proxyTls: { timeout: 2000 } });
+      expect(undiciFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('instrumentedFetch', () => {
+    vi.mock('~/services/instrumentation-service.server', () => ({
+      getInstrumentationService: vi.fn().mockReturnValue({
+        countHttpStatus: vi.fn(),
+      }),
+    }));
+
+    it('should successfully fetch and count HTTP status', async () => {
+      const fetchFn = vi.fn().mockResolvedValue({ status: 200 });
+      const response = await instrumentedFetch(fetchFn, 'test_prefix', 'https://example.com');
+
+      expect(response.status).toBe(200);
+      expect(getInstrumentationService().countHttpStatus).toHaveBeenCalledWith('test_prefix', 200);
+    });
+
+    it('should handle different HTTP status codes', async () => {
+      const fetchFn = vi.fn().mockResolvedValue({ status: 404 });
+      const response = await instrumentedFetch(fetchFn, 'test_prefix', 'https://example.com');
+
+      expect(response.status).toBe(404);
+      expect(getInstrumentationService().countHttpStatus).toHaveBeenCalledWith('test_prefix', 404);
+    });
+
+    it('should handle fetch errors and count 500 status code', async () => {
+      const fetchFn = vi.fn().mockRejectedValue(new Error('Fetch error'));
+
+      await expect(instrumentedFetch(fetchFn, 'test_prefix', 'https://example.com')).rejects.toThrow('Fetch error');
+      expect(getInstrumentationService().countHttpStatus).toHaveBeenCalledWith('test_prefix', 500);
+    });
+  });
+});


### PR DESCRIPTION
### Description
As per title

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/83d22513-f9c4-477d-98d4-9bbf804725a7)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`