### PR TITLE
refactor(frontend): implement 'configProvider.getServerConfig' in routes

### DIFF
--- a/frontend/__tests__/routes/public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/public/communication-preference.test.tsx
@@ -17,14 +17,6 @@ vi.mock('~/route-helpers/apply-adult-route-helpers.server', () => ({
   }),
 }));
 
-vi.mock('~/utils/env-utils.server', () => ({
-  getEnv: vi.fn().mockReturnValue({
-    COMMUNICATION_METHOD_EMAIL_ID: 'email',
-    ENGLISH_LANGUAGE_CODE: 'en',
-    FRENCH_LANGUAGE_CODE: 'fr',
-  }),
-}));
-
 vi.mock('~/utils/locale-utils.server', () => ({
   getFixedT: vi.fn().mockResolvedValue(vi.fn()),
   getLocale: vi.fn().mockResolvedValue('en'),
@@ -40,6 +32,11 @@ describe('_public.apply.id.communication-preference', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: {
+          getServerConfig: vi.fn().mockReturnValue({
+            COMMUNICATION_METHOD_EMAIL_ID: 'email',
+          }),
+        },
         serviceProvider: {
           getPreferredCommunicationMethodService: () => ({
             listPreferredCommunicationMethods: vi.fn(),
@@ -102,9 +99,17 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('_csrf', 'csrfToken');
       formData.append('preferredLanguage', 'fr');
 
+      const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: {
+          getServerConfig: vi.fn().mockReturnValue({
+            COMMUNICATION_METHOD_EMAIL_ID: 'email',
+          }),
+        },
+      });
+
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { ...mock<AppLoadContext>(), session },
+        context: { ...mockAppLoadContext, session },
         params: {},
       });
 
@@ -123,9 +128,17 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('email', '');
       formData.append('preferredLanguage', 'fr');
 
+      const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: {
+          getServerConfig: vi.fn().mockReturnValue({
+            COMMUNICATION_METHOD_EMAIL_ID: 'email',
+          }),
+        },
+      });
+
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { ...mock<AppLoadContext>(), session },
+        context: { ...mockAppLoadContext, session },
         params: {},
       });
 
@@ -145,9 +158,17 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('confirmEmail', 'johndoe@example.com');
       formData.append('preferredLanguage', 'fr');
 
+      const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: {
+          getServerConfig: vi.fn().mockReturnValue({
+            COMMUNICATION_METHOD_EMAIL_ID: 'email',
+          }),
+        },
+      });
+
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
-        context: { ...mock<AppLoadContext>(), session },
+        context: { ...mockAppLoadContext, session },
         params: {},
       });
 

--- a/frontend/__tests__/routes/public/contact-information.test.tsx
+++ b/frontend/__tests__/routes/public/contact-information.test.tsx
@@ -17,11 +17,9 @@ vi.mock('~/route-helpers/apply-adult-route-helpers.server', () => ({
   }),
 }));
 
-vi.mock('~/utils/env-utils.server', () => ({
-  getEnv: vi.fn().mockReturnValue({
-    CANADA_COUNTRY_ID: 'CAN',
-    USA_COUNTRY_ID: 'USA',
-  }),
+vi.mock('~/utils/locale-utils.server', () => ({
+  getFixedT: vi.fn().mockResolvedValue(vi.fn()),
+  getLocale: vi.fn().mockReturnValue('en'),
 }));
 
 describe('_public.apply.id.contact-information', () => {
@@ -34,6 +32,14 @@ describe('_public.apply.id.contact-information', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: {
+          getServerConfig: vi.fn().mockReturnValue({
+            MARITAL_STATUS_CODE_COMMONLAW: 'COMMONLAW',
+            MARITAL_STATUS_CODE_MARRIED: 'MARRIED',
+            CANADA_COUNTRY_ID: 'CAN',
+            USA_COUNTRY_ID: 'USA',
+          }),
+        },
         serviceProvider: {
           getCountryService: () => ({
             getCountryById: vi.fn(),

--- a/frontend/app/routes/$lang-$.tsx
+++ b/frontend/app/routes/$lang-$.tsx
@@ -17,7 +17,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('gcweb:public-not-found.document-title') }) };
   return json({ meta }, { status: 404 });

--- a/frontend/app/routes/$lang-index.tsx
+++ b/frontend/app/routes/$lang-index.tsx
@@ -5,12 +5,12 @@ import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/publ
 import { isAppLocale } from '~/utils/locale-utils';
 import { getLogger } from '~/utils/logging.server';
 
-export function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   // Return a 404 status response because the displayed content is "not found"
   return new Response(null, { status: 404 });
 }
 
-export function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('$lang/index');
   const lang = params.lang;
 

--- a/frontend/app/routes/$lang-layout.tsx
+++ b/frontend/app/routes/$lang-layout.tsx
@@ -6,7 +6,7 @@ import { BilingualNotFoundError, NotFoundError, ServerError } from '~/components
 import { isAppLocale } from '~/utils/locale-utils';
 import { getLogger } from '~/utils/logging.server';
 
-export function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const log = getLogger('$lang/_route');
   const lang = params.lang;
 

--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -12,7 +12,7 @@ import { getLogger } from '~/utils/logging.server';
 const API_APPLY_STATE_ACTIONS = ['extend'] as const;
 export type ApiApplyStateAction = (typeof API_APPLY_STATE_ACTIONS)[number];
 
-export async function action({ context: { session }, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, request }: ActionFunctionArgs) {
   const log = getLogger('routes/api/apply-state');
   const sessionId = session.id;
   log.debug("Action with with user's apply state; sessionId: [%s]", sessionId);

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -29,7 +29,7 @@ const dummyHealthCheck: HealthCheck = {
   check: () => new Promise((resolve) => setTimeout(resolve, 2 * 1000)),
 };
 
-export async function loader({ context: { serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const { include, exclude, timeout } = Object.fromEntries(new URL(request.url).searchParams);
   const { buildRevision: buildId, buildVersion: version } = getBuildInfoService().getBuildInfo();
 

--- a/frontend/app/routes/api/readyz.ts
+++ b/frontend/app/routes/api/readyz.ts
@@ -6,6 +6,6 @@ import { json } from '@remix-run/node';
  *
  * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
  */
-export function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   return json({ ready: true });
 }

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -17,7 +17,7 @@ export type ApiSessionAction = (typeof API_SESSION_ACTIONS)[number];
 const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', 'cdcp-website-status'] as const;
 export type ApiSessionRedirectTo = (typeof API_SESSION_REDIRECT_TO_OPTIONS)[number];
 
-export async function action({ context: { session }, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, request }: ActionFunctionArgs) {
   const log = getLogger('routes/api/session');
   const sessionId = session.id;
   log.debug("Action with user's server-side session; sessionId: [%s]", sessionId);

--- a/frontend/app/routes/protected/home.tsx
+++ b/frontend/app/routes/protected/home.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request, session);
 

--- a/frontend/app/routes/protected/letters/$id.download.tsx
+++ b/frontend/app/routes/protected/letters/$id.download.tsx
@@ -12,7 +12,7 @@ import { getNameByLanguage } from '~/utils/locale-utils';
 import { getLocale } from '~/utils/locale-utils.server';
 import type { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
   const auditService = getAuditService();

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -50,7 +50,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
   return { meta, defaultValues };
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -64,7 +64,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, ageCategory, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/applicant-information');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/apply-children');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -40,7 +40,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/apply-yourself');
   loadApplyAdultChildState({ params, request, session });
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/cannot-apply-child');
 
   loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/dental-insurance');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -18,7 +18,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,13 +47,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const { CANADA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const federalSocialPrograms = serviceProvider.getFederalGovernmentInsurancePlanService().listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provinceTerritoryStates = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
@@ -83,7 +82,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/federal-provincial-territorial-benefits');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +66,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/information');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -40,7 +40,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/parent-or-guardian');
 
   loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -76,7 +76,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
 
   const log = getLogger('apply/adult-child/child-summary');

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { CommunicationPreferencesState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -42,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -75,10 +74,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -164,7 +164,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/contact-apply-child');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -24,7 +24,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { ContactInformationState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -46,11 +45,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -74,12 +73,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/contact-information');
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +53,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: { dateOfBirth, allChildrenUnder18 }, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/date-of-birth');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/dental-insurance');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -57,7 +57,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/disability-tax-credit');
   const state = loadApplyAdultChildState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/dob-eligibility');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -20,7 +20,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,8 +47,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = getEnv();
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -76,7 +75,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/federal-provincial-territorial');
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.livingIndependently });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/living-independently');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, ageCategory });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/parent-or-guardian');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/partner-information');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -22,7 +22,6 @@ import { loadApplyAdultChildStateForReview } from '~/route-helpers/apply-adult-c
 import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -56,7 +55,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -148,12 +147,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/review-adult-information');
 
   loadApplyAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -25,7 +25,6 @@ import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-hel
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getBenefitApplicationService } from '~/services/benefit-application-service.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -51,13 +50,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -111,12 +110,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/review-child-information');
 
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -64,7 +64,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ ageCategory, csrfToken, defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, maritalStatuses, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/applicant-information');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { CommunicationPreferencesState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -42,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,10 +73,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -131,7 +131,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
@@ -24,7 +24,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { ContactInformationState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -46,11 +45,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -74,12 +73,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/contact-information');
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
@@ -34,7 +34,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -45,7 +45,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: { dateOfBirth }, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/date-of-birth');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/dental-insurance');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -57,7 +57,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/disability-tax-credit');
   const state = loadApplyAdultState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/dob-eligibility');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -19,7 +19,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,8 +47,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = getEnv();
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,7 +73,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/federal-provincial-territorial');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.livingIndependently, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/living-independently');
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ ageCategory, csrfToken, defaultState: state.disabilityTaxCredit, id: state.id, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/parent-or-guardian');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/partner-information');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -26,7 +26,6 @@ import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-hel
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getBenefitApplicationService } from '~/services/benefit-application-service.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -60,7 +59,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -158,12 +157,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/review-information');
 
   const state = loadApplyAdultStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/application-delegate');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -63,7 +63,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, dateOfBirth: state.dateOfBirth, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/applicant-information');
 
   const state = loadApplyChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -28,7 +28,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/cannot-apply-child');
   loadApplySingleChildState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/dental-insurance');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -18,7 +18,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,10 +47,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
 
-  const { CANADA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -83,7 +82,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/federal-provincial-territorial-benefits');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +66,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/information');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/parent-or-guardian');
 
   loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -77,7 +77,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
 
   const log = getLogger('apply/child/child-summary');

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { CommunicationPreferencesState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -42,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -75,10 +74,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -152,7 +152,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/contact-apply-child');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -24,7 +24,6 @@ import { Progress } from '~/components/progress';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { ContactInformationState } from '~/route-helpers/apply-route-helpers.server';
 import { saveApplyState } from '~/route-helpers/apply-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -46,11 +45,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -74,12 +73,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/contact-information');
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/partner-information');
 
   const state = loadApplyChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -26,7 +26,6 @@ import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-hel
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { getBenefitApplicationService } from '~/services/benefit-application-service.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -60,7 +59,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -133,12 +132,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/review-adult-information');
 
   const state = loadApplyChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -21,7 +21,6 @@ import { loadApplyChildStateForReview } from '~/route-helpers/apply-child-route-
 import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -47,13 +46,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -103,12 +102,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/review-child-information');
 
   loadApplyChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/index.tsx
+++ b/frontend/app/routes/public/apply/$id/index.tsx
@@ -5,7 +5,7 @@ import { loadApplyState, saveApplyState } from '~/route-helpers/apply-route-help
 import { getPathById } from '~/utils/route-utils';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyState({ params, session });
   saveApplyState({ params, session, state: {} });
   return redirect(getPathById('public/apply/$id/type-application', params));

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   loadApplyState({ params, session });
   const csrfToken = String(session.get('csrfToken'));
 
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, request, params }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('apply/terms-and-conditions');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfApplication });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/type-of-application');
   loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -25,7 +25,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/dental-insurance');
 
   const state = loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -19,7 +19,6 @@ import { Progress } from '~/components/progress';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,8 +47,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = getEnv();
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,7 +73,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/federal-provincial-territorial');
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const renewState = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -43,7 +43,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -59,7 +59,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/information');
 
   const state = loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/parent-or-guardian');
 
   loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -46,7 +46,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -75,7 +75,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
 
   const log = getLogger('renew/adult-child/child-summary');

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress } });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-address');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -48,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -67,7 +67,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-email');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -48,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -69,7 +69,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-phone');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/dental-insurance');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -19,7 +19,6 @@ import { Progress } from '~/components/progress';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,8 +47,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = getEnv();
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,7 +73,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/federal-provincial-territorial');
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/renew-route-helpers.server';
 import { renewStateHasPartner, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,12 +47,12 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = serviceProvider.getMaritalStatusService().listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:marital-status.page-title') }) };
@@ -61,7 +60,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ csrfToken, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/marital-status');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -23,7 +23,6 @@ import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers
 import { loadRenewAdultChildStateForReview } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import { clearRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -48,13 +47,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true
   saveRenewState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -108,12 +107,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/review-child-information');
 
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import type { AddressInformationState } from '~/route-helpers/renew-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -43,11 +42,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -68,12 +67,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/update-address');
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const addressInformationSchema = z
     .object({

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/renew/$id/file-taxes.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadRenewItaState } from '~/route-helpers/renew-ita-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
 import type { CommunicationPreferenceState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -42,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,10 +73,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = getEnv();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress } });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/confirm-address');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -131,7 +131,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
@@ -43,7 +43,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +60,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/contact-information');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/dental-insurance');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewItaState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -19,7 +19,6 @@ import { Progress } from '~/components/progress';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/route-helpers/apply-route-helpers.server';
 import { loadRenewItaState } from '~/route-helpers/renew-ita-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,8 +47,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = getEnv();
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,7 +73,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/federal-provincial-territorial');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadRenewItaState } from '~/route-helpers/renew-ita-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/renew-route-helpers.server';
 import { renewStateHasPartner, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -48,12 +47,12 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = serviceProvider.getMaritalStatusService().listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:marital-status.page-title') }) };
@@ -61,7 +60,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   return json({ csrfToken, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/marital-status');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -24,7 +24,6 @@ import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers
 import { loadRenewItaStateForReview } from '~/route-helpers/renew-ita-route-helpers.server';
 import { clearRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getEnv } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
@@ -58,7 +57,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // renew state is valid then edit mode can be set to true
   saveRenewState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -156,12 +155,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/review-information');
 
   const state = loadRenewItaStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -21,7 +21,6 @@ import { Progress } from '~/components/progress';
 import { loadRenewItaState } from '~/route-helpers/renew-ita-route-helpers.server';
 import type { AddressInformationState } from '~/route-helpers/renew-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
-import { getEnv } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -43,11 +42,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -68,12 +67,12 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/update-address');
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = getEnv();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
 
   const addressInformationSchema = z
     .object({

--- a/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
+++ b/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/renew-delegate');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +47,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   loadRenewState({ params, session });
   const csrfToken = String(session.get('csrfToken'));
 
@@ -47,7 +47,7 @@ export async function loader({ context: { session }, request, params }: LoaderFu
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('renew/terms-and-conditions');
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/type-of-renewal');
   loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -41,7 +41,7 @@ export async function loader({ context: { session }, request }: LoaderFunctionAr
   return json({ locale, meta, csrfToken });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/index');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -25,7 +25,7 @@ import { getStatusResultUrl, saveStatusState, startStatusState } from '~/route-h
 import { getApplicationStatusService } from '~/services/application-status-service.server';
 import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
-import { featureEnabled, getEnv } from '~/utils/env-utils.server';
+import { featureEnabled } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -53,9 +53,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
 
   const csrfToken = String(session.get('csrfToken'));
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -67,10 +67,10 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/child/index');
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -16,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers.server';
-import { featureEnabled, getEnv } from '~/utils/env-utils.server';
+import { featureEnabled } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -42,9 +42,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
 
   const csrfToken = String(session.get('csrfToken'));
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -56,10 +56,10 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/index');
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const formData = await request.formData();

--- a/frontend/app/routes/public/status/myself.tsx
+++ b/frontend/app/routes/public/status/myself.tsx
@@ -20,7 +20,7 @@ import { getHCaptchaRouteHelpers } from '~/route-helpers/h-captcha-route-helpers
 import { getStatusResultUrl, saveStatusState, startStatusState } from '~/route-helpers/status-route-helpers.server';
 import { getApplicationStatusService } from '~/services/application-status-service.server';
 import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/application-code-utils';
-import { featureEnabled, getEnv } from '~/utils/env-utils.server';
+import { featureEnabled } from '~/utils/env-utils.server';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -43,9 +43,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = getEnv();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
 
   const csrfToken = String(session.get('csrfToken'));
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -57,10 +57,10 @@ export async function loader({ context: { session }, params, request }: LoaderFu
   return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/myself/index');
-  const { ENABLED_FEATURES } = getEnv();
+  const { ENABLED_FEATURES } = configProvider.getServerConfig();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -39,7 +39,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
 
   const statusStateId = getStatusStateIdFromUrl(request.url);
@@ -63,7 +63,7 @@ export async function loader({ context: { serviceProvider, session }, params, re
   });
 }
 
-export async function action({ context: { session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
 
   const statusStateId = getStatusStateIdFromUrl(request.url);


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Implement the `configProvider.getServerConfig()` function in routes to replace the existing `getEnv` call from the `~\utils\env-utils.server` module. This change improves performance by utilizing `getServerConfig` as a singleton, avoiding the repeated parsing of environment variables that occurs with each `getEnv` call.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->