### PR TITLE
make address information optional

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -17,7 +17,7 @@ export type BenefitRenewalRequestDto = Readonly<{
     email?: string;
   }>;
   hasAddressChanged?: boolean;
-  addressInformation: Readonly<{
+  addressInformation?: Readonly<{
     copyMailingAddress: boolean;
     homeAddress?: string;
     homeApartment?: string;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -47,7 +47,7 @@ export interface ToBenefitRenewalRequestFromRenewItaStateArgs {
   contactInformation?: ContactInformationState;
   typeOfRenewal: Extract<TypeOfRenewalState, 'adult-child'>;
   maritalStatus: string;
-  addressInformation: AddressInformationState;
+  addressInformation?: AddressInformationState;
 }
 
 export function toBenefitRenewalRequestFromRenewItaState({
@@ -83,7 +83,7 @@ interface ToBenefitRenewalRequestArgs {
   contactInformation?: ContactInformationState;
   typeOfRenewal: TypeOfRenewalState;
   maritalStatus: string;
-  addressInformation: AddressInformationState;
+  addressInformation?: AddressInformationState;
 }
 
 function toBenefitRenewalRequest({
@@ -107,7 +107,7 @@ function toBenefitRenewalRequest({
         PersonBirthDate: toDate(applicantInformation.dateOfBirth),
         PersonContactInformation: [
           {
-            Address: [toMailingAddress(addressInformation), toHomeAddress(addressInformation)],
+            Address: addressInformation ? [toMailingAddress(addressInformation), toHomeAddress(addressInformation)] : [],
             EmailAddress: toEmailAddress({ contactEmail: contactInformation?.email, communicationEmail: communicationPreferences?.email }),
             TelephoneNumber: toTelephoneNumber(contactInformation ?? {}),
           },
@@ -127,7 +127,7 @@ function toBenefitRenewalRequest({
           IdentificationID: applicantInformation.clientNumber,
         },
         RelatedPerson: toRelatedPersons({ partnerInformation }),
-        MailingSameAsHomeIndicator: addressInformation.copyMailingAddress,
+        MailingSameAsHomeIndicator: addressInformation?.copyMailingAddress ?? false,
         PreferredMethodCommunicationCode: {
           ReferenceDataID: communicationPreferences?.preferredMethod,
         },

--- a/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
+++ b/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
@@ -24,7 +24,7 @@ export interface ToBenefitRenewalRequestFromApplyAdultStateArgs {
   contactInformation: ContactInformationState;
   typeOfRenewal: Extract<TypeOfRenewalState, 'adult-child'>;
   maritalStatus: string;
-  addressInformation: AddressInformationState;
+  addressInformation?: AddressInformationState;
 }
 
 export function toBenefitRenewalRequestFromRenewItaState({
@@ -60,7 +60,7 @@ interface ToBenefitRenewalRequestArgs {
   contactInformation: ContactInformationState;
   typeOfRenewal: TypeOfRenewalState;
   maritalStatus: string;
-  addressInformation: AddressInformationState;
+  addressInformation?: AddressInformationState;
 }
 
 function toBenefitRenewalRequest({
@@ -84,7 +84,7 @@ function toBenefitRenewalRequest({
         PersonBirthDate: toDate(applicantInformation.dateOfBirth),
         PersonContactInformation: [
           {
-            Address: [toMailingAddress(addressInformation), toHomeAddress(addressInformation)],
+            Address: addressInformation ? [toMailingAddress(addressInformation), toHomeAddress(addressInformation)] : [],
             EmailAddress: toEmailAddress({ contactEmail: contactInformation.email, communicationEmail: communicationPreferences?.email }),
             TelephoneNumber: toTelephoneNumber(contactInformation),
           },
@@ -104,7 +104,7 @@ function toBenefitRenewalRequest({
           IdentificationID: applicantInformation.clientNumber,
         },
         RelatedPerson: toRelatedPersons({ partnerInformation }),
-        MailingSameAsHomeIndicator: addressInformation.copyMailingAddress,
+        MailingSameAsHomeIndicator: addressInformation?.copyMailingAddress ?? false,
         PreferredMethodCommunicationCode: {
           ReferenceDataID: communicationPreferences?.preferredMethod,
         },

--- a/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
@@ -78,7 +78,7 @@ interface ValidateRenewItaStateForReviewArgs {
 }
 
 export function validateRenewItaStateForReview({ params, state }: ValidateRenewItaStateForReviewArgs) {
-  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference, addressInformation, applicantInformation, dentalBenefits, dentalInsurance } = state;
+  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference, addressInformation, applicantInformation, dentalBenefits, dentalInsurance, hasAddressChanged } = state;
 
   if (typeOfRenewal === undefined) {
     throw redirect(getPathById('public/renew/$id/type-renewal', params));
@@ -108,8 +108,8 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     throw redirect(getPathById('public/renew/$id/ita/communication-preference', params));
   }
 
-  if (addressInformation === undefined) {
-    throw redirect(getPathById('public/renew/$id/ita/confirm-address', params));
+  if (hasAddressChanged && addressInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/ita/update-address', params));
   }
 
   if (dentalInsurance === undefined) {
@@ -133,5 +133,6 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     dentalInsurance,
     addressInformation,
     partnerInformation,
+    hasAddressChanged,
   };
 }

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
     state.contactInformation === undefined ||
     state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
-    state.addressInformation?.homeCountry === undefined ||
+    (state.hasAddressChanged && state.addressInformation===undefined) ||
     state.submissionInfo === undefined ||
     state.maritalStatus === undefined ||
     state.typeOfRenewal === undefined) {
@@ -60,10 +60,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
     ? serviceProvider.getProvincialGovernmentInsurancePlanService().getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const mailingProvinceTerritoryStateAbbr = state.addressInformation.mailingProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.addressInformation.homeProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
-  const countryMailing = serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.mailingCountry, locale);
-  const countryHome = serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.homeCountry, locale);
+  const mailingProvinceTerritoryStateAbbr = state.addressInformation?.mailingProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
+  const homeProvinceTerritoryStateAbbr = state.addressInformation?.homeProvince ? serviceProvider.getProvinceTerritoryStateService().getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
+  const countryMailing = state.addressInformation?.mailingCountry ? serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.mailingCountry, locale) : undefined;
+  const countryHome = state.addressInformation?.homeCountry ? serviceProvider.getCountryService().getLocalizedCountryById(state.addressInformation.homeCountry, locale) : undefined;
   const maritalStatus = serviceProvider.getMaritalStatusService().getLocalizedMaritalStatusById(state.maritalStatus, locale);
   const communicationPreference = serviceProvider.getPreferredCommunicationMethodService().getLocalizedPreferredCommunicationMethodById(state.communicationPreference.preferredMethod, locale);
 
@@ -88,23 +88,27 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
       }
     : null;
 
-  const mailingAddressInfo = {
-    address: state.addressInformation.mailingAddress,
-    city: state.addressInformation.mailingCity,
-    province: mailingProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation.mailingPostalCode,
-    country: countryMailing.name,
-    apartment: state.addressInformation.mailingApartment,
-  };
+  const mailingAddressInfo = state.addressInformation
+    ? {
+        address: state.addressInformation.mailingAddress,
+        city: state.addressInformation.mailingCity,
+        province: mailingProvinceTerritoryStateAbbr,
+        postalCode: state.addressInformation.mailingPostalCode,
+        country: countryMailing?.name ?? '',
+        apartment: state.addressInformation.mailingApartment,
+      }
+    : null;
 
-  const homeAddressInfo = {
-    address: state.addressInformation.homeAddress,
-    city: state.addressInformation.homeCity,
-    province: homeProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation.homePostalCode,
-    country: countryHome.name,
-    apartment: state.addressInformation.homeApartment,
-  };
+  const homeAddressInfo = state.addressInformation
+    ? {
+        address: state.addressInformation.homeAddress,
+        city: state.addressInformation.homeCity,
+        province: homeProvinceTerritoryStateAbbr,
+        postalCode: state.addressInformation.homePostalCode,
+        country: countryHome?.name ?? '',
+        apartment: state.addressInformation.homeApartment,
+      }
+    : null;
 
   const dentalInsurance = {
     acessToDentalInsurance: state.dentalInsurance,
@@ -242,28 +246,36 @@ export default function RenewFlowConfirm() {
               <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
             </DescriptionListItem>
             <DescriptionListItem term={t('confirm.mailing')}>
-              <Address
-                address={{
-                  address: mailingAddressInfo.address,
-                  city: mailingAddressInfo.city,
-                  provinceState: mailingAddressInfo.province,
-                  postalZipCode: mailingAddressInfo.postalCode,
-                  country: mailingAddressInfo.country,
-                  apartment: mailingAddressInfo.apartment,
-                }}
-              />
+              {mailingAddressInfo ? (
+                <Address
+                  address={{
+                    address: mailingAddressInfo.address,
+                    city: mailingAddressInfo.city,
+                    provinceState: mailingAddressInfo.province,
+                    postalZipCode: mailingAddressInfo.postalCode,
+                    country: mailingAddressInfo.country,
+                    apartment: mailingAddressInfo.apartment,
+                  }}
+                />
+              ) : (
+                t('renew-ita:confirm.no-change')
+              )}
             </DescriptionListItem>
             <DescriptionListItem term={t('confirm.home')}>
-              <Address
-                address={{
-                  address: homeAddressInfo.address ?? '',
-                  city: homeAddressInfo.city ?? '',
-                  provinceState: homeAddressInfo.province,
-                  postalZipCode: homeAddressInfo.postalCode,
-                  country: homeAddressInfo.country,
-                  apartment: homeAddressInfo.apartment,
-                }}
-              />
+              {homeAddressInfo ? (
+                <Address
+                  address={{
+                    address: homeAddressInfo.address ?? '',
+                    city: homeAddressInfo.city ?? '',
+                    provinceState: homeAddressInfo.province,
+                    postalZipCode: homeAddressInfo.postalCode,
+                    country: homeAddressInfo.country,
+                    apartment: homeAddressInfo.apartment,
+                  }}
+                />
+              ) : (
+                t('renew-ita:confirm.no-change')
+              )}
             </DescriptionListItem>
           </dl>
         </section>

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -238,7 +238,8 @@
     "exit-button": "Exit application",
     "back-button": "Back",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "no-change": "No change"
   },
   "exit-application": {
     "page-title": "Exiting the application",
@@ -282,6 +283,7 @@
     "dental-public": "Access to government dental benefits",
     "yes": "Yes",
     "no": "No",
+    "no-change": "No change",
     "close-application": "Close application",
     "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html",
     "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -238,7 +238,8 @@
     "exit-button": "Exit application",
     "back-button": "Back",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "no-change": "No change"
   },
   "exit-application": {
     "page-title": "Quitter la demande",
@@ -282,6 +283,7 @@
     "dental-public": "(FR) Access to government dental benefits",
     "yes": "(FR) Yes",
     "no": "(FR) No",
+    "no-change": "(FR) No change",
     "close-application": "(FR) Close application",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html",
     "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html",


### PR DESCRIPTION
### Description
makes the address information in state optional.  If they select "no" to "has my address changed", they'll be able to navigate throughout the application without being redirected back to the update address route upon reaching the review information screen.

### Related Azure Boards Work Items
[AB#4585](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4585)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
