### PR TITLE
Removing `user-api` enabled mocks environment variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -196,7 +196,7 @@ REDIS_PASSWORD=password
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress,user-api,client-application
+ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress,client-application
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -21,7 +21,7 @@ function tryOrElseFalse(fn: () => unknown) {
   catch { return false; }
 }
 
-const validMockNames = ['cct', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'user-api', 'client-application'] as const;
+const validMockNames = ['cct', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'client-application'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 // refiners

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       AUTH_RAOIDC_CLIENT_ID: 'CDCP',
       AUTH_RASCL_LOGOUT_URL: 'http://localhost:3000/',
       ENABLED_FEATURES: "doc-upload,hcaptcha,view-letters,view-messages,status,show-prototype-banner",
-      ENABLED_MOCKS: 'cct,power-platform,raoidc,status-check,wsaddress,user-api',
+      ENABLED_MOCKS: 'cct,power-platform,raoidc,status-check,wsaddress',
       HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000',
       HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',
       INTEROP_API_BASE_URI: 'https://api.example.com',


### PR DESCRIPTION
### Description
As per title.

Corresponding `user-api` mock was removed in #2197 

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`