### PR TITLE
Type of renewal navigation

### DIFF
--- a/frontend/app/mocks/client-application-data/client-application.json
+++ b/frontend/app/mocks/client-application-data/client-application.json
@@ -161,7 +161,7 @@
           "FlagCategoryText": "isCraAssessed"
         },
         {
-          "Flag": true,
+          "Flag": false,
           "FlagCategoryText": "appliedBeforeApril302024"
         }
       ],

--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -18,6 +18,15 @@ export interface RenewState {
     dateOfBirth: string;
     clientNumber: string;
   };
+  readonly clientApplication?: {
+    clientNumber: string;
+    dateOfBirth: string;
+    firstName: string;
+    hasAppliedBeforeApril302024: boolean;
+    hasBeenAssessedByCRA: boolean;
+    lastName: string;
+    sin: string;
+  };
   readonly children: {
     readonly id: string;
     readonly dentalBenefits?: {

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -132,7 +132,7 @@ export async function action({ context: { session, serviceProvider }, params, re
   // TODO: handle when clientApplication is not found (null)
   invariant(clientApplication, 'Expected clientApplication to be found (not null).');
 
-  saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data } });
+  saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data, clientApplication: clientApplication } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/review-information', params));

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -132,7 +132,7 @@ export async function action({ context: { session, serviceProvider }, params, re
   // TODO: handle when clientApplication is not found (null)
   invariant(clientApplication, 'Expected clientApplication to be found (not null).');
 
-  saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data, clientApplication: clientApplication } });
+  saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data, clientApplication } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/review-information', params));

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -50,7 +50,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
 
 export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/type-of-renewal');
-  loadRenewState({ params, session });
+  const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   /**
@@ -90,7 +90,10 @@ export async function action({ context: { configProvider, serviceProvider, sessi
   });
 
   if (parsedDataResult.data.typeOfRenewal === RenewalType.AdultChild) {
-    return redirect(getPathById('public/renew/$id/ita/marital-status', params));
+    if (state.clientApplication?.hasAppliedBeforeApril302024) {
+      return redirect(getPathById('public/renew/$id/ita/marital-status', params));
+    }
+    return redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
   }
 
   if (parsedDataResult.data.typeOfRenewal === RenewalType.Child) {


### PR DESCRIPTION
### Description
On `TypeRenewal` page, load `clientApplication` from state. if `hasAppliedBeforeApril302024` is true, go to `ita` flow, if false, go to `adult-child` flow. 
In the client application mock, the `hasAppliedBeforeApril302024` is set to false, so typeRenewal should navigate to the `adult-child` flow.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->