### PR TITLE
Refactoring `personalInformationRouteHelpers` into /letters' loader and various minor fixes

### DIFF
--- a/frontend/__tests__/routes/protected/letters/index.test.tsx
+++ b/frontend/__tests__/routes/protected/letters/index.test.tsx
@@ -69,7 +69,10 @@ describe('Letters Page', () => {
 
       const mockAppLoadContext = mock<AppLoadContext>({
         configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
-        serviceProvider: { getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }) },
+        serviceProvider: {
+          getApplicantService: vi.fn().mockReturnValue({ findClientNumberBySin: vi.fn().mockReturnValue('some-client-number') }),
+          getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }),
+        },
       });
 
       const response = await loader({
@@ -95,7 +98,10 @@ describe('Letters Page', () => {
 
     const mockAppLoadContext = mock<AppLoadContext>({
       configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
-      serviceProvider: { getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }) },
+      serviceProvider: {
+        getApplicantService: vi.fn().mockReturnValue({ findClientNumberBySin: vi.fn().mockReturnValue('some-client-number') }),
+        getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }),
+      },
     });
 
     const response = await loader({

--- a/frontend/app/.server/domain/services/applicant.service.ts
+++ b/frontend/app/.server/domain/services/applicant.service.ts
@@ -41,7 +41,7 @@ export class ApplicantServiceImpl implements ApplicantService {
     const applicantRequestEntity = this.applicantDtoMapper.mapSinToApplicantRequestEntity(sin);
     const applicantResponseEntity = await this.applicantRepository.findApplicantBySin(applicantRequestEntity);
     if (applicantResponseEntity === null) {
-      this.log.trace('No applicant found for [%s]; Returning null');
+      this.log.trace('No applicant found for sin [%s]; Returning null', sin);
       return null;
     }
 

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -41,7 +41,7 @@ export function getPowerPlatformApiMockHandlers() {
       const peronalInformationEntity = getPersonalInformation(parsedSinId);
 
       if (!peronalInformationEntity) {
-        throw new HttpResponse('Client Not found', { status: 204, headers: { 'Content-Type': 'text/plain' } });
+        throw new HttpResponse(null, { status: 204 });
       }
       const listOfClientId = [];
       if (peronalInformationEntity.applicantId) {

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -46,7 +46,7 @@ export default function DataUnavailable() {
   const doyouqualify = <InlineLink to={t('data-unavailable:do-you-qualify.href')} className="external-link" newTabIndicator target="_blank" />;
   const howtoapply = <InlineLink to={t('data-unavailable:how-to-apply.href')} className="external-link" newTabIndicator target="_blank" />;
   const contactus = <InlineLink to={t('data-unavailable:contact-us.href')} className="external-link" newTabIndicator target="_blank" />;
-  const statuschecker = <InlineLink routeId="$lang/_public/status/index" className="external-link" newTabIndicator target="_blank" params={params} />;
+  const statuschecker = <InlineLink routeId="public/status/index" className="external-link" newTabIndicator target="_blank" params={params} />;
 
   return (
     <>

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -9,7 +9,6 @@ import { z } from 'zod';
 import { Button } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { InputPatternField } from '~/components/input-pattern-field';
 import { featureEnabled } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT } from '~/utils/locale-utils.server';
@@ -18,7 +17,6 @@ import type { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { sinInputPatternFormat } from '~/utils/sin-utils';
 import { transformFlattenedError } from '~/utils/zod-utils.server';
 
 export const handle = {
@@ -114,6 +112,7 @@ export async function action({ context: { configProvider, serviceProvider, sessi
     session.set('userInfoToken', userInfoToken);
   }
   session.set('idToken', idToken);
+  session.unset('clientNumber');
 
   return redirect(getPathById('protected/home', params));
 }
@@ -134,7 +133,7 @@ export default function StubLogin() {
     <div className="max-w-prose">
       <errorSummary.ErrorSummary />
       <fetcher.Form method="post" noValidate className="space-y-6">
-        <InputPatternField id="sin" name="sin" label={t('stub-login:index.sin')} required inputMode="numeric" format={sinInputPatternFormat} defaultValue={defaultValues.sin} />
+        <InputField id="sin" name="sin" label={t('stub-login:index.sin')} required inputMode="numeric" defaultValue={defaultValues.sin} />
         <fieldset>
           <legend className="mb-2 text-xl font-semibold">{t('stub-login:index.raoidc')}</legend>
           <div className="space-y-6">


### PR DESCRIPTION
### Description
This PR will remove the need for [personal-information-route-helpers](https://github.com/DTS-STN/canadian-dental-care-plan/blob/main/frontend/app/route-helpers/personal-information-route-helpers.server.ts). As a result of #2197, there is no need for this route helper as retrieving the client number (ie. personal information) is only required in a single route (`/letters/index`).

Also sneaked in some fixes/changes while testing:
- Adding `sin` to log statement when no applicant is found (response is a `204`)
- Fixing mock when returning a `204` - there should be no response body when 204 No content is returned
- Fixing route id on `/data-unavailable`
- Removing `clientNumber` from session upon login with `/stub-login` - impersonating a different user would mean a different client number for the user
- Removing use of `InputPatternField` in `/stub-login` - the mock to retrieve applicants consists of SINs that are not formatted with no spaces 

### Screenshots (if applicable)
Applicant returned from mock (`200` response):
![image](https://github.com/user-attachments/assets/c13b4bcc-6c36-4577-b461-58265a372510)

No applicant returned from mock (`204 response):
![image](https://github.com/user-attachments/assets/5e11831d-de35-4add-827c-cb2bfdf969e5)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Applicant returned from mock (`200` response):
- Set the logger level to `trace`
- Navigate to `/en/stub-login` and use SIN `800000002` or `800011819` to login
- Navigate to `/en/letters`. You should see a log similar to the screenshot "Applicant returned from mock (`200` response)" above
- Refresh the page or make another request to `/en/letters`. The above log should not appear as request to retrieve letters is using a client number stored in session.

No applicant returned from mock (`204 response):
- Set the logger level to `trace`
- Navigate to `/en/stub-login` and use any SIN that is not `800000002` or `800011819` to login
- Navigate to `/en/letters`. You should see a log similar to the screenshot "No applicant returned from mock (`204 response)" above. 
- You should also be redirected to `/en/data-unavailable`.

### Additional Notes
Personal information route helper, services, and other depending unused files will be removed in a future PR.