### PR TITLE
Initial implementation of `/api/health`

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -33,6 +33,14 @@
     }
   },
   {
+    "id": "api/health",
+    "file": "routes/api/health.ts",
+    "paths": {
+      "en": "/api/health",
+      "fr": "/api/health"
+    }
+  },
+  {
     "id": "api/readyz",
     "file": "routes/api/readyz.ts",
     "paths": {

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -1,0 +1,60 @@
+import type { LoaderFunctionArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+
+import type { HealthCheck, HealthCheckOptions } from '@dts-stn/health-checks';
+import { HealthCheckConfig, execute, getHttpStatusCode } from '@dts-stn/health-checks';
+import { isEmpty } from 'moderndash';
+
+import { getBuildInfoService } from '~/services/build-info-service.server';
+
+function isAuthorized(request: Request): boolean {
+  return false; // TODO :: GjB :: add authentication check when AAD integration is ready
+}
+
+function toArray(str?: string): string[] | undefined {
+  const result = str?.split(',').filter(Boolean);
+  return isEmpty(result) ? undefined : result;
+}
+
+function toNumber(str?: string): number | undefined {
+  const num = parseInt(str ?? '');
+  return isNaN(num) ? undefined : num;
+}
+
+/**
+ * A do-nothing health check intended to be used while testing.
+ */
+const dummyHealthCheck: HealthCheck = {
+  name: 'dummy-check',
+  check: () => new Promise((resolve) => setTimeout(resolve, 2 * 1000)),
+};
+
+export async function loader({ context: { serviceProvider, session }, request }: LoaderFunctionArgs) {
+  const { include, exclude, timeout } = Object.fromEntries(new URL(request.url).searchParams);
+  const { buildRevision: buildId, buildVersion: version } = getBuildInfoService().getBuildInfo();
+
+  const healthCheckOptions: HealthCheckOptions = {
+    excludeComponents: toArray(exclude),
+    includeComponents: toArray(include),
+    includeDetails: isAuthorized(request),
+    metadata: { buildId, version },
+    timeout: toNumber(timeout),
+  };
+
+  //
+  // TODO :: GjB ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+  //
+  //   - add actual, non-dummy health checks
+  //   - include details when isAuthorized()
+  //   - cache execute() response for a short period (ie: rate-limiting)
+  //
+  // TODO :: GjB ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+  //
+
+  const systemHealthSummary = await execute([dummyHealthCheck], healthCheckOptions);
+
+  return json(systemHealthSummary, {
+    headers: { 'Content-Type': HealthCheckConfig.responses.contentType },
+    status: getHttpStatusCode(systemHealthSummary.status),
+  });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@date-fns/utc": "^2.1.0",
+        "@dts-stn/health-checks": "^1.0.0",
         "@faker-js/faker": "^9.0.3",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
@@ -925,6 +926,15 @@
       "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.0.tgz",
       "integrity": "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==",
       "license": "MIT"
+    },
+    "node_modules/@dts-stn/health-checks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dts-stn/health-checks/-/health-checks-1.0.0.tgz",
+      "integrity": "sha512-pzkfOW7MYHfNH1RsWD9o+z22YpR/NSe3pwQFCO57Kj5GGjYMiL7GJZjYbTP2xb+PE6skLJo4FUsmLQ/MRvyfqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@date-fns/utc": "^2.1.0",
+    "@dts-stn/health-checks": "^1.0.0",
     "@faker-js/faker": "^9.0.3",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-regular-svg-icons": "^6.6.0",


### PR DESCRIPTION
### Description

This is an incremental PR that adds the boilerplate required for a new `/api/health` endpoint.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

``` shell
➜  frontend git:(development) curl --dump-header /dev/stderr --silent 'http://localhost:3000/api/health' | jq
HTTP/1.1 200 OK

{
  "buildId": "00000000",
  "components": [
    {
      "dummy-check": {
        "status": "HEALTHY",
        "responseTime": 2001
      }
    }
  ],
  "responseTime": 2001,
  "status": "HEALTHY",
  "version": "0.0.0"
}
```

``` shell
➜  frontend git:(development) curl --dump-header /dev/stderr --silent 'http://localhost:3000/api/health?timeout=100' | jq
HTTP/1.1 500 Internal Server Error

{
  "buildId": "00000000",
  "components": [
    {
      "dummy-check": {
        "status": "UNKNOWN",
        "responseTime": 100
      }
    }
  ],
  "responseTime": 101,
  "status": "UNKNOWN",
  "version": "0.0.0"
}
```

### Additional Notes

This is an incremental PR that only adds boilerplate (to keep this and future PRs small). The actual health checks will be added separately in future PRs.
