### PR TITLE
Adding unit tests for address validation repository and service

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/address-validation.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/address-validation.repository.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs';
+import { AddressValidationRepositoryImpl } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+import { instrumentedFetch } from '~/utils/fetch-utils.server';
+
+vi.mock('~/utils/fetch-utils.server', () => ({
+  getFetchFn: vi.fn(),
+  instrumentedFetch: vi.fn(),
+}));
+
+describe('AddressValidationRepositoryImpl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('getAddressCorrectionResult', () => {
+    it('should return address correction results on successful fetch', async () => {
+      const mockResponseData = {
+        'wsaddr:CorrectionResults': {
+          'nc:AddressFullText': '123 Fake St',
+          'nc:AddressCityName': 'North Pole',
+          'nc:AddressPostalCode': 'H0H 0H0',
+          'can:ProvinceCode': 'ON',
+          'wsaddr:Information': {
+            'wsaddr:StatusCode': 'Corrected',
+          },
+        },
+      };
+      vi.mocked(instrumentedFetch).mockResolvedValue(Response.json(mockResponseData));
+
+      const mockLogFactory = mock<LogFactory>();
+      mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+      const mockServerConfig = mock<ServerConfig>();
+      mockServerConfig.INTEROP_API_BASE_URI = 'https://api.example.com';
+
+      const repository = new AddressValidationRepositoryImpl(mockLogFactory, mockServerConfig);
+
+      const result = await repository.getAddressCorrectionResult({ address: '123 Fake Street', city: 'North Pole', provinceCode: 'ON', postalCode: 'H0H 0H0' });
+      expect(result).toEqual(mockResponseData);
+    });
+
+    it('should throw an error when fetch response is not ok', async () => {
+      vi.mocked(instrumentedFetch).mockResolvedValue(Response.json(null, { status: 500 }));
+
+      const mockLogFactory = mock<LogFactory>();
+      mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+      const mockServerConfig = mock<ServerConfig>();
+      mockServerConfig.INTEROP_API_BASE_URI = 'https://api.example.com';
+
+      const repository = new AddressValidationRepositoryImpl(mockLogFactory, mockServerConfig);
+      await expect(() => repository.getAddressCorrectionResult({ address: '123 Fake Street', city: 'North Pole', provinceCode: 'ON', postalCode: 'H0H 0H0' })).rejects.toThrowError();
+    });
+  });
+});

--- a/frontend/__tests__/.server/domain/services/address-validation.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/address-validation.service.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { AddressCorrectionResultDto } from '~/.server/domain/dtos';
+import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
+import type { AddressValidationDtoMapper } from '~/.server/domain/mappers';
+import type { AddressValidationRepository } from '~/.server/domain/repositories';
+import { AddressValidationServiceImpl } from '~/.server/domain/services';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+describe('AddressValidationServiceImpl', () => {
+  describe('getAddressCorrectionResult', () => {
+    it('should return address correction result DTO', async () => {
+      const mockLogFactory = mock<LogFactory>();
+      mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+      const mockAddressCorrectionResultDto: AddressCorrectionResultDto = {
+        status: 'Corrected',
+        address: '123 Fake St',
+        city: 'North Pole',
+        postalCode: 'H0H 0H0',
+        provinceCode: 'ON',
+      };
+      const mockAddressValidationDtoMapper = mock<AddressValidationDtoMapper>();
+      mockAddressValidationDtoMapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto.mockReturnValue(mockAddressCorrectionResultDto);
+
+      const mockAddressCorrectionResultEntity: AddressCorrectionResultEntity = {
+        'wsaddr:CorrectionResults': {
+          'nc:AddressFullText': '123 Fake St',
+          'nc:AddressCityName': 'North Pole',
+          'nc:AddressPostalCode': 'H0H 0H0',
+          'can:ProvinceCode': 'ON',
+          'wsaddr:Information': {
+            'wsaddr:StatusCode': 'Corrected',
+          },
+        },
+      };
+      const mockAddressValidationRepository = mock<AddressValidationRepository>();
+      mockAddressValidationRepository.getAddressCorrectionResult.mockResolvedValue(mockAddressCorrectionResultEntity);
+
+      const service = new AddressValidationServiceImpl(mockLogFactory, mockAddressValidationDtoMapper, mockAddressValidationRepository);
+
+      const result = await service.getAddressCorrectionResult({ address: '123 Fake Street', city: 'North Pole', provinceCode: 'ON', postalCode: 'H0H 0H0' });
+      expect(result).toEqual(mockAddressCorrectionResultDto);
+    });
+  });
+});


### PR DESCRIPTION
### Description
As per title

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/e91ed628-ee07-4dbd-8acd-635623a5eaca)
![image](https://github.com/user-attachments/assets/29e640b7-4fc0-428a-bce4-2fc6c051dfbf)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`