### PR TITLE
Adding injectable audit service

### DIFF
--- a/frontend/__tests__/routes/protected/letters/index.test.tsx
+++ b/frontend/__tests__/routes/protected/letters/index.test.tsx
@@ -6,12 +6,6 @@ import { mock } from 'vitest-mock-extended';
 
 import { loader } from '~/routes/protected/letters/index';
 
-vi.mock('~/services/audit-service.server', () => ({
-  getAuditService: vi.fn().mockReturnValue({
-    audit: vi.fn(),
-  }),
-}));
-
 vi.mock('~/services/instrumentation-service.server', () => ({
   getInstrumentationService: () => ({
     countHttpStatus: vi.fn(),
@@ -73,7 +67,10 @@ describe('Letters Page', () => {
       session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
       session.set('userInfoToken', { sin: '999999999', sub: '1111111' });
 
-      const mockAppLoadContext = mock<AppLoadContext>({ configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) } });
+      const mockAppLoadContext = mock<AppLoadContext>({
+        configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
+        serviceProvider: { getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }) },
+      });
 
       const response = await loader({
         request: new Request('http://localhost/letters?sort=desc'),
@@ -96,7 +93,10 @@ describe('Letters Page', () => {
     session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
     session.set('userInfoToken', { sin: '999999999' });
 
-    const mockAppLoadContext = mock<AppLoadContext>({ configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) } });
+    const mockAppLoadContext = mock<AppLoadContext>({
+      configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
+      serviceProvider: { getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }) },
+    });
 
     const response = await loader({
       request: new Request('http://localhost/letters'),

--- a/frontend/app/.server/constants/service-identifier.constant.ts
+++ b/frontend/app/.server/constants/service-identifier.constant.ts
@@ -3,6 +3,7 @@ export const SERVICE_IDENTIFIER = {
   ADDRESS_VALIDATION_DTO_MAPPER: Symbol.for('AddressValidationDtoMapper'),
   ADDRESS_VALIDATION_REPOSITORY: Symbol.for('AddressValidationRepository'),
   ADDRESS_VALIDATION_SERVICE: Symbol.for('AddressValidationService'),
+  AUDIT_SERVICE: Symbol.for('AuditService'),
   BENEFIT_RENEWAL_DTO_MAPPER: Symbol.for('BenefitRenewalDtoMapper'),
   BENEFIT_RENEWAL_REPOSITORY: Symbol.for('BenefitRenewalRepository'),
   BENEFIT_RENEWAL_SERVICE: Symbol.for('BenefitRenewalService'),

--- a/frontend/app/.server/container-modules/services.container-module.ts
+++ b/frontend/app/.server/container-modules/services.container-module.ts
@@ -3,6 +3,7 @@ import { ContainerModule } from 'inversify';
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type {
   AddressValidationService,
+  AuditService,
   BenefitRenewalService,
   ClientApplicationService,
   ClientFriendlyStatusService,
@@ -16,6 +17,7 @@ import type {
 } from '~/.server/domain/services';
 import {
   AddressValidationServiceImpl,
+  AuditServiceImpl,
   BenefitRenewalServiceImpl,
   ClientApplicationServiceImpl,
   ClientFriendlyStatusServiceImpl,
@@ -33,6 +35,7 @@ import {
  */
 export const servicesContainerModule = new ContainerModule((bind) => {
   bind<AddressValidationService>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_SERVICE).to(AddressValidationServiceImpl);
+  bind<AuditService>(SERVICE_IDENTIFIER.AUDIT_SERVICE).to(AuditServiceImpl);
   bind<BenefitRenewalService>(SERVICE_IDENTIFIER.BENEFIT_RENEWAL_SERVICE).to(BenefitRenewalServiceImpl);
   bind<ClientApplicationService>(SERVICE_IDENTIFIER.CLIENT_APPLICATION_SERVICE).to(ClientApplicationServiceImpl);
   bind<ClientFriendlyStatusService>(SERVICE_IDENTIFIER.CLIENT_FRIENDLY_STATUS_SERVICE).to(ClientFriendlyStatusServiceImpl);

--- a/frontend/app/.server/domain/dtos/audit.dto.ts
+++ b/frontend/app/.server/domain/dtos/audit.dto.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents the details associated with an audit event.
+ */
+export type AuditDetails = Readonly<
+  Record<string, unknown> & {
+    /** Optional identifier for the user associated with the audit event. */
+    userId?: string;
+  }
+>;

--- a/frontend/app/.server/domain/services/audit.service.ts
+++ b/frontend/app/.server/domain/services/audit.service.ts
@@ -1,0 +1,31 @@
+import { UTCDate } from '@date-fns/utc';
+import { inject, injectable } from 'inversify';
+
+import { AuditDetails } from '../dtos/audit.dto';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+export interface AuditService {
+  /**
+   * Creates an audit log entry for a given event.
+   *
+   * @param eventId An identifier for the event being audited
+   * @param auditDetails Optional audit-related information, including `userId` and other metadata
+   */
+  createAudit(eventId: string, auditDetails?: AuditDetails): void;
+}
+
+@injectable()
+export class AuditServiceImpl implements AuditService {
+  private readonly log: Logger;
+
+  constructor(@inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory) {
+    this.log = logFactory.createLogger('AuditServiceImpl');
+  }
+
+  createAudit(eventId: string, auditDetails?: AuditDetails): void {
+    const { userId, ...otherDetails } = auditDetails ?? {};
+    const details = Object.keys(otherDetails).length === 0 ? undefined : otherDetails;
+    this.log.audit('%j', { eventId, userId, details, timestamp: new UTCDate().toISOString() });
+  }
+}

--- a/frontend/app/.server/domain/services/index.ts
+++ b/frontend/app/.server/domain/services/index.ts
@@ -1,4 +1,5 @@
 export * from './address-validation.service';
+export * from './audit.service';
 export * from './client-application.service';
 export * from './client-friendly-status.service';
 export * from './country.service';

--- a/frontend/app/.server/providers/container-service.provider.ts
+++ b/frontend/app/.server/providers/container-service.provider.ts
@@ -3,6 +3,7 @@ import type { interfaces } from 'inversify';
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type {
   AddressValidationService,
+  AuditService,
   BenefitRenewalService,
   ClientApplicationService,
   ClientFriendlyStatusService,
@@ -17,6 +18,7 @@ import type {
 
 export interface ContainerServiceProvider {
   getAddressValidationService(): AddressValidationService;
+  getAuditService(): AuditService;
   getBenefitRenewalService(): BenefitRenewalService;
   getClientApplicationService(): ClientApplicationService;
   getClientFriendlyStatusService(): ClientFriendlyStatusService;
@@ -34,6 +36,10 @@ export class ContainerServiceProviderImpl implements ContainerServiceProvider {
 
   getAddressValidationService(): AddressValidationService {
     return this.container.get<AddressValidationService>(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_SERVICE);
+  }
+
+  getAuditService(): AuditService {
+    return this.container.get<AuditService>(SERVICE_IDENTIFIER.AUDIT_SERVICE);
   }
 
   getBenefitRenewalService(): BenefitRenewalService {

--- a/frontend/app/routes/protected/home.tsx
+++ b/frontend/app/routes/protected/home.tsx
@@ -10,7 +10,6 @@ import pageIds from '../page-ids.json';
 import type { AppLinkProps } from '~/components/app-link';
 import { AppLink } from '~/components/app-link';
 import { useFeature } from '~/root';
-import { getAuditService } from '~/services/audit-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -36,7 +35,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   await raoidcService.handleSessionValidation(request, session);
 
   const idToken: IdToken = session.get('idToken');
-  getAuditService().audit('page-view.home', { userId: idToken.sub });
+  serviceProvider.getAuditService().createAudit('page-view.home', { userId: idToken.sub });
 
   const userOrigin = getUserOrigin(request, session);
   session.set('userOrigin', userOrigin);

--- a/frontend/app/routes/protected/letters/$id.download.tsx
+++ b/frontend/app/routes/protected/letters/$id.download.tsx
@@ -3,7 +3,6 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Buffer } from 'node:buffer';
 import { sanitize } from 'sanitize-filename-ts';
 
-import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLettersService } from '~/services/letters-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -15,7 +14,6 @@ import type { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
-  const auditService = getAuditService();
   const instrumentationService = getInstrumentationService();
 
   if (!params.id) {
@@ -47,7 +45,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   instrumentationService.countHttpStatus('letters.download', 200);
 
   const idToken: IdToken = session.get('idToken');
-  auditService.audit('download.letter', { userId: idToken.sub });
+  serviceProvider.getAuditService().createAudit('download.letter', { userId: idToken.sub });
 
   const decodedPdfBytes = Buffer.from(pdfBytes, 'base64');
   return new Response(decodedPdfBytes, {

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -13,7 +13,6 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { InlineLink } from '~/components/inline-link';
 import { InputSelect } from '~/components/input-select';
 import { getPersonalInformationRouteHelpers } from '~/route-helpers/personal-information-route-helpers.server';
-import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getLettersService } from '~/services/letters-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -42,7 +41,6 @@ const orderEnumSchema = z.enum(['asc', 'desc']);
 export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
-  const auditService = getAuditService();
   const instrumentationService = getInstrumentationService();
   const lettersService = getLettersService();
   const raoidcService = await getRaoidcService();
@@ -66,7 +64,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   const { SCCH_BASE_URI } = configProvider.getClientConfig();
 
   const idToken: IdToken = session.get('idToken');
-  auditService.audit('page-view.letters', { userId: idToken.sub });
+  serviceProvider.getAuditService().createAudit('page-view.letters', { userId: idToken.sub });
   instrumentationService.countHttpStatus('letters.view', 200);
 
   return json({ letters, letterTypes, meta, sortOrder, SCCH_BASE_URI });


### PR DESCRIPTION
### Description
This injectable service should ultimately replace the existing `audit-service.server`. 

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/0418e8a6-78a8-464e-8b30-887a2363cb2c)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Change logging level to `audit` and navigate to `/en/home`. Verify that the `AuditServiceImpl` is being hit for an audit log.

### Additional Notes
There exists other services that still depend directly on the old `audit-service.server`. These services will eventually be modified to injected an audit service.