### PR TITLE
Move base container image to ARG

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -21,10 +21,9 @@
 # 	$ docker run --init --rm --publish 3000:3000 canadian-dental-care-plan
 #
 
+ARG BASE_IMAGE=docker.io/node:20.17.0-bookworm-slim
 
-
-# base node image
-FROM docker.io/node:20.17.0-bookworm-slim AS base
+FROM $BASE_IMAGE AS base
 ENV NODE_ENV production
 
 


### PR DESCRIPTION
### Description

Move the base container image to an ARG in the dockerfile to make it easier to extract during CI/CD builds.

### Related Azure Boards Work Items

- [AB#4409](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4409)
