### PR TITLE
[gitops] Deploy frontend v3.3.0 to prod

### DIFF
--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,status
+ENABLED_FEATURES=hcaptcha,status,status-checker-redirects
 
 #
 # Session/redis configuration

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.2.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.3.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
Marking as draft - v3.3.0 is scheduled to be deployed between 7:00am-8:00am Eastern on September 11, 2024.

`status-checker-redirects` feature to be enabled to add "Back" and "Exit" buttons within Status Checker pages.