### PR TITLE
Increasing unit test coverage for `h-captcha-route-helpers.server`

### DIFF
--- a/frontend/__tests__/route-helpers/h-captcha-route-helpers.server.test.ts
+++ b/frontend/__tests__/route-helpers/h-captcha-route-helpers.server.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
+import { getHCaptchaService } from '~/services/hcaptcha-service.server';
+import { getLogger } from '~/utils/logging.server';
+
+vi.mock('~/services/hcaptcha-service.server', () => ({
+  getHCaptchaService: vi.fn().mockReturnValue({
+    verifyHCaptchaResponse: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/env-utils.server', () => ({
+  getEnv: vi.fn().mockReturnValue({
+    HCAPTCHA_MAX_SCORE: 0.5,
+  }),
+}));
+
+vi.mock('~/utils/ip-address-utils.server', () => ({
+  getClientIpAddress: vi.fn(),
+}));
+
+vi.mock('~/utils/logging.server', () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+describe('h-captcha-route-helpers.server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('verifyHCaptchaResponse', () => {
+    it('should return false if hCaptcha verification results in a score greater than the HCAPTCHA_MAX_SCORE', async () => {
+      vi.mocked(getHCaptchaService().verifyHCaptchaResponse).mockResolvedValue({ success: true, score: 0.51 });
+
+      const result = await getHCaptchaRouteHelpers().verifyHCaptchaResponse('sample-h-captcha-response', new Request('http://www.example.com'));
+      expect(result).toEqual(false);
+    });
+
+    it('should return true if hCaptcha verification results in a score less than the HCAPTCHA_MAX_SCORE', async () => {
+      vi.mocked(getHCaptchaService().verifyHCaptchaResponse).mockResolvedValue({ success: true, score: 0.49 });
+
+      const result = await getHCaptchaRouteHelpers().verifyHCaptchaResponse('sample-h-captcha-response', new Request('http://www.example.com'));
+      expect(result).toEqual(true);
+    });
+
+    it('should return true and log warning if hCaptcha verification results in an error', async () => {
+      vi.mocked(getHCaptchaService().verifyHCaptchaResponse).mockRejectedValue(() => {
+        throw new Error('Example error');
+      });
+
+      const result = await getHCaptchaRouteHelpers().verifyHCaptchaResponse('sample-h-captcha-response', new Request('http://www.example.com'));
+      expect(result).toEqual(true);
+      expect(getLogger('h-captcha-route-helpers.server').warn).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
### Description
As per title

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/4664974e-722d-4a37-9d87-acb2e566276d)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`