### PR TITLE
prevent keyboard accessibility on parent/guardian input if not is new child

### DIFF
--- a/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/adult-child/children/$childId/information.tsx
@@ -329,8 +329,8 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-adult-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew },
-                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew },
+                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
             />

--- a/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/$lang/_public/apply/$id/child/children/$childId/information.tsx
@@ -329,8 +329,8 @@ export default function ApplyFlowChildInformation() {
               name="isParent"
               legend={t('apply-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew },
-                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew },
+                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
               required


### PR DESCRIPTION
### Description
the parent/legal guardian input should be disabled if the child isn't newly added, i.e. when editing.  We can't disable keyboard interactions with CSS alone, so there are 2 options.  One is to use the 'disabled' prop on the input, but this has added server side validations that would need to be added and zod thinks that an input is missing without them, or we can take the easy route and add a conditonal for setting a tabIndex=-1.

### Related Azure Boards Work Items
AB#4453

### Test Instructions
- go to child flow
- enter child info fully
- click 'edit child info' button
- check if it's possible to use a keyboard or mouse to change the parent/legal guardian radios