### PR TITLE
[gitops] Bumping int, perf, staging, and training to `0.0.0-72389cd5-0062a`

### DIFF
--- a/gitops/overlays/int/patches/deployments.yaml
+++ b/gitops/overlays/int/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-afd6a0b4-00628
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-72389cd5-0062a
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-afd6a0b4-00628
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-72389cd5-0062a
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-afd6a0b4-00628
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-72389cd5-0062a
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-afd6a0b4-00628
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-72389cd5-0062a
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
As per title

![image](https://github.com/user-attachments/assets/5e0bcbd4-399b-4c4c-b9d3-abad0d6111f2)
