### PR TITLE
Add lookup dtos and mappers

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-friendly-status.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-friendly-status.dto.mapper.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClientFriendlyStatusDto } from '~/.server/domain/dtos/client-friendly-status.dto';
+import type { ClientFriendlyStatusEntity } from '~/.server/domain/entities/client-friendly-status.entity';
+import { ClientFriendlyStatusDtoMapperImpl } from '~/.server/domain/mappers/client-friendly-status.dto.mapper';
+
+describe('ClientFriendlyStatusDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('mapClientFriendlyStatusEntityToClientFriendlyStatusDto', () => {
+    it('maps a ClientFriendlyStatusEntity with both English and French labels to a ClientFriendlyStatusDto', () => {
+      const mockEntity: ClientFriendlyStatusEntity = {
+        esdc_clientfriendlystatusid: '1',
+        esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+        esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+      };
+
+      const expectedDto: ClientFriendlyStatusDto = {
+        id: '1',
+        nameEn: 'You have qualified for the Canadian Dental Care Plan.',
+        nameFr: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+      };
+
+      const mapper = new ClientFriendlyStatusDtoMapperImpl();
+
+      const dto = mapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+  });
+
+  describe('mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos', () => {
+    it('maps an array of ClientFriendlyStatusEntities to an array of ClientFriendlyStatusDtos', () => {
+      const mockEntities: ClientFriendlyStatusEntity[] = [
+        {
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        },
+        {
+          esdc_clientfriendlystatusid: '2',
+          esdc_descriptionenglish: 'We reviewed your application for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: "Nous avons examiné votre demande d'adhésion au Régime canadien de soins dentaires.",
+        },
+      ];
+
+      const expectedDtos: ClientFriendlyStatusDto[] = [
+        {
+          id: '1',
+          nameEn: 'You have qualified for the Canadian Dental Care Plan.',
+          nameFr: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        },
+        {
+          id: '2',
+          nameEn: 'We reviewed your application for the Canadian Dental Care Plan.',
+          nameFr: "Nous avons examiné votre demande d'adhésion au Régime canadien de soins dentaires.",
+        },
+      ];
+
+      const mapper = new ClientFriendlyStatusDtoMapperImpl();
+
+      const dtos = mapper.mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/country.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/country.dto.mapper.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { CountryDto } from '~/.server/domain/dtos/country.dto';
+import type { CountryEntity } from '~/.server/domain/entities/country.entity';
+import { CountryDtoMapperImpl } from '~/.server/domain/mappers/country.dto.mapper';
+
+describe('CountryDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('mapCountryEntityToCountryDto', () => {
+    it('maps a CountryEntity with both English and French labels to a CountryDto', () => {
+      const mockEntity: CountryEntity = {
+        esdc_countryid: '1',
+        esdc_nameenglish: 'Canada English',
+        esdc_namefrench: 'Canada Français',
+        esdc_countrycodealpha3: 'CAN',
+      };
+
+      const expectedDto: CountryDto = { id: '1', nameEn: 'Canada English', nameFr: 'Canada Français' };
+
+      const mapper = new CountryDtoMapperImpl();
+
+      const dto = mapper.mapCountryEntityToCountryDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+  });
+
+  describe('mapCountryEntitiesToCountryDtos', () => {
+    it('maps an array of CountryEntities to an array of CountryDtos', () => {
+      const mockEntities: CountryEntity[] = [
+        {
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+          esdc_countrycodealpha3: 'CAN',
+        },
+        {
+          esdc_countryid: '2',
+          esdc_nameenglish: 'United States English',
+          esdc_namefrench: 'États-Unis Français',
+          esdc_countrycodealpha3: 'USA',
+        },
+      ];
+
+      const expectedDtos: CountryDto[] = [
+        { id: '1', nameEn: 'Canada English', nameFr: 'Canada Français' },
+        { id: '2', nameEn: 'United States English', nameFr: 'États-Unis Français' },
+      ];
+
+      const mapper = new CountryDtoMapperImpl();
+
+      const dtos = mapper.mapCountryEntitiesToCountryDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/federal-government-insurance-plan.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/federal-government-insurance-plan.dto.mapper.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { FederalGovernmentInsurancePlanDto } from '~/.server/domain/dtos/federal-government-insurance-plan.dto';
+import type { FederalGovernmentInsurancePlanEntity } from '~/.server/domain/entities/federal-government-insurance-plan.entity';
+import { FederalGovernmentInsurancePlanDtoMapperImpl } from '~/.server/domain/mappers/federal-government-insurance-plan.dto.mapper';
+
+describe('FederalGovernmentInsurancePlanDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto', () => {
+    it('maps a FederalGovernmentInsurancePlanEntity with both English and French labels to a FederalGovernmentInsurancePlanDto', () => {
+      const mockEntity: FederalGovernmentInsurancePlanEntity = {
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+      };
+
+      const expectedDto: FederalGovernmentInsurancePlanDto = { id: '1', nameEn: 'First Insurance Plan', nameFr: "Premier plan d'assurance" };
+
+      const mapper = new FederalGovernmentInsurancePlanDtoMapperImpl();
+
+      const dto = mapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+  });
+
+  describe('mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos', () => {
+    it('maps an array of FederalGovernmentInsurancePlanEntities to an array of FederalGovernmentInsurancePlanDtos', () => {
+      const mockEntities: FederalGovernmentInsurancePlanEntity[] = [
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+        },
+      ];
+
+      const expectedDtos: FederalGovernmentInsurancePlanDto[] = [
+        { id: '1', nameEn: 'First Insurance Plan', nameFr: "Premier plan d'assurance" },
+        { id: '2', nameEn: 'Second Insurance Plan', nameFr: "Deuxième plan d'assurance" },
+      ];
+
+      const mapper = new FederalGovernmentInsurancePlanDtoMapperImpl();
+
+      const dtos = mapper.mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/marital-status.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/marital-status.dto.mapper.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { MaritalStatusDto } from '~/.server/domain/dtos/marital-status.dto';
+import type { MaritalStatusEntity } from '~/.server/domain/entities/marital-status.entity';
+import { MaritalStatusDtoMapperImpl } from '~/.server/domain/mappers/marital-status.dto.mapper';
+
+describe('MaritalStatusDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  const mockServerConfig: Pick<ServerConfig, 'ENGLISH_LANGUAGE_CODE' | 'FRENCH_LANGUAGE_CODE'> = { ENGLISH_LANGUAGE_CODE: 1033, FRENCH_LANGUAGE_CODE: 1036 };
+
+  describe('mapMaritalStatusEntityToMaritalStatusDto', () => {
+    it('maps a MaritalStatusEntity with both English and French labels to a MaritalStatusDto', () => {
+      const mockEntity: MaritalStatusEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [
+            { Label: 'English', LanguageCode: 1033 },
+            { Label: 'Anglais', LanguageCode: 1036 },
+          ],
+        },
+      };
+
+      const expectedDto: MaritalStatusDto = { id: '1033', nameEn: 'English', nameFr: 'Anglais' };
+
+      const mapper = new MaritalStatusDtoMapperImpl(mockServerConfig);
+
+      const dto = mapper.mapMaritalStatusEntityToMaritalStatusDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+
+    it('throws an error if the MaritalStatusEntity is missing the English label', () => {
+      const mockEntity: MaritalStatusEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [{ Label: 'Anglais', LanguageCode: 1036 }],
+        },
+      };
+
+      const mapper = new MaritalStatusDtoMapperImpl(mockServerConfig);
+
+      expect(() => mapper.mapMaritalStatusEntityToMaritalStatusDto(mockEntity)).toThrowError(`Marital status missing English or French name; id: [1033]`);
+    });
+
+    it('throws an error if the MaritalStatusEntity is missing the French label', () => {
+      const mockEntity: MaritalStatusEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [{ Label: 'English', LanguageCode: 1033 }],
+        },
+      };
+
+      const mapper = new MaritalStatusDtoMapperImpl(mockServerConfig);
+
+      expect(() => mapper.mapMaritalStatusEntityToMaritalStatusDto(mockEntity)).toThrowError(`Marital status missing English or French name; id: [1033]`);
+    });
+  });
+
+  describe('mapMaritalStatusEntitiesToMaritalStatusDtos', () => {
+    it('maps an array of MaritalStatusEntities to an array of MaritalStatusDtos', () => {
+      const mockEntities: MaritalStatusEntity[] = [
+        {
+          Value: 1033,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'English', LanguageCode: 1033 },
+              { Label: 'Anglais', LanguageCode: 1036 },
+            ],
+          },
+        },
+        {
+          Value: 1036,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'French', LanguageCode: 1033 },
+              { Label: 'Français', LanguageCode: 1036 },
+            ],
+          },
+        },
+      ];
+
+      const expectedDtos: MaritalStatusDto[] = [
+        { id: '1033', nameEn: 'English', nameFr: 'Anglais' },
+        { id: '1036', nameEn: 'French', nameFr: 'Français' },
+      ];
+
+      const mapper = new MaritalStatusDtoMapperImpl(mockServerConfig);
+
+      const dtos = mapper.mapMaritalStatusEntitiesToMaritalStatusDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/preferred-communication-method.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/preferred-communication-method.dto.mapper.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { PreferredCommunicationMethodDto } from '~/.server/domain/dtos/preferred-communication-method.dto';
+import type { PreferredCommunicationMethodEntity } from '~/.server/domain/entities/preferred-communication-method.entity';
+import { PreferredCommunicationMethodDtoMapperImpl } from '~/.server/domain/mappers/preferred-communication-method.dto.mapper';
+
+describe('PreferredCommunicationMethodDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  const mockServerConfig: Pick<ServerConfig, 'ENGLISH_LANGUAGE_CODE' | 'FRENCH_LANGUAGE_CODE'> = { ENGLISH_LANGUAGE_CODE: 1033, FRENCH_LANGUAGE_CODE: 1036 };
+
+  describe('mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto', () => {
+    it('maps a PreferredCommunicationMethodEntity with both English and French labels to a PreferredCommunicationMethodDto', () => {
+      const mockEntity: PreferredCommunicationMethodEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [
+            { Label: 'English', LanguageCode: 1033 },
+            { Label: 'Anglais', LanguageCode: 1036 },
+          ],
+        },
+      };
+
+      const expectedDto: PreferredCommunicationMethodDto = { id: '1033', nameEn: 'English', nameFr: 'Anglais' };
+
+      const mapper = new PreferredCommunicationMethodDtoMapperImpl(mockServerConfig);
+
+      const dto = mapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+
+    it('throws an error if the PreferredCommunicationMethodEntity is missing the English label', () => {
+      const mockEntity: PreferredCommunicationMethodEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [{ Label: 'Anglais', LanguageCode: 1036 }],
+        },
+      };
+
+      const mapper = new PreferredCommunicationMethodDtoMapperImpl(mockServerConfig);
+
+      expect(() => mapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(mockEntity)).toThrowError(`Preferred communication method missing English or French name; id: [1033]`);
+    });
+
+    it('throws an error if the PreferredCommunicationMethodEntity is missing the French label', () => {
+      const mockEntity: PreferredCommunicationMethodEntity = {
+        Value: 1033,
+        Label: {
+          LocalizedLabels: [{ Label: 'English', LanguageCode: 1033 }],
+        },
+      };
+
+      const mapper = new PreferredCommunicationMethodDtoMapperImpl(mockServerConfig);
+
+      expect(() => mapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(mockEntity)).toThrowError(`Preferred communication method missing English or French name; id: [1033]`);
+    });
+  });
+
+  describe('mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos', () => {
+    it('maps an array of PreferredCommunicationMethodEntities to an array of PreferredCommunicationMethodDtos', () => {
+      const mockEntities: PreferredCommunicationMethodEntity[] = [
+        {
+          Value: 1033,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'English', LanguageCode: 1033 },
+              { Label: 'Anglais', LanguageCode: 1036 },
+            ],
+          },
+        },
+        {
+          Value: 1036,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'French', LanguageCode: 1033 },
+              { Label: 'Français', LanguageCode: 1036 },
+            ],
+          },
+        },
+      ];
+
+      const expectedDtos: PreferredCommunicationMethodDto[] = [
+        { id: '1033', nameEn: 'English', nameFr: 'Anglais' },
+        { id: '1036', nameEn: 'French', nameFr: 'Français' },
+      ];
+
+      const mapper = new PreferredCommunicationMethodDtoMapperImpl(mockServerConfig);
+
+      const dtos = mapper.mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/province-territory-state.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/province-territory-state.dto.mapper.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProvinceTerritoryStateDto } from '~/.server/domain/dtos/province-territory-state.dto';
+import type { ProvinceTerritoryStateEntity } from '~/.server/domain/entities/province-territory-state.entity';
+import { ProvinceTerritoryStateDtoMapperImpl } from '~/.server/domain/mappers/province-territory-state.dto.mapper';
+
+describe('ProvinceTerritoryStateDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto', () => {
+    it('maps a ProvinceTerritoryStateEntity with both English and French labels to a ProvinceTerritoryStateDto', () => {
+      const mockEntity: ProvinceTerritoryStateEntity = {
+        esdc_provinceterritorystateid: '1',
+        _esdc_countryid_value: '10',
+        esdc_nameenglish: 'Alabama EN',
+        esdc_namefrench: 'Alabama FR',
+        esdc_internationalalphacode: 'AL',
+      };
+
+      const expectedDto: ProvinceTerritoryStateDto = { id: '1', countryId: '10', nameEn: 'Alabama EN', nameFr: 'Alabama FR', abbr: 'AL' };
+
+      const mapper = new ProvinceTerritoryStateDtoMapperImpl();
+
+      const dto = mapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+  });
+
+  describe('mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos', () => {
+    it('maps an array of ProvinceTerritoryStateEntities to an array of ProvinceTerritoryStateDtos', () => {
+      const mockEntities: ProvinceTerritoryStateEntity[] = [
+        {
+          esdc_provinceterritorystateid: '1',
+          _esdc_countryid_value: '10',
+          esdc_nameenglish: 'Alabama EN',
+          esdc_namefrench: 'Alabama FR',
+          esdc_internationalalphacode: 'AL',
+        },
+        {
+          esdc_provinceterritorystateid: '2',
+          _esdc_countryid_value: '10',
+          esdc_nameenglish: 'Alaska EN',
+          esdc_namefrench: 'Alaska FR',
+          esdc_internationalalphacode: 'AK',
+        },
+      ];
+
+      const expectedDtos: ProvinceTerritoryStateDto[] = [
+        { id: '1', countryId: '10', nameEn: 'Alabama EN', nameFr: 'Alabama FR', abbr: 'AL' },
+        { id: '2', countryId: '10', nameEn: 'Alaska EN', nameFr: 'Alaska FR', abbr: 'AK' },
+      ];
+
+      const mapper = new ProvinceTerritoryStateDtoMapperImpl();
+
+      const dtos = mapper.mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProvincialGovernmentInsurancePlanDto } from '~/.server/domain/dtos/provincial-government-insurance-plan.dto';
+import type { ProvincialGovernmentInsurancePlanEntity } from '~/.server/domain/entities/provincial-government-insurance-plan.entity';
+import { ProvincialGovernmentInsurancePlanDtoMapperImpl } from '~/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper';
+
+describe('ProvincialGovernmentInsurancePlanDtoMapperImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto', () => {
+    it('maps a ProvincialGovernmentInsurancePlanEntity with both English and French labels to a ProvincialGovernmentInsurancePlanDto', () => {
+      const mockEntity: ProvincialGovernmentInsurancePlanEntity = {
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+        _esdc_provinceterritorystateid_value: '10',
+      };
+
+      const expectedDto: ProvincialGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+        provinceTerritoryStateId: '10',
+      };
+
+      const mapper = new ProvincialGovernmentInsurancePlanDtoMapperImpl();
+
+      const dto = mapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+  });
+
+  describe('mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos', () => {
+    it('maps an array of ProvincialGovernmentInsurancePlanEntities to an array of ProvincialGovernmentInsurancePlanDtos', () => {
+      const mockEntities: ProvincialGovernmentInsurancePlanEntity[] = [
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: '10',
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '20',
+        },
+      ];
+
+      const expectedDtos: ProvincialGovernmentInsurancePlanDto[] = [
+        {
+          id: '1',
+          nameEn: 'First Insurance Plan',
+          nameFr: "Premier plan d'assurance",
+          provinceTerritoryStateId: '10',
+        },
+        {
+          id: '2',
+          nameEn: 'Second Insurance Plan',
+          nameFr: "Deuxième plan d'assurance",
+          provinceTerritoryStateId: '20',
+        },
+      ];
+
+      const mapper = new ProvincialGovernmentInsurancePlanDtoMapperImpl();
+
+      const dtos = mapper.mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(mockEntities);
+
+      expect(dtos).toEqual(expectedDtos);
+    });
+  });
+});

--- a/frontend/app/.server/domain/dtos/client-friendly-status.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-friendly-status.dto.ts
@@ -1,0 +1,5 @@
+export interface ClientFriendlyStatusDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}

--- a/frontend/app/.server/domain/dtos/country.dto.ts
+++ b/frontend/app/.server/domain/dtos/country.dto.ts
@@ -1,0 +1,5 @@
+export interface CountryDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}

--- a/frontend/app/.server/domain/dtos/federal-government-insurance-plan.dto.ts
+++ b/frontend/app/.server/domain/dtos/federal-government-insurance-plan.dto.ts
@@ -1,0 +1,5 @@
+export interface FederalGovernmentInsurancePlanDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}

--- a/frontend/app/.server/domain/dtos/marital-status.dto.ts
+++ b/frontend/app/.server/domain/dtos/marital-status.dto.ts
@@ -1,0 +1,5 @@
+export interface MaritalStatusDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}

--- a/frontend/app/.server/domain/dtos/preferred-communication-method.dto.ts
+++ b/frontend/app/.server/domain/dtos/preferred-communication-method.dto.ts
@@ -1,0 +1,5 @@
+export interface PreferredCommunicationMethodDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}

--- a/frontend/app/.server/domain/dtos/province-territory-state.dto.ts
+++ b/frontend/app/.server/domain/dtos/province-territory-state.dto.ts
@@ -1,0 +1,7 @@
+export interface ProvinceTerritoryStateDto {
+  id: string;
+  countryId: string;
+  nameEn: string;
+  nameFr: string;
+  abbr: string;
+}

--- a/frontend/app/.server/domain/dtos/provincial-government-insurance-plan.dto.ts
+++ b/frontend/app/.server/domain/dtos/provincial-government-insurance-plan.dto.ts
@@ -1,0 +1,6 @@
+export interface ProvincialGovernmentInsurancePlanDto {
+  id: string;
+  nameEn: string;
+  nameFr: string;
+  provinceTerritoryStateId: string;
+}

--- a/frontend/app/.server/domain/mappers/client-friendly-status.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-friendly-status.dto.mapper.ts
@@ -1,0 +1,23 @@
+import { injectable } from 'inversify';
+
+import type { ClientFriendlyStatusDto } from '~/.server/domain/dtos/client-friendly-status.dto';
+import type { ClientFriendlyStatusEntity } from '~/.server/domain/entities/client-friendly-status.entity';
+
+export interface ClientFriendlyStatusDtoMapper {
+  mapClientFriendlyStatusEntityToClientFriendlyStatusDto(clientFriendlyStatusEntity: ClientFriendlyStatusEntity): ClientFriendlyStatusDto;
+  mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos(clientFriendlyStatusEntities: ClientFriendlyStatusEntity[]): ClientFriendlyStatusDto[];
+}
+
+@injectable()
+export class ClientFriendlyStatusDtoMapperImpl implements ClientFriendlyStatusDtoMapper {
+  mapClientFriendlyStatusEntityToClientFriendlyStatusDto(clientFriendlyStatusEntity: ClientFriendlyStatusEntity): ClientFriendlyStatusDto {
+    const id = clientFriendlyStatusEntity.esdc_clientfriendlystatusid;
+    const nameEn = clientFriendlyStatusEntity.esdc_descriptionenglish;
+    const nameFr = clientFriendlyStatusEntity.esdc_descriptionfrench;
+    return { id, nameEn, nameFr };
+  }
+
+  mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos(clientFriendlyStatusEntities: ClientFriendlyStatusEntity[]): ClientFriendlyStatusDto[] {
+    return clientFriendlyStatusEntities.map((entity) => this.mapClientFriendlyStatusEntityToClientFriendlyStatusDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/country.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/country.dto.mapper.ts
@@ -1,0 +1,23 @@
+import { injectable } from 'inversify';
+
+import type { CountryDto } from '~/.server/domain/dtos/country.dto';
+import type { CountryEntity } from '~/.server/domain/entities/country.entity';
+
+export interface CountryDtoMapper {
+  mapCountryEntityToCountryDto(countryEntity: CountryEntity): CountryDto;
+  mapCountryEntitiesToCountryDtos(countryEntities: CountryEntity[]): CountryDto[];
+}
+
+@injectable()
+export class CountryDtoMapperImpl implements CountryDtoMapper {
+  mapCountryEntityToCountryDto(countryEntity: CountryEntity): CountryDto {
+    const id = countryEntity.esdc_countryid.toString();
+    const nameEn = countryEntity.esdc_nameenglish;
+    const nameFr = countryEntity.esdc_namefrench;
+    return { id, nameEn, nameFr };
+  }
+
+  mapCountryEntitiesToCountryDtos(countryEntities: CountryEntity[]): CountryDto[] {
+    return countryEntities.map((entity) => this.mapCountryEntityToCountryDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/federal-government-insurance-plan.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/federal-government-insurance-plan.dto.mapper.ts
@@ -1,0 +1,23 @@
+import { injectable } from 'inversify';
+
+import type { FederalGovernmentInsurancePlanDto } from '~/.server/domain/dtos/federal-government-insurance-plan.dto';
+import type { FederalGovernmentInsurancePlanEntity } from '~/.server/domain/entities/federal-government-insurance-plan.entity';
+
+export interface FederalGovernmentInsurancePlanDtoMapper {
+  mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto(federalGovernmentInsurancePlanEntity: FederalGovernmentInsurancePlanEntity): FederalGovernmentInsurancePlanDto;
+  mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(federalGovernmentInsurancePlanEntities: FederalGovernmentInsurancePlanEntity[]): FederalGovernmentInsurancePlanDto[];
+}
+
+@injectable()
+export class FederalGovernmentInsurancePlanDtoMapperImpl implements FederalGovernmentInsurancePlanDtoMapper {
+  mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto(federalGovernmentInsurancePlanEntity: FederalGovernmentInsurancePlanEntity): FederalGovernmentInsurancePlanDto {
+    const id = federalGovernmentInsurancePlanEntity.esdc_governmentinsuranceplanid;
+    const nameEn = federalGovernmentInsurancePlanEntity.esdc_nameenglish;
+    const nameFr = federalGovernmentInsurancePlanEntity.esdc_namefrench;
+    return { id, nameEn, nameFr };
+  }
+
+  mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(federalGovernmentInsurancePlanEntities: FederalGovernmentInsurancePlanEntity[]): FederalGovernmentInsurancePlanDto[] {
+    return federalGovernmentInsurancePlanEntities.map((entity) => this.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/marital-status.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/marital-status.dto.mapper.ts
@@ -1,0 +1,34 @@
+import { inject, injectable } from 'inversify';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import { SERVICE_IDENTIFIER } from '~/.server/constants/service-identifier.contant';
+import type { MaritalStatusDto } from '~/.server/domain/dtos/marital-status.dto';
+import type { MaritalStatusEntity } from '~/.server/domain/entities/marital-status.entity';
+
+export interface MaritalStatusDtoMapper {
+  mapMaritalStatusEntityToMaritalStatusDto(maritalStatusEntity: MaritalStatusEntity): MaritalStatusDto;
+  mapMaritalStatusEntitiesToMaritalStatusDtos(maritalStatusEntities: MaritalStatusEntity[]): MaritalStatusDto[];
+}
+
+@injectable()
+export class MaritalStatusDtoMapperImpl implements MaritalStatusDtoMapper {
+  constructor(@inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'ENGLISH_LANGUAGE_CODE' | 'FRENCH_LANGUAGE_CODE'>) {}
+
+  mapMaritalStatusEntityToMaritalStatusDto(maritalStatusEntity: MaritalStatusEntity): MaritalStatusDto {
+    const { ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = this.serverConfig;
+
+    const id = maritalStatusEntity.Value.toString();
+    const nameEn = maritalStatusEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === ENGLISH_LANGUAGE_CODE)?.Label;
+    const nameFr = maritalStatusEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label;
+
+    if (nameEn === undefined || nameFr === undefined) {
+      throw new Error(`Marital status missing English or French name; id: [${id}]`);
+    }
+
+    return { id, nameEn, nameFr };
+  }
+
+  mapMaritalStatusEntitiesToMaritalStatusDtos(maritalStatusEntities: MaritalStatusEntity[]): MaritalStatusDto[] {
+    return maritalStatusEntities.map((entity) => this.mapMaritalStatusEntityToMaritalStatusDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/preferred-communication-method.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/preferred-communication-method.dto.mapper.ts
@@ -1,0 +1,34 @@
+import { inject, injectable } from 'inversify';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import { SERVICE_IDENTIFIER } from '~/.server/constants/service-identifier.contant';
+import type { PreferredCommunicationMethodDto } from '~/.server/domain/dtos/preferred-communication-method.dto';
+import type { PreferredCommunicationMethodEntity } from '~/.server/domain/entities/preferred-communication-method.entity';
+
+export interface PreferredCommunicationMethodDtoMapper {
+  mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(preferredCommunicationMethodEntity: PreferredCommunicationMethodEntity): PreferredCommunicationMethodDto;
+  mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos(preferredCommunicationMethodEntities: PreferredCommunicationMethodEntity[]): PreferredCommunicationMethodDto[];
+}
+
+@injectable()
+export class PreferredCommunicationMethodDtoMapperImpl implements PreferredCommunicationMethodDtoMapper {
+  constructor(@inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'ENGLISH_LANGUAGE_CODE' | 'FRENCH_LANGUAGE_CODE'>) {}
+
+  mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(preferredCommunicationMethodEntity: PreferredCommunicationMethodEntity): PreferredCommunicationMethodDto {
+    const { ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = this.serverConfig;
+
+    const id = preferredCommunicationMethodEntity.Value.toString();
+    const nameEn = preferredCommunicationMethodEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === ENGLISH_LANGUAGE_CODE)?.Label;
+    const nameFr = preferredCommunicationMethodEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label;
+
+    if (nameEn === undefined || nameFr === undefined) {
+      throw new Error(`Preferred nommunication method missing English or French name; id: [${id}]`);
+    }
+
+    return { id, nameEn, nameFr };
+  }
+
+  mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos(preferredCommunicationMethodEntities: PreferredCommunicationMethodEntity[]): PreferredCommunicationMethodDto[] {
+    return preferredCommunicationMethodEntities.map((entity) => this.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/preferred-communication-method.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/preferred-communication-method.dto.mapper.ts
@@ -22,7 +22,7 @@ export class PreferredCommunicationMethodDtoMapperImpl implements PreferredCommu
     const nameFr = preferredCommunicationMethodEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label;
 
     if (nameEn === undefined || nameFr === undefined) {
-      throw new Error(`Preferred nommunication method missing English or French name; id: [${id}]`);
+      throw new Error(`Preferred communication method missing English or French name; id: [${id}]`);
     }
 
     return { id, nameEn, nameFr };

--- a/frontend/app/.server/domain/mappers/province-territory-state.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/province-territory-state.dto.mapper.ts
@@ -1,0 +1,25 @@
+import { injectable } from 'inversify';
+
+import type { ProvinceTerritoryStateDto } from '~/.server/domain/dtos/province-territory-state.dto';
+import type { ProvinceTerritoryStateEntity } from '~/.server/domain/entities/province-territory-state.entity';
+
+export interface ProvinceTerritoryStateDtoMapper {
+  mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto(provinceTerritoryStateEntity: ProvinceTerritoryStateEntity): ProvinceTerritoryStateDto;
+  mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos(provinceTerritoryStateEntities: ProvinceTerritoryStateEntity[]): ProvinceTerritoryStateDto[];
+}
+
+@injectable()
+export class ProvinceTerritoryStateDtoMapperImpl implements ProvinceTerritoryStateDtoMapper {
+  mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto(provinceTerritoryStateEntity: ProvinceTerritoryStateEntity): ProvinceTerritoryStateDto {
+    const id = provinceTerritoryStateEntity.esdc_provinceterritorystateid;
+    const countryId = provinceTerritoryStateEntity._esdc_countryid_value;
+    const nameEn = provinceTerritoryStateEntity.esdc_nameenglish;
+    const nameFr = provinceTerritoryStateEntity.esdc_namefrench;
+    const abbr = provinceTerritoryStateEntity.esdc_internationalalphacode;
+    return { id, countryId, nameEn, nameFr, abbr };
+  }
+
+  mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos(provinceTerritoryStateEntities: ProvinceTerritoryStateEntity[]): ProvinceTerritoryStateDto[] {
+    return provinceTerritoryStateEntities.map((entity) => this.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto(entity));
+  }
+}

--- a/frontend/app/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper.ts
@@ -1,0 +1,24 @@
+import { injectable } from 'inversify';
+
+import type { ProvincialGovernmentInsurancePlanDto } from '~/.server/domain/dtos/provincial-government-insurance-plan.dto';
+import type { ProvincialGovernmentInsurancePlanEntity } from '~/.server/domain/entities/provincial-government-insurance-plan.entity';
+
+export interface ProvincialGovernmentInsurancePlanDtoMapper {
+  mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto(provincialGovernmentInsurancePlanEntity: ProvincialGovernmentInsurancePlanEntity): ProvincialGovernmentInsurancePlanDto;
+  mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanEntities: ProvincialGovernmentInsurancePlanEntity[]): ProvincialGovernmentInsurancePlanDto[];
+}
+
+@injectable()
+export class ProvincialGovernmentInsurancePlanDtoMapperImpl implements ProvincialGovernmentInsurancePlanDtoMapper {
+  mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto(provincialGovernmentInsurancePlanEntity: ProvincialGovernmentInsurancePlanEntity): ProvincialGovernmentInsurancePlanDto {
+    const id = provincialGovernmentInsurancePlanEntity.esdc_governmentinsuranceplanid;
+    const nameEn = provincialGovernmentInsurancePlanEntity.esdc_nameenglish;
+    const nameFr = provincialGovernmentInsurancePlanEntity.esdc_namefrench;
+    const provinceTerritoryStateId = provincialGovernmentInsurancePlanEntity._esdc_provinceterritorystateid_value;
+    return { id, nameEn, nameFr, provinceTerritoryStateId };
+  }
+
+  mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanEntities: ProvincialGovernmentInsurancePlanEntity[]): ProvincialGovernmentInsurancePlanDto[] {
+    return provincialGovernmentInsurancePlanEntities.map((entity) => this.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto(entity));
+  }
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add lookup dtos and mappers for the following items:

- client-friendly-status
- country
- federal-government-insurance-plan
- marital-status
- preferred-communication-method
- province-territory-state
- provincial-government-insurance-plan

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

Unit tests coverage
![image](https://github.com/user-attachments/assets/37b796cf-bd78-483f-8f9a-87e7751ea804)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->