### PR TITLE
Enable `future.v3_singleFetch`

### DIFF
--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -86,4 +86,9 @@ declare module '@remix-run/server-runtime' {
     serviceProvider: ContainerServiceProvider;
     session: Session;
   }
+
+  interface Future {
+    // see: https://remix.run/docs/en/main/guides/single-fetch#type-inference
+    v3_singleFetch: true;
+  }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
             unstable_optimizeDeps: true,
             v3_fetcherPersist: true,
             v3_relativeSplatPath: true,
+            v3_singleFetch: true,
             v3_throwAbortReason: true,
           },
         }),


### PR DESCRIPTION
### Description

The `future.v3_singleFetch` optimizes how Remix handles data fetching by preventing duplicate fetches at the server level. Here's what it specifically improves:

- **Performance Optimization:** without this flag, Remix might make the same fetch request multiple times -- once during SSR and again during hydration. With `future.v3_singleFetch`, Remix caches the result of the first fetch and reuses it.
- **Future Compatibility:** this flag is part of Remix's v3 features. Adopting it now makes your application more ready for v3 when it releases.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

Single fetch will be the default in the next major release of Remix (React Router v7).

- See: https://remix.run/docs/en/main/guides/single-fetch
