### PR TITLE
[gitops] Bumping int, perf, staging, and training to `0.0.0-ecdbda5c-00627`

### DIFF
--- a/gitops/overlays/int/patches/deployments.yaml
+++ b/gitops/overlays/int/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-73233ac3-00616
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-ecdbda5c-00627
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-73233ac3-00616
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-ecdbda5c-00627
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-73233ac3-00616
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-ecdbda5c-00627
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-73233ac3-00616
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-ecdbda5c-00627
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
As per title

![image](https://github.com/user-attachments/assets/22552a6f-dca1-472e-b39c-e296f65fe512)

