### PR TITLE
Removing unused `CDCP_API_BASE_URI` environment variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -107,10 +107,6 @@ INTEROP_STATUS_CHECK_API_BASE_URI=
 # (optional; default: undefined)
 INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 
-# CDCP back end api
-# (required; use the example below)
-CDCP_API_BASE_URI=https://api.cdcp.example.com
-
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)
 OTEL_LOG_LEVEL=info

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -89,8 +89,6 @@ const serverEnv = clientEnvSchema.extend({
   INTEROP_STATUS_CHECK_API_BASE_URI: z.string().trim().transform(emptyToUndefined).optional(),
   INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY: z.string().trim().transform(emptyToUndefined).optional(),
 
-  CDCP_API_BASE_URI: z.string().url(),
-
   // auth/oidc settings
   AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),
   AUTH_JWT_PUBLIC_KEY: z.string().refine(isValidPublicKey),

--- a/frontend/other/docker-compose.yml
+++ b/frontend/other/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - INTEROP_API_BASE_URI=https://api.example.com
       - INTEROP_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
       - MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc
-      - CDCP_API_BASE_URI=https://api.cdcp.example.com
 
   # Start a password-protected Redis instance on the default port.
   # @see https://redis.io/docs/management/security/#authentication

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
       INTEROP_API_BASE_URI: 'https://api.example.com',
       INTEROP_API_SUBSCRIPTION_KEY: '00000000000000000000000000000000',
       MOCK_AUTH_ALLOWED_REDIRECTS: 'http://localhost:3000/auth/callback/raoidc',
-      CDCP_API_BASE_URI : 'https://api.cdcp.example.com',
       PORT: port,
     },
   },

--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -49,8 +49,3 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 # Interop API configuration
 #
 INTEROP_API_BASE_URI=https://api.example.com
-
-#
-# CDCP API configuration
-#
-CDCP_API_BASE_URI=https://api.cdcp.example.com


### PR DESCRIPTION
### Description
The use of `CDCP_API_BASE_URI` was removed in #2187 and #2197.

Also removed from the `dev` environment config. 
Note that we should remove this config from the rest of the environments (int, perf, prod, staging, training) when they are bumped up to a more recent build.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`