### PR TITLE
revert status-not-found heading in result route

### DIFF
--- a/frontend/public/locales/fr/status.json
+++ b/frontend/public/locales/fr/status.json
@@ -127,7 +127,7 @@
     "exit-btn": "Quitter le vérificateur de l'état",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#etat",
     "status-not-found": {
-      "heading": "Nous n'avons pas pu trouver le statut de votre candidature avec les informations que vous nous avez fournies.",
+      "heading": "Nous n'avons pas pu trouver l'état de votre demande avec les informations.",
       "please-review": "Veuillez vous assurer que les informations que vous avez saisies sont correctes. Si vous avez postulé récemment, réessayez dans 48 heures.",
       "if-submitted": "Si vous avez soumis plus d'une demande pour vous-même, vos enfants ou les deux, utilisez le dernier code de demande que vous avez reçu.",
       "contact-service-canada": "Contactez Service Canada si ce problème persiste en appelant au <noWrap>1-833-537-4342</noWrap>."


### PR DESCRIPTION
### Description
The heading on the result screen when a status cannot be found should be changed to match figma. 

see:  https://github.com/DTS-STN/canadian-dental-care-plan/pull/2112

### Related Azure Boards Work Items
[AB#4487](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4487)