### PR TITLE
review ITA confirmation screen

### DIFF
--- a/frontend/app/components/contextual-alert.tsx
+++ b/frontend/app/components/contextual-alert.tsx
@@ -1,26 +1,44 @@
 import type { ReactNode } from 'react';
 
+import { faCommentDots } from '@fortawesome/free-regular-svg-icons';
 import { faCheckCircle, faCircleInfo, faExclamationCircle, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { cn } from '~/utils/tw-utils';
 
+export type AlertType = 'warning' | 'success' | 'danger' | 'info' | 'comment';
+
 export interface ContextualAlertProps {
   children: ReactNode;
-  type: 'warning' | 'success' | 'danger' | 'info';
+  type: AlertType;
 }
+
+const alertBackgroundColors: Partial<Record<AlertType, string>> & { default: string } = {
+  comment: 'bg-sky-50',
+  default: 'bg-white',
+};
+
+const alertBorderColors: Partial<Record<AlertType, string>> & { default: string } = {
+  comment: 'border-l-sky-800',
+  danger: 'border-l-red-700',
+  default: 'border-l-gray-700',
+  info: 'border-l-cyan-700',
+  warning: 'border-l-amber-700',
+  success: 'border-l-green-700',
+};
 
 export function ContextualAlert(props: ContextualAlertProps) {
   const { children, type } = props;
 
-  const alertColor = type === 'warning' ? 'border-l-amber-700' : type === 'danger' ? 'border-l-red-700' : type === 'info' ? 'border-l-cyan-700' : 'border-l-green-700';
+  const alertBackgroundColor = alertBackgroundColors[type] ?? alertBackgroundColors.default;
+  const alertBorderColor = alertBorderColors[type] ?? alertBorderColors.default;
 
   return (
-    <div className="relative pl-4 sm:pl-6">
-      <div className="absolute left-1.5 top-3 bg-white pt-1 sm:left-3.5">
+    <div className={cn('relative pl-4 sm:pl-6', alertBackgroundColor)}>
+      <div className={cn('absolute left-1.5 top-3 pt-1 sm:left-3.5', alertBackgroundColor)}>
         <Icon type={type} />
       </div>
-      <div className={cn('overflow-auto border-l-4 pb-2.5 pl-6 pt-4', alertColor)}>{children}</div>
+      <div className={cn('overflow-auto border-l-4 pb-2.5 pl-6 pt-4', alertBorderColor)}>{children}</div>
     </div>
   );
 }
@@ -35,6 +53,8 @@ function Icon({ type }: { type: string }) {
       return <FontAwesomeIcon icon={faExclamationCircle} className="h-6 w-6 text-red-700" data-testid="danger" />;
     case 'info':
       return <FontAwesomeIcon icon={faCircleInfo} className="h-6 w-6 text-cyan-700" data-testid="info" />;
+    case 'comment':
+      return <FontAwesomeIcon icon={faCommentDots} className="h-6 w-6 text-sky-800" data-testid="comment" />;
     default:
       break;
   }

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -6,7 +6,8 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import pageIds from '../../../../page-ids.json';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
+import { ContextualAlert } from '~/components/contextual-alert';
 import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { InlineLink } from '~/components/inline-link';
@@ -42,7 +43,6 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   if (state.applicantInformation === undefined ||
     state.communicationPreference === undefined ||
     state.contactInformation === undefined ||
-    state.partnerInformation === undefined ||
     state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
     state.addressInformation?.homeCountry === undefined ||
@@ -80,11 +80,13 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
     clientNumber: state.applicantInformation.clientNumber,
   };
 
-  const spouseInfo = {
-    confirm: state.partnerInformation.confirm,
-    yearOfBirth: state.partnerInformation.yearOfBirth,
-    sin: state.partnerInformation.socialInsuranceNumber,
-  };
+  const spouseInfo = state.partnerInformation
+    ? {
+        confirm: state.partnerInformation.confirm,
+        yearOfBirth: state.partnerInformation.yearOfBirth,
+        sin: state.partnerInformation.socialInsuranceNumber,
+      }
+    : null;
 
   const mailingAddressInfo = {
     address: state.addressInformation.mailingAddress,
@@ -164,7 +166,7 @@ export default function RenewFlowConfirm() {
         <Button
           variant="primary"
           size="lg"
-          className="mt-8 print:hidden"
+          className="mt-8 px-12 print:hidden"
           onClick={(event) => {
             event.preventDefault();
             window.print();
@@ -174,6 +176,17 @@ export default function RenewFlowConfirm() {
           {t('confirm.print-btn')}
         </Button>
       </section>
+
+      <ContextualAlert type="comment">
+        <div className="space-y-5">
+          <h3 className="font-lato text-2xl font-bold">{t('renew-ita:confirm.alert.title')}</h3>
+          <p>{t('renew-ita:confirm.alert.survey')}</p>
+          <p>{t('renew-ita:confirm.alert.answers')}</p>
+          <ButtonLink variant="primary" to="/">
+            {t('renew-ita:confirm.alert.btn')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
@@ -203,16 +216,18 @@ export default function RenewFlowConfirm() {
           </dl>
         </section>
 
-        <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h3>
-          <dl className="divide-y border-y">
-            <DescriptionListItem term={t('confirm.sin')}>
-              <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
-            </DescriptionListItem>
-            <DescriptionListItem term={t('confirm.year-of-birth')}>{spouseInfo.yearOfBirth}</DescriptionListItem>
-            <DescriptionListItem term={t('confirm.consent')}>{t('confirm.consent-answer')}</DescriptionListItem>
-          </dl>
-        </section>
+        {spouseInfo && (
+          <section className="space-y-6">
+            <h3 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h3>
+            <dl className="divide-y border-y">
+              <DescriptionListItem term={t('confirm.sin')}>
+                <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+              </DescriptionListItem>
+              <DescriptionListItem term={t('confirm.year-of-birth')}>{spouseInfo.yearOfBirth}</DescriptionListItem>
+              <DescriptionListItem term={t('confirm.consent')}>{t('confirm.consent-answer')}</DescriptionListItem>
+            </dl>
+          </section>
+        )}
 
         <section className="space-y-6">
           <h3 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h3>

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -251,7 +251,7 @@
   "confirm": {
     "page-title": "Your renewal for the Canadian Dental Care Plan is complete!",
     "keep-copy": "Keep a copy of your application",
-    "print-copy-text": "You will <strong>not</strong> receive a <strong>confirmation email</strong>. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
+    "print-copy-text": "You will <strong>not</strong> receive a confirmation email. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
     "print-btn": "Print",
     "whats-next": "What happens next",
     "begin-process": "We will begin processing your renewal application immediately. You can continue to use your Canadian Dental Care Plan benefits.",
@@ -285,6 +285,12 @@
     "close-application": "Close application",
     "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html",
     "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",
+    "alert": {
+      "title": "Help us improve the Canadian Dental Care Plan",
+      "survey": "This short survey has 5 demographic questions and will take 3 minutes of your time. It will open in a new window.",
+      "answers": "Your answers will help Health Canada improve the Canadian Dental Care Plan and make sure our services are accessible to everyone.",
+      "btn": "Take the survey"
+    },
     "modal": {
       "header": "Close application",
       "info": "By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -251,7 +251,7 @@
   "confirm": {
     "page-title": "(FR) Your renewal for the Canadian Dental Care Plan is complete!",
     "keep-copy": "(FR) Keep a copy of your application",
-    "print-copy-text": "(FR) You will <strong>not</strong> receive a <strong>confirmation email</strong>. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
+    "print-copy-text": "(FR) You will <strong>not</strong> receive a confirmation email. It is important to keep a copy of your application. <noPrint>You can use this button to print.<noPrint>",
     "print-btn": "(FR) Print",
     "whats-next": "(FR) What happens next",
     "begin-process": "(FR) We will begin processing your renewal application immediately. You can continue to use your Canadian Dental Care Plan benefits.",
@@ -285,6 +285,12 @@
     "close-application": "(FR) Close application",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
     "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html",
+    "alert": {
+      "title": "Help us improve the Canadian Dental Care Plan",
+      "survey": "This short survey has 5 demographic questions and will take 3 minutes of your time. It will open in a new window.",
+      "answers": "Your answers will help Health Canada improve the Canadian Dental Care Plan and make sure our services are accessible to everyone.",
+      "btn": "Take the survey"
+    },
     "modal": {
       "header": "(FR) Close application",
       "info": "(FR) By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",


### PR DESCRIPTION
### Description
review of `/renew/$id/ita/confirmation`
- adds `type='comment'` to the `ContextualAlert` component 
- makes `partnerInformation`optional in loader for applicants who aren't married or common-law
- minor fixes to text and styling

### Related Azure Boards Work Items
[AB#4585](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4585)

### Screenshots (if applicable)
![Screenshot from 2024-10-16 09-30-31](https://github.com/user-attachments/assets/355676b4-7967-4884-811b-c8e709db37a9)
![Screenshot from 2024-10-16 09-30-47](https://github.com/user-attachments/assets/588dce96-f6cc-47b9-842d-e0aa88c3e96e)
![Screenshot from 2024-10-16 09-30-53](https://github.com/user-attachments/assets/956f00e1-6827-4e06-b59f-ed71a41bfdac)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`