### PR TITLE
disable parent-guardian radio on edit

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.information.page-title', { childName: childNumber }) }),
   };
 
-  return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode });
+  return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
@@ -211,7 +211,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowChildInformation() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, childName, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, childName, editMode, isNew } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -327,8 +327,8 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-adult-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: editMode },
-                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: editMode },
+                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew },
+                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew },
               ]}
               errorMessage={errors?.isParent}
             />

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-child:children.information.page-title', { childName: childNumber }) }),
   };
 
-  return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode });
+  return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
@@ -211,7 +211,7 @@ export async function action({ context: { session }, params, request }: ActionFu
 
 export default function ApplyFlowChildInformation() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, childName, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, childName, editMode, isNew } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -327,8 +327,8 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: editMode },
-                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: editMode },
+                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew },
+                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew },
               ]}
               errorMessage={errors?.isParent}
               required


### PR DESCRIPTION
### Description
take advantage of state variable `isNew` to make the parent/legal guardian question in the child information screens readonly if and only if the child isn't newly created.

### Related Azure Boards Work Items
[AB#4401](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4401)