### PR TITLE
review ITA confirm-address route

### DIFF
--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -30,6 +30,7 @@ export interface RenewState {
     email?: string;
   };
   readonly hasAddressChanged?: boolean;
+  readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly addressInformation?: {
     copyMailingAddress: boolean;
     homeAddress?: string;

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -55,14 +55,16 @@
   },
   "confirm-address": {
     "page-title": "Address",
-    "form-instructions": "Have you moved or changed your mailing address since you applied for the Canadian Dental Care Plan?",
+    "have-you-moved": "Have you moved or changed your mailing address since you applied for the Canadian Dental Care Plan?",
+    "is-home-address-same-as-mailing-address": "Is your home address the same as your mailing address?",
     "radio-options": {
       "yes": "Yes",
       "no": "No"
     },
     "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
-      "has-address-changed-required": "Select whether or not your address has changed"
+      "has-address-changed-required": "Select whether or not your address has changed",
+      "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
     },
     "back-btn": "Back",
     "continue-btn": "Continue"

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -56,14 +56,16 @@
   },
   "confirm-address": {
     "page-title": "Address",
-    "form-instructions": "Have you moved or changed your mailing address since you applied for the Canadian Dental Care Plan?",
+    "have-you-moved": "Have you moved or changed your mailing address since you applied for the Canadian Dental Care Plan?",
+    "is-home-address-same-as-mailing-address": "Is your home address the same as your mailing address?",
     "radio-options": {
       "yes": "Yes",
       "no": "No"
     },
     "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
-      "has-address-changed-required": "Select whether or not your address has changed"
+      "has-address-changed-required": "Select whether or not your address has changed",
+      "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
     },
     "back-btn": "Back",
     "continue-btn": "Continue"


### PR DESCRIPTION
### Description
adds an additional radio option to select whether the user's mailing address is the same as their home address

### Related Azure Boards Work Items
[AB#4585](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4585)

### Screenshots (if applicable)
![Screenshot from 2024-10-17 08-49-45](https://github.com/user-attachments/assets/81638fd0-8700-4261-859b-defef9b9521f)
![Screenshot from 2024-10-17 08-51-54](https://github.com/user-attachments/assets/61ed7dc8-c7f6-416f-a901-ee7898feed2b)
![Screenshot from 2024-10-17 08-52-01](https://github.com/user-attachments/assets/b021dfdf-6760-460c-9221-e4247e63850c)
