### PR TITLE
[gitops] Bumping int, perf, staging, training to `3.5.0-RC120`

### DIFF
--- a/gitops/overlays/int/configs/frontend/config.conf
+++ b/gitops/overlays/int/configs/frontend/config.conf
@@ -1,4 +1,9 @@
 LOG_LEVEL=debug
+
+#
+# ECAS & SCCH/MSCA-D configuration
+#
+ECAS_BASE_URI=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca
 SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
 
 #

--- a/gitops/overlays/int/patches/deployments.yaml
+++ b/gitops/overlays/int/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.4.0-RC118
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.5.0-RC120
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/perf/configs/frontend/config.conf
+++ b/gitops/overlays/perf/configs/frontend/config.conf
@@ -1,6 +1,7 @@
 #
-# SCCH/MSCA-D base URL -- used as a base URL for all SCCH calls
+# ECAS & SCCH/MSCA-D configuration
 #
+ECAS_BASE_URI=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca
 SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
 
 #

--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.4.0-RC118
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.5.0-RC120
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/staging/configs/frontend/config.conf
+++ b/gitops/overlays/staging/configs/frontend/config.conf
@@ -1,4 +1,9 @@
 LOG_LEVEL=debug
+
+#
+# ECAS & SCCH/MSCA-D configuration
+#
+ECAS_BASE_URI=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca
 SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
 
 #

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.4.0-RC118
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.5.0-RC120
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.4.0-RC118
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.5.0-RC120
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
![image](https://github.com/user-attachments/assets/e7a6ed18-61f5-4ce9-aa97-674dbd7a7c3d)

`training` isn't hooked up to an ECAS environment so we'll use the default `ECAS_BASE_URI` value.