### PR TITLE
add renew-route-helpers.server.ts, index page content, and toc page html

### DIFF
--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -1,0 +1,133 @@
+import type { Session } from '@remix-run/node';
+import { redirectDocument } from '@remix-run/node';
+import type { Params } from '@remix-run/react';
+
+import { z } from 'zod';
+
+import { getLocaleFromParams } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { getCdcpWebsiteApplyUrl } from '~/utils/url-utils.server';
+
+export interface RenewState {
+  readonly id: string;
+}
+
+/**
+ * Schema for validating UUID.
+ */
+const idSchema = z.string().uuid();
+
+/**
+ * Gets the session name.
+ * @param id - The ID.
+ * @returns The session name.
+ */
+function getSessionName(id: string) {
+  return `renew-flow-${idSchema.parse(id)}`;
+}
+
+export function getRenewStateIdFromUrl(url: string | URL) {
+  const { searchParams } = new URL(url);
+  return searchParams.get('id');
+}
+
+interface LoadStateArgs {
+  params: Params;
+  session: Session;
+}
+
+/**
+ * Loads renew state.
+ * @param args - The arguments.
+ * @returns The loaded state.
+ */
+export function loadRenewState({ params, session }: LoadStateArgs) {
+  const log = getLogger('renew-route-helpers.server/loadRenewState');
+  const locale = getLocaleFromParams(params);
+  const cdcpWebsiteApplyUrl = getCdcpWebsiteApplyUrl(locale);
+
+  const parsedId = idSchema.safeParse(params.id);
+
+  if (!parsedId.success) {
+    log.warn('Invalid "id" query string format; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplyUrl, params.id, session.id);
+    throw redirectDocument(cdcpWebsiteApplyUrl);
+  }
+
+  const sessionName = getSessionName(parsedId.data);
+
+  if (!session.has(sessionName)) {
+    log.warn('Renew session state has not been found; redirecting to [%s]; sessionName: [%s], sessionId: [%s]', cdcpWebsiteApplyUrl, sessionName, session.id);
+    throw redirectDocument(cdcpWebsiteApplyUrl);
+  }
+
+  const state: RenewState = session.get(sessionName);
+  return state;
+}
+
+interface SaveStateArgs {
+  params: Params;
+  session: Session;
+  state: Partial<OmitStrict<RenewState, 'id'>>;
+  remove?: keyof OmitStrict<RenewState, 'id'>;
+}
+
+/**
+ * Saves renew state.
+ * @param args - The arguments.
+ * @returns The new renew state.
+ */
+export function saveRenewState({ params, session, state }: SaveStateArgs) {
+  const log = getLogger('renew-route-helpers.server/saveRenewState');
+  const currentState = loadRenewState({ params, session });
+
+  const newState = {
+    ...currentState,
+    ...state,
+  } satisfies RenewState;
+
+  const sessionName = getSessionName(currentState.id);
+  session.set(sessionName, newState);
+  log.info('Renew session state saved; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+  return newState;
+}
+
+interface ClearStateArgs {
+  params: Params;
+  session: Session;
+}
+
+/**
+ * Clears renew state.
+ * @param args - The arguments.
+ */
+export function clearRenewState({ params, session }: ClearStateArgs) {
+  const log = getLogger('renew-route-helpers.server/clearRenewState');
+  const state = loadRenewState({ params, session });
+  const sessionName = getSessionName(state.id);
+  session.unset(sessionName);
+  log.info('Renew session state cleared; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+}
+
+interface StartArgs {
+  id: string;
+  session: Session;
+}
+
+/**
+ * Starts Renew state.
+ * @param args - The arguments.
+ * @returns The initial Renew state.
+ */
+export function startRenewState({ id, session }: StartArgs) {
+  const log = getLogger('renew-route-helpers.server/startRenewState');
+  const parsedId = idSchema.parse(id);
+
+  const initialState: RenewState = {
+    id: parsedId,
+  };
+
+  const sessionName = getSessionName(parsedId);
+  session.set(sessionName, initialState);
+  log.info('Renew session state started; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+  return initialState;
+}

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -675,6 +675,24 @@
               "en": "/:lang/renew",
               "fr": "/:lang/renew"
             }
+          },
+          {
+            "id": "public/renew/$id/_route",
+            "file": "routes/public/renew/$id/_route.tsx",
+            "paths": {
+              "en": "/:lang/renew/:id",
+              "fr": "/:lang/renew/:id"
+            },
+            "children": [
+              {
+                "id": "public/renew/$id/terms-and-conditions",
+                "file": "routes/public/renew/$id/terms-and-conditions.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/terms-and-conditions",
+                  "fr": "/:lang/renew/:id/conditions-utilisation"
+                }
+              }
+            ]
           }
         ]
       },

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -81,7 +81,8 @@
       "result": "CDCP-STAT-0004"
     },
     "renew": {
-      "index": "CDCP-RENW-0001"
+      "index": "CDCP-RENW-0001",
+      "termsAndConditions": "CDCP-RENW-0002"
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",
     "notFound": "CDCP-ERR-0404"

--- a/frontend/app/routes/public/renew/$id/_route.tsx
+++ b/frontend/app/routes/public/renew/$id/_route.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+import { Outlet, useNavigate, useParams } from '@remix-run/react';
+
+import { handle as layoutHandle } from '~/routes/public/renew/_route';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+
+export const handle = {
+  // ensure that the parent layout's i18n namespaces are loaded
+  i18nNamespaces: [...layoutHandle.i18nNamespaces],
+} as const satisfies RouteHandleData;
+
+/**
+ * The parent route of all /renew/{id}/* routes, used to
+ * redirect to /apply if the flow has not yet been initialized.
+ */
+export default function Route() {
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const path = getPathById('public/renew/index', params);
+
+  useEffect(() => {
+    // redirect to start if the flow has not yet been initialized
+    const flowState = sessionStorage.getItem('flow.state');
+
+    if (flowState !== 'active') {
+      navigate(path, { replace: true });
+    }
+  }, [navigate, path]);
+
+  return <Outlet />;
+}

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -1,0 +1,34 @@
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+
+import pageIds from '../../../page-ids.json';
+import { loadRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.termsAndConditions,
+  pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, request, params }: LoaderFunctionArgs) {
+  loadRenewState({ params, session });
+  const csrfToken = String(session.get('csrfToken'));
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew:terms-and-conditions.page-title') }) };
+
+  return json({ csrfToken, meta });
+}
+
+export default function TermsAndConditions() {
+  return <>Terms and conditions</>;
+}

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -1,14 +1,21 @@
-import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
+import { redirect, useFetcher, useLoaderData } from '@remix-run/react';
 
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { randomUUID } from 'crypto';
+import { useTranslation } from 'react-i18next';
 
 import pageIds from '../../page-ids.json';
-import { startApplyState } from '~/route-helpers/apply-route-helpers.server';
+import { ButtonLink } from '~/components/buttons';
+import { LoadingButton } from '~/components/loading-button';
+import { startRenewState } from '~/route-helpers/renew-route-helpers.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
@@ -25,14 +32,67 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const id = randomUUID().toString();
-  const state = startApplyState({ id, session });
+  const csrfToken = String(session.get('csrfToken'));
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:index.page-title') }) };
 
-  return json({ id: state.id, locale, meta });
+  return json({ locale, meta, csrfToken });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/index');
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const id = randomUUID().toString();
+  startRenewState({ id, session });
+
+  return redirect(getPathById('public/renew/$id/terms-and-conditions', { ...params, id }));
 }
 
 export default function RenewIndex() {
-  return <div className="max-w-prose animate-pulse"></div>;
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <>
+      <div className="space-y-6">
+        <section className="space-y-4">
+          <p>{t('renew:index.eligibility')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('renew:index.full-name')}</li>
+            <li>{t('renew:index.client-number')}</li>
+            <li>{t('renew:index.dob')}</li>
+            <li>{t('renew:index.sin')}</li>
+            <li>{t('renew:index.address')}</li>
+            <li>{t('renew:index.dental-coverage')}</li>
+          </ul>
+        </section>
+        <section className="space-y-4">
+          <h2 className="font-lato text-lg font-bold">{t('renew:index.renew-now')}</h2>
+          <p>{t('renew:index.to-apply')}</p>
+        </section>
+      </div>
+      <fetcher.Form method="post" noValidate>
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <LoadingButton aria-describedby="application-consent" variant="green" id="continue-button" loading={isSubmitting} endIcon={faChevronRight}>
+            {t('renew:index.start-button')}
+          </LoadingButton>
+          <ButtonLink id="back-button" to={t('renew:index.apply-link')} disabled={isSubmitting} startIcon={faChevronLeft}>
+            {t('renew:index.back-button')}
+          </ButtonLink>
+        </div>
+      </fetcher.Form>
+    </>
+  );
 }

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -1,5 +1,20 @@
 {
   "index": {
-    "page-title": "Renew"
+    "page-title": "Renew",
+    "eligibility": "To renew your Canadian Dental Care Plan, you'll need to provide the following information for each applicant:",
+    "full-name": "Full name",
+    "client-number": "Client number",
+    "dob": "Date of birth",
+    "sin": "Spouse or common-law partner's Social Insurance Number (SIN) (if applicable)",
+    "address": "Home and mailing address",
+    "dental-coverage": "List of the dental coverage you currently have through government social programs (if applicable)",
+    "renew-now": "Renew now",
+    "to-apply": "To apply for the Canadian Dental Care Plan, click the button below.",
+    "start-button": "Renew now",
+    "back-button": "Back",
+    "apply-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html"
+  },
+  "terms-and-conditions": {
+    "page-title": "Terms and conditions"
   }
 }

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -1,5 +1,20 @@
 {
   "index": {
-    "page-title": "(FR) Renew"
+    "page-title": "(FR) Renew",
+    "eligibility": "(FR) To renew your Canadian Dental Care Plan, you'll need to provide the following information for each applicant:",
+    "full-name": "(FR) Full name",
+    "client-number": "(FR) Client number",
+    "dob": "(FR) Date of birth",
+    "sin": "(FR) Spouse or common-law partner's Social Insurance Number (SIN) (if applicable)",
+    "address": "(FR) Home and mailing address",
+    "dental-coverage": "(FR) List of the dental coverage you currently have through government social programs (if applicable)",
+    "renew-now": "(FR) Renew now",
+    "to-apply": "(FR) To apply for the Canadian Dental Care Plan, click the button below.",
+    "start-button": "(FR) Renew now",
+    "back-button": "(FR) Back",
+    "apply-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
+  },
+  "terms-and-conditions": {
+    "page-title": "(FR) Terms and conditions"
   }
 }


### PR DESCRIPTION
### Description
- adds `renew-route-helpers.server.ts`
- adds content to `renew/index`
- adds route for `renew/$id/terms-and-conditions` (just the structure, not the content)

### Related Azure Boards Work Items
AB#4640