### PR TITLE
Adding unit tests for address validation dto mapper

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/address-validation.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/address-validation.dto.mapper.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AddressCorrectionResultDto, AddressCorrectionStatus } from '~/.server/domain/dtos';
+import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
+import { AddressValidationDtoMapperImpl } from '~/.server/domain/mappers';
+
+describe('AddressValidationDtoMapperImpl', () => {
+  describe('mapAddressCorrectionResultEntityToAddressCorrectionResultDto', () => {
+    it.each([
+      { statusCode: 'Corrected', expectedStatus: 'Corrected' as AddressCorrectionStatus },
+      { statusCode: 'NotCorrect', expectedStatus: 'NotCorrect' as AddressCorrectionStatus },
+      { statusCode: 'Valid', expectedStatus: 'Valid' as AddressCorrectionStatus },
+    ])('should map AddressCorrectionResultEntity to AddressCorrectionResultDto with correct status', ({ statusCode, expectedStatus }) => {
+      const mockEntity: AddressCorrectionResultEntity = {
+        'wsaddr:CorrectionResults': {
+          'nc:AddressFullText': '123 Fake St',
+          'nc:AddressCityName': 'North Pole',
+          'nc:AddressPostalCode': 'H0H 0H0',
+          'can:ProvinceCode': 'ON',
+          'wsaddr:Information': {
+            'wsaddr:StatusCode': statusCode,
+          },
+        },
+      };
+
+      const expectedDto: AddressCorrectionResultDto = {
+        status: expectedStatus,
+        address: '123 Fake St',
+        city: 'North Pole',
+        postalCode: 'H0H 0H0',
+        provinceCode: 'ON',
+      };
+
+      const mapper = new AddressValidationDtoMapperImpl();
+      const dto = mapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(mockEntity);
+
+      expect(dto).toEqual(expectedDto);
+    });
+
+    it('should throw error for unknown status', () => {
+      const mockEntity: AddressCorrectionResultEntity = {
+        'wsaddr:CorrectionResults': {
+          'nc:AddressFullText': '123 Fake St',
+          'nc:AddressCityName': 'North Pole',
+          'nc:AddressPostalCode': 'H0H 0H0',
+          'can:ProvinceCode': 'ON',
+          'wsaddr:Information': {
+            'wsaddr:StatusCode': 'Invalid status',
+          },
+        },
+      };
+
+      const mapper = new AddressValidationDtoMapperImpl();
+      expect(() => mapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(mockEntity)).toThrowError();
+    });
+  });
+});

--- a/frontend/app/.server/domain/dtos/address-validation.dto.ts
+++ b/frontend/app/.server/domain/dtos/address-validation.dto.ts
@@ -3,7 +3,7 @@
  */
 export type AddressCorrectionResultDto = Readonly<{
   /** The status of the address correction. */
-  status: 'Corrected' | 'NotCorrect' | 'Valid';
+  status: AddressCorrectionStatus;
 
   /** The full or partial address. */
   address: string;
@@ -17,3 +17,8 @@ export type AddressCorrectionResultDto = Readonly<{
   /** The 2-character Canadian province or territorial code. */
   provinceCode: string;
 }>;
+
+/**
+ * Represents the possible statuses for an address correction result.
+ */
+export type AddressCorrectionStatus = 'Corrected' | 'NotCorrect' | 'Valid';


### PR DESCRIPTION
### Description
As per title

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/7db95ae5-d5a5-433b-8e0e-a7a169958b2d)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`