### PR TITLE
Add lookup service unit tests

### DIFF
--- a/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
@@ -75,7 +75,7 @@ describe('ClientFriendlyStatusServiceImpl', () => {
 
   describe('findById', () => {
     it('fetches client friendly status by id', () => {
-      const id = '1033';
+      const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
       mockClientFriendlyStatusRepository.findById.mockReturnValueOnce({
         esdc_clientfriendlystatusid: '1',

--- a/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { ClientFriendlyStatusDto } from '~/.server/domain/dtos/client-friendly-status.dto';
+import type { ClientFriendlyStatusDtoMapper } from '~/.server/domain/mappers/client-friendly-status.dto.mapper';
+import type { ClientFriendlyStatusRepository } from '~/.server/domain/repositories/client-friendly-status.repository';
+import { ClientFriendlyStatusServiceImpl } from '~/.server/domain/services/client-friendly-status.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('ClientFriendlyStatusServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
+      const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
+
+      const service = new ClientFriendlyStatusServiceImpl(mockLogFactory, mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all client friendly statuses', () => {
+      const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
+      mockClientFriendlyStatusRepository.findAll.mockReturnValueOnce([
+        {
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        },
+        {
+          esdc_clientfriendlystatusid: '2',
+          esdc_descriptionenglish: 'We reviewed your application for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: "Nous avons examiné votre demande d'adhésion au Régime canadien de soins dentaires.",
+        },
+      ]);
+
+      const mockDtos: ClientFriendlyStatusDto[] = [
+        {
+          id: '1',
+          nameEn: 'You have qualified for the Canadian Dental Care Plan.',
+          nameFr: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        },
+        {
+          id: '2',
+          nameEn: 'We reviewed your application for the Canadian Dental Care Plan.',
+          nameFr: "Nous avons examiné votre demande d'adhésion au Régime canadien de soins dentaires.",
+        },
+      ];
+
+      const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
+      mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new ClientFriendlyStatusServiceImpl(mockLogFactory, mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockClientFriendlyStatusRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntitiesToClientFriendlyStatusDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches client friendly status by id', () => {
+      const id = '1033';
+      const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
+      mockClientFriendlyStatusRepository.findById.mockReturnValueOnce({
+        esdc_clientfriendlystatusid: '1',
+        esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+        esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+      });
+
+      const mockDto: ClientFriendlyStatusDto = {
+        id: '1',
+        nameEn: 'You have qualified for the Canadian Dental Care Plan.',
+        nameFr: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+      };
+
+      const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
+      mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto.mockReturnValueOnce(mockDto);
+
+      const service = new ClientFriendlyStatusServiceImpl(mockLogFactory, mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockClientFriendlyStatusRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches client friendly status by id returns null if not found', () => {
+      const id = '1033';
+      const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
+      mockClientFriendlyStatusRepository.findById.mockReturnValueOnce(null);
+
+      const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
+
+      const service = new ClientFriendlyStatusServiceImpl(mockLogFactory, mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockClientFriendlyStatusRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/country.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/country.service.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { CountryDto } from '~/.server/domain/dtos/country.dto';
+import type { CountryDtoMapper } from '~/.server/domain/mappers/country.dto.mapper';
+import type { CountryRepository } from '~/.server/domain/repositories/country.repository';
+import { CountryServiceImpl } from '~/.server/domain/services/country.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('CountryServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_COUNTRIES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_COUNTRY_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_COUNTRIES_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_COUNTRY_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockCountryDtoMapper = mock<CountryDtoMapper>();
+      const mockCountryRepository = mock<CountryRepository>();
+
+      const service = new CountryServiceImpl(mockLogFactory, mockCountryDtoMapper, mockCountryRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all countries', () => {
+      const mockCountryRepository = mock<CountryRepository>();
+      mockCountryRepository.findAll.mockReturnValueOnce([
+        {
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+          esdc_countrycodealpha3: 'CAN',
+        },
+        {
+          esdc_countryid: '2',
+          esdc_nameenglish: 'United States English',
+          esdc_namefrench: 'États-Unis Français',
+          esdc_countrycodealpha3: 'USA',
+        },
+      ]);
+
+      const mockDtos: CountryDto[] = [
+        { id: '1', nameEn: 'Canada English', nameFr: 'Canada Français' },
+        { id: '2', nameEn: 'United States English', nameFr: 'États-Unis Français' },
+      ];
+
+      const mockCountryDtoMapper = mock<CountryDtoMapper>();
+      mockCountryDtoMapper.mapCountryEntitiesToCountryDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new CountryServiceImpl(mockLogFactory, mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockCountryRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockCountryDtoMapper.mapCountryEntitiesToCountryDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches country by id', () => {
+      const id = '1033';
+      const mockCountryRepository = mock<CountryRepository>();
+      mockCountryRepository.findById.mockReturnValueOnce({
+        esdc_countryid: '1',
+        esdc_nameenglish: 'Canada English',
+        esdc_namefrench: 'Canada Français',
+        esdc_countrycodealpha3: 'CAN',
+      });
+
+      const mockDto: CountryDto = { id: '1', nameEn: 'Canada English', nameFr: 'Canada Français' };
+
+      const mockCountryDtoMapper = mock<CountryDtoMapper>();
+      mockCountryDtoMapper.mapCountryEntityToCountryDto.mockReturnValueOnce(mockDto);
+
+      const service = new CountryServiceImpl(mockLogFactory, mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockCountryRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockCountryDtoMapper.mapCountryEntityToCountryDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches country by id returns null if not found', () => {
+      const id = '1033';
+      const mockCountryRepository = mock<CountryRepository>();
+      mockCountryRepository.findById.mockReturnValueOnce(null);
+
+      const mockCountryDtoMapper = mock<CountryDtoMapper>();
+
+      const service = new CountryServiceImpl(mockLogFactory, mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockCountryRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockCountryDtoMapper.mapCountryEntityToCountryDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/country.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/country.service.test.ts
@@ -69,7 +69,7 @@ describe('CountryServiceImpl', () => {
 
   describe('findById', () => {
     it('fetches country by id', () => {
-      const id = '1033';
+      const id = '1';
       const mockCountryRepository = mock<CountryRepository>();
       mockCountryRepository.findById.mockReturnValueOnce({
         esdc_countryid: '1',

--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -75,7 +75,7 @@ describe('FederalGovernmentInsurancePlanServiceImpl', () => {
 
   describe('findById', () => {
     it('fetches federal government insurance plan by id', () => {
-      const id = '1033';
+      const id = '1';
       const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
       mockFederalGovernmentInsurancePlanRepository.findById.mockReturnValueOnce({
         esdc_governmentinsuranceplanid: '1',

--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { FederalGovernmentInsurancePlanDto } from '~/.server/domain/dtos/federal-government-insurance-plan.dto';
+import type { FederalGovernmentInsurancePlanDtoMapper } from '~/.server/domain/mappers/federal-government-insurance-plan.dto.mapper';
+import type { FederalGovernmentInsurancePlanRepository } from '~/.server/domain/repositories/federal-government-insurance-plan.repository';
+import { FederalGovernmentInsurancePlanServiceImpl } from '~/.server/domain/services/federal-government-insurance-plan.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('FederalGovernmentInsurancePlanServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_FEDERAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_FEDERAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_FEDERAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_FEDERAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+
+      const service = new FederalGovernmentInsurancePlanServiceImpl(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all federal government insurance plans', () => {
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findAll.mockReturnValueOnce([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+        },
+      ]);
+
+      const mockDtos: FederalGovernmentInsurancePlanDto[] = [
+        {
+          id: '1',
+          nameEn: 'First Insurance Plan',
+          nameFr: "Premier plan d'assurance",
+        },
+        {
+          id: '2',
+          nameEn: 'Second Insurance Plan',
+          nameFr: "Deuxième plan d'assurance",
+        },
+      ];
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+      mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new FederalGovernmentInsurancePlanServiceImpl(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockFederalGovernmentInsurancePlanRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches federal government insurance plan by id', () => {
+      const id = '1033';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+      });
+
+      const mockDto: FederalGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+      };
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+      mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+
+      const service = new FederalGovernmentInsurancePlanServiceImpl(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockFederalGovernmentInsurancePlanRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches federal government insurance plan by id returns null if not found', () => {
+      const id = '1033';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findById.mockReturnValueOnce(null);
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+
+      const service = new FederalGovernmentInsurancePlanServiceImpl(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockFederalGovernmentInsurancePlanRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/marital-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/marital-status.service.test.ts
@@ -76,7 +76,7 @@ describe('MaritalStatusServiceImpl', () => {
 
   describe('findById', () => {
     it('fetches marital status by id', () => {
-      const id = '1033';
+      const id = '1';
       const mockMaritalStatusRepository = mock<MaritalStatusRepository>();
       mockMaritalStatusRepository.findById.mockReturnValueOnce({
         Value: 1,

--- a/frontend/__tests__/.server/domain/services/marital-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/marital-status.service.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { MaritalStatusDto } from '~/.server/domain/dtos/marital-status.dto';
+import type { MaritalStatusDtoMapper } from '~/.server/domain/mappers/marital-status.dto.mapper';
+import type { MaritalStatusRepository } from '~/.server/domain/repositories/marital-status.repository';
+import { MaritalStatusServiceImpl } from '~/.server/domain/services/marital-status.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('MaritalStatusServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_MARITAL_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_MARITAL_STATUS_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_MARITAL_STATUSES_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_MARITAL_STATUS_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockMaritalStatusDtoMapper = mock<MaritalStatusDtoMapper>();
+      const mockMaritalStatusRepository = mock<MaritalStatusRepository>();
+
+      const service = new MaritalStatusServiceImpl(mockLogFactory, mockMaritalStatusDtoMapper, mockMaritalStatusRepository, mockServerConfig);
+
+      // Act and Assert
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all marital statuses', () => {
+      const mockMaritalStatusRepository = mock<MaritalStatusRepository>();
+      mockMaritalStatusRepository.findAll.mockReturnValueOnce([
+        {
+          Value: 1,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'Single', LanguageCode: 1033 },
+              { Label: 'Célibataire', LanguageCode: 1036 },
+            ],
+          },
+        },
+        {
+          Value: 2,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'Married', LanguageCode: 1033 },
+              { Label: 'Marié(e)', LanguageCode: 1036 },
+            ],
+          },
+        },
+      ]);
+
+      const mockDtos: MaritalStatusDto[] = [
+        { id: '1', nameEn: 'Single', nameFr: 'Célibataire' },
+        { id: '2', nameEn: 'Married', nameFr: 'Marié(e)' },
+      ];
+
+      const mockMaritalStatusDtoMapper = mock<MaritalStatusDtoMapper>();
+      mockMaritalStatusDtoMapper.mapMaritalStatusEntitiesToMaritalStatusDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new MaritalStatusServiceImpl(mockLogFactory, mockMaritalStatusDtoMapper, mockMaritalStatusRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockMaritalStatusRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockMaritalStatusDtoMapper.mapMaritalStatusEntitiesToMaritalStatusDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches marital status by id', () => {
+      const id = '1033';
+      const mockMaritalStatusRepository = mock<MaritalStatusRepository>();
+      mockMaritalStatusRepository.findById.mockReturnValueOnce({
+        Value: 1,
+        Label: {
+          LocalizedLabels: [
+            { Label: 'Single', LanguageCode: 1033 },
+            { Label: 'Célibataire', LanguageCode: 1036 },
+          ],
+        },
+      });
+
+      const mockDto: MaritalStatusDto = { id: '1', nameEn: 'Single', nameFr: 'Célibataire' };
+
+      const mockMaritalStatusDtoMapper = mock<MaritalStatusDtoMapper>();
+      mockMaritalStatusDtoMapper.mapMaritalStatusEntityToMaritalStatusDto.mockReturnValueOnce(mockDto);
+
+      const service = new MaritalStatusServiceImpl(mockLogFactory, mockMaritalStatusDtoMapper, mockMaritalStatusRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockMaritalStatusRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockMaritalStatusDtoMapper.mapMaritalStatusEntityToMaritalStatusDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches marital status by id returns null if not found', () => {
+      const id = '1033';
+      const mockMaritalStatusRepository = mock<MaritalStatusRepository>();
+      mockMaritalStatusRepository.findById.mockReturnValueOnce(null);
+
+      const mockMaritalStatusDtoMapper = mock<MaritalStatusDtoMapper>();
+
+      const service = new MaritalStatusServiceImpl(mockLogFactory, mockMaritalStatusDtoMapper, mockMaritalStatusRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockMaritalStatusRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockMaritalStatusDtoMapper.mapMaritalStatusEntityToMaritalStatusDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/preferred-communication-method.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/preferred-communication-method.service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { PreferredCommunicationMethodDto } from '~/.server/domain/dtos/preferred-communication-method.dto';
+import type { PreferredCommunicationMethodDtoMapper } from '~/.server/domain/mappers/preferred-communication-method.dto.mapper';
+import type { PreferredCommunicationMethodRepository } from '~/.server/domain/repositories/preferred-communication-method.repository';
+import { PreferredCommunicationMethodServiceImpl } from '~/.server/domain/services/preferred-communication-method.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('PreferredCommunicationMethodServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_PREFERRED_COMMUNICATION_METHODS_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_PREFERRED_COMMUNICATION_METHOD_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_PREFERRED_COMMUNICATION_METHODS_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_PREFERRED_COMMUNICATION_METHOD_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockPreferredCommunicationMethodDtoMapper = mock<PreferredCommunicationMethodDtoMapper>();
+      const mockPreferredCommunicationMethodRepository = mock<PreferredCommunicationMethodRepository>();
+
+      const service = new PreferredCommunicationMethodServiceImpl(mockLogFactory, mockPreferredCommunicationMethodDtoMapper, mockPreferredCommunicationMethodRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all preferred communication methods', () => {
+      const mockPreferredCommunicationMethodRepository = mock<PreferredCommunicationMethodRepository>();
+      mockPreferredCommunicationMethodRepository.findAll.mockReturnValueOnce([
+        {
+          Value: 1,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'Email', LanguageCode: 1033 },
+              { Label: 'Courriel', LanguageCode: 1036 },
+            ],
+          },
+        },
+        {
+          Value: 2,
+          Label: {
+            LocalizedLabels: [
+              { Label: 'Mail', LanguageCode: 1033 },
+              { Label: 'Courrier', LanguageCode: 1036 },
+            ],
+          },
+        },
+      ]);
+
+      const mockDtos: PreferredCommunicationMethodDto[] = [
+        { id: '1', nameEn: 'Email', nameFr: 'Courriel' },
+        { id: '2', nameEn: 'Mail', nameFr: 'Courrier' },
+      ];
+
+      const mockPreferredCommunicationMethodDtoMapper = mock<PreferredCommunicationMethodDtoMapper>();
+      mockPreferredCommunicationMethodDtoMapper.mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new PreferredCommunicationMethodServiceImpl(mockLogFactory, mockPreferredCommunicationMethodDtoMapper, mockPreferredCommunicationMethodRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockPreferredCommunicationMethodRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockPreferredCommunicationMethodDtoMapper.mapPreferredCommunicationMethodEntitiesToPreferredCommunicationMethodDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches preferred communication method by id', () => {
+      const id = '1';
+      const mockPreferredCommunicationMethodRepository = mock<PreferredCommunicationMethodRepository>();
+      mockPreferredCommunicationMethodRepository.findById.mockReturnValueOnce({
+        Value: 1,
+        Label: {
+          LocalizedLabels: [
+            { Label: 'Email', LanguageCode: 1033 },
+            { Label: 'Courriel', LanguageCode: 1036 },
+          ],
+        },
+      });
+
+      const mockDto: PreferredCommunicationMethodDto = { id: '1', nameEn: 'Email', nameFr: 'Courriel' };
+
+      const mockPreferredCommunicationMethodDtoMapper = mock<PreferredCommunicationMethodDtoMapper>();
+      mockPreferredCommunicationMethodDtoMapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto.mockReturnValueOnce(mockDto);
+
+      const service = new PreferredCommunicationMethodServiceImpl(mockLogFactory, mockPreferredCommunicationMethodDtoMapper, mockPreferredCommunicationMethodRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockPreferredCommunicationMethodRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockPreferredCommunicationMethodDtoMapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches preferred communication method by id returns null if not found', () => {
+      const id = '1033';
+      const mockPreferredCommunicationMethodRepository = mock<PreferredCommunicationMethodRepository>();
+      mockPreferredCommunicationMethodRepository.findById.mockReturnValueOnce(null);
+
+      const mockPreferredCommunicationMethodDtoMapper = mock<PreferredCommunicationMethodDtoMapper>();
+
+      const service = new PreferredCommunicationMethodServiceImpl(mockLogFactory, mockPreferredCommunicationMethodDtoMapper, mockPreferredCommunicationMethodRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockPreferredCommunicationMethodRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockPreferredCommunicationMethodDtoMapper.mapPreferredCommunicationMethodEntityToPreferredCommunicationMethodDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/province-territory-state.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/province-territory-state.service.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { ProvinceTerritoryStateDto } from '~/.server/domain/dtos/province-territory-state.dto';
+import type { ProvinceTerritoryStateDtoMapper } from '~/.server/domain/mappers/province-territory-state.dto.mapper';
+import type { ProvinceTerritoryStateRepository } from '~/.server/domain/repositories/province-territory-state.repository';
+import { ProvinceTerritoryStateServiceImpl } from '~/.server/domain/services/province-territory-state.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('ProvinceTerritoryStateServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_PROVINCE_TERRITORY_STATES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_PROVINCE_TERRITORY_STATE_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_PROVINCE_TERRITORY_STATES_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_PROVINCE_TERRITORY_STATE_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockProvinceTerritoryStateDtoMapper = mock<ProvinceTerritoryStateDtoMapper>();
+      const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
+
+      const service = new ProvinceTerritoryStateServiceImpl(mockLogFactory, mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all province territory states', () => {
+      const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
+      mockProvinceTerritoryStateRepository.findAll.mockReturnValueOnce([
+        {
+          esdc_provinceterritorystateid: '1',
+          _esdc_countryid_value: '10',
+          esdc_nameenglish: 'Alabama',
+          esdc_namefrench: 'Alabama',
+          esdc_internationalalphacode: 'AL',
+        },
+        {
+          esdc_provinceterritorystateid: '2',
+          _esdc_countryid_value: '10',
+          esdc_nameenglish: 'Alaska',
+          esdc_namefrench: 'Alaska',
+          esdc_internationalalphacode: 'AK',
+        },
+      ]);
+
+      const mockDtos: ProvinceTerritoryStateDto[] = [
+        { id: '1', countryId: '10', nameEn: 'Alabama EN', nameFr: 'Alabama FR', abbr: 'AL' },
+        { id: '2', countryId: '10', nameEn: 'Alaska EN', nameFr: 'Alaska FR', abbr: 'AK' },
+      ];
+
+      const mockProvinceTerritoryStateDtoMapper = mock<ProvinceTerritoryStateDtoMapper>();
+      mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new ProvinceTerritoryStateServiceImpl(mockLogFactory, mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockProvinceTerritoryStateRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches province territory state by id', () => {
+      const id = '1';
+      const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
+      mockProvinceTerritoryStateRepository.findById.mockReturnValueOnce({
+        esdc_provinceterritorystateid: '1',
+        _esdc_countryid_value: '10',
+        esdc_nameenglish: 'Alabama',
+        esdc_namefrench: 'Alabama',
+        esdc_internationalalphacode: 'AL',
+      });
+
+      const mockDto: ProvinceTerritoryStateDto = { id: '1', countryId: '10', nameEn: 'Alabama EN', nameFr: 'Alabama FR', abbr: 'AL' };
+
+      const mockProvinceTerritoryStateDtoMapper = mock<ProvinceTerritoryStateDtoMapper>();
+      mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto.mockReturnValueOnce(mockDto);
+
+      const service = new ProvinceTerritoryStateServiceImpl(mockLogFactory, mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockProvinceTerritoryStateRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches province territory state by id returns null if not found', () => {
+      const id = '1033';
+      const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
+      mockProvinceTerritoryStateRepository.findById.mockReturnValueOnce(null);
+
+      const mockProvinceTerritoryStateDtoMapper = mock<ProvinceTerritoryStateDtoMapper>();
+
+      const service = new ProvinceTerritoryStateServiceImpl(mockLogFactory, mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockProvinceTerritoryStateRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs/server.config';
+import type { ProvincialGovernmentInsurancePlanDto } from '~/.server/domain/dtos/provincial-government-insurance-plan.dto';
+import type { ProvincialGovernmentInsurancePlanDtoMapper } from '~/.server/domain/mappers/provincial-government-insurance-plan.dto.mapper';
+import type { ProvincialGovernmentInsurancePlanRepository } from '~/.server/domain/repositories/provincial-government-insurance-plan.repository';
+import { ProvincialGovernmentInsurancePlanServiceImpl } from '~/.server/domain/services/provincial-government-insurance-plan.service';
+import type { LogFactory, Logger } from '~/.server/factories/log.factory';
+
+vi.mock('moize');
+
+describe('ProvincialGovernmentInsurancePlanServiceImpl', () => {
+  const mockServerConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_PROVINCIAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS'> = {
+    LOOKUP_SVC_ALL_PROVINCIAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS: 10,
+    LOOKUP_SVC_PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS: 5,
+  };
+
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  describe('constructor', () => {
+    it('sets the correct maxAge for moize options', () => {
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+
+      const service = new ProvincialGovernmentInsurancePlanServiceImpl(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig); // Act and Assert
+
+      expect(service.findAll.options.maxAge).toBe(10000); // 10 seconds in milliseconds
+      expect(service.findById.options.maxAge).toBe(5000); // 5 seconds in milliseconds
+    });
+  });
+
+  describe('findAll', () => {
+    it('fetches all provincial government insurance plans', () => {
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findAll.mockReturnValueOnce([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: '10',
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '20',
+        },
+      ]);
+
+      const mockDtos: ProvincialGovernmentInsurancePlanDto[] = [
+        {
+          id: '1',
+          nameEn: 'First Insurance Plan',
+          nameFr: "Premier plan d'assurance",
+          provinceTerritoryStateId: '10',
+        },
+        {
+          id: '2',
+          nameEn: 'Second Insurance Plan',
+          nameFr: "Deuxième plan d'assurance",
+          provinceTerritoryStateId: '20',
+        },
+      ];
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+      mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos.mockReturnValueOnce(mockDtos);
+
+      const service = new ProvincialGovernmentInsurancePlanServiceImpl(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dtos = service.findAll();
+
+      expect(dtos).toEqual(mockDtos);
+      expect(mockProvincialGovernmentInsurancePlanRepository.findAll).toHaveBeenCalledTimes(1);
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches provincial government insurance plan by id', () => {
+      const id = '1';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+        _esdc_provinceterritorystateid_value: '10',
+      });
+
+      const mockDto: ProvincialGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+        provinceTerritoryStateId: '10',
+      };
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+      mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+
+      const service = new ProvincialGovernmentInsurancePlanServiceImpl(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockProvincialGovernmentInsurancePlanRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches provincial government insurance plan by id returns null if not found', () => {
+      const id = '1033';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findById.mockReturnValueOnce(null);
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+
+      const service = new ProvincialGovernmentInsurancePlanServiceImpl(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findById(id);
+
+      expect(dto).toEqual(null);
+      expect(mockProvincialGovernmentInsurancePlanRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/.server/domain/services/client-friendly-status.service.ts
+++ b/frontend/app/.server/domain/services/client-friendly-status.service.ts
@@ -21,13 +21,13 @@ export class ClientFriendlyStatusServiceImpl implements ClientFriendlyStatusServ
     @inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory,
     @inject(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_DTO_MAPPER) private readonly clientFriendlyStatusDtoMapper: ClientFriendlyStatusDtoMapper,
     @inject(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_REPOSITORY) private readonly clientFriendlyStatusRepository: ClientFriendlyStatusRepository,
-    @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_CLIENT_FRIENDLY_STATUSE_CACHE_TTL_SECONDS'>,
+    @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS'>,
   ) {
     this.log = logFactory.createLogger('ClientFriendlyStatusRepositoryImpl');
 
     // set moize options
     this.findAll.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_ALL_CLIENT_FRIENDLY_STATUSES_CACHE_TTL_SECONDS;
-    this.findById.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_CLIENT_FRIENDLY_STATUSE_CACHE_TTL_SECONDS;
+    this.findById.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS;
   }
 
   private findAllImpl(): ClientFriendlyStatusDto[] {

--- a/frontend/app/.server/domain/services/marital-status.service.ts
+++ b/frontend/app/.server/domain/services/marital-status.service.ts
@@ -21,13 +21,13 @@ export class MaritalStatusServiceImpl implements MaritalStatusService {
     @inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory,
     @inject(SERVICE_IDENTIFIER.MARITAL_STATUS_DTO_MAPPER) private readonly maritalStatusDtoMapper: MaritalStatusDtoMapper,
     @inject(SERVICE_IDENTIFIER.MARITAL_STATUS_REPOSITORY) private readonly maritalStatusRepository: MaritalStatusRepository,
-    @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_MARITAL_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_MARITAL_STATUSE_CACHE_TTL_SECONDS'>,
+    @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_MARITAL_STATUSES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_MARITAL_STATUS_CACHE_TTL_SECONDS'>,
   ) {
     this.log = logFactory.createLogger('MaritalStatusRepositoryImpl');
 
     // set moize options
     this.findAll.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_ALL_MARITAL_STATUSES_CACHE_TTL_SECONDS;
-    this.findById.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_MARITAL_STATUSE_CACHE_TTL_SECONDS;
+    this.findById.options.maxAge = 1000 * this.serverConfig.LOOKUP_SVC_MARITAL_STATUS_CACHE_TTL_SECONDS;
   }
 
   private findAllImpl(): MaritalStatusDto[] {

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -158,7 +158,7 @@ const serverEnv = clientEnvSchema.extend({
   LOOKUP_SVC_ALL_PROVINCE_TERRITORY_STATES_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_ALL_PROVINCIAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_ALL_SEX_AT_BIRTH_TYPES_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
-  LOOKUP_SVC_CLIENT_FRIENDLY_STATUSE_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
+  LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_COUNTRY_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_FEDERAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_MARITAL_STATUSE_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -161,7 +161,7 @@ const serverEnv = clientEnvSchema.extend({
   LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_COUNTRY_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_FEDERAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
-  LOOKUP_SVC_MARITAL_STATUSE_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
+  LOOKUP_SVC_MARITAL_STATUS_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_PREFERRED_COMMUNICATION_METHOD_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_PREFERRED_LANGUAGE_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   LOOKUP_SVC_PROVINCE_TERRITORY_STATE_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add the following lookup service unit tests:

- client-friendly-status
- country
- federal-government-insurance-plan
- marital-status
- preferred-communication-method
- province-territory-state
- provincial-government-insurance-plan

> Container binding will be done in future pull request

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

![image](https://github.com/user-attachments/assets/72608c48-c7e1-4a2e-ad03-6232dee544eb)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->