### PR TITLE
AB#4487 -- status checker language change

### DIFF
--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -69,7 +69,7 @@
     "exit-btn": "Quitter le vérificateur de l'état",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#etat",
     "status-not-found": {
-      "heading": "Nous n'avons pas pu trouver le statut de votre candidature avec les informations que vous nous avez fournies.",
+      "heading": "Nous n'avons pas pu trouver l'état de votre demande avec les informations.",
       "please-review": "Veuillez vous assurer que les informations que vous avez saisies sont correctes. Si vous avez postulé récemment, réessayez dans 48 heures.",
       "if-submitted": "Si vous avez soumis plus d'une demande pour vous-même, vos enfants ou les deux, utilisez le dernier code de demande que vous avez reçu.",
       "contact-service-canada": "Contactez Service Canada si ce problème persiste en appelant au <noWrap>1-833-537-4342</noWrap>."
@@ -97,7 +97,7 @@
     "exit-btn": "Quitter le vérificateur de l'état",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#etat",
     "status-not-found": {
-      "heading": "Nous n'avons pas pu trouver le statut de votre candidature avec les informations que vous nous avez fournies.",
+      "heading": "Nous n'avons pas pu trouver l'état de votre demande avec les informations.",
       "please-review": "Veuillez vous assurer que les informations que vous avez saisies sont correctes. Si vous avez postulé récemment, réessayez dans 48 heures.",
       "contact-service-canada": "Si vous rencontrez toujours des difficultés, contactez Service Canada au <noWrap>1-833-537-4342</noWrap>."
     },


### PR DESCRIPTION
### Description

From the ADO workitem:

> On the `/myself` and `/child`, the error message when there is no data needs to be changed in French
> From: "Nous n'avons pas pu trouver le statut de votre candidature avec les informations que vous nous avez fournies."
> To: "Nous n'avons pas pu trouver l’état de votre demande avec les informations"

### Related Azure Boards Work Items

- [AB#4487](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4487)

### Checklist

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
