### PR TITLE
add exit-application route to renew-adult-child flow

### DIFF
--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -946,6 +946,14 @@
                   "en": "/:lang/renew/:id/adult-child/review-child-information",
                   "fr": "/:lang/renew/:id/adult-child/review-child-information"
                 }
+              },
+              {
+                "id": "public/renew/$id/adult-child/exit-application",
+                "file": "routes/public/renew/$id/adult-child/exit-application.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/exit-application",
+                  "fr": "/:lang/renew/:id/adult-child/exit-application"
+                }
               }
             ]
           }

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -111,7 +111,8 @@
         "childInformation": "CDCP-RENW-ADCH-0008",
         "parentOrGuardian": "CDCP-RENW-ADCH-0009",
         "childFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-00010",
-        "reviewChildInformation": "CDCP-APPL-ADCH-0011"
+        "reviewChildInformation": "CDCP-APPL-ADCH-0011",
+        "exitApplication": "CDCP-RENw-ITA-0012"
       }
     },
     "unableToProcessRequest": "CDCP-UNAB-0001",

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -1,0 +1,90 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import pageIds from '../../../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { LoadingButton } from '~/components/loading-button';
+import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import { clearRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.exitApplication,
+  pageTitleI18nKey: 'renew-adult-child:exit-application.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+  const { id } = loadRenewAdultChildState({ params, request, session });
+
+  const csrfToken = String(session.get('csrfToken'));
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:exit-application.page-title') }) };
+
+  return json({ id, csrfToken, meta });
+}
+
+export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/exit-application');
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  clearRenewState({ params, session });
+  return redirect(t('exit-application.exit-link'));
+}
+
+export default function RenewAdultChildExitApplication() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <div className="max-w-prose">
+      <div className="mb-8 space-y-4">
+        <p>{t('renew-adult-child:exit-application.are-you-sure')}</p>
+        <p>{t('renew-adult-child:exit-application.click-back')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <input type="hidden" name="_csrf" value={csrfToken} />
+        <ButtonLink
+          id="back-button"
+          routeId="public/renew/$id/adult-child/review-child-information"
+          params={params}
+          disabled={isSubmitting}
+          startIcon={faChevronLeft}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Exiting the application click"
+        >
+          {t('renew-adult-child:exit-application.back-btn')}
+        </ButtonLink>
+        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Exit - Exiting the application click">
+          {t('renew-adult-child:exit-application.exit-btn')}
+        </LoadingButton>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -401,5 +401,13 @@
     "exit-button": "Exit application",
     "yes": "Yes",
     "no": "No"
+  },
+  "exit-application": {
+    "page-title": "Exiting the application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and the information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -399,5 +399,13 @@
     "exit-button": "Exit application",
     "yes": "Yes",
     "no": "No"
+  },
+  "exit-application": {
+    "page-title": "Exiting the application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and the information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }


### PR DESCRIPTION
### Description
adds `renew/$id/adult-child/exit-application`

### Related Azure Boards Work Items
[AB#4586](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4586)