### PR TITLE
Addng server modules (service, repository, DTO, entity, mapper, etc.) for address validation

### DIFF
--- a/frontend/app/.server/constants/service-identifier.constant.ts
+++ b/frontend/app/.server/constants/service-identifier.constant.ts
@@ -1,7 +1,10 @@
 export const SERVICE_IDENTIFIER = {
   CLIENT_CONFIG: Symbol.for('ClientConfig'),
+  ADDRESS_VALIDATION_DTO_MAPPER: Symbol.for('AddressValidationDtoMapper'),
+  ADDRESS_VALIDATION_REPOSITORY: Symbol.for('AddressValidationRepository'),
+  ADDRESS_VALIDATION_SERVICE: Symbol.for('AddressValidationService'),
   CLIENT_APPLICATION_DTO_MAPPER: Symbol.for('ClientApplicationDtoMapper'),
-  CLIENT_APPLICATION_REPOSITORY: Symbol.for('ClientApplicationDtoRepository'),
+  CLIENT_APPLICATION_REPOSITORY: Symbol.for('ClientApplicationRepository'),
   CLIENT_APPLICATION_SERVICE: Symbol.for('ClientApplicationService'),
   CLIENT_FRIENDLY_STATUS_DTO_MAPPER: Symbol.for('ClientFriendlyStatusDtoMapper'),
   CLIENT_FRIENDLY_STATUS_REPOSITORY: Symbol.for('ClientFriendlyStatusRepository'),

--- a/frontend/app/.server/container-modules/mappers.container-module.ts
+++ b/frontend/app/.server/container-modules/mappers.container-module.ts
@@ -2,6 +2,7 @@ import { ContainerModule } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import {
+  AddressValidationDtoMapperImpl,
   ClientApplicationDtoMapperImpl,
   ClientFriendlyStatusDtoMapperImpl,
   CountryDtoMapperImpl,
@@ -13,6 +14,7 @@ import {
   ProvincialGovernmentInsurancePlanDtoMapperImpl,
 } from '~/.server/domain/mappers';
 import type {
+  AddressValidationDtoMapper,
   ClientApplicationDtoMapper,
   ClientFriendlyStatusDtoMapper,
   CountryDtoMapper,
@@ -28,6 +30,7 @@ import type {
  * Container module for mappers.
  */
 export const mappersContainerModule = new ContainerModule((bind) => {
+  bind<AddressValidationDtoMapper>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_DTO_MAPPER).to(AddressValidationDtoMapperImpl);
   bind<ClientApplicationDtoMapper>(SERVICE_IDENTIFIER.CLIENT_APPLICATION_DTO_MAPPER).to(ClientApplicationDtoMapperImpl);
   bind<ClientFriendlyStatusDtoMapper>(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_DTO_MAPPER).to(ClientFriendlyStatusDtoMapperImpl);
   bind<CountryDtoMapper>(SERVICE_IDENTIFIER.COUNTRY_DTO_MAPPER).to(CountryDtoMapperImpl);

--- a/frontend/app/.server/container-modules/repositories.container-module.ts
+++ b/frontend/app/.server/container-modules/repositories.container-module.ts
@@ -2,6 +2,7 @@ import { ContainerModule } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type {
+  AddressValidationRepository,
   ClientApplicationRepository,
   ClientFriendlyStatusRepository,
   CountryRepository,
@@ -13,6 +14,7 @@ import type {
   ProvincialGovernmentInsurancePlanRepository,
 } from '~/.server/domain/repositories';
 import {
+  AddressValidationRepositoryImpl,
   ClientApplicationRepositoryImpl,
   ClientFriendlyStatusRepositoryImpl,
   CountryRepositoryImpl,
@@ -28,6 +30,7 @@ import {
  * Container module for repositories.
  */
 export const repositoriesContainerModule = new ContainerModule((bind) => {
+  bind<AddressValidationRepository>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_REPOSITORY).to(AddressValidationRepositoryImpl);
   bind<ClientApplicationRepository>(SERVICE_IDENTIFIER.CLIENT_APPLICATION_REPOSITORY).to(ClientApplicationRepositoryImpl);
   bind<ClientFriendlyStatusRepository>(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_REPOSITORY).to(ClientFriendlyStatusRepositoryImpl);
   bind<CountryRepository>(SERVICE_IDENTIFIER.COUNTRY_REPOSITORY).to(CountryRepositoryImpl);

--- a/frontend/app/.server/container-modules/services.container-module.ts
+++ b/frontend/app/.server/container-modules/services.container-module.ts
@@ -2,6 +2,7 @@ import { ContainerModule } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type {
+  AddressValidationService,
   ClientApplicationService,
   ClientFriendlyStatusService,
   CountryService,
@@ -13,6 +14,7 @@ import type {
   ProvincialGovernmentInsurancePlanService,
 } from '~/.server/domain/services';
 import {
+  AddressValidationServiceImpl,
   ClientApplicationServiceImpl,
   ClientFriendlyStatusServiceImpl,
   CountryServiceImpl,
@@ -28,6 +30,7 @@ import {
  * Container module for services.
  */
 export const servicesContainerModule = new ContainerModule((bind) => {
+  bind<AddressValidationService>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_SERVICE).to(AddressValidationServiceImpl);
   bind<ClientApplicationService>(SERVICE_IDENTIFIER.CLIENT_APPLICATION_SERVICE).to(ClientApplicationServiceImpl);
   bind<ClientFriendlyStatusService>(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_SERVICE).to(ClientFriendlyStatusServiceImpl);
   bind<CountryService>(SERVICE_IDENTIFIER.COUNTRY_SERVICE).to(CountryServiceImpl);

--- a/frontend/app/.server/domain/dtos/address-validation.dto.ts
+++ b/frontend/app/.server/domain/dtos/address-validation.dto.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents a Data Transfer Object (DTO) for an address correction result.
+ */
+export type AddressCorrectionResultDto = Readonly<{
+  /** The status of the address correction. */
+  status: 'Corrected' | 'NotCorrect' | 'Valid';
+
+  /** The full or partial address. */
+  address: string;
+
+  /** The name of the city. */
+  city: string;
+
+  /** The 6-character postal code. */
+  postalCode: string;
+
+  /** The 2-character Canadian province or territorial code. */
+  provinceCode: string;
+}>;

--- a/frontend/app/.server/domain/dtos/index.ts
+++ b/frontend/app/.server/domain/dtos/index.ts
@@ -1,3 +1,4 @@
+export type * from './address-validation.dto';
 export type * from './client-application.dto';
 export type * from './client-friendly-status.dto';
 export type * from './country.dto';

--- a/frontend/app/.server/domain/entities/address-validation.entity.ts
+++ b/frontend/app/.server/domain/entities/address-validation.entity.ts
@@ -1,0 +1,11 @@
+export type AddressCorrectionResultEntity = Readonly<{
+  'wsaddr:CorrectionResults': Readonly<{
+    'nc:AddressFullText': string;
+    'nc:AddressCityName': string;
+    'can:ProvinceCode': string;
+    'nc:AddressPostalCode': string;
+    'wsaddr:Information': Readonly<{
+      'wsaddr:StatusCode': string;
+    }>;
+  }>;
+}>;

--- a/frontend/app/.server/domain/entities/index.ts
+++ b/frontend/app/.server/domain/entities/index.ts
@@ -1,3 +1,4 @@
+export type * from './address-validation.entity';
 export type * from './client-application.entity';
 export type * from './client-friendly-status.entity';
 export type * from './country.entity';

--- a/frontend/app/.server/domain/mappers/address-validation.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/address-validation.dto.mapper.ts
@@ -1,0 +1,36 @@
+import { injectable } from 'inversify';
+
+import type { AddressCorrectionResultDto } from '~/.server/domain/dtos';
+import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
+
+export interface AddressValidationDtoMapper {
+  mapAddressCorrectionResultEntityToAddressCorrectionResultDto(addressCorrectionResultEntity: AddressCorrectionResultEntity): AddressCorrectionResultDto;
+}
+
+@injectable()
+export class AddressValidationDtoMapperImpl implements AddressValidationDtoMapper {
+  mapAddressCorrectionResultEntityToAddressCorrectionResultDto(addressCorrectionResultEntity: AddressCorrectionResultEntity): AddressCorrectionResultDto {
+    const correctionResults = addressCorrectionResultEntity['wsaddr:CorrectionResults'];
+
+    const address = correctionResults['nc:AddressFullText'];
+    const city = correctionResults['nc:AddressCityName'];
+    const postalCode = correctionResults['nc:AddressPostalCode'];
+    const provinceCode = correctionResults['can:ProvinceCode'];
+    const status = this.mapStatusCodeToStatus(correctionResults['wsaddr:Information']['wsaddr:StatusCode']);
+
+    return { address, city, postalCode, provinceCode, status };
+  }
+
+  protected mapStatusCodeToStatus(statusCode: string) {
+    switch (statusCode) {
+      case 'Corrected':
+        return 'Corrected';
+      case 'NotCorrect':
+        return 'NotCorrect';
+      case 'Valid':
+        return 'Valid';
+      default:
+        throw new Error(`Unknown correction result status: [${statusCode}]`);
+    }
+  }
+}

--- a/frontend/app/.server/domain/mappers/index.ts
+++ b/frontend/app/.server/domain/mappers/index.ts
@@ -1,3 +1,4 @@
+export * from './address-validation.dto.mapper';
 export * from './client-application.dto.mapper';
 export * from './client-friendly-status.dto.mapper';
 export * from './country.dto.mapper';

--- a/frontend/app/.server/domain/repositories/address-validation.repository.ts
+++ b/frontend/app/.server/domain/repositories/address-validation.repository.ts
@@ -1,0 +1,79 @@
+import { inject, injectable } from 'inversify';
+
+import type { ServerConfig } from '~/.server/configs';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
+import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
+import type { LogFactory, Logger } from '~/.server/factories';
+import { getFetchFn, instrumentedFetch } from '~/utils/fetch-utils.server';
+
+export interface AddressCorrectionRequest {
+  /** The full or partial address. */
+  address: string;
+
+  /** The name of the city. */
+  city: string;
+
+  /** The 6-character postal code. */
+  postalCode: string;
+
+  /** The 2-character Canadian province or territorial code. */
+  provinceCode: string;
+}
+
+export interface AddressValidationRepository {
+  /**
+   * Corrects the provided address using the data passed in the `AddressCorrectionRequest` object.
+   *
+   * @param addressCorrectionRequest The request object containing the address details that need to be corrected
+   * @returns A promise that resolves to a `AddressCorrectionResultEntity` object containing corrected address results
+   */
+  getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultEntity>;
+}
+
+@injectable()
+export class AddressValidationRepositoryImpl implements AddressValidationRepository {
+  private readonly log: Logger;
+
+  constructor(
+    @inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory,
+    @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) private readonly serverConfig: Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY'>,
+  ) {
+    this.log = logFactory.createLogger('AddressValidationRepositoryImpl');
+  }
+
+  async getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultEntity> {
+    this.log.trace('Checking correctness of address for addressCorrectionRequest: [%j]', addressCorrectionRequest);
+    const { address, city, postalCode, provinceCode } = addressCorrectionRequest;
+
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/address/validation/v1/CAN/correct`);
+    url.searchParams.set('AddressFullText', address);
+    url.searchParams.set('AddressCityName', city);
+    url.searchParams.set('AddressPostalCode', postalCode);
+    url.searchParams.set('ProvinceCode', provinceCode);
+
+    const response = await instrumentedFetch(getFetchFn(this.serverConfig.HTTP_PROXY_URL), 'http.client.interop-api.address-validation-correct.gets', url, {
+      method: 'GET',
+      headers: {
+        'Accept-Language': 'en-CA',
+        'Content-Type': 'application/json',
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+    });
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: 'Failed to correct address',
+        status: response.status,
+        statusText: response.statusText,
+        url: url,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to correct address. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    const addressCorrectionResults: AddressCorrectionResultEntity = await response.json();
+    this.log.trace('Address correction results: [%j]', addressCorrectionResults);
+
+    return addressCorrectionResults;
+  }
+}

--- a/frontend/app/.server/domain/repositories/index.ts
+++ b/frontend/app/.server/domain/repositories/index.ts
@@ -1,3 +1,4 @@
+export * from './address-validation.repository';
 export * from './client-application.repository';
 export * from './client-friendly-status.repository';
 export * from './country.repository';

--- a/frontend/app/.server/domain/services/address-validation.service.ts
+++ b/frontend/app/.server/domain/services/address-validation.service.ts
@@ -1,0 +1,52 @@
+import { inject, injectable } from 'inversify';
+
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
+import type { AddressCorrectionResultDto } from '~/.server/domain/dtos';
+import type { AddressValidationDtoMapper } from '~/.server/domain/mappers';
+import type { AddressValidationRepository } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+export interface AddressCorrectionRequest {
+  /** The full or partial address. */
+  address: string;
+
+  /** The name of the city. */
+  city: string;
+
+  /** The 6-character postal code. */
+  postalCode: string;
+
+  /** The 2-character Canadian province or territorial code. */
+  provinceCode: string;
+}
+
+export interface AddressValidationService {
+  /**
+   * Corrects the provided address using the data passed in the `AddressCorrectionRequest` object.
+   *
+   * @param addressCorrectionRequest The request object containing the address details that need to be corrected
+   * @returns A promise that resolves to a `AddressCorrectionResultDto` object containing corrected address results
+   */
+  getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultDto>;
+}
+
+@injectable()
+export class AddressValidationServiceImpl implements AddressValidationService {
+  private readonly log: Logger;
+
+  constructor(
+    @inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory,
+    @inject(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_DTO_MAPPER) private readonly addressValidationDtoMapper: AddressValidationDtoMapper,
+    @inject(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_REPOSITORY) private readonly addressValidationRepository: AddressValidationRepository,
+  ) {
+    this.log = logFactory.createLogger('AddressValidationServiceImpl');
+  }
+
+  async getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultDto> {
+    this.log.trace('Getting address correction results with addressCorrectionRequest: [%j]', addressCorrectionRequest);
+    const addressCorrectionResultEntity = await this.addressValidationRepository.getAddressCorrectionResult(addressCorrectionRequest);
+    const addressCorrectionResultDto = this.addressValidationDtoMapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(addressCorrectionResultEntity);
+    this.log.trace('Returning address correction result: [%j]', addressCorrectionResultDto);
+    return addressCorrectionResultDto;
+  }
+}

--- a/frontend/app/.server/domain/services/index.ts
+++ b/frontend/app/.server/domain/services/index.ts
@@ -1,3 +1,4 @@
+export * from './address-validation.service';
 export * from './client-application.service';
 export * from './client-friendly-status.service';
 export * from './country.service';

--- a/frontend/app/.server/providers/container-service.provider.ts
+++ b/frontend/app/.server/providers/container-service.provider.ts
@@ -3,6 +3,7 @@ import { injectable } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type {
+  AddressValidationService,
   ClientApplicationService,
   ClientFriendlyStatusService,
   CountryService,
@@ -15,6 +16,7 @@ import type {
 } from '~/.server/domain/services';
 
 export interface ContainerServiceProvider {
+  getAddressValidationService(): AddressValidationService;
   getClientApplicationService(): ClientApplicationService;
   getClientFriendlyStatusService(): ClientFriendlyStatusService;
   getCountryService(): CountryService;
@@ -29,6 +31,10 @@ export interface ContainerServiceProvider {
 @injectable()
 export class ContainerServiceProviderImpl implements ContainerServiceProvider {
   constructor(private readonly container: Container) {}
+
+  getAddressValidationService(): AddressValidationService {
+    return this.container.get<AddressValidationService>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_SERVICE);
+  }
 
   getClientApplicationService(): ClientApplicationService {
     return this.container.get<ClientApplicationService>(SERVICE_IDENTIFIER.CLIENT_APPLICATION_SERVICE);


### PR DESCRIPTION
### Description
As per title.

This PR can be broken down into smaller PRs upon request.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/e6a4274e-c738-474c-b81a-b29f699dca93)
![image](https://github.com/user-attachments/assets/42bc0147-2f4b-46a9-bd9a-db7daa1b38e8)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
1. Port-forward to the in-cluster squid proxy.
2. Reconfigure CDCP to connect to a valid instance of Interop API. 
3. Add an address validation service call in some route.

### Additional Notes
Updated mocks and unit tests to be added in a future PR.