### PR TITLE
Fix vite's dependency optimization issues

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -79,6 +79,12 @@ export default defineConfig({
     port: 3000,
     host: true,
   },
+  optimizeDeps: {
+    // exclude the otlp-exporter-base package because it causes
+    // issues with vite's dependency optimization
+    // see: https://github.com/open-telemetry/opentelemetry-js/issues/4794
+    exclude: ['@opentelemetry/otlp-exporter-base'],
+  },
   plugins: [
     expressDevServer(),
     tsconfigPaths(),
@@ -91,6 +97,9 @@ export default defineConfig({
           ignoredRouteFiles: ['**/*'], // we will manually configure routes
           routes: (defineRoutes) => jsonRoutes(defineRoutes, JSON.parse(readFileSync('./app/routes.json', 'utf8'))),
           future: {
+            // Fix vite client-side dependency optimization issues that trigger a server restart.
+            // https://remix.run/docs/en/main/guides/dependency-optimization
+            unstable_optimizeDeps: true,
             v3_fetcherPersist: true,
             v3_relativeSplatPath: true,
             v3_throwAbortReason: true,


### PR DESCRIPTION
### Description

Fix the issue where vite's dependency optimization triggers a server restart.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

- The OpenTelemetry exporter package must be excluded from vite's optimization candidates until `opentelemetry-js#4794` is fixed (not linked to avoid backlinking to our project in that issue).
- More info about `unstable_optimizeDeps` can be found here: <https://remix.run/docs/en/main/guides/dependency-optimization>.