### PR TITLE
add federal-provincial-territorial-benefits route to renew-adult-child-flow

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -867,6 +867,22 @@
                   "en": "/:lang/renew/:id/adult-child/update-address",
                   "fr": "/:lang/renew/:id/adult-child/update-address"
                 }
+              },
+              {
+                "id": "public/renew/$id/adult-child/dental-insurance",
+                "file": "routes/public/renew/$id/adult-child/dental-insurance.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/dental-insurance",
+                  "fr": "/:lang/renew/:id/adult-child/dental-insurance"
+                }
+              },
+              {
+                "id": "public/renew/$id/adult-child/federal-provincial-territorial-benefits",
+                "file": "routes/public/renew/$id/adult-child/federal-provincial-territorial-benefits.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/federal-provincial-territorial-benefits",
+                  "fr": "/:lang/renew/:id/adult-child/federal-provincial-territorial-benefits"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -105,7 +105,9 @@
         "confirmPhone": "CDCP-RENW-ADCH-0002",
         "confirmEmail": "CDCP-RENW-ADCH-0003",
         "confirmAddress": "CDCP-RENW-ADCH-0004",
-        "updateAddress": "CDCP-RENW-ADCH-0005"
+        "updateAddress": "CDCP-RENW-ADCH-0005",
+        "dentalInsurance": "CDCP-RENW-ITA-0006",
+        "federalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0007"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -1,0 +1,368 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button, ButtonLink } from '~/components/buttons';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
+import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { getEnv } from '~/utils/env-utils.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+enum HasFederalBenefitsOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+enum HasProvincialTerritorialBenefitsOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.federalProvincialTerritorialBenefits,
+  pageTitleI18nKey: 'renew-adult-child:dental-benefits.title',
+};
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = getEnv();
+
+  const state = loadRenewAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const federalSocialPrograms = serviceProvider.getFederalGovernmentInsurancePlanService().listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
+  const provinceTerritoryStates = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provincialTerritorialSocialPrograms = serviceProvider.getProvincialGovernmentInsurancePlanService().listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:dental-benefits.title') }) };
+
+  return json({
+    csrfToken,
+    defaultState: state.dentalBenefits,
+    editMode: state.editMode,
+    federalSocialPrograms,
+    id: state.id,
+    meta,
+    provincialTerritorialSocialPrograms,
+    provinceTerritoryStates,
+  });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/federal-provincial-territorial');
+  const state = loadRenewAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // NOTE: state validation schemas are independent otherwise user have to anwser
+  // both question first before the superRefine can be executed
+  const federalBenefitsSchema = z
+    .object({
+      hasFederalBenefits: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:dental-benefits.error-message.federal-benefit-required') }) }),
+      federalSocialProgram: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasFederalBenefits) {
+        if (!val.federalSocialProgram || validator.isEmpty(val.federalSocialProgram)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:dental-benefits.error-message.federal-benefit-program-required'), path: ['federalSocialProgram'] });
+        }
+      }
+    })
+    .transform((val) => {
+      return {
+        ...val,
+        federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
+      };
+    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+
+  const provincialTerritorialBenefitsSchema = z
+    .object({
+      hasProvincialTerritorialBenefits: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:dental-benefits.error-message.provincial-benefit-required') }) }),
+      provincialTerritorialSocialProgram: z.string().trim().optional(),
+      province: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasProvincialTerritorialBenefits) {
+        if (!val.province || validator.isEmpty(val.province)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:dental-benefits.error-message.provincial-territorial-required'), path: ['province'] });
+        } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:dental-benefits.error-message.provincial-benefit-program-required'), path: ['provincialTerritorialSocialProgram'] });
+        }
+      }
+    })
+    .transform((val) => {
+      return {
+        ...val,
+        province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
+        provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
+      };
+    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const dentalBenefits = {
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
+    province: formData.get('province') ? String(formData.get('province')) : undefined,
+  };
+
+  const parsedFederalBenefitsResult = federalBenefitsSchema.safeParse(dentalBenefits);
+  const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
+
+  if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
+    return json({
+      errors: {
+        ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
+        ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+      },
+    });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      dentalBenefits: {
+        ...parsedFederalBenefitsResult.data,
+        ...parsedProvincialTerritorialBenefitsResult.data,
+      },
+      editMode: true, // last step in the flow
+    },
+  });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
+}
+
+export default function RenewAdultChildFederalProvincialTerritorialBenefits() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);
+  const [hasProvincialTerritorialBenefitValue, setHasProvincialTerritorialBenefitValue] = useState(defaultState?.hasProvincialTerritorialBenefits);
+  const [provincialTerritorialSocialProgramValue, setProvincialTerritorialSocialProgramValue] = useState(defaultState?.provincialTerritorialSocialProgram);
+  const [provinceValue, setProvinceValue] = useState(defaultState?.province);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasFederalBenefits: 'input-radio-has-federal-benefits-option-0',
+    federalSocialProgram: 'input-radio-federal-social-programs-option-0',
+    hasProvincialTerritorialBenefits: 'input-radio-has-provincial-territorial-benefits-option-0',
+    province: 'province',
+    provincialTerritorialSocialProgram: 'input-radio-provincial-territorial-social-programs-option-0',
+  });
+
+  function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+  }
+
+  function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
+    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+      setProvinceValue(undefined);
+      setProvincialTerritorialSocialProgramValue(undefined);
+    }
+  }
+
+  function handleOnProvincialTerritorialSocialProgramChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setProvincialTerritorialSocialProgramValue(e.target.value);
+  }
+
+  function handleOnRegionChanged(e: React.ChangeEvent<HTMLSelectElement>) {
+    setProvinceValue(e.target.value);
+    setProvincialTerritorialSocialProgramValue(undefined);
+  }
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={88} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4">{t('renew-adult-child:dental-benefits.access-to-dental')}</p>
+        <p className="mb-4">{t('renew-adult-child:dental-benefits.eligibility-criteria')}</p>
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <fieldset className="mb-6">
+            <legend className="mb-4 font-lato text-2xl font-bold">{t('renew-adult-child:dental-benefits.federal-benefits.title')}</legend>
+            <InputRadios
+              id="has-federal-benefits"
+              name="hasFederalBenefits"
+              legend={t('renew-adult-child:dental-benefits.federal-benefits.legend')}
+              helpMessagePrimary={t('renew-adult-child:dental-benefits.federal-benefits.help-message')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:dental-benefits.federal-benefits.option-yes" />,
+                  value: HasFederalBenefitsOption.Yes,
+                  defaultChecked: hasFederalBenefitValue === true,
+                  onChange: handleOnHasFederalBenefitChanged,
+                  append: hasFederalBenefitValue === true && (
+                    <InputRadios
+                      id="federal-social-programs"
+                      name="federalSocialProgram"
+                      legend={t('renew-adult-child:dental-benefits.federal-benefits.social-programs.legend')}
+                      legendClassName="font-normal"
+                      options={federalSocialPrograms.map((option) => ({
+                        children: option.name,
+                        defaultChecked: defaultState?.federalSocialProgram === option.id,
+                        value: option.id,
+                      }))}
+                      errorMessage={errors?.federalSocialProgram}
+                      required
+                    />
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:dental-benefits.federal-benefits.option-no" />,
+                  value: HasFederalBenefitsOption.No,
+                  defaultChecked: hasFederalBenefitValue === false,
+                  onChange: handleOnHasFederalBenefitChanged,
+                },
+              ]}
+              errorMessage={errors?.hasFederalBenefits}
+              required
+            />
+          </fieldset>
+          <fieldset className="mb-8">
+            <legend className="mb-4 font-lato text-2xl font-bold">{t('renew-adult-child:dental-benefits.provincial-territorial-benefits.title')}</legend>
+            <InputRadios
+              id="has-provincial-territorial-benefits"
+              name="hasProvincialTerritorialBenefits"
+              legend={t('renew-adult-child:dental-benefits.provincial-territorial-benefits.legend')}
+              helpMessagePrimary={t('renew-adult-child:dental-benefits.provincial-territorial-benefits.help-message')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:dental-benefits.provincial-territorial-benefits.option-yes" />,
+                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
+                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  append: hasProvincialTerritorialBenefitValue === true && (
+                    <div className="space-y-6">
+                      <InputSelect
+                        id="province"
+                        name="province"
+                        className="w-full sm:w-1/2"
+                        label={t('renew-adult-child:dental-benefits.provincial-territorial-benefits.social-programs.input-legend')}
+                        onChange={handleOnRegionChanged}
+                        options={[
+                          {
+                            children: t('renew-adult-child:dental-benefits.select-one'),
+                            value: '',
+                            hidden: true,
+                          },
+                          ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                        ]}
+                        defaultValue={provinceValue}
+                        errorMessage={errors?.province}
+                        required
+                      />
+                      {provinceValue && (
+                        <InputRadios
+                          id="provincial-territorial-social-programs"
+                          name="provincialTerritorialSocialProgram"
+                          legend={t('renew-adult-child:dental-benefits.provincial-territorial-benefits.social-programs.radio-legend')}
+                          legendClassName="font-normal"
+                          errorMessage={errors?.provincialTerritorialSocialProgram}
+                          options={provincialTerritorialSocialPrograms
+                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                            .map((option) => ({
+                              children: option.name,
+                              value: option.id,
+                              checked: provincialTerritorialSocialProgramValue === option.id,
+                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                            }))}
+                          required
+                        />
+                      )}
+                    </div>
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:dental-benefits.provincial-territorial-benefits.option-no" />,
+                  value: HasProvincialTerritorialBenefitsOption.No,
+                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                },
+              ]}
+              errorMessage={errors?.hasProvincialTerritorialBenefits}
+              required
+            />
+          </fieldset>
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental benefits click">
+                {t('renew-adult-child:dental-benefits.button.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/review-adult-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental benefits click"
+              >
+                {t('renew-adult-child:dental-benefits.button.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Access to other dental benefits click">
+                {t('renew-adult-child:dental-benefits.button.continue')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/dental-insurance"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to other dental benefits click"
+              >
+                {t('renew-adult-child:dental-benefits.button.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -144,5 +144,45 @@
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
+  },
+  "dental-benefits": {
+    "title": "Access to other federal, provincial or territorial dental benefits",
+    "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
+    "select-one": "Select one",
+    "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
+    "federal-benefits": {
+      "title": "Federal benefits",
+      "legend": "Has your access to federal benefits changed since you applied for the Canadian Dental Care Plan?",
+      "help-message": "The government benefits we have on file can also be found on the renewal letter you received from Service Canada.",
+      "option-yes": "<strong>Yes</strong>, my <strong>federal</strong> benefits have changed.",
+      "option-no": "<strong>No</strong>, my <strong>federal</strong> benefits have not changed.",
+      "social-programs": {
+        "legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "provincial-territorial-benefits": {
+      "title": "Provincial or territorial benefits",
+      "legend": "Has your access to provincial or territorial benefits changed since you applied for the Canadian Dental Care Plan?",
+      "help-message": "The government benefits we have on file can also be found on the renewal letter you received from Service Canada.",
+      "option-yes": "<strong>Yes</strong>, my <strong>provincial or territorial</strong> benefits have changed.",
+      "option-no": "<strong>No</strong>, my <strong>provincial or territorial</strong> benefits have not changed.",
+      "social-programs": {
+        "input-legend": "Through which province or territory?",
+        "radio-legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "error-message": {
+      "federal-benefit-program-required": "Select which federal program you are covered under",
+      "federal-benefit-required": "Select whether you have federal dental benefits",
+      "provincial-benefit-program-required": "Select which provincial or territorial program you are covered under",
+      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
+      "provincial-territorial-required": "Select a province or territory"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -144,5 +144,43 @@
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
     }
+  },
+  "dental-benefits": {
+    "title": "Access to other federal, provincial or territorial dental benefits",
+    "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
+    "select-one": "Select one",
+    "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
+    "federal-benefits": {
+      "title": "Federal benefits",
+      "legend": "Do you have dental benefits through a federal social program?",
+      "option-yes": "<strong>Yes</strong>, I have <strong>federal</strong> dental benefits",
+      "option-no": "<strong>No</strong>, I do not have <strong>federal</strong> dental benefits",
+      "social-programs": {
+        "legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "provincial-territorial-benefits": {
+      "title": "Provincial or territorial benefits",
+      "legend": "Do you have dental benefits through a provincial or territorial social program?",
+      "option-yes": "<strong>Yes</strong>, I have <strong>provincial or territorial</strong> dental benefits",
+      "option-no": "<strong>No</strong>, I do not have <strong>provincial or territorial</strong> dental benefits",
+      "social-programs": {
+        "input-legend": "Through which province or territory?",
+        "radio-legend": "Please select which social program you are covered under. If you have more than one, please select the one you use most."
+      }
+    },
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "error-message": {
+      "federal-benefit-program-required": "Select which federal program you are covered under",
+      "federal-benefit-required": "Select whether you have federal dental benefits",
+      "provincial-benefit-program-required": "Select which provincial or territorial program you are covered under",
+      "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
+      "provincial-territorial-required": "Select a province or territory"
+    }
   }
 }


### PR DESCRIPTION
### Description
- adds `renew/$id/adult-child/federal-provincial-territorial-benefits`
- adds empty `renew/$id/adult-child/dental-insurance` route to prevent `500`ing on page load

### Related Azure Boards Work Items
[AB#4586](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4586)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b203edbf-bf37-436c-9184-e78c041e2125)
