### PR TITLE
playwright teamcity reporter

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,6 +99,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "jsdom": "^24.1.1",
         "patch-package": "^8.0.0",
+        "playwright-teamcity-reporter": "^1.0.3",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.6",
         "tailwindcss": "^3.4.10",
@@ -11918,6 +11919,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/playwright-teamcity-reporter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/playwright-teamcity-reporter/-/playwright-teamcity-reporter-1.0.3.tgz",
+      "integrity": "sha512-3ww0YkOt/Np490XGxwvNSkn/Z0tytgJYIosMmRWeXMsls6QxCGvSrSeKYPhYBHxHnTmiCwRh8aYIrAM1Dm8Brw==",
+      "dev": true
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "jsdom": "^24.1.1",
     "patch-package": "^8.0.0",
+    "playwright-teamcity-reporter": "^1.0.3",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.6",
     "tailwindcss": "^3.4.10",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: [['playwright-teamcity-reporter']],
   use: { baseURL: `http://localhost:${port}/`, trace: 'on-first-retry' },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,9 @@
+import type { ReporterDescription } from '@playwright/test';
 import { defineConfig, devices } from '@playwright/test';
 
 const port = process.env.PORT ?? '3000';
+
+const reporter: ReporterDescription[] = [['list'], ['html']];
 
 export default defineConfig({
   testDir: './e2e',
@@ -10,7 +13,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [['html'], ['playwright-teamcity-reporter']],
+  reporter: process.env.CI ? [...reporter, ['playwright-teamcity-reporter']] : reporter,
   use: { baseURL: `http://localhost:${port}/`, trace: 'on-first-retry' },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [['playwright-teamcity-reporter']],
+  reporter: [['html'], ['playwright-teamcity-reporter']],
   use: { baseURL: `http://localhost:${port}/`, trace: 'on-first-retry' },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {


### PR DESCRIPTION
### Description
Added `playwright-teamcity-reporter` package into our playwright test configuration. 
I'm not sure if this is going to work, but how it works is that the `playwright-teamcity-reporter` sends test results directly to TeamCity, allows us to see the test reports directly within the TeamCity interface.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`