### PR TITLE
[gitops] Enabling `view-letters-online-application` feature flag in prod

### DIFF
--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,status,status-checker-redirects,view-letters
+ENABLED_FEATURES=hcaptcha,status,status-checker-redirects,view-letters,view-letters-online-application
 
 #
 # Session/redis configuration


### PR DESCRIPTION
### Description
Marking as draft.

The `view-letters-online-application` feature flag, which changes the text related to MSCA in the online application's confirmation page,  is to be enabled Tuesday, October 29, 2024 at 7:00am Eastern.