### PR TITLE
4585 add ITA review information route

### DIFF
--- a/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
@@ -78,18 +78,22 @@ interface ValidateRenewItaStateForReviewArgs {
 }
 
 export function validateRenewItaStateForReview({ params, state }: ValidateRenewItaStateForReviewArgs) {
-  const { maritalStatus, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference } = state;
+  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference, addressInformation, applicantInformation, dentalBenefits, dentalInsurance } = state;
 
   if (typeOfRenewal === undefined) {
-    throw redirect(getPathById('public/renew/$id/type-application', params));
+    throw redirect(getPathById('public/renew/$id/type-renewal', params));
   }
 
   if (typeOfRenewal === 'delegate') {
-    throw redirect(getPathById('public/renew/$id/application-delegate', params));
+    throw redirect(getPathById('public/renew/$id/renewal-delegate', params));
   }
 
   if (typeOfRenewal !== 'adult-child') {
-    throw redirect(getPathById('public/renew/$id/type-application', params));
+    throw redirect(getPathById('public/renew/$id/type-renewal', params));
+  }
+
+  if (applicantInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/applicant-information', params));
   }
 
   if (maritalStatus === undefined) {
@@ -104,7 +108,17 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     throw redirect(getPathById('public/renew/$id/ita/communication-preference', params));
   }
 
-  // TODO add remaining states when screens are available
+  if (addressInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/ita/confirm-address', params));
+  }
+
+  if (dentalInsurance === undefined) {
+    throw redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
+  }
+
+  if (dentalBenefits === undefined) {
+    throw redirect(getPathById('public/renew/$id/ita/federal-provincial-territorial-benefits', params));
+  }
 
   return {
     maritalStatus,
@@ -114,5 +128,10 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     typeOfRenewal,
     contactInformation,
     communicationPreference,
+    applicantInformation,
+    dentalBenefits,
+    dentalInsurance,
+    addressInformation,
+    partnerInformation,
   };
 }

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -779,6 +779,22 @@
                   "en": "/:lang/renew/:id/ita/contact-information",
                   "fr": "/:lang/renew/:id/ita/renseignements-personnels"
                 }
+              },
+              {
+                "id": "public/renew/$id/ita/review-information",
+                "file": "routes/public/renew/$id/ita/review-information.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/ita/review-information",
+                  "fr": "/:lang/renew/:id/ita/review-information"
+                }
+              },
+              {
+                "id": "public/renew/$id/ita/confirmation",
+                "file": "routes/public/renew/$id/ita/confirmation.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/ita/confirmation",
+                  "fr": "/:lang/renew/:id/ita/confirmation"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -90,11 +90,13 @@
       "ita": {
         "maritalStatus": "CDCP-RENW-ITA-0001",
         "contactInformation": "CDCP-RENW-ITA-0002",
+        "communicationPreference": "CDCP-ITA-0003",
         "confirmAddress": "CDCP-RENW-ITA-0004",
         "updateAddress": "CDCP-RENW-ITA-0005",
         "dentalInsurance": "CDCP-RENW-ITA-0006",
         "federalProvincialTerritorialBenefits": "CDCP-RENW-ITA-0007",
-        "communicationPreference": "CDCP-ITA-0003"
+        "reviewInformation": "CDCP-RENW-ITA-0008",
+        "confirmation": "CDCP-RENW-ITA-0009"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -79,10 +79,10 @@ export async function action({ context: { session }, params, request }: ActionFu
   saveRenewState({ params, session, state: { hasAddressChanged: parsedDataResult.data.hasAddressChanged === HasAddressChangedOption.Yes } });
 
   if (parsedDataResult.data.hasAddressChanged === HasAddressChangedOption.No) {
-    return redirect(getPathById('public/apply/$id/ita/dental-insurance', params));
+    return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
   }
 
-  return redirect(getPathById('public/apply/$id/ita/update-address', params));
+  return redirect(getPathById('public/renew/$id/ita/update-address', params));
 }
 
 export default function RenewItaConfirmAddress() {

--- a/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
@@ -127,7 +127,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     return json({ errors: transformFlattenedError(parsedDataResult.error.flatten()) });
   }
 
-  saveRenewState({ params, session, state });
+  saveRenewState({ params, session, state: { contactInformation: parsedDataResult.data } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/ita/review-information', params));

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -164,7 +164,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     },
   });
 
-  return redirect(getPathById('public/apply/$id/ita/review-information', params));
+  return redirect(getPathById('public/renew/$id/ita/review-information', params));
 }
 
 export default function RenewItaFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -1,0 +1,421 @@
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Address } from '~/components/address';
+import { Button } from '~/components/buttons';
+import { DescriptionListItem } from '~/components/description-list-item';
+import { InlineLink } from '~/components/inline-link';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
+import { loadRenewItaStateForReview } from '~/route-helpers/renew-ita-route-helpers.server';
+import { clearRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
+import { getEnv } from '~/utils/env-utils.server';
+import { useHCaptcha } from '~/utils/hcaptcha-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { localizePreferredCommunicationMethod, localizeProvincialGovernmentInsurancePlan } from '~/utils/lookup-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin } from '~/utils/sin-utils';
+
+enum FormAction {
+  Back = 'back',
+  Submit = 'submit',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.ita.reviewInformation,
+  pageTitleI18nKey: 'renew-ita:review-information.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewItaStateForReview({ params, request, session });
+
+  invariant(state.addressInformation.homeCountry, `Unexpected home address country: ${state.addressInformation.homeCountry}`);
+
+  // renew state is valid then edit mode can be set to true
+  saveRenewState({ params, session, state: { editMode: true } });
+
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const mailingProvinceTerritoryStateAbbr = state.addressInformation.mailingProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
+  const homeProvinceTerritoryStateAbbr = state.addressInformation.homeProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
+  const countryMailing = serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.mailingCountry, locale);
+  const countryHome = serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.homeCountry, locale);
+  const communicationPreference = serviceProvider.getPreferredCommunicationMethodService().getPreferredCommunicationMethodById(state.communicationPreference.preferredMethod);
+  const maritalStatus = serviceProvider.getMaritalStatusService().getLocalizedMaritalStatusById(state.maritalStatus, locale);
+
+  const userInfo = {
+    firstName: state.applicantInformation.firstName,
+    lastName: state.applicantInformation.lastName,
+    phoneNumber: state.contactInformation.phoneNumber,
+    altPhoneNumber: state.contactInformation.phoneNumberAlt,
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
+    clientNumber: state.applicantInformation.clientNumber,
+    maritalStatus: maritalStatus.name,
+    contactInformationEmail: state.contactInformation.email,
+    communicationPreferenceEmail: state.communicationPreference.email,
+    communicationPreference: localizePreferredCommunicationMethod(communicationPreference, locale).name,
+  };
+
+  const spouseInfo = state.partnerInformation && {
+    birthday: toLocaleDateString(parseDateString(state.partnerInformation.dateOfBirth), locale),
+    sin: state.partnerInformation.socialInsuranceNumber,
+    consent: state.partnerInformation.confirm,
+  };
+
+  const mailingAddressInfo = {
+    address: state.addressInformation.mailingAddress,
+    city: state.addressInformation.mailingCity,
+    province: mailingProvinceTerritoryStateAbbr,
+    postalCode: state.addressInformation.mailingPostalCode,
+    country: countryMailing,
+    apartment: state.addressInformation.mailingApartment,
+  };
+
+  const homeAddressInfo = {
+    address: state.addressInformation.homeAddress,
+    city: state.addressInformation.homeCity,
+    province: homeProvinceTerritoryStateAbbr,
+    postalCode: state.addressInformation.homePostalCode,
+    country: countryHome,
+    apartment: state.addressInformation.homeApartment,
+  };
+
+  const dentalInsurance = state.dentalInsurance;
+
+  const selectedFederalGovernmentInsurancePlan = state.dentalBenefits.federalSocialProgram
+    ? serviceProvider.getFederalGovernmentInsurancePlanService().getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
+    : undefined;
+
+  const selectedProvincialBenefit = state.dentalBenefits.provincialTerritorialSocialProgram
+    ? serviceProvider.getProvincialGovernmentInsurancePlanService().getProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram)
+    : undefined;
+
+  const dentalBenefit = {
+    federalBenefit: {
+      access: state.dentalBenefits.hasFederalBenefits,
+      benefit: selectedFederalGovernmentInsurancePlan?.name,
+    },
+    provTerrBenefit: {
+      access: state.dentalBenefits.hasProvincialTerritorialBenefits,
+      province: state.dentalBenefits.province,
+      benefit: selectedProvincialBenefit && localizeProvincialGovernmentInsurancePlan(selectedProvincialBenefit, locale).name,
+    },
+  };
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  // const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:review-information.page-title') }) };
+
+  // todo create and call payload mapper
+  // const payload = viewPayloadEnabled && toBenefitApplicationRequestFromApplyAdultState(state);
+
+  return json({
+    id: state.id,
+    userInfo,
+    spouseInfo,
+    homeAddressInfo,
+    mailingAddressInfo,
+    dentalInsurance,
+    dentalBenefit,
+    csrfToken,
+    meta,
+    siteKey: HCAPTCHA_SITE_KEY,
+    hCaptchaEnabled,
+    // payload,
+  });
+}
+
+export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/ita/review-information');
+
+  loadRenewItaStateForReview({ params, request, session });
+
+  const { ENABLED_FEATURES } = getEnv();
+  const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  if (formAction === FormAction.Back) {
+    saveRenewState({ params, session, state: { editMode: false } });
+    return redirect(getPathById('public/renew/$id/ita/federal-provincial-territorial-benefits', params));
+  }
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  if (hCaptchaEnabled) {
+    const hCaptchaResponse = String(formData.get('h-captcha-response') ?? '');
+    if (!(await hCaptchaRouteHelpers.verifyHCaptchaResponse(hCaptchaResponse, request))) {
+      clearRenewState({ params, session });
+      return redirect(getPathById('public/unable-to-process-request', params));
+    }
+  }
+
+  // todo create and call renewal application service and redirect to /ita/confirmation on success
+  // const benefitApplicationService = getBenefitApplicationService();
+  // const benefitApplicationRequest = toBenefitApplicationRequestFromApplyAdultState(state);
+  // const confirmationCode = await benefitApplicationService.submitApplication(benefitApplicationRequest);
+  // const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
+
+  // saveRenewState({ params, session, state: { submissionInfo } });
+
+  // return redirect(getPathById('public/renew/$id/ita/confirmation', params));
+}
+
+export default function RenewItaReviewInformation() {
+  const params = useParams();
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, csrfToken, siteKey, hCaptchaEnabled } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const { captchaRef } = useHCaptcha();
+  const [submitAction, setSubmitAction] = useState<string>();
+
+  function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={99} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-8 text-lg">{t('renew-ita:review-information.read-carefully')}</p>
+        <div className="space-y-10">
+          <section className="space-y-6">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-ita:review-information.page-sub-title')}</h2>
+            <dl className="divide-y border-y">
+              <DescriptionListItem term={t('renew-ita:review-information.full-name-title')}>
+                <p>{`${userInfo.firstName} ${userInfo.lastName}`}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-full-name" routeId="public/renew/$id/applicant-information" params={params}>
+                    {t('renew-ita:review-information.full-name-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.dob-title')}>
+                <p>{userInfo.birthday}</p>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.client-number-title')}>
+                <p>{userInfo.clientNumber}</p>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.marital-title')}>
+                <p>{userInfo.maritalStatus}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-martial-status" routeId="public/renew/$id/ita/marital-status" params={params}>
+                    {t('renew-ita:review-information.marital-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+            </dl>
+          </section>
+          {spouseInfo && (
+            <section className="space-y-6">
+              <h2 className="font-lato text-2xl font-bold">{t('renew-ita:review-information.spouse-title')}</h2>
+              <dl className="divide-y border-y">
+                <DescriptionListItem term={t('renew-ita:review-information.sin-title')}>
+                  <p>{formatSin(spouseInfo.sin)}</p>
+                  <div className="mt-4">
+                    <InlineLink id="change-spouse-sin" routeId="public/renew/$id/ita/marital-status" params={params}>
+                      {t('renew-ita:review-information.sin-change')}
+                    </InlineLink>
+                  </div>
+                </DescriptionListItem>
+                <DescriptionListItem term={t('renew-ita:review-information.dob-title')}>
+                  <p>{spouseInfo.birthday}</p>
+                  <div className="mt-4">
+                    <InlineLink id="change-spouse-date-of-birth" routeId="public/renew/$id/ita/marital-status" params={params}>
+                      {t('renew-ita:review-information.dob-change')}
+                    </InlineLink>
+                  </div>
+                </DescriptionListItem>
+                <DescriptionListItem term={t('renew-ita:review-information.spouse-consent.label')}>{spouseInfo.consent ? t('renew-ita:review-information.spouse-consent.yes') : t('renew-ita:review-information.spouse-consent.no')}</DescriptionListItem>
+              </dl>
+            </section>
+          )}
+          <section className="space-y-6">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-ita:review-information.contact-info-title')}</h2>
+            <dl className="divide-y border-y">
+              <DescriptionListItem term={t('renew-ita:review-information.phone-title')}>
+                <p>{userInfo.phoneNumber}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-phone-number" routeId="public/renew/$id/ita/contact-information" params={params}>
+                    {t('renew-ita:review-information.phone-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.alt-phone-title')}>
+                <p>{userInfo.altPhoneNumber}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-alternate-phone-number" routeId="public/apply/$id/adult/contact-information" params={params}>
+                    {t('renew-ita:review-information.alt-phone-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.email')}>
+                <p>{userInfo.contactInformationEmail}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-email" routeId="public/renew/$id/ita/contact-information" params={params}>
+                    {t('renew-ita:review-information.email-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.mailing-title')}>
+                <Address
+                  address={mailingAddressInfo.address}
+                  city={mailingAddressInfo.city}
+                  provinceState={mailingAddressInfo.province}
+                  postalZipCode={mailingAddressInfo.postalCode}
+                  country={mailingAddressInfo.country.name}
+                  apartment={mailingAddressInfo.apartment}
+                />
+                <div className="mt-4">
+                  <InlineLink id="change-mailing-address" routeId="public/renew/$id/ita/contact-information" params={params}>
+                    {t('renew-ita:review-information.mailing-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.home-title')}>
+                <Address
+                  address={homeAddressInfo.address ?? ''}
+                  city={homeAddressInfo.city ?? ''}
+                  provinceState={homeAddressInfo.province}
+                  postalZipCode={homeAddressInfo.postalCode}
+                  country={homeAddressInfo.country.name}
+                  apartment={homeAddressInfo.apartment}
+                />
+                <div className="mt-4">
+                  <InlineLink id="change-home-address" routeId="public/renew/$id/ita/contact-information" params={params}>
+                    {t('renew-ita:review-information.home-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+            </dl>
+          </section>
+          <section className="space-y-6">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-ita:review-information.dental-title')}</h2>
+            <dl className="divide-y border-y">
+              <DescriptionListItem term={t('renew-ita:review-information.dental-insurance-title')}>
+                <p>{dentalInsurance ? t('renew-ita:review-information.yes') : t('renew-ita:review-information.no')}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-access-dental" routeId="public/renew/$id/ita/dental-insurance" params={params}>
+                    {t('renew-ita:review-information.dental-insurance-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('renew-ita:review-information.dental-benefit-title')}>
+                {dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
+                  <>
+                    <p>{t('renew-ita:review-information.yes')}</p>
+                    <p>{t('renew-ita:review-information.dental-benefit-has-access')}</p>
+                    <ul className="ml-6 list-disc">
+                      {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
+                      {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
+                    </ul>
+                  </>
+                ) : (
+                  <p>{t('renew-ita:review-information.no')}</p>
+                )}
+                <div className="mt-4">
+                  <InlineLink id="change-dental-benefits" routeId="public/renew/$id/ita/federal-provincial-territorial-benefits" params={params}>
+                    {t('renew-ita:review-information.dental-benefit-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+            </dl>
+          </section>
+          <section className="space-y-4">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-ita:review-information.submit-app-title')}</h2>
+            <p>{t('renew-ita:review-information.submit-p-proceed')}</p>
+            <p>{t('renew-ita:review-information.submit-p-false-info')}</p>
+            <p>{t('renew-ita:review-information.submit-p-repayment')}</p>
+          </section>
+        </div>
+        <fetcher.Form onSubmit={handleSubmit} method="post" className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+          <LoadingButton
+            id="confirm-button"
+            name="_action"
+            value={FormAction.Submit}
+            variant="green"
+            disabled={isSubmitting}
+            loading={isSubmitting && submitAction === FormAction.Submit}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Submit - Review your information click"
+          >
+            {t('renew-ita:review-information.submit-button')}
+          </LoadingButton>
+          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Exit - Review your information click">
+            {t('renew-ita:review-information.back-button')}
+          </Button>
+        </fetcher.Form>
+        {/* todo add exit application route (not currently in Figma) like the apply flow? */}
+        {/* <div className="mt-8">
+          <InlineLink routeId="public/renew/$id/ita/exit-application" params={params}>
+            {t('renew-ita:review-information.exit-button')}
+          </InlineLink>
+        </div> */}
+      </div>
+      {/* {payload && (
+        <div className="mt-8">
+          <DebugPayload data={payload} enableCopy></DebugPayload>
+        </div>
+      )} */}
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -199,7 +199,7 @@ export async function action({ context: { session }, params, request }: ActionFu
     return redirect(getPathById('public/renew/$id/ita/review-information', params));
   }
 
-  return redirect(getPathById('public/apply/$id/ita/dental-insurance', params));
+  return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
 }
 
 export default function RenewItaUpdateAddress() {

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -199,5 +199,51 @@
     "error-message": {
       "dental-insurance-required": "Select whether you have access to dental insurance"
     }
+  },
+  "review-information": {
+    "read-carefully": "Review this information carefully. The information provided will be used to update your Canadian Dental Care Plan member account.",
+    "page-title": "Review your information",
+    "page-sub-title": "Member information",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "client-number-title": "Client number",
+    "sin-title": "Social Insurance Number (SIN)",
+    "sin-change": "Change SIN",
+    "full-name-title": "Full name",
+    "full-name-change": "Change full name",
+    "marital-title": "Marital status",
+    "marital-change": "Change marital status",
+    "spouse-title": "Spouse or common-law partner information",
+    "spouse-consent": {
+      "label": "Consent",
+      "yes": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
+      "no": "My spouse or common-law partner is aware and has not consented to sharing of their personal information."
+    },
+    "contact-info-title": "Contact Information",
+    "phone-title": "Phone number",
+    "phone-change": "Change phone number",
+    "alt-phone-title": "Alternate phone number",
+    "alt-phone-change": "Change alternate phone number",
+    "email": "Email",
+    "email-change": "Change email address",
+    "mailing-title": "Mailing address",
+    "mailing-change": "Change mailing address",
+    "home-title": "Home address",
+    "home-change": "Change home address",
+    "dental-title": "Access to dental insurance",
+    "dental-insurance-title": "Access to other dental insurance or coverage",
+    "dental-insurance-change": "Change answer to dental insurance",
+    "dental-benefit-title": "Access to government dental benefits",
+    "dental-benefit-change": "Change answer to government dental benefits",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "submit-app-title": "Submit your renewal application",
+    "submit-p-proceed": "By proceeding with this renewal, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
+    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "submit-button": "Submit Application",
+    "exit-button": "Exit application",
+    "back-button": "Back",
+    "yes": "Yes",
+    "no": "No"
   }
 }

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -199,5 +199,51 @@
     "error-message": {
       "dental-insurance-required": "Select whether you have access to dental insurance"
     }
+  },
+  "review-information": {
+    "read-carefully": "Review this information carefully. The information provided will be used to update your Canadian Dental Care Plan member account.",
+    "page-title": "Review your information",
+    "page-sub-title": "Member information",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "client-number-title": "Client number",
+    "sin-title": "Social Insurance Number (SIN)",
+    "sin-change": "Change SIN",
+    "full-name-title": "Full name",
+    "full-name-change": "Change full name",
+    "marital-title": "Marital status",
+    "marital-change": "Change marital status",
+    "spouse-title": "Spouse or common-law partner information",
+    "spouse-consent": {
+      "label": "Consent",
+      "yes": "My spouse or common-law partner is aware and has consented to sharing of their personal information.",
+      "no": "My spouse or common-law partner is aware and has not consented to sharing of their personal information."
+    },
+    "contact-info-title": "Contact Information",
+    "phone-title": "Phone number",
+    "phone-change": "Change phone number",
+    "alt-phone-title": "Alternate phone number",
+    "alt-phone-change": "Change alternate phone number",
+    "email": "Email",
+    "email-change": "Change email address",
+    "mailing-title": "Mailing address",
+    "mailing-change": "Change mailing address",
+    "home-title": "Home address",
+    "home-change": "Change home address",
+    "dental-title": "Access to dental insurance",
+    "dental-insurance-title": "Access to other dental insurance or coverage",
+    "dental-insurance-change": "Change answer to dental insurance",
+    "dental-benefit-title": "Access to government dental benefits",
+    "dental-benefit-change": "Change answer to government dental benefits",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "submit-app-title": "Submit your renewal application",
+    "submit-p-proceed": "By proceeding with this renewal, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
+    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "submit-button": "Submit Application",
+    "exit-button": "Exit application",
+    "back-button": "Back",
+    "yes": "Yes",
+    "no": "No"
   }
 }


### PR DESCRIPTION
### Description
adds `/renew/$id/ita/review-information`

NOTES:
- todos have been added indicating possible work items that will need to be addressed
- a blank `/renew/$id/ita/confirmation` route has been added to prevent `500`ing on page load
- this PR is already very large, thus adding the renewal-to-payload mapper will be addressed in a separate PR

### Related Azure Boards Work Items
[AB#4585](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4585)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d155363a-c90b-4b33-b1a2-3fee03545fa9)
![image](https://github.com/user-attachments/assets/a7b1c6d0-4b40-4023-b896-953a98ac16a7)
![image](https://github.com/user-attachments/assets/2e8388ff-a683-484c-948c-c62c7d92fc3b)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`