### PR TITLE
Adding communication-preference ITA page.

### DIFF
--- a/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
@@ -78,7 +78,7 @@ interface ValidateRenewItaStateForReviewArgs {
 }
 
 export function validateRenewItaStateForReview({ params, state }: ValidateRenewItaStateForReviewArgs) {
-  const { maritalStatus, contactInformation, editMode, id, submissionInfo, typeOfRenewal } = state;
+  const { maritalStatus, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference } = state;
 
   if (typeOfRenewal === undefined) {
     throw redirect(getPathById('public/renew/$id/type-application', params));
@@ -100,6 +100,10 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     throw redirect(getPathById('public/renew/$id/ita/contact-information', params));
   }
 
+  if (communicationPreference === undefined) {
+    throw redirect(getPathById('public/renew/$id/ita/communication-preference', params));
+  }
+
   // TODO add remaining states when screens are available
 
   return {
@@ -109,5 +113,6 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     submissionInfo,
     typeOfRenewal,
     contactInformation,
+    communicationPreference,
   };
 }

--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -54,6 +54,10 @@ export interface RenewState {
     province?: string;
   };
   readonly typeOfRenewal?: 'adult-child' | 'child' | 'delegate';
+  readonly communicationPreference?: {
+    email?: string;
+    preferredMethod: string;
+  };
   readonly submissionInfo?: {
     /**
      * The UTC date and time when the application was submitted.
@@ -70,6 +74,7 @@ export type PartnerInformationState = NonNullable<RenewState['partnerInformation
 export type AddressInformationState = NonNullable<RenewState['addressInformation']>;
 export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
 export type ContactInformationState = NonNullable<RenewState['contactInformation']>;
+export type CommunicationPreferenceState = NonNullable<RenewState['communicationPreference']>;
 
 /**
  * Schema for validating UUID.

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -749,6 +749,14 @@
                 }
               },
               {
+                "id": "public/renew/$id/ita/communication-preference",
+                "file": "routes/public/renew/$id/ita/communication-preference.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/ita/communication-preference",
+                  "fr": "/:lang/renew/:id/ita/communication-preference"
+                }
+              },
+              {
                 "id": "public/renew/$id/ita/dental-insurance",
                 "file": "routes/public/renew/$id/ita/dental-insurance.tsx",
                 "paths": {

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -93,7 +93,8 @@
         "confirmAddress": "CDCP-RENW-ITA-0004",
         "updateAddress": "CDCP-RENW-ITA-0005",
         "dentalInsurance": "CDCP-RENW-ITA-0006",
-        "federalProvincialTerritorialBenefits": "CDCP-RENW-ITA-0007"
+        "federalProvincialTerritorialBenefits": "CDCP-RENW-ITA-0007",
+        "communicationPreference": "CDCP-ITA-0003"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
@@ -1,0 +1,240 @@
+import type { ChangeEventHandler } from 'react';
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { loadRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import type { CommunicationPreferenceState } from '~/route-helpers/renew-route-helpers.server';
+import { getEnv } from '~/utils/env-utils.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { localizeAndSortPreferredCommunicationMethods, localizeAndSortPreferredLanguages } from '~/utils/lookup-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.ita.communicationPreference,
+  pageTitleI18nKey: 'renew:communication-preference.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID, ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = getEnv();
+
+  const state = loadRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const preferredLanguages = localizeAndSortPreferredLanguages(serviceProvider.getPreferredLanguageService().listPreferredLanguages(), locale, locale === 'en' ? ENGLISH_LANGUAGE_CODE : FRENCH_LANGUAGE_CODE);
+  const preferredCommunicationMethods = localizeAndSortPreferredCommunicationMethods(serviceProvider.getPreferredCommunicationMethodService().listPreferredCommunicationMethods(), locale);
+
+  const communicationMethodEmail = preferredCommunicationMethods.find((method) => method.id === COMMUNICATION_METHOD_EMAIL_ID);
+  if (!communicationMethodEmail) {
+    throw new Response('Expected communication method email not found!', { status: 500 });
+  }
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew:communication-preference.page-title') }) };
+
+  return json({
+    communicationMethodEmail,
+    id: state.id,
+    csrfToken,
+    meta,
+    preferredCommunicationMethods,
+    preferredLanguages,
+    defaultState: {
+      ...(state.communicationPreference ?? {}),
+      email: state.communicationPreference?.email ?? state.contactInformation?.email,
+    },
+    isReadOnlyEmail: !!state.contactInformation?.email,
+  });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/ita/communication-preference');
+
+  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+
+  const state = loadRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formSchema = z
+    .object({
+      preferredMethod: z.string().trim().min(1, t('renew:communication-preference.error-message.communication-preference-required')),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:communication-preference.error-message.email-required'), path: ['email'] });
+        } else if (!validator.isEmail(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:communication-preference.error-message.email-valid'), path: ['email'] });
+        }
+
+        if (!state.contactInformation?.email) {
+          if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          } else if (!validator.isEmail(val.confirmEmail)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:communication-preference.error-message.confirm-email-valid'), path: ['confirmEmail'] });
+          } else if (val.email !== val.confirmEmail) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
+          }
+        }
+      }
+    }) satisfies z.ZodType<CommunicationPreferenceState>;
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = {
+    confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail') ?? '') : undefined,
+    email: formData.get('email') ? String(formData.get('email') ?? '') : undefined,
+    preferredMethod: String(formData.get('preferredMethod') ?? ''),
+  };
+  const parsedDataResult = formSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({
+      errors: transformFlattenedError(parsedDataResult.error.flatten()),
+    });
+  }
+
+  saveRenewState({ params, session, state: { communicationPreference: parsedDataResult.data } });
+
+  return redirect(getPathById('public/renew/$id/ita/confirm-address', params));
+}
+
+export default function RenewFlowCommunicationPreferencePage() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, communicationMethodEmail, preferredCommunicationMethods, defaultState, isReadOnlyEmail } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    preferredMethod: 'input-radio-preferred-methods-option-0',
+    email: 'email',
+    confirmEmail: 'confirm-email',
+  });
+
+  const handleOnPreferredMethodChecked: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setPreferredMethodValue(e.target.value);
+  };
+
+  const nonEmailOptions: InputRadiosProps['options'] = preferredCommunicationMethods
+    .filter((method) => method.id !== communicationMethodEmail.id)
+    .map((method) => ({
+      children: method.name,
+      value: method.id,
+      defaultChecked: defaultState.preferredMethod === method.id,
+      onChange: handleOnPreferredMethodChecked,
+    }));
+
+  const options: InputRadiosProps['options'] = [
+    {
+      children: communicationMethodEmail.name,
+      value: communicationMethodEmail.id,
+      defaultChecked: defaultState.preferredMethod === communicationMethodEmail.id,
+      append: preferredMethodValue === communicationMethodEmail.id && (
+        <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+          <InputField
+            id="email"
+            type="email"
+            inputMode="email"
+            className="w-full"
+            label={t('renew:communication-preference.email')}
+            maxLength={64}
+            name="email"
+            errorMessage={errors?.email}
+            autoComplete="email"
+            defaultValue={defaultState.email ?? ''}
+            required
+            readOnly={isReadOnlyEmail}
+          />
+          {!isReadOnlyEmail && (
+            <InputField
+              id="confirm-email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              label={t('renew:communication-preference.confirm-email')}
+              maxLength={64}
+              name="confirmEmail"
+              errorMessage={errors?.confirmEmail}
+              autoComplete="email"
+              defaultValue={defaultState.email ?? ''}
+              required
+            />
+          )}
+        </div>
+      ),
+      onChange: handleOnPreferredMethodChecked,
+    },
+    ...nonEmailOptions,
+  ];
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={66} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="mb-8 space-y-6">
+            {preferredCommunicationMethods.length > 0 && <InputRadios id="preferred-methods" legend={t('renew:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errors?.preferredMethod} required />}
+          </div>
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Communication click">
+              {t('renew:communication-preference.continue-btn')}
+            </LoadingButton>
+            <ButtonLink
+              id="back-button"
+              routeId="public/renew/$id/ita/confirm-address" // Change to 'contact-information' when it is created.
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Communication click"
+            >
+              {t('renew:communication-preference.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -172,5 +172,23 @@
     "back-btn": "Back",
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "communication-preference": {
+    "page-title": "Communication Preference",
+    "required-label": "Complete all fields unless marked as optinal.",
+    "preferred-method": "What is your prefered method of communication for Sun Life?",
+    "email": "Email address",
+    "confirm-email": "Confirm email address",
+    "error-message": {
+      "communication-preference-required": "Select a prefered method of communication.",
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com",
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "preferred-method-required": "Select preferred method of communication"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
   }
 }

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -172,5 +172,23 @@
     "back-btn": "Back",
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "communication-preference": {
+    "page-title": "(FR) Communication Preference",
+    "required-label": "Complete all fields unless marked as optinal.",
+    "preferred-method": "(FR) What is your prefered method of communication for Sun Life?",
+    "email": "(FR) Email address",
+    "confirm-email": "(FR) Confirm email address",
+    "error-message": {
+      "communication-preference-required": "(FR) Select a prefered method of communication.",
+      "email-match": "(FR) The email addresses entered do not match",
+      "confirm-email-required": "(FR) Confirm email address",
+      "email-required": "(FR) Enter email address",
+      "email-valid": "(FR) Enter an email address in the correct format, such as name@example.com",
+      "confirm-email-valid": "(FR) Enter confirmation of email address in the correct format, such as name@example.com",
+      "preferred-method-required": "(FR) Select preferred method of communication"
+    },
+    "back-btn": "(FR) Back",
+    "continue-btn": "(FR) Continue"
   }
 }


### PR DESCRIPTION
### Description
Adding communication-preference ITA page.

### Related Azure Boards Work Items
AB#4791

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
navigate to `http://localhost:3000/en/renew/$id/ita/communication-preference`
