### PR TITLE
add renew adult child flow files

### DIFF
--- a/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
@@ -1,0 +1,137 @@
+import type { Session } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import type { Params } from '@remix-run/react';
+import { isRedirectResponse, isResponse } from '@remix-run/server-runtime/dist/responses';
+
+import { loadRenewState, saveRenewState } from './renew-route-helpers.server';
+import type { RenewState } from './renew-route-helpers.server';
+import { getLogger } from '~/utils/logging.server';
+import { getPathById } from '~/utils/route-utils';
+
+interface LoadRenewAdultChildStateArgs {
+  params: Params;
+  request: Request;
+  session: Session;
+}
+
+/**
+ * Loads renew AdultChild state.
+ * @param args - The arguments.
+ * @returns The loaded AdultChild state.
+ */
+export function loadRenewAdultChildState({ params, request, session }: LoadRenewAdultChildStateArgs) {
+  const log = getLogger('renew-adult-child-route-helpers.server/loadRenewAdultChildState');
+  const { pathname } = new URL(request.url);
+  const renewState = loadRenewState({ params, session });
+
+  if (renewState.typeOfRenewal !== 'adult-child') {
+    throw redirect(getPathById('public/renew/$id/type-renewal', params));
+  }
+
+  // Redirect to the confirmation page if the application has been submitted and
+  // the current route is not the confirmation page.
+  const confirmationRouteUrl = getPathById('public/renew/$id/adult-child/confirmation', params);
+  if (renewState.submissionInfo && !pathname.endsWith(confirmationRouteUrl)) {
+    log.warn('Redirecting user to "%s" since the application has been submitted; sessionId: [%s], ', renewState.id, confirmationRouteUrl);
+    throw redirect(confirmationRouteUrl);
+  }
+
+  // Redirect to the first flow page if the application has not been submitted and
+  // the current route is the confirmation page.
+  const termsAndConditionsRouteUrl = getPathById('public/renew/$id/terms-and-conditions', params);
+  if (!renewState.submissionInfo && pathname.endsWith(confirmationRouteUrl)) {
+    log.warn('Redirecting user to "%s" since the application has not been submitted; sessionId: [%s], ', renewState.id, termsAndConditionsRouteUrl);
+    throw redirect(termsAndConditionsRouteUrl);
+  }
+
+  return renewState;
+}
+
+interface LoadRenewAdultChildStateForReviewArgs {
+  params: Params;
+  request: Request;
+  session: Session;
+}
+
+/**
+ * Loads the renewal state for the review page. It validates the state and throws a redirect if invalid.
+ * If a redirect exception is thrown, state.editMode is set to false.
+ * @param args - The arguments.
+ * @returns The validated adult state.
+ */
+export function loadRenewAdultChildStateForReview({ params, request, session }: LoadRenewAdultChildStateForReviewArgs) {
+  const state = loadRenewAdultChildState({ params, request, session });
+
+  try {
+    return validateRenewAdultChildStateForReview({ params, state });
+  } catch (err) {
+    if (isResponse(err) && isRedirectResponse(err)) {
+      saveRenewState({ params, session, state: { editMode: false } });
+    }
+    throw err;
+  }
+}
+
+interface ValidateRenewAdultChildStateForReviewArgs {
+  params: Params;
+  state: RenewState;
+}
+
+export function validateRenewAdultChildStateForReview({ params, state }: ValidateRenewAdultChildStateForReviewArgs) {
+  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference, addressInformation, applicantInformation, dentalBenefits, dentalInsurance } = state;
+
+  if (typeOfRenewal === undefined) {
+    throw redirect(getPathById('public/renew/$id/type-renewal', params));
+  }
+
+  if (typeOfRenewal === 'delegate') {
+    throw redirect(getPathById('public/renew/$id/renewal-delegate', params));
+  }
+
+  if (typeOfRenewal !== 'adult-child') {
+    throw redirect(getPathById('public/renew/$id/type-renewal', params));
+  }
+
+  if (applicantInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/applicant-information', params));
+  }
+
+  if (maritalStatus === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
+  }
+
+  if (contactInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/contact-information', params));
+  }
+
+  if (communicationPreference === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/communication-preference', params));
+  }
+
+  if (addressInformation === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
+  }
+
+  if (dentalInsurance === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/dental-insurance', params));
+  }
+
+  if (dentalBenefits === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/federal-provincial-territorial-benefits', params));
+  }
+
+  return {
+    maritalStatus,
+    editMode,
+    id,
+    submissionInfo,
+    typeOfRenewal,
+    contactInformation,
+    communicationPreference,
+    applicantInformation,
+    dentalBenefits,
+    dentalInsurance,
+    addressInformation,
+    partnerInformation,
+  };
+}

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -819,6 +819,22 @@
                   "en": "/:lang/renew/:id/ita/exit-application",
                   "fr": "/:lang/renew/:id/ita/exit-application"
                 }
+              },
+              {
+                "id": "public/renew/$id/adult-child/marital-status",
+                "file": "routes/public/renew/$id/adult-child/marital-status.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/marital-status",
+                  "fr": "/:lang/renew/:id/adult-child/marital-status"
+                }
+              },
+              {
+                "id": "public/renew/$id/adult-child/confirmation",
+                "file": "routes/public/renew/$id/adult-child/confirmation.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/confirmation",
+                  "fr": "/:lang/renew/:id/adult-child/confirmation"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -99,6 +99,9 @@
         "reviewInformation": "CDCP-RENW-ITA-0008",
         "confirmation": "CDCP-RENW-ITA-0009",
         "exitApplication": "CDCP-RENw-ITA-0010"
+      },
+      "adultChild": {
+        "maritalStatus": "CDCP-RENW-ADCH-0001"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -1,0 +1,230 @@
+import type { ChangeEventHandler } from 'react';
+import { useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import type { PartnerInformationState } from '~/route-helpers/renew-route-helpers.server';
+import { renewStateHasPartner, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { getEnv } from '~/utils/env-utils.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.maritalStatus,
+  pageTitleI18nKey: 'renew-adult-child:marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const maritalStatuses = serviceProvider.getMaritalStatusService().listLocalizedMaritalStatuses(locale);
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:marital-status.page-title') }) };
+
+  return json({ csrfToken, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/marital-status');
+
+  const state = loadRenewAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  // state validation schema
+  const maritalStatusSchema = z.object({
+    maritalStatus: z
+      .string({ errorMap: () => ({ message: t('renew-adult-child:marital-status.error-message.marital-status-required') }) })
+      .trim()
+      .min(1, t('renew-adult-child:marital-status.error-message.marital-status-required')),
+  });
+
+  const partnerInformationSchema = z.object({
+    confirm: z.boolean().refine((val) => val === true, t('renew-adult-child:marital-status.error-message.confirm-required')),
+    yearOfBirth: z.string().trim().min(1, t('renew-adult-child:marital-status.error-message.date-of-birth-year-required')),
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('renew-adult-child:marital-status.error-message.sin-required'))
+      .refine(isValidSin, t('renew-adult-child:marital-status.error-message.sin-valid'))
+      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-adult-child:marital-status.error-message.sin-unique')),
+  }) satisfies z.ZodType<PartnerInformationState>;
+
+  const maritalStatusData = {
+    maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,
+  };
+  const partnerInformationData = {
+    confirm: formData.get('confirm') === 'yes',
+    yearOfBirth: String(formData.get('yearOfBirth') ?? ''),
+    socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),
+  };
+
+  const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
+  const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
+
+  if (!parsedMaritalStatus.success || (renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
+    return json({
+      errors: {
+        ...(parsedMaritalStatus.error ? transformFlattenedError(parsedMaritalStatus.error.flatten()) : {}),
+        ...(parsedMaritalStatus.success && renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(parsedPartnerInformation.error.flatten()) : {}),
+      },
+    });
+  }
+
+  saveRenewState({ params, session, state: { maritalStatus: parsedMaritalStatus.data.maritalStatus, partnerInformation: parsedPartnerInformation.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult-family/review-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-family/contact-information', params));
+}
+
+export default function RenewAdultChildMaritalStatus() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState, editMode, maritalStatuses, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const [marriedOrCommonlaw, setMarriedOrCommonlaw] = useState(defaultState.maritalStatus);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    maritalStatus: 'input-radio-marital-status-option-0',
+    yearOfBirth: 'year-of-birth',
+    socialInsuranceNumber: 'social-insurance-number',
+    confirm: 'input-checkbox-confirm',
+  });
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setMarriedOrCommonlaw(e.target.value);
+  };
+
+  const maritalStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState.maritalStatus, children: status.name, value: status.id, onChange: handleChange }));
+  }, [defaultState, maritalStatuses]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={44} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="mb-8 space-y-6">
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('renew-adult-child:marital-status.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+
+            {(marriedOrCommonlaw === MARITAL_STATUS_CODE_COMMONLAW.toString() || marriedOrCommonlaw === MARITAL_STATUS_CODE_MARRIED.toString()) && (
+              <>
+                <h2 className="mb-6 font-lato text-2xl font-bold">{t('renew-adult-child:marital-status.spouse-or-commonlaw')}</h2>
+                <p className="mb-4">{t('renew-adult-child:marital-status.provide-sin')}</p>
+                <p className="mb-6">{t('renew-adult-child:marital-status.required-information')}</p>
+                <InputPatternField
+                  id="year-of-birth"
+                  name="yearOfBirth"
+                  inputMode="numeric"
+                  format="####"
+                  defaultValue={defaultState.yearOfBirth ?? ''}
+                  label={t('renew-adult-child:marital-status.year-of-birth')}
+                  errorMessage={errors?.yearOfBirth}
+                  required
+                />
+                <InputPatternField
+                  id="social-insurance-number"
+                  name="socialInsuranceNumber"
+                  format={sinInputPatternFormat}
+                  label={t('marital-status.sin')}
+                  inputMode="numeric"
+                  helpMessagePrimary={t('renew-adult-child:marital-status.help-message.sin')}
+                  helpMessagePrimaryClassName="text-black"
+                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                  errorMessage={errors?.socialInsuranceNumber}
+                  required
+                />
+                <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.confirm === true} required>
+                  {t('renew-adult-child:marital-status.confirm-checkbox')}
+                </InputCheckbox>
+              </>
+            )}
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Marital status click">
+                {t('renew-adult-child:marital-status.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Marital status click">
+                {t('renew-adult-child:marital-status.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Marital status click"
+              >
+                {t('renew-adult-child:marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink id="back-button" routeId="public/renew/$id/type-renewal" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Marital status click">
+                {t('renew-adult-child:marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -9,6 +9,7 @@ import type dataUnavailable from '../public/locales/en/data-unavailable.json';
 import type gcweb from '../public/locales/en/gcweb.json';
 import type index from '../public/locales/en/index.json';
 import type letters from '../public/locales/en/letters.json';
+import type renewAdultChild from '../public/locales/en/renew-adult-child.json';
 import type renewIta from '../public/locales/en/renew-ita.json';
 import type renew from '../public/locales/en/renew.json';
 import type status from '../public/locales/en/status.json';
@@ -72,6 +73,7 @@ declare module 'i18next' {
       status: typeof status;
       renew: typeof renew;
       'renew-ita': typeof renewIta;
+      'renew-adult-child': typeof renewAdultChild;
       'stub-login': typeof stubLogin;
       'unable-to-process-request': typeof unableToProcessRequest;
     };

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -1,0 +1,31 @@
+{
+  "marital-status": {
+    "page-title": "Marital status",
+    "marital-status": "What is your current marital status?",
+    "spouse-or-commonlaw": "Spouse or common-law partner information",
+    "provide-sin": "Provide the SIN of your current spouse or common-law partner. The information is required to calculate your adjusted family net income.",
+    "required-information": "Your spouse or common-law partner must submit their own application or renewal for the Canadian Dental Care Plan.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Social Insurance Number (SIN)",
+    "year-of-birth": "Year of birth",
+    "single-legal-name": "If your spouse or common-law partner has a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "help-message": {
+      "sin": "Enter the 9-digit SIN"
+    },
+    "error-message": {
+      "marital-status-required": "Select marital status",
+      "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-year-required": "Year of birth is required",
+      "sin-required": "Enter 9-digit SIN, for example 123 456 789",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
+    }
+  }
+}

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -1,0 +1,31 @@
+{
+  "marital-status": {
+    "page-title": "Marital status",
+    "marital-status": "What is your current marital status?",
+    "spouse-or-commonlaw": "Spouse or common-law partner information",
+    "provide-sin": "Provide the SIN of your current spouse or common-law partner. The information is required to calculate your adjusted family net income.",
+    "required-information": "Your spouse or common-law partner must submit their own application or renewal for the Canadian Dental Care Plan.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Social Insurance Number (SIN)",
+    "year-of-birth": "Year of birth",
+    "single-legal-name": "If your spouse or common-law partner has a single legal name",
+    "name-instructions": "If using a single legal name, please enter that name in BOTH the first name and last name fields.",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "help-message": {
+      "sin": "Enter the 9-digit SIN"
+    },
+    "error-message": {
+      "marital-status-required": "Select marital status",
+      "marital-status-no-partner-information": "If you are married or in a common-law relationship you must enter their information on the next page. Select your marital status and press 'Save'.",
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-year-required": "Year of birth is required",
+      "sin-required": "Enter 9-digit SIN, for example 123 456 789",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
+    }
+  }
+}


### PR DESCRIPTION
### Description
adds `adult-child` flow for the renew application
adds:
- `route-helpers/renew-adult-child-route-helpers.server.ts`
- `/marital-status`
- blank `/confirmation` (needed by route-helper otherwise will 500)
- new locales files and types added to `types.d.ts`
- page ids and routes added to their respective files

### Related Azure Boards Work Items
[AB#4586](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4586)