### PR TITLE
fix typo in parent-guardian screen in adult-child flow

### DIFF
--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -312,7 +312,7 @@
       "must-be": "You must be a parent or legal guardian.",
       "unable-to-apply": "You are not able to apply for this child. You must be a parent or legal guardian to apply on behalf of a child.",
       "back-btn": "Back",
-      "continue-btn": "Proceed to apply for yourself"
+      "continue-btn": "Return to application"
     },
     "dental-insurance": {
       "title": "{{childName}}: access to other dental insurance",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -312,7 +312,7 @@
       "must-be": "Vous devez être le parent ou le tuteur légal",
       "unable-to-apply": "Vous ne pouvez pas présenter de demande pour cet enfant. Vous devez être le parent ou le tuteur légal d'un enfant pour présenter une demande en son nom.",
       "back-btn": "Retour",
-      "continue-btn": "Procédez à faire la demande vous-même"
+      "continue-btn": "Retour à l'application"
     },
     "dental-insurance": {
       "title": "{{childName}}: access to other dental insurance",


### PR DESCRIPTION
### Description
changes text to match figma

### Related Azure Boards Work Items
[AB#4781](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4781)
