### PR TITLE
Ignore a11y lint warnings

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/applicant-information.tsx
@@ -207,6 +207,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName}
@@ -222,6 +223,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -283,6 +283,7 @@ export default function ApplyFlowChildInformation() {
                 label={t('apply-adult-child:children.information.first-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('apply-adult-child:children.information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName}
@@ -298,6 +299,7 @@ export default function ApplyFlowChildInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('apply-adult-child:children.information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/partner-information.tsx
@@ -202,6 +202,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={errors?.firstName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />
@@ -214,6 +215,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/applicant-information.tsx
@@ -201,6 +201,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName}
@@ -213,6 +214,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.last-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}

--- a/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult/partner-information.tsx
@@ -196,6 +196,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={errors?.firstName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />
@@ -208,6 +209,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/applicant-information.tsx
@@ -270,6 +270,7 @@ export default function ApplyFlowApplicationInformation() {
                 label={t('applicant-information.first-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName}
@@ -285,6 +286,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('applicant-information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -283,6 +283,7 @@ export default function ApplyFlowChildInformation() {
                 label={t('apply-child:children.information.first-name')}
                 className="w-full"
                 maxLength={100}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('apply-child:children.information.name-instructions')}
                 autoComplete="given-name"
                 errorMessage={errors?.firstName}
@@ -298,6 +299,7 @@ export default function ApplyFlowChildInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('apply-child:children.information.name-instructions')}
                 required
               />

--- a/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/partner-information.tsx
@@ -201,6 +201,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="given-name"
                 defaultValue={defaultState?.firstName ?? ''}
                 errorMessage={errors?.firstName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />
@@ -213,6 +214,7 @@ export default function ApplyFlowApplicationInformation() {
                 autoComplete="family-name"
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
                 aria-description={t('partner-information.name-instructions')}
                 required
               />


### PR DESCRIPTION
### Description

Ignore the `aria-description: This attribute is an invalid ARIA attribute  jsx-a11y/aria-props` warnings emitted by eslint.

### Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
