### PR TITLE
Refactor client-side i18n language detector

### DIFF
--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -1,6 +1,5 @@
-import type { FlatNamespace } from 'i18next';
+import type { FlatNamespace, LanguageDetectorModule } from 'i18next';
 import { createInstance } from 'i18next';
-import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector';
 import I18NextHttpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
@@ -75,17 +74,19 @@ export async function initI18n(namespaces: Array<string>) {
   const { I18NEXT_DEBUG } = getClientEnv();
   const i18n = createInstance();
 
+  const languageDetector = {
+    type: 'languageDetector',
+    detect: () => document.documentElement.lang,
+  } satisfies LanguageDetectorModule;
+
   await i18n
     .use(initReactI18next)
-    .use(I18nextBrowserLanguageDetector)
+    .use(languageDetector)
     .use(I18NextHttpBackend)
     .init({
       appendNamespaceToMissingKey: true,
       debug: I18NEXT_DEBUG,
       defaultNS: false,
-      detection: {
-        order: ['htmlTag'],
-      },
       fallbackLng: false,
       interpolation: {
         escapeValue: false,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,6 @@
         "fast-json-patch": "^3.1.1",
         "fast-xml-parser": "^4.4.1",
         "i18next": "^23.14.0",
-        "i18next-browser-languagedetector": "^8.0.0",
         "i18next-fs-backend": "^2.3.2",
         "i18next-http-backend": "^2.6.1",
         "ioredis": "^5.4.1",
@@ -9712,15 +9711,6 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
-    },
-    "node_modules/i18next-browser-languagedetector": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz",
-      "integrity": "sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,6 @@
     "fast-json-patch": "^3.1.1",
     "fast-xml-parser": "^4.4.1",
     "i18next": "^23.14.0",
-    "i18next-browser-languagedetector": "^8.0.0",
     "i18next-fs-backend": "^2.3.2",
     "i18next-http-backend": "^2.6.1",
     "ioredis": "^5.4.1",


### PR DESCRIPTION
### Description

Detecting the locale/language on the client only requires inspecting the `<html lang>` attribute. Since we don't use a cookie, localstorage, or sessionstorage, there's no positive advantage to using `i18next-browser-languagedetector`, so it has been removed and replaced with a basic language detector implementation.

See: <https://pkg-size.dev/i18next-browser-languagedetector>

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`