### PR TITLE
Remove unnecessary `installGlobals(..)` call

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import { vitePlugin as remix } from '@remix-run/dev';
 import type { DefineRouteFunction, DefineRoutesFunction } from '@remix-run/dev/dist/config/routes';
-import { installGlobals } from '@remix-run/node';
 
 import { readFileSync } from 'node:fs';
 import { expressDevServer } from 'remix-express-dev-server';
@@ -20,10 +19,6 @@ interface JsonRoute {
 }
 
 type Language = 'en' | 'fr';
-
-// install global node polyfills
-// see: https://remix.run/docs/en/main/other-api/node#polyfills
-installGlobals({ nativeFetch: true });
 
 function jsonRoutes(defineRoutesFn: DefineRoutesFunction, jsonRoutes: Array<JsonRoute>) {
   return defineRoutesFn((routeFn) => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,13 +1,6 @@
-/// <reference types="vitest" />
-import { installGlobals } from '@remix-run/node';
-
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults, defineConfig } from 'vitest/config';
-
-// install global node polyfills
-// see: https://remix.run/docs/en/main/other-api/node#polyfills
-installGlobals({ nativeFetch: true });
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],


### PR DESCRIPTION
### Description

When using NodeJS v20+, `installGlobals(..)` is not required.

### Checklist

- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

- <https://github.com/remix-run/remix/blob/main/packages/remix-node/globals.ts>