### PR TITLE
Replacing `SHOW_SIN_EDIT_STUB_PAGE` env variable with feature flag

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -47,7 +47,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env-utils.server.ts for valid values
 # (optional; default: "")
-ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status,authenticated-status-check,update-governmental-benefit,dependent-status-checker,view-payload,status-checker-redirects
+ENABLED_FEATURES=doc-upload,email-alerts,hcaptcha,view-personal-info,view-applications,view-letters,view-messages,edit-personal-info,status,authenticated-status-check,update-governmental-benefit,dependent-status-checker,view-payload,status-checker-redirects,stub-login
 
 
 # hCaptcha maximum allowed score denoting malicious activity
@@ -320,10 +320,6 @@ MARITAL_STATUS_CODE_MARRIED=775170001
 # id for 'Common-Law' marital status
 # (optional; default: 775170002)
 MARITAL_STATUS_CODE_COMMONLAW=775170002
-
-# show stub page to edit the SIN
-# (optional; default: false)
-SHOW_SIN_EDIT_STUB_PAGE=true
 
 # Adobe Analytics Script URL
 # (optional)

--- a/frontend/app/routes/$lang/_protected/stub-login.tsx
+++ b/frontend/app/routes/$lang/_protected/stub-login.tsx
@@ -11,7 +11,7 @@ import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { InputPatternField } from '~/components/input-pattern-field';
 import { getSubscriptionService } from '~/services/subscription-service.server';
-import { getEnv } from '~/utils/env-utils.server';
+import { featureEnabled } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -34,10 +34,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
-  const { SHOW_SIN_EDIT_STUB_PAGE } = getEnv();
-  if (!SHOW_SIN_EDIT_STUB_PAGE) {
-    throw new Response(null, { status: 404 });
-  }
+  featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('stub-login:index.page-title') }) };
@@ -55,11 +52,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
 }
 
 export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
-  // TODO SHOW_SIN_EDIT_STUB_PAGE should be added as a feature flag
-  const { SHOW_SIN_EDIT_STUB_PAGE } = getEnv();
-  if (!SHOW_SIN_EDIT_STUB_PAGE) {
-    throw new Response(null, { status: 404 });
-  }
+  featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -94,8 +94,6 @@ const serverEnv = clientEnvSchema.extend({
 
   CDCP_API_BASE_URI: z.string().url(),
 
-  SHOW_SIN_EDIT_STUB_PAGE : z.string().transform(toBoolean).default('false'),
-
   // auth/oidc settings
   AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),
   AUTH_JWT_PUBLIC_KEY: z.string().refine(isValidPublicKey),

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -16,6 +16,7 @@ const validFeatureNames = [
   'dependent-status-checker',
   'view-payload',
   'status-checker-redirects',
+  'stub-login',
 ] as const;
 export type FeatureName = (typeof validFeatureNames)[number];
 


### PR DESCRIPTION
### Description
Trivial PR that is a continuation of #2122.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Add `stub-login` feature flag (`ENABLED_FEATURES` environment variable) and navigate to `/en/stub-login`. The Stub Login page should appear. Removing the `stub-login` feature flag should yield a 404.