### PR TITLE
Fix broken matcher in `vite.config.ts`

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -115,7 +115,7 @@ export default defineConfig({
     include: ['./__tests__/**/*.test.{ts,tsx}'],
     coverage: {
       include: ['**/app/**/*.{ts,tsx}'],
-      exclude: ['**/app/mocks/**', ...coverageConfigDefaults.exclude.filter((pattern) => pattern !== '**/[.]**'), '**/[.]!(server|client)**'],
+      exclude: ['!**/app/[.]client/**', '!**/app/[.]server/**', '**/app/mocks/**', ...coverageConfigDefaults.exclude],
     },
     globals: true,
   },


### PR DESCRIPTION
### Description

Fix an invalid syntax in `vite.config.ts`

