### PR TITLE
chore(frontend): bump node to latest LTS

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -32,7 +32,7 @@
 
 
 # Base image used for all future stages
-ARG BASE_IMAGE=docker.io/node:20.18.0-bookworm-slim
+ARG BASE_IMAGE=docker.io/node:22.10.0-bookworm-slim
 FROM $BASE_IMAGE AS base
 ENV NODE_ENV production
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -81,7 +81,7 @@
         "@types/eslint__js": "^8.42.3",
         "@types/jsdom": "^21.1.7",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^20.17.1",
+        "@types/node": "^22.8.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/validator": "^13.12.2",
@@ -111,7 +111,7 @@
         "vitest-mock-extended": "^2.0.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4439,11 +4439,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.1.tgz",
-      "integrity": "sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==",
+      "version": "22.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
+      "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/pluralize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -95,7 +95,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jsdom": "^21.1.7",
     "@types/morgan": "^1.9.9",
-    "@types/node": "^20.17.1",
+    "@types/node": "^22.8.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/validator": "^13.12.2",
@@ -125,7 +125,7 @@
     "vitest-mock-extended": "^2.0.2"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "prettier": {
     "semi": true,


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Bump node to latest LTS version 22.10.0.

@gregory-j-baker noticed the latest LTS version changed from v20 to v22 on their website.