### PR TITLE
AB#4731 B9-1 Parent/legal guardian screen

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -914,6 +914,14 @@
                     }
                   },
                   {
+                    "id": "public/renew/$id/adult-child/children/$childId/parent-or-guardian",
+                    "file": "routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx",
+                    "paths": {
+                      "en": "/:lang/renew/:id/adult-child/children/:childId/parent-or-guardian",
+                      "fr": "/:lang/renew/:id/adult-child/children/:childId/parent-ou-tuteur"
+                    }
+                  },
+                  {
                     "id": "public/renew/$id/adult-child/children/$childId/dental-insurance",
                     "file": "routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx",
                     "paths": {

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -109,8 +109,9 @@
         "dentalInsurance": "CDCP-RENW-ITA-0006",
         "federalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0007",
         "childInformation": "CDCP-APPL-ADCH-0008",
-        "childFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0009",
-        "reviewChildInformation": "CDCP-APPL-ADCH-0010"
+        "parentOrGuardian": "CDCP-APPL-ADCH-0009",
+        "childFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-00010",
+        "reviewChildInformation": "CDCP-APPL-ADCH-0011"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -108,8 +108,8 @@
         "updateAddress": "CDCP-RENW-ADCH-0005",
         "dentalInsurance": "CDCP-RENW-ITA-0006",
         "federalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0007",
-        "childInformation": "CDCP-APPL-ADCH-0008",
-        "parentOrGuardian": "CDCP-APPL-ADCH-0009",
+        "childInformation": "CDCP-RENW-ADCH-0008",
+        "parentOrGuardian": "CDCP-RENW-ADCH-0009",
         "childFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-00010",
         "reviewChildInformation": "CDCP-APPL-ADCH-0011"
       }

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -1,0 +1,97 @@
+import type { FormEvent } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../../../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { LoadingButton } from '~/components/loading-button';
+import { loadRenewAdultSingleChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.parentOrGuardian,
+  pageTitleI18nKey: 'renew-adult-child:children.parent-or-guardian.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  loadRenewAdultSingleChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:children.parent-or-guardian.page-title') }) };
+
+  return json({ csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/children/parent-or-guardian');
+
+  loadRenewAdultSingleChildState({ params, request, session });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  // TODO: The link is unsure at the moment. For now, the 'Proceed to apply for yourself' button will return to the chhildren index
+  return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
+}
+
+export default function RenewFlowParentOrGuardian() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    fetcher.submit(event.currentTarget, { method: 'POST' });
+    sessionStorage.removeItem('flow.state');
+  }
+
+  return (
+    <>
+      <div className="mb-8 space-y-4">
+        <p>{t('renew-adult-child:children.parent-or-guardian.must-be')}</p>
+        <p>{t('renew-adult-child:children.parent-or-guardian.unable-to-apply')}</p>
+      </div>
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink
+          id="back-button"
+          routeId="public/renew/$id/adult-child/children/$childId/information"
+          params={params}
+          disabled={isSubmitting}
+          startIcon={faChevronLeft}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Child must be a parent or legal guardian click"
+        >
+          {t('renew-adult-child:children.parent-or-guardian.back-btn')}
+        </ButtonLink>
+        <LoadingButton type="submit" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Child must be a parent or legal guardian click">
+          {t('renew-adult-child:children.parent-or-guardian.continue-btn')}
+        </LoadingButton>
+      </fetcher.Form>
+    </>
+  );
+}

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -287,6 +287,13 @@
         "no-digits": "Last name must contain letters only"
       }
     },
+    "parent-or-guardian": {
+      "page-title": "You must be a parent or legal guardian",
+      "must-be": "You must be a parent or legal guardian.",
+      "unable-to-apply": "You are not able to apply for this child. You must be a parent or legal guardian to apply on behalf of a child.",
+      "back-btn": "Back",
+      "continue-btn": "Proceed to apply for yourself"
+    },
     "dental-insurance": {
       "title": "{{childName}}: access to other dental insurance",
       "legend": "Does {{childName}} have access to dental insurance or coverage:",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -285,6 +285,13 @@
         "no-digits": "Le nom de famille doit contenir uniquement des lettres"
       }
     },
+    "parent-or-guardian": {
+      "page-title": "Vous devez être le parent ou le tuteur légal",
+      "must-be": "Vous devez être le parent ou le tuteur légal",
+      "unable-to-apply": "Vous ne pouvez pas présenter de demande pour cet enfant. Vous devez être le parent ou le tuteur légal d'un enfant pour présenter une demande en son nom.",
+      "back-btn": "Retour",
+      "continue-btn": "Procédez à faire la demande vous-même"
+    },
     "dental-insurance": {
       "title": "{{childName}}: access to other dental insurance",
       "legend": "Does {{childName}} have access to dental insurance or coverage:",


### PR DESCRIPTION
### Description
added `parent-or-guardian` page in renew adult-child flow

### Related Azure Boards Work Items
[AB#4731](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4731)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->