### PR TITLE
Moving `AddressCorrectionRequest` interfaces into their respective DTO/entity types

### DIFF
--- a/frontend/app/.server/domain/dtos/address-validation.dto.ts
+++ b/frontend/app/.server/domain/dtos/address-validation.dto.ts
@@ -1,4 +1,21 @@
 /**
+ * Represents a Data Transfer Object (DTO) for an address correction request.
+ */
+export type AddressCorrectionRequestDto = Readonly<{
+  /** The full or partial address. */
+  address: string;
+
+  /** The name of the city. */
+  city: string;
+
+  /** The 6-character postal code. */
+  postalCode: string;
+
+  /** The 2-character Canadian province or territorial code. */
+  provinceCode: string;
+}>;
+
+/**
  * Represents a Data Transfer Object (DTO) for an address correction result.
  */
 export type AddressCorrectionResultDto = Readonly<{

--- a/frontend/app/.server/domain/entities/address-validation.entity.ts
+++ b/frontend/app/.server/domain/entities/address-validation.entity.ts
@@ -1,3 +1,10 @@
+export type AddressCorrectionRequestEntity = Readonly<{
+  address: string;
+  city: string;
+  postalCode: string;
+  provinceCode: string;
+}>;
+
 export type AddressCorrectionResultEntity = Readonly<{
   'wsaddr:CorrectionResults': Readonly<{
     'nc:AddressFullText': string;

--- a/frontend/app/.server/domain/repositories/address-validation.repository.ts
+++ b/frontend/app/.server/domain/repositories/address-validation.repository.ts
@@ -2,32 +2,18 @@ import { inject, injectable } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
-import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
+import type { AddressCorrectionRequestEntity, AddressCorrectionResultEntity } from '~/.server/domain/entities';
 import type { LogFactory, Logger } from '~/.server/factories';
 import { getFetchFn, instrumentedFetch } from '~/utils/fetch-utils.server';
-
-export interface AddressCorrectionRequest {
-  /** The full or partial address. */
-  address: string;
-
-  /** The name of the city. */
-  city: string;
-
-  /** The 6-character postal code. */
-  postalCode: string;
-
-  /** The 2-character Canadian province or territorial code. */
-  provinceCode: string;
-}
 
 export interface AddressValidationRepository {
   /**
    * Corrects the provided address using the data passed in the `AddressCorrectionRequest` object.
    *
-   * @param addressCorrectionRequest The request object containing the address details that need to be corrected
+   * @param addressCorrectionRequestEntity The request entity object containing the address details that need to be corrected
    * @returns A promise that resolves to a `AddressCorrectionResultEntity` object containing corrected address results
    */
-  getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultEntity>;
+  getAddressCorrectionResult(addressCorrectionRequestEntity: AddressCorrectionRequestEntity): Promise<AddressCorrectionResultEntity>;
 }
 
 @injectable()
@@ -41,9 +27,9 @@ export class AddressValidationRepositoryImpl implements AddressValidationReposit
     this.log = logFactory.createLogger('AddressValidationRepositoryImpl');
   }
 
-  async getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultEntity> {
-    this.log.trace('Checking correctness of address for addressCorrectionRequest: [%j]', addressCorrectionRequest);
-    const { address, city, postalCode, provinceCode } = addressCorrectionRequest;
+  async getAddressCorrectionResult(addressCorrectionRequestEntity: AddressCorrectionRequestEntity): Promise<AddressCorrectionResultEntity> {
+    this.log.trace('Checking correctness of address for addressCorrectionRequest: [%j]', addressCorrectionRequestEntity);
+    const { address, city, postalCode, provinceCode } = addressCorrectionRequestEntity;
 
     const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/address/validation/v1/CAN/correct`);
     url.searchParams.set('AddressFullText', address);

--- a/frontend/app/.server/domain/services/address-validation.service.ts
+++ b/frontend/app/.server/domain/services/address-validation.service.ts
@@ -1,33 +1,19 @@
 import { inject, injectable } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
-import type { AddressCorrectionResultDto } from '~/.server/domain/dtos';
+import type { AddressCorrectionRequestDto, AddressCorrectionResultDto } from '~/.server/domain/dtos';
 import type { AddressValidationDtoMapper } from '~/.server/domain/mappers';
 import type { AddressValidationRepository } from '~/.server/domain/repositories';
 import type { LogFactory, Logger } from '~/.server/factories';
-
-export interface AddressCorrectionRequest {
-  /** The full or partial address. */
-  address: string;
-
-  /** The name of the city. */
-  city: string;
-
-  /** The 6-character postal code. */
-  postalCode: string;
-
-  /** The 2-character Canadian province or territorial code. */
-  provinceCode: string;
-}
 
 export interface AddressValidationService {
   /**
    * Corrects the provided address using the data passed in the `AddressCorrectionRequest` object.
    *
-   * @param addressCorrectionRequest The request object containing the address details that need to be corrected
+   * @param addressCorrectionRequestDto The request DTO object containing the address details that need to be corrected
    * @returns A promise that resolves to a `AddressCorrectionResultDto` object containing corrected address results
    */
-  getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultDto>;
+  getAddressCorrectionResult(addressCorrectionRequestDto: AddressCorrectionRequestDto): Promise<AddressCorrectionResultDto>;
 }
 
 @injectable()
@@ -42,9 +28,9 @@ export class AddressValidationServiceImpl implements AddressValidationService {
     this.log = logFactory.createLogger('AddressValidationServiceImpl');
   }
 
-  async getAddressCorrectionResult(addressCorrectionRequest: AddressCorrectionRequest): Promise<AddressCorrectionResultDto> {
-    this.log.trace('Getting address correction results with addressCorrectionRequest: [%j]', addressCorrectionRequest);
-    const addressCorrectionResultEntity = await this.addressValidationRepository.getAddressCorrectionResult(addressCorrectionRequest);
+  async getAddressCorrectionResult(addressCorrectionRequestDto: AddressCorrectionRequestDto): Promise<AddressCorrectionResultDto> {
+    this.log.trace('Getting address correction results with addressCorrectionRequest: [%j]', addressCorrectionRequestDto);
+    const addressCorrectionResultEntity = await this.addressValidationRepository.getAddressCorrectionResult(addressCorrectionRequestDto);
     const addressCorrectionResultDto = this.addressValidationDtoMapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(addressCorrectionResultEntity);
     this.log.trace('Returning address correction result: [%j]', addressCorrectionResultDto);
     return addressCorrectionResultDto;


### PR DESCRIPTION
### Description
As per title to follow existing conventions.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/en/address-validation` and ensure that it still works.