### PR TITLE
add renewal applicant information route

### DIFF
--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -10,7 +10,16 @@ import { getCdcpWebsiteApplyUrl } from '~/utils/url-utils.server';
 
 export interface RenewState {
   readonly id: string;
+  readonly editMode: boolean;
+  readonly applicantInformation?: {
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    clientNumber: string;
+  };
 }
+
+export type ApplicantInformationState = NonNullable<RenewState['applicantInformation']>;
 
 /**
  * Schema for validating UUID.
@@ -124,6 +133,7 @@ export function startRenewState({ id, session }: StartArgs) {
 
   const initialState: RenewState = {
     id: parsedId,
+    editMode: false,
   };
 
   const sessionName = getSessionName(parsedId);

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -691,6 +691,14 @@
                   "en": "/:lang/renew/:id/terms-and-conditions",
                   "fr": "/:lang/renew/:id/conditions-utilisation"
                 }
+              },
+              {
+                "id": "public/renew/$id/applicant-information",
+                "file": "routes/public/renew/$id/applicant-information.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/applicant-information",
+                  "fr": "/:lang/renew/:id/renseignements-demandeur"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -82,7 +82,8 @@
     },
     "renew": {
       "index": "CDCP-RENW-0001",
-      "termsAndConditions": "CDCP-RENW-0002"
+      "termsAndConditions": "CDCP-RENW-0002",
+      "applicantInformation": "CDCP-RNEW-0003"
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",
     "notFound": "CDCP-ERR-0404"

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -1,0 +1,291 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { Collapsible } from '~/components/collapsible';
+import { ContextualAlert } from '~/components/contextual-alert';
+import { DatePickerField } from '~/components/date-picker-field';
+import { useErrorSummary } from '~/components/error-summary';
+import { InlineLink } from '~/components/inline-link';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import type { ApplicantInformationState } from '~/route-helpers/renew-route-helpers.server';
+import { loadRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.applicantInformation,
+  pageTitleI18nKey: 'renew:applicant-information.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew:applicant-information.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta, defaultState: state.applicantInformation, editMode: state.editMode });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/applicant-information');
+
+  const state = loadRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // state validation schema
+  const applicantInformationSchema = z
+    .object({
+      dateOfBirthYear: z.number({
+        required_error: t('renew:applicant-information.error-message.date-of-birth-year-required'),
+        invalid_type_error: t('renew:applicant-information.error-message.date-of-birth-year-number'),
+      }),
+      dateOfBirthMonth: z.number({
+        required_error: t('renew:applicant-information.error-message.date-of-birth-month-required'),
+      }),
+      dateOfBirthDay: z.number({
+        required_error: t('renew:applicant-information.error-message.date-of-birth-day-required'),
+        invalid_type_error: t('renew:applicant-information.error-message.date-of-birth-day-number'),
+      }),
+      dateOfBirth: z.string(),
+      firstName: z.string().trim().min(1, t('renew:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('renew:applicant-information.error-message.characters-valid')),
+      lastName: z.string().trim().min(1, t('renew:applicant-information.error-message.last-name-required')).max(100).refine(isAllValidInputCharacters, t('renew:applicant-information.error-message.characters-valid')),
+      clientNumber: z.string().trim().min(1, t('renew:applicant-information.error-message.client-number-required')),
+    })
+    .superRefine((val, ctx) => {
+      // At this point the year, month and day should have been validated as positive integer
+      const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
+      const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
+
+      if (!isValidDateString(dateOfBirth)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:applicant-information.error-message.date-of-birth-valid'), path: ['dateOfBirth'] });
+      } else if (!isPastDateString(dateOfBirth)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:applicant-information.error-message.date-of-birth-is-past'), path: ['dateOfBirth'] });
+      } else if (getAgeFromDateString(dateOfBirth) > 150) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:applicant-information.error-message.date-of-birth-is-past-valid'), path: ['dateOfBirth'] });
+      }
+    })
+    .transform((val) => {
+      // At this point the year, month and day should have been validated as positive integer
+      const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
+      return {
+        ...val,
+        dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
+      };
+    }) satisfies z.ZodType<ApplicantInformationState>;
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = {
+    confirm: formData.get('confirm') === 'yes',
+    dateOfBirthYear: formData.get('dateOfBirthYear') ? Number(formData.get('dateOfBirthYear')) : undefined,
+    dateOfBirthMonth: formData.get('dateOfBirthMonth') ? Number(formData.get('dateOfBirthMonth')) : undefined,
+    dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
+    dateOfBirth: '',
+    firstName: String(formData.get('firstName') ?? ''),
+    lastName: String(formData.get('lastName') ?? ''),
+    clientNumber: String(formData.get('clientNumber') ?? ''),
+  };
+  const parsedDataResult = applicantInformationSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({
+      errors: transformFlattenedError(parsedDataResult.error.flatten()),
+    });
+  }
+
+  // todo: make request for client application => if not found return back to page to display the <StausNotFound /> otherwise continue with next page
+
+  saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/review-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/type-renewal', params));
+}
+
+export default function ApplyFlowApplicationInformation() {
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    firstName: 'first-name',
+    lastName: 'last-name',
+    ...(i18n.language === 'fr'
+      ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
+      : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
+    dateOfBirthYear: 'date-picker-date-of-birth-year',
+    clientNumber: 'client-number',
+  });
+
+  const eligibilityLink = <InlineLink to={t('renew:applicant-information.eligibility-link')} className="external-link" newTabIndicator target="_blank" />;
+
+  return (
+    <>
+      <StatusNotFound />
+      <div className="my-6 sm:my-8">
+        <Progress value={25} size="lg" label={t('apply:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('apply:required-label')}</p>
+        <p className="mb-6">{t('renew:applicant-information.required-information')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="space-y-6">
+            <Collapsible id="name-instructions" summary={t('renew:applicant-information.single-legal-name')}>
+              <p>{t('renew:applicant-information.name-instructions')}</p>
+            </Collapsible>
+            <div className="grid items-end gap-6 md:grid-cols-2">
+              <InputSanitizeField
+                id="first-name"
+                name="firstName"
+                className="w-full"
+                label={t('renew:applicant-information.first-name')}
+                maxLength={100}
+                autoComplete="given-name"
+                defaultValue={defaultState?.firstName ?? ''}
+                errorMessage={errors?.firstName}
+                // eslint-disable-next-line jsx-a11y/aria-props
+                aria-description={t('renew:applicant-information.name-instructions')}
+                required
+              />
+              <InputSanitizeField
+                id="last-name"
+                name="lastName"
+                className="w-full"
+                label={t('renew:applicant-information.last-name')}
+                maxLength={100}
+                autoComplete="family-name"
+                defaultValue={defaultState?.lastName ?? ''}
+                errorMessage={errors?.lastName}
+                // eslint-disable-next-line jsx-a11y/aria-props
+                aria-description={t('renew:applicant-information.name-instructions')}
+                required
+              />
+            </div>
+            <DatePickerField
+              id="date-of-birth"
+              names={{
+                day: 'dateOfBirthDay',
+                month: 'dateOfBirthMonth',
+                year: 'dateOfBirthYear',
+              }}
+              defaultValue={defaultState?.dateOfBirth ?? ''}
+              legend={t('renew:applicant-information.date-of-birth')}
+              errorMessages={{
+                all: errors?.dateOfBirth,
+                year: errors?.dateOfBirthYear,
+                month: errors?.dateOfBirthMonth,
+                day: errors?.dateOfBirthDay,
+              }}
+              required
+            />
+            <InputSanitizeField
+              id="client-number"
+              name="clientNumber"
+              label={t('renew:applicant-information.client-number')}
+              inputMode="numeric"
+              helpMessagePrimary={t('renew:applicant-information.help-message.client-number')}
+              helpMessagePrimaryClassName="text-black"
+              defaultValue={defaultState?.clientNumber ?? ''}
+              errorMessage={errors?.clientNumber}
+              required
+            />
+            <Collapsible id="no-client-number" summary={t('renew:applicant-information.no-client-number')}>
+              <div className="space-y-2">
+                <p>{t('renew:applicant-information.unique-client-number')}</p>
+                <p>{t('renew:applicant-information.not-eligible')}</p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey="renew:applicant-information.check-eligibility" components={{ eligibilityLink }} />
+                </p>
+              </div>
+            </Collapsible>
+          </div>
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Save - Applicant information click">
+                {t('renew:applicant-information.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId={defaultState ? 'public/renew/$id/review-information' : 'public/renew/$id/terms-and-conditions'}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Cancel - Applicant information click"
+              >
+                {t('renew:applicant-information.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Continue - Applicant information click">
+                {t('renew:applicant-information.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/terms-and-conditions"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Back - Applicant information click"
+              >
+                {t('renew:applicant-information.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}
+
+function StatusNotFound() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const noWrap = <span className="whitespace-nowrap" />;
+  return (
+    <div className="mb-4">
+      <ContextualAlert type="danger">
+        <h2 className="mb-2 font-bold">{t('renew:applicant-information.status-not-found.heading')}</h2>
+        <p className="mb-2">{t('renew:applicant-information.status-not-found.please-review')}</p>
+        <p>
+          <Trans ns={handle.i18nNamespaces} i18nKey="renew:applicant-information.status-not-found.contact-service-canada" components={{ noWrap }} />
+        </p>
+      </ContextualAlert>
+    </div>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -53,7 +53,7 @@ export async function action({ context: { session }, request, params }: ActionFu
 
   saveRenewState({ params, session, state: {} });
 
-  return redirect(getPathById('public/renew/$id/personal-information', params));
+  return redirect(getPathById('public/renew/$id/applicant-information', params));
 }
 
 export default function RenewTermsAndConditions() {

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -89,5 +89,47 @@
       "microsoft-data-privacy-policy": "https://www.microsoft.com/en-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/en/"
     }
+  },
+  "applicant-information": {
+    "page-title": "Applicant information",
+    "required-information": "We will use the information you provide below to verify your identity.",
+    "client-number": "Client number",
+    "date-of-birth": "Date of birth",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "single-legal-name": "If you have a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "no-client-number": "I don't have a client number",
+    "unique-client-number": "All CDCP members have unique client number. It is also your Sun Life Member ID.",
+    "not-eligible": "If you are not a CDCP member and do not have a client number, you are not eligible for renewal.",
+    "check-eligibility": "<eligibilityLink>Check if you are eligible to apply for the CDCP.</eligibilityLink>",
+    "eligibility-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/qualify.html",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "help-message": {
+      "client-number": "You can find your client number in the upper right corner of the renewal letter from Service Canada or on your Sun Life member card."
+    },
+    "error-message": {
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-day-number": "Day must be a number",
+      "date-of-birth-day-required": "Date of birth must include a day",
+      "date-of-birth-is-past": "Date of birth must be in the past",
+      "date-of-birth-is-past-valid": "Date of birth too far in the past",
+      "date-of-birth-month-required": "Date of birth must include a month",
+      "date-of-birth-valid": "Day must be valid for the given month and year",
+      "date-of-birth-year-number": "Year must be a number, for example 1950",
+      "date-of-birth-year-required": "Date of birth must include a year",
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "client-number-required": "Enter client number",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
+    },
+    "status-not-found": {
+      "heading": "We could not find your application with the information you gave us.",
+      "please-review": "Please make sure the information you entered is correct.",
+      "contact-service-canada": "Contact Service Canada if this issue continues by calling <noWrap>1-833-537-4342</noWrap>."
+    }
   }
 }

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -89,5 +89,47 @@
       "microsoft-data-privacy-policy": "https://www.microsoft.com/fr-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/fr/"
     }
+  },
+  "applicant-information": {
+    "page-title": "Applicant information",
+    "required-information": "We will use the information you provide below to verify your identity.",
+    "client-number": "Client number",
+    "date-of-birth": "Date of birth",
+    "last-name": "Last name",
+    "first-name": "First name",
+    "single-legal-name": "If you have a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "no-client-number": "I don't have a client number",
+    "unique-client-number": "All CDCP members have unique client number. It is also your Sun Life Member ID.",
+    "not-eligible": "If you are not a CDCP member and do not have a client number, you are not eligible for renewal.",
+    "check-eligibility": "<eligibilityLink>Check if you are eligible to apply for the CDCP.</eligibilityLink>",
+    "eligibility-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/qualify.html",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "help-message": {
+      "client-number": "You can find your client number in the upper right corner of the renewal letter from Service Canada or on your Sun Life member card."
+    },
+    "error-message": {
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-day-number": "Day must be a number",
+      "date-of-birth-day-required": "Date of birth must include a day",
+      "date-of-birth-is-past": "Date of birth must be in the past",
+      "date-of-birth-is-past-valid": "Date of birth too far in the past",
+      "date-of-birth-month-required": "Date of birth must include a month",
+      "date-of-birth-valid": "Day must be valid for the given month and year",
+      "date-of-birth-year-number": "Year must be a number, for example 1950",
+      "date-of-birth-year-required": "Date of birth must include a year",
+      "first-name-required": "Enter first name",
+      "last-name-required": "Enter last name",
+      "client-number-required": "Enter client number",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
+    },
+    "status-not-found": {
+      "heading": "We could not find your application with the information you gave us.",
+      "please-review": "Please make sure the information you entered is correct.",
+      "contact-service-canada": "Contact Service Canada if this issue continues by calling <noWrap>1-833-537-4342</noWrap>."
+    }
   }
 }


### PR DESCRIPTION
### Description
adds `/renew/$id/applicant-information`

NOTE:
- the figma has page heading as 'personal information', but for the sake of continuity, I've renamed our heading to be 'applicant information' so it matches the Online Application
- french locales are the same as english since it's worthless to update them right now
- the `StatusNotFound` component is currently always displayed.  I've added a 'todo' indicating that we'll have to call the service to verify if a client application is found or not which will toggle this component, or continue routing to the next page in the flow

### Related Azure Boards Work Items
[AB#4060](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4060)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/27cc1c27-245b-4fc9-952f-599b8e9bcf87)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`