### PR TITLE
Increasing unit test coverage for `letters-service.server`

### DIFF
--- a/frontend/__tests__/services/letters-service.server.test.ts
+++ b/frontend/__tests__/services/letters-service.server.test.ts
@@ -2,16 +2,11 @@ import { HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getLettersService } from '~/services/letters-service.server';
+import { instrumentedFetch } from '~/utils/fetch-utils.server';
 
-global.fetch = vi.fn();
-
-vi.mock('~/utils/logging.server', () => ({
-  getLogger: vi.fn().mockReturnValue({
-    info: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+vi.mock('~/services/audit-service.server', () => ({
+  getAuditService: vi.fn().mockReturnValue({
     audit: vi.fn(),
-    trace: vi.fn(),
   }),
 }));
 
@@ -25,6 +20,20 @@ vi.mock('~/utils/env-utils.server', () => ({
   }),
 }));
 
+vi.mock('~/utils/fetch-utils.server', () => ({
+  getFetchFn: vi.fn(),
+  instrumentedFetch: vi.fn(),
+}));
+
+vi.mock('~/utils/logging.server', () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  }),
+}));
+
 describe('letters-service.server tests', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -33,7 +42,7 @@ describe('letters-service.server tests', () => {
 
   describe('getLetters()', () => {
     it('should return all letters found for a user', async () => {
-      vi.mocked(fetch).mockResolvedValue(
+      vi.mocked(instrumentedFetch).mockResolvedValue(
         HttpResponse.json([
           {
             LetterDate: 'some-date',
@@ -55,7 +64,7 @@ describe('letters-service.server tests', () => {
     });
 
     it('should throw error if response is not ok', async () => {
-      vi.mocked(fetch).mockResolvedValue(new HttpResponse(null, { status: 500 }));
+      vi.mocked(instrumentedFetch).mockResolvedValue(new HttpResponse(null, { status: 500 }));
 
       const lettersService = getLettersService();
       await expect(() => lettersService.getLetters('clientId', 'userId')).rejects.toThrowError();
@@ -64,9 +73,61 @@ describe('letters-service.server tests', () => {
 
   describe('getAllLetterTypes()', () => {
     it('should return all the letter types', () => {
+      vi.mock('~/resources/power-platform/letter-types.json', () => ({
+        default: {
+          value: [
+            {
+              OptionSet: {
+                Options: [
+                  {
+                    Value: 'Letter 1',
+                    Label: {
+                      LocalizedLabels: [
+                        { Label: 'English Letter 1', LanguageCode: 1033 },
+                        { Label: 'French Letter 1', LanguageCode: 1036 },
+                      ],
+                    },
+                  },
+                  {
+                    Value: 'Letter 2',
+                    Label: {
+                      LocalizedLabels: [
+                        { Label: 'English Letter 2', LanguageCode: 1033 },
+                        { Label: 'French Letter 2', LanguageCode: 1036 },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }));
+
       const lettersService = getLettersService();
       const letterTypes = lettersService.getAllLetterTypes();
-      expect(letterTypes.length).toBe(12);
+      expect(letterTypes.length).toBe(2);
+    });
+  });
+
+  describe('getPdf()', () => {
+    it('should return PDF contents for a user and letter id', async () => {
+      vi.mocked(instrumentedFetch).mockResolvedValue(
+        HttpResponse.json({
+          documentBytes: 'sample-pdf-contents',
+        }),
+      );
+
+      const lettersService = getLettersService();
+      const pdf = await lettersService.getPdf('letterId', 'userId');
+      expect(pdf).toEqual('sample-pdf-contents');
+    });
+
+    it('should throw error if response is not ok', async () => {
+      vi.mocked(instrumentedFetch).mockResolvedValue(new HttpResponse(null, { status: 500 }));
+
+      const lettersService = getLettersService();
+      await expect(() => lettersService.getPdf('letterId', 'userId')).rejects.toThrowError();
     });
   });
 });


### PR DESCRIPTION
### Description
As per title:
- Adding unit tests for `getPdf(..)`
- Replacing actual calls to dependencies with calls to mocks

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`