### PR TITLE
Clean up test config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ import { expressDevServer } from 'remix-express-dev-server';
 import tailwindcss from 'tailwindcss';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { configDefaults } from 'vitest/config';
+import { coverageConfigDefaults } from 'vitest/config';
 
 /**
  * Represents a single route definition in the JSON configuration file.
@@ -110,16 +110,12 @@ export default defineConfig({
     noExternal: ['react-idle-timer', 'fast-json-patch'],
   },
   test: {
-    testTimeout: 50000,
-    // happy-dom doesn't support button submit or FormData
-    // https://github.com/capricorn86/happy-dom/issues/527
-    // https://github.com/capricorn86/happy-dom/issues/585
     environment: 'jsdom',
     setupFiles: ['./__tests__/setup-test-env.ts'],
-    exclude: [...configDefaults.exclude, '**/build/**', '**/e2e/**'],
+    include: ['./__tests__/**/*.test.{ts,tsx}'],
     coverage: {
-      include: ['**/app/**'],
-      exclude: ['**/app/**/*.d.ts', '**/app/mocks/**'],
+      include: ['**/app/**/*.{ts,tsx}'],
+      exclude: ['**/app/mocks/**', ...coverageConfigDefaults.exclude],
     },
   },
 });


### PR DESCRIPTION
### Description

Clean up test config in `vite.config.ts`. The 50s test timeout was removed since it isn't really necessary for these tests, and the coverage config has been tweaked slightly.

### Checklist

- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
