### PR TITLE
fix(frontend): set document cache-control header to 'no-cache'

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useContext, useEffect } from 'react';
 
-import type { LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import type { HeadersFunction, LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData, useLocation, useRouteLoaderData } from '@remix-run/react';
 
@@ -52,6 +52,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     { property: 'og:site_name', content: data.meta.siteName },
     { property: 'og:type', content: 'website' },
   ];
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return {
+    'Cache-Control': `private, no-cache, no-store, must-revalidate, max-age=0`,
+  };
 };
 
 export async function loader({ context: { session }, request }: LoaderFunctionArgs) {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Set the document's cache-control header to `no-cache` to instruct the browser not to cache the document. This resolves the issue where, after a user is redirected to an external website and clicks the browser's "back" button, the browser retrieves content from the cache instead of making a new request to the server.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

- https://remix.run/docs/en/main/route/headers
- https://gist.github.com/kentcdodds/0c6f183531beeafe771eb48a3586707b