### PR TITLE
Remove explicit undici dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,7 +59,6 @@
         "source-map-support": "^0.5.21",
         "tailwind-merge": "^2.5.2",
         "tiny-invariant": "^1.3.3",
-        "undici": "^6.19.8",
         "use-deep-compare": "^1.3.0",
         "validator": "^13.12.0",
         "web-streams-node": "^0.4.0",
@@ -14389,8 +14388,7 @@
     "node_modules/readable-stream-node-to-web": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
-      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==",
-      "license": "MIT"
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -17714,7 +17712,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/web-streams-node/-/web-streams-node-0.4.0.tgz",
       "integrity": "sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "is-stream": "^1.1.0",
         "readable-stream-node-to-web": "^1.0.1",
@@ -17725,7 +17722,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17742,8 +17738,7 @@
     "node_modules/web-streams-ponyfill": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
-      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==",
-      "license": "MIT"
+      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,6 @@
     "source-map-support": "^0.5.21",
     "tailwind-merge": "^2.5.2",
     "tiny-invariant": "^1.3.3",
-    "undici": "^6.19.8",
     "use-deep-compare": "^1.3.0",
     "validator": "^13.12.0",
     "web-streams-node": "^0.4.0",


### PR DESCRIPTION
### Description

Remix v2.9.x has undici as a transitive (peer) dependency, so we can remove it from our package.json

see: https://github.com/remix-run/remix/blob/main/CHANGELOG.md#undici

### Additional Notes

This is the first of a few PRs that should eventually allow us to refactor how the fetch proxies work in the application.