### PR TITLE
Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,21 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      dev-minor-versions:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'
+      prod-minor-versions:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'
 
   - package-ecosystem: docker
     directory: /frontend


### PR DESCRIPTION
### Description

Reconfigure dependabot to group all minor+patch updates into a single PR.

See: <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups>
