### PR TITLE
Using `INTEROP_API_BASE_URI` env var instead of hardcoded api.example.com in mocks

### DIFF
--- a/frontend/app/mocks/cct-api.server.ts
+++ b/frontend/app/mocks/cct-api.server.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from 'msw';
 
 import getPdfByLetterIdJson from './cct-data/get-pdf-by-letter-id.json';
+import { getEnv } from '~/utils/env-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 /**
@@ -9,12 +10,13 @@ import { getLogger } from '~/utils/logging.server';
 export function getCCTApiMockHandlers() {
   const log = getLogger('cct-api.server');
   log.info('Initializing CCT API mock handlers');
+  const { INTEROP_API_BASE_URI } = getEnv();
 
   return [
     //
     // Handler for GET requests to retrieve pdf
     //
-    http.get('https://api.example.com/dental-care/client-letters/cct/v1/GetPdfByLetterId', ({ request }) => {
+    http.get(`${INTEROP_API_BASE_URI}/dental-care/client-letters/cct/v1/GetPdfByLetterId`, ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
 
       const url = new URL(request.url);
@@ -36,7 +38,7 @@ export function getCCTApiMockHandlers() {
     /**
      * Handler for GET requests to retrieve letter details.
      */
-    http.get('https://api.example.com/dental-care/client-letters/cct/v1/GetDocInfoByClientId', ({ request }) => {
+    http.get(`${INTEROP_API_BASE_URI}/dental-care/client-letters/cct/v1/GetDocInfoByClientId`, ({ request }) => {
       const url = new URL(request.url);
       const clientId = url.searchParams.get('clientid');
       const community = request.headers.get('cct-community');

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -6,6 +6,7 @@ import type { BenefitApplicationResponse } from '~/schemas/benefit-application-s
 import { benefitApplicationRequestSchema } from '~/schemas/benefit-application-service-schemas.server';
 import { benefitRenewalRequestSchema } from '~/schemas/benefit-renewal-service-schemas.server';
 import type { BenefitRenewalResponse } from '~/schemas/benefit-renewal-service-schemas.server';
+import { getEnv } from '~/utils/env-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 const sinIdSchema = z.object({
@@ -22,12 +23,13 @@ const sinIdSchema = z.object({
 export function getPowerPlatformApiMockHandlers() {
   const log = getLogger('power-platform-api.server');
   log.info('Initializing Power Platform mock handlers');
+  const { INTEROP_API_BASE_URI } = getEnv();
 
   return [
     //
     // Retrieve personal details information (using POST instead of GET due the sin params logging with GET)
     //
-    http.post('https://api.example.com/dental-care/applicant-information/dts/v1/applicant', async ({ request }) => {
+    http.post(`${INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/applicant`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');
       if (!subscriptionKey) {
@@ -172,7 +174,7 @@ export function getPowerPlatformApiMockHandlers() {
     /**
      * Handler for POST request to submit application to Power Platform
      */
-    http.post('https://api.example.com/dental-care/applicant-information/dts/v1/benefit-application', async ({ request }) => {
+    http.post(`${INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/benefit-application`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
 
       const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');
@@ -205,7 +207,7 @@ export function getPowerPlatformApiMockHandlers() {
     /**
      * Handler for POST request to submit renewal to Power Platform
      */
-    http.post('https://api.example.com/dental-care/applicant-information/dts/v1/benefit-renewal', async ({ request }) => {
+    http.post(`${INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/benefit-renewal`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
 
       const subscriptionKey = request.headers.get('Ocp-Apim-Subscription-Key');

--- a/frontend/app/mocks/status-check-api.server.ts
+++ b/frontend/app/mocks/status-check-api.server.ts
@@ -2,6 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { z } from 'zod';
 
 import clientFriendlyStatusDataSource from '~/.server/resources/power-platform/client-friendly-status.json';
+import { getEnv } from '~/utils/env-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 /**
@@ -23,9 +24,10 @@ const MOCK_APPLICATION_CODES_TO_STATUS_CODES_MAP: Record<string, string> = clien
 export function getStatusCheckApiMockHandlers() {
   const log = getLogger('status-check-api.server');
   log.info('Initializing Status Check mock handlers');
+  const { INTEROP_API_BASE_URI } = getEnv();
 
   return [
-    http.post('https://api.example.com/dental-care/status-check/v1/status', async ({ request }) => {
+    http.post(`${INTEROP_API_BASE_URI}/dental-care/status-check/v1/status`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       const statusRequestSchema = z.object({
         BenefitApplication: z.object({
@@ -65,7 +67,7 @@ export function getStatusCheckApiMockHandlers() {
         },
       });
     }),
-    http.post('https://api.example.com/dental-care/status-check/v1/status_fnlndob', async ({ request }) => {
+    http.post(`${INTEROP_API_BASE_URI}/dental-care/status-check/v1/status_fnlndob`, async ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       const statusRequestSchema = z.object({
         BenefitApplication: z.object({

--- a/frontend/app/mocks/wsaddress-api.server.ts
+++ b/frontend/app/mocks/wsaddress-api.server.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
 
+import { getEnv } from '~/utils/env-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
 /**
@@ -8,12 +9,13 @@ import { getLogger } from '~/utils/logging.server';
 export function getWSAddressApiMockHandlers() {
   const log = getLogger('wsaddress-api.server');
   log.info('Initializing WSAddress API mock handlers');
+  const { INTEROP_API_BASE_URI } = getEnv();
 
   return [
     //
     // Handler for GET requests to WSAddress correct service
     //
-    http.get('https://api.example.com/address/validation/v1/CAN/correct', ({ request }) => {
+    http.get(`${INTEROP_API_BASE_URI}/address/validation/v1/CAN/correct`, ({ request }) => {
       log.debug('Handling request for [%s]', request.url);
       return HttpResponse.json({
         '@context': {


### PR DESCRIPTION
### Description
This will allow us to test various Interop endpoints while still using mocks. 

Previously, even if the mock is enabled, `INTEROP_API_BASE_URI` had to be set to `https://api.example.com` in order to hit it.


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`