### PR TITLE
Refactoring endpoint for submitting renewal and removing unused mock

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -195,7 +195,7 @@ REDIS_PASSWORD=password
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress,client-application
+ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -1,5 +1,5 @@
 export type BenefitRenewalRequestEntity = Readonly<{
-  BenefitRenewal: Readonly<{
+  BenefitApplication: Readonly<{
     Applicant: Readonly<{
       ApplicantDetail: Readonly<{
         PrivateDentalInsuranceIndicator?: boolean;
@@ -114,7 +114,7 @@ export type BenefitRenewalRequestEntity = Readonly<{
 }>;
 
 export type BenefitRenewalResponseEntity = Readonly<{
-  BenefitRenewal: Readonly<{
+  BenefitApplication: Readonly<{
     BenefitRenewalIdentification: ReadonlyArray<
       Readonly<{
         IdentificationID: string;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -32,7 +32,7 @@ export class BenefitRenewalDtoMapperImpl implements BenefitRenewalDtoMapper {
 
   mapBenefitRenewalResponseEntityToBenefitRenewalResponseDto(benefitRenewalResponseEntity: BenefitRenewalResponseEntity): BenefitRenewalResponseDto {
     return {
-      confirmationCode: benefitRenewalResponseEntity.BenefitRenewal.BenefitRenewalIdentification[0].IdentificationID,
+      confirmationCode: benefitRenewalResponseEntity.BenefitApplication.BenefitRenewalIdentification[0].IdentificationID,
       submittedOn: new UTCDate().toISOString(),
     };
   }
@@ -98,7 +98,7 @@ function toBenefitRenewalRequest({
   addressInformation,
 }: ToBenefitRenewalRequestArgs): BenefitRenewalRequestEntity {
   return {
-    BenefitRenewal: {
+    BenefitApplication: {
       Applicant: {
         ApplicantDetail: {
           PrivateDentalInsuranceIndicator: dentalInsurance,

--- a/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
+++ b/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
@@ -30,9 +30,10 @@ export class BenefitRenewalRepositoryImpl implements BenefitRenewalRepository {
   async createBenefitRenewal(benefitRenewalRequest: BenefitRenewalRequestEntity): Promise<BenefitRenewalResponseEntity> {
     this.log.trace('Submiting benefit renewal for request [%j]', benefitRenewalRequest);
 
-    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/benefit-renewal`);
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/benefit-application`);
+    url.searchParams.set('scenario', 'RENEWAL');
 
-    const response = await instrumentedFetch(getFetchFn(this.serverConfig.HTTP_PROXY_URL), 'http.client.interop-api.client-application.posts', url, {
+    const response = await instrumentedFetch(getFetchFn(this.serverConfig.HTTP_PROXY_URL), 'http.client.interop-api.benefit-application_renewal.posts', url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
+++ b/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
@@ -114,7 +114,7 @@ function toBenefitRenewalRequest({
   children,
 }: ToBenefitRenewalRequestArgs): BenefitRenewalRequest {
   return {
-    BenefitRenewal: {
+    BenefitApplication: {
       Applicant: {
         ApplicantDetail: {
           PrivateDentalInsuranceIndicator: dentalInsurance,

--- a/frontend/app/schemas/benefit-renewal-service-schemas.server.ts
+++ b/frontend/app/schemas/benefit-renewal-service-schemas.server.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const benefitRenewalRequestSchema = z.object({
-  BenefitRenewal: z.object({
+  BenefitApplication: z.object({
     Applicant: z.object({
       ApplicantDetail: z.object({
         PrivateDentalInsuranceIndicator: z.boolean().optional(),
@@ -122,7 +122,7 @@ export const benefitRenewalRequestSchema = z.object({
 export type BenefitRenewalRequest = z.infer<typeof benefitRenewalRequestSchema>;
 
 export const benefitRenewalResponseSchema = z.object({
-  BenefitRenewal: z.object({
+  BenefitApplication: z.object({
     BenefitRenewalIdentification: z.array(
       z.object({
         IdentificationID: z.string(),

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -19,7 +19,7 @@ function tryOrElseFalse(fn: () => unknown) {
   catch { return false; }
 }
 
-const validMockNames = ['cct', 'power-platform', 'raoidc', 'status-check', 'wsaddress', 'client-application'] as const;
+const validMockNames = ['cct', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 // refiners


### PR DESCRIPTION
### Description
Submitting a renewal application will reuse the online benefit application submission endpoint except with an extra query param (`scenario=RENEWAL`).

Also remove unused `client-application` mock because it's not used or referenced anywhere.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and submit an ITA renewal application