### PR TITLE
add review-child-information route to renew-adult-child flow

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -914,6 +914,14 @@
                     }
                   }
                 ]
+              },
+              {
+                "id": "public/renew/$id/adult-child/review-child-information",
+                "file": "routes/public/renew/$id/adult-child/review-child-information.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/review-child-information",
+                  "fr": "/:lang/renew/:id/adult-child/review-child-information"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -108,7 +108,8 @@
         "updateAddress": "CDCP-RENW-ADCH-0005",
         "dentalInsurance": "CDCP-RENW-ITA-0006",
         "federalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0007",
-        "childInformation": "CDCP-APPL-ADCH-0008"
+        "childInformation": "CDCP-APPL-ADCH-0008",
+        "reviewChildInformation": "CDCP-APPL-ADCH-0010"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -1,0 +1,306 @@
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { Button } from '~/components/buttons';
+import { DebugPayload } from '~/components/debug-payload';
+import { DescriptionListItem } from '~/components/description-list-item';
+import { InlineLink } from '~/components/inline-link';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { toBenefitRenewRequestFromRenewAdultChildState } from '~/mappers/benefit-renewal-service-mappers.server';
+import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
+import { loadRenewAdultChildStateForReview } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import { clearRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
+import { getEnv } from '~/utils/env-utils.server';
+import { useHCaptcha } from '~/utils/hcaptcha-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Back = 'back',
+  Submit = 'submit',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.reviewChildInformation,
+  pageTitleI18nKey: 'renew-adult-child:review-child-information.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultChildStateForReview({ params, request, session });
+
+  // renew state is valid then edit mode can be set to true
+  saveRenewState({ params, session, state: { editMode: true } });
+
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:review-child-information.page-title') }) };
+
+  const payload = viewPayloadEnabled && toBenefitRenewRequestFromRenewAdultChildState(state);
+
+  const children = state.children.map((child) => {
+    const selectedFederalGovernmentInsurancePlan = child.dentalBenefits.federalSocialProgram
+      ? serviceProvider.getFederalGovernmentInsurancePlanService().getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+      : undefined;
+
+    const selectedProvincialBenefit = child.dentalBenefits.provincialTerritorialSocialProgram
+      ? serviceProvider.getProvincialGovernmentInsurancePlanService().getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+      : undefined;
+
+    return {
+      id: child.id,
+      firstName: child.information.firstName,
+      lastName: child.information.lastName,
+      birthday: child.information.dateOfBirth,
+      clientNumber: child.information.clientNumber,
+      isParent: child.information.isParent,
+      dentalInsurance: {
+        acessToDentalInsurance: child.dentalInsurance,
+        federalBenefit: {
+          access: child.dentalBenefits.hasFederalBenefits,
+          benefit: selectedFederalGovernmentInsurancePlan?.name,
+        },
+        provTerrBenefit: {
+          access: child.dentalBenefits.hasProvincialTerritorialBenefits,
+          province: child.dentalBenefits.province,
+          benefit: selectedProvincialBenefit?.name,
+        },
+      },
+    };
+  });
+
+  return json({
+    id: state.id,
+    children,
+    csrfToken,
+    meta,
+    siteKey: HCAPTCHA_SITE_KEY,
+    hCaptchaEnabled,
+    payload,
+  });
+}
+
+export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/review-child-information');
+
+  const state = loadRenewAdultChildStateForReview({ params, request, session });
+
+  const { ENABLED_FEATURES } = getEnv();
+  const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  if (formAction === FormAction.Back) {
+    saveRenewState({ params, session, state: {} });
+    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
+  }
+
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  if (hCaptchaEnabled) {
+    const hCaptchaResponse = String(formData.get('h-captcha-response') ?? '');
+    if (!(await hCaptchaRouteHelpers.verifyHCaptchaResponse(hCaptchaResponse, request))) {
+      clearRenewState({ params, session });
+      return redirect(getPathById('public/unable-to-process-request', params));
+    }
+  }
+
+  const submissionInfo = await serviceProvider.getBenefitRenewalService().createBenefitRenewal(state);
+
+  saveRenewState({ params, session, state: { submissionInfo } });
+
+  return redirect(getPathById('public/renew/$id/adult-child/confirmation', params));
+}
+
+export default function RenewAdultChildReviewChildInformation() {
+  const params = useParams();
+  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { children, csrfToken, siteKey, hCaptchaEnabled, payload } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const { captchaRef } = useHCaptcha();
+  const [submitAction, setSubmitAction] = useState<string>();
+
+  function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={99} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="my-4 text-lg">{t('renew-adult-child:review-child-information.read-carefully')}</p>
+        <div className="space-y-10">
+          {children.map((child) => {
+            const childParams = { ...params, childId: child.id };
+            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), i18n.language);
+            return (
+              <section key={child.id} className="space-y-8">
+                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                <section className="space-y-6">
+                  <h3 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-child-information.page-sub-title', { child: child.firstName })}</h3>
+                  <dl className="divide-y border-y">
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.full-name-title')}>
+                      {`${child.firstName} ${child.lastName}`}
+                      <p className="mt-4">
+                        <InlineLink id="change-full-name" routeId="public/renew/$id/adult-child/children/$childId/information" params={childParams}>
+                          {t('renew-adult-child:review-child-information.full-name-change')}
+                        </InlineLink>
+                      </p>
+                    </DescriptionListItem>
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.dob-title')}>
+                      {dateOfBirth}
+                      <p className="mt-4">
+                        <InlineLink id="change-date-of-birth" routeId="public/renew/$id/adult-child/children/$childId/information" params={childParams}>
+                          {t('renew-adult-child:review-child-information.dob-change')}
+                        </InlineLink>
+                      </p>
+                    </DescriptionListItem>
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.client-number-title')}>
+                      {child.clientNumber}
+                      <p className="mt-4">
+                        <InlineLink id="client-number" routeId="public/renew/$id/adult-child/children/$childId/information" params={childParams}>
+                          {t('renew-adult-child:review-child-information.client-number-change')}
+                        </InlineLink>
+                      </p>
+                    </DescriptionListItem>
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.is-parent')}>{child.isParent ? t('renew-adult-child:review-child-information.yes') : t('renew-adult-child:review-child-information.no')}</DescriptionListItem>
+                  </dl>
+                </section>
+                <section className="space-y-6">
+                  <h3 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-child-information.dental-title', { child: child.firstName })}</h3>
+                  <dl className="divide-y border-y">
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.dental-insurance-title')}>
+                      {child.dentalInsurance.acessToDentalInsurance ? t('renew-adult-child:review-child-information.yes') : t('renew-adult-child:review-child-information.no')}
+                      <p className="mt-4">
+                        <InlineLink id="change-access-dental" routeId="public/renew/$id/adult-child/children/$childId/dental-insurance" params={childParams}>
+                          {t('renew-adult-child:review-child-information.dental-insurance-change')}
+                        </InlineLink>
+                      </p>
+                    </DescriptionListItem>
+                    <DescriptionListItem term={t('renew-adult-child:review-child-information.dental-benefit-title')}>
+                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                        <>
+                          <p>{t('renew-adult-child:review-child-information.yes')}</p>
+                          <p>{t('renew-adult-child:review-child-information.dental-benefit-has-access')}</p>
+                          <div>
+                            <ul className="ml-6 list-disc">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        </>
+                      ) : (
+                        <>{t('renew-adult-child:review-child-information.no')}</>
+                      )}
+                      <p className="mt-4">
+                        <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult-child/children/$childId/federal-provincial-territorial-benefits" params={childParams}>
+                          {t('renew-adult-child:review-child-information.dental-benefit-change')}
+                        </InlineLink>
+                      </p>
+                    </DescriptionListItem>
+                  </dl>
+                </section>
+              </section>
+            );
+          })}
+          <section className="space-y-4">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-child-information.submit-app-title')}</h2>
+            <p className="mb-4">{t('renew-adult-child:review-child-information.submit-p-proceed')}</p>
+            <p className="mb-4">{t('renew-adult-child:review-child-information.submit-p-false-info')}</p>
+            <p className="mb-4">{t('renew-adult-child:review-child-information.submit-p-repayment')}</p>
+          </section>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton
+              id="confirm-button"
+              name="_action"
+              value={FormAction.Submit}
+              variant="green"
+              disabled={isSubmitting}
+              loading={isSubmitting && submitAction === FormAction.Submit}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Submit - Review child(ren) information click"
+            >
+              {t('renew-adult-child:review-child-information.submit-button')}
+            </LoadingButton>
+            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Review child(ren) information click">
+              {t('renew-adult-child:review-child-information.back-button')}
+            </Button>
+          </div>
+        </fetcher.Form>
+        <div className="mt-8">
+          <InlineLink routeId="public/renew/$id/adult-child/exit-application" params={params}>
+            {t('renew-adult-child:review-child-information.exit-button')}
+          </InlineLink>
+        </div>
+      </div>
+      {payload && (
+        <div className="mt-8">
+          <DebugPayload data={payload} enableCopy></DebugPayload>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -290,5 +290,33 @@
         "dental-insurance-required": "Select whether the child has access to dental insurance"
       }
     }
+  },
+  "review-child-information": {
+    "read-carefully": "Review this information carefully. The information provided will be used to update your child(ren)'s Canadian Dental Care Plan member account.",
+    "page-title": "Review child(ren) information",
+    "page-sub-title": "{{child}} information",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "is-parent": "Parent or legal guardian of child",
+    "client-number-title": "Client number",
+    "client-number-change": "Change client number",
+    "full-name-title": "Full name",
+    "full-name-change": "Change full name",
+    "dental-title": "{{child}} access to dental insurance",
+    "dental-insurance-title": "Access to other dental insurance or coverage",
+    "dental-insurance-change": "Change answer to dental insurance",
+    "dental-benefit-title": "Access to government dental benefits",
+    "dental-benefit-change": "Change answer to government dental benefits",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "submit-app-title": "Submit your renewal application",
+    "submit-p-proceed": "By proceeding with this renewal, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
+    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "continue-button": "Continue",
+    "back-button": "Back",
+    "submit-button": "Submit renewal application",
+    "exit-button": "Exit application",
+    "yes": "Yes",
+    "no": "No"
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -288,5 +288,33 @@
         "dental-insurance-required": "Select whether the child has access to dental insurance"
       }
     }
+  },
+  "review-child-information": {
+    "read-carefully": "Review this information carefully. The information provided will be used to update your child(ren)'s Canadian Dental Care Plan member account.",
+    "page-title": "Review child(ren) information",
+    "page-sub-title": "{{child}} information",
+    "dob-title": "Date of birth",
+    "dob-change": "Change date of birth",
+    "is-parent": "Parent or legal guardian of child",
+    "client-number-title": "Client number",
+    "client-number-change": "Change client number",
+    "full-name-title": "Full name",
+    "full-name-change": "Change full name",
+    "dental-title": "{{child}} access to dental insurance",
+    "dental-insurance-title": "Access to other dental insurance or coverage",
+    "dental-insurance-change": "Change answer to dental insurance",
+    "dental-benefit-title": "Access to government dental benefits",
+    "dental-benefit-change": "Change answer to government dental benefits",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "submit-app-title": "Submit your renewal application",
+    "submit-p-proceed": "By proceeding with this renewal, you are agreeing to attest truthfully to the information provided.",
+    "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
+    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "continue-button": "Continue",
+    "back-button": "Back",
+    "submit-button": "Submit renewal application",
+    "exit-button": "Exit application",
+    "yes": "Yes",
+    "no": "No"
   }
 }


### PR DESCRIPTION
### Description
- adds `renew/$id/adult-child/review-child-information`
- adds various helper functions (copy/pasted/modified from the Online Application and adapted to the Renew Application)

### Related Azure Boards Work Items
[AB#4586](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4586)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`