### PR TITLE
chore(frontend): bump eslint-plugin-react-hooks to RC

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -88,7 +88,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.1",
-        "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-hooks": "^5.1.0-rc-459fd418-20241001",
         "jsdom": "^25.0.1",
         "patch-package": "^8.0.0",
         "playwright-teamcity-reporter": "^1.0.4",
@@ -7759,16 +7759,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.1.0-rc-459fd418-20241001",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-rc-459fd418-20241001.tgz",
+      "integrity": "sha512-vBUzji1JDwLxFAsmVtdbWQBo6LMnN7J2ZpDrGWo/ve4NnJGDeNFQOGqMJM1j0uDzLC1/sgQcFEOHofb8BsvJUQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.1",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "^5.1.0-rc-459fd418-20241001",
     "jsdom": "^25.0.1",
     "patch-package": "^8.0.0",
     "playwright-teamcity-reporter": "^1.0.4",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title. It should give us the ability to migrate Eslint to v9.