### PR TITLE
make country select input Canada by default

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -255,10 +255,10 @@ export default function ApplyFlowPersonalInformation() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState?.copyMailingAddress === true);
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry);
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
@@ -323,8 +323,8 @@ export default function ApplyFlowPersonalInformation() {
   const dummyOption: InputOptionProps = { children: t('apply-adult-child:contact-information.address-field.select-one'), value: '' };
 
   const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
-  const mailingPostalCodeRequired = selectedMailingCountry !== undefined && postalCodeRequiredContries.includes(selectedMailingCountry);
-  const homePostalCodeRequired = selectedHomeCountry !== undefined && postalCodeRequiredContries.includes(selectedHomeCountry);
+  const mailingPostalCodeRequired = postalCodeRequiredContries.includes(selectedMailingCountry);
+  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
 
   return (
     <>
@@ -438,7 +438,7 @@ export default function ApplyFlowPersonalInformation() {
                 autoComplete="country"
                 defaultValue={defaultState?.mailingCountry ?? ''}
                 errorMessage={errors?.mailingCountry}
-                options={[dummyOption, ...countries]}
+                options={countries}
                 onChange={mailingCountryChangeHandler}
                 required
               />
@@ -519,7 +519,7 @@ export default function ApplyFlowPersonalInformation() {
                     autoComplete="country"
                     defaultValue={defaultState?.homeCountry ?? ''}
                     errorMessage={errors?.homeCountry}
-                    options={[dummyOption, ...countries]}
+                    options={countries}
                     onChange={homeCountryChangeHandler}
                     required
                   />

--- a/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
@@ -255,10 +255,10 @@ export default function ApplyFlowPersonalInformation() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState?.copyMailingAddress === true);
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry);
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
@@ -313,12 +313,10 @@ export default function ApplyFlowPersonalInformation() {
 
   // populate home region/province/state list with selected country or current address country
   const homeRegions: InputOptionProps[] = homeCountryRegions.map(({ id, name }) => ({ children: name, value: id }));
-
   const dummyOption: InputOptionProps = { children: t('apply-adult:contact-information.address-field.select-one'), value: '' };
-
   const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
-  const mailingPostalCodeRequired = selectedMailingCountry !== undefined && postalCodeRequiredContries.includes(selectedMailingCountry);
-  const homePostalCodeRequired = selectedHomeCountry !== undefined && postalCodeRequiredContries.includes(selectedHomeCountry);
+  const mailingPostalCodeRequired = postalCodeRequiredContries.includes(selectedMailingCountry);
+  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
 
   return (
     <>
@@ -432,7 +430,7 @@ export default function ApplyFlowPersonalInformation() {
                 autoComplete="country"
                 defaultValue={defaultState?.mailingCountry ?? ''}
                 errorMessage={errors?.mailingCountry}
-                options={[dummyOption, ...countries]}
+                options={countries}
                 onChange={mailingCountryChangeHandler}
                 required
               />
@@ -513,7 +511,7 @@ export default function ApplyFlowPersonalInformation() {
                     autoComplete="country"
                     defaultValue={defaultState?.homeCountry ?? ''}
                     errorMessage={errors?.homeCountry}
-                    options={[dummyOption, ...countries]}
+                    options={countries}
                     onChange={homeCountryChangeHandler}
                     required
                   />

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -257,10 +257,10 @@ export default function ApplyFlowPersonalInformation() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState?.copyMailingAddress === true);
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry);
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
@@ -319,8 +319,8 @@ export default function ApplyFlowPersonalInformation() {
   const dummyOption: InputOptionProps = { children: t('apply-child:contact-information.address-field.select-one'), value: '' };
 
   const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
-  const mailingPostalCodeRequired = selectedMailingCountry !== undefined && postalCodeRequiredContries.includes(selectedMailingCountry);
-  const homePostalCodeRequired = selectedHomeCountry !== undefined && postalCodeRequiredContries.includes(selectedHomeCountry);
+  const mailingPostalCodeRequired = postalCodeRequiredContries.includes(selectedMailingCountry);
+  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
 
   return (
     <>
@@ -434,7 +434,7 @@ export default function ApplyFlowPersonalInformation() {
                 autoComplete="country"
                 defaultValue={defaultState?.mailingCountry ?? ''}
                 errorMessage={errors?.mailingCountry}
-                options={[dummyOption, ...countries]}
+                options={countries}
                 onChange={mailingCountryChangeHandler}
                 required
               />
@@ -515,7 +515,7 @@ export default function ApplyFlowPersonalInformation() {
                     autoComplete="country"
                     defaultValue={defaultState?.homeCountry ?? ''}
                     errorMessage={errors?.homeCountry}
-                    options={[dummyOption, ...countries]}
+                    options={countries}
                     onChange={homeCountryChangeHandler}
                     required
                   />

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -208,10 +208,10 @@ export default function RenewItaUpdateAddress() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState?.copyMailingAddress === true);
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry);
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
@@ -270,8 +270,8 @@ export default function RenewItaUpdateAddress() {
   const dummyOption: InputOptionProps = { children: t('renew-ita:update-address.address-field.select-one'), value: '' };
 
   const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
-  const mailingPostalCodeRequired = selectedMailingCountry !== undefined && postalCodeRequiredContries.includes(selectedMailingCountry);
-  const homePostalCodeRequired = selectedHomeCountry !== undefined && postalCodeRequiredContries.includes(selectedHomeCountry);
+  const mailingPostalCodeRequired = postalCodeRequiredContries.includes(selectedMailingCountry);
+  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
 
   return (
     <>
@@ -317,7 +317,7 @@ export default function RenewItaUpdateAddress() {
                 autoComplete="country"
                 defaultValue={defaultState?.mailingCountry ?? ''}
                 errorMessage={errors?.mailingCountry}
-                options={[dummyOption, ...countries]}
+                options={countries}
                 onChange={mailingCountryChangeHandler}
                 required
               />
@@ -398,7 +398,7 @@ export default function RenewItaUpdateAddress() {
                     autoComplete="country"
                     defaultValue={defaultState?.homeCountry ?? ''}
                     errorMessage={errors?.homeCountry}
-                    options={[dummyOption, ...countries]}
+                    options={countries}
                     onChange={homeCountryChangeHandler}
                     required
                   />


### PR DESCRIPTION
### Description
Makes country input select default to `CANADA_COUNTRY_ID` across all flows.

### Related Azure Boards Work Items
[AB#4713](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4713)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/14f83e03-90b3-4de5-b8a5-e023628edec6)