### PR TITLE
Conditionally display Status not found alert on applicant information page

### DIFF
--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -51,21 +51,25 @@ export class ClientApplicationRepositoryImpl implements ClientApplicationReposit
       body: JSON.stringify(clientApplicationBasicInfoRequestEntity),
     });
 
-    if (!response.ok) {
-      this.log.error('%j', {
-        message: "Failed to 'POST' for client application data",
-        status: response.status,
-        statusText: response.statusText,
-        url: url,
-        responseBody: await response.text(),
-      });
-      throw new Error(`Failed to 'POST' for client application data. Status: ${response.status}, Status Text: ${response.statusText}`);
+    if (response.ok) {
+      const data = await response.json();
+      this.log.trace('Client application [%j]', data);
+      return data;
     }
 
-    const data = await response.json();
-    this.log.trace('Client application [%j]', data);
+    if (response.status === 404) {
+      this.log.trace('Client application not found for basic info [%j]', clientApplicationBasicInfoRequestEntity);
+      return null;
+    }
 
-    return data;
+    this.log.error('%j', {
+      message: "Failed to 'POST' for client application data",
+      status: response.status,
+      statusText: response.statusText,
+      url: url,
+      responseBody: await response.text(),
+    });
+    throw new Error(`Failed to 'POST' for client application data. Status: ${response.status}, Status Text: ${response.statusText}`);
   }
 
   async findClientApplicationBySin(clientApplicationSinRequestEntity: ClientApplicationSinRequestEntity): Promise<ClientApplicationEntity | null> {

--- a/frontend/app/mocks/client-application-data/client-application.json
+++ b/frontend/app/mocks/client-application-data/client-application.json
@@ -184,8 +184,8 @@
             "ReferenceDataName": ""
           },
           "ApplicantDetail": {
-            "AttestParentOrGuardianIndicator": "",
-            "ConsentToSharePersonalInformationIndicator": "",
+            "AttestParentOrGuardianIndicator": false,
+            "ConsentToSharePersonalInformationIndicator": false,
             "DisabilityTaxCreditIndicator": "",
             "FederalDentalCoverageIndicator": "",
             "InsurancePlan": [
@@ -215,7 +215,7 @@
               }
             ],
             "LivingIndependentlyIndicator": "",
-            "PrivateDentalInsuranceIndicator": "",
+            "PrivateDentalInsuranceIndicator": false,
             "ProvincialDentalCoverageIndicator": ""
           },
           "PersonSINIdentification": {

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -246,11 +246,6 @@ export function getPowerPlatformApiMockHandlers() {
         // Otherwise, return specific flags or the default
         const clientApplicationFlags = mockApplicantFlags.get(identificationId) ?? clientApplicationJsonDataSource.BenefitApplication.Applicant.Flags;
 
-        if (!clientApplicationFlags) {
-          log.debug('Client application not found for identification id [%s]', identificationId);
-          return new HttpResponse(null, { status: 404 });
-        }
-
         return HttpResponse.json({
           ...clientApplicationJsonDataSource,
           BenefitApplication: {

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -193,18 +193,11 @@ export function getPowerPlatformApiMockHandlers() {
           '10000000001',
           [
             { Flag: false, FlagCategoryText: 'isCraAssessed' },
-            { Flag: false, FlagCategoryText: 'appliedBeforeApril302024' },
-          ],
-        ],
-        [
-          '10000000002',
-          [
-            { Flag: false, FlagCategoryText: 'isCraAssessed' },
             { Flag: true, FlagCategoryText: 'appliedBeforeApril302024' },
           ],
         ],
         [
-          '10000000003',
+          '10000000002',
           [
             { Flag: true, FlagCategoryText: 'isCraAssessed' },
             { Flag: false, FlagCategoryText: 'appliedBeforeApril302024' },
@@ -244,7 +237,14 @@ export function getPowerPlatformApiMockHandlers() {
         const personSurName = parsedClientApplicationRequest.data.Applicant.PersonName[0].PersonSurName;
         const personBirthDate = parsedClientApplicationRequest.data.Applicant.PersonBirthDate.date;
 
-        const clientApplicationFlags = mockApplicantFlags.get(identificationId);
+        // If the ID is '10000000000', return a 404 error
+        if (identificationId === '10000000000') {
+          log.debug('Client application not found for identification id [%s]', identificationId);
+          return new HttpResponse(null, { status: 404 });
+        }
+
+        // Otherwise, return specific flags or the default
+        const clientApplicationFlags = mockApplicantFlags.get(identificationId) ?? clientApplicationJsonDataSource.BenefitApplication.Applicant.Flags;
 
         if (!clientApplicationFlags) {
           log.debug('Client application not found for identification id [%s]', identificationId);

--- a/frontend/app/mocks/power-platform-api.server.ts
+++ b/frontend/app/mocks/power-platform-api.server.ts
@@ -192,7 +192,7 @@ export function getPowerPlatformApiMockHandlers() {
         [
           '10000000001',
           [
-            { Flag: true, FlagCategoryText: 'isCraAssessed' },
+            { Flag: false, FlagCategoryText: 'isCraAssessed' },
             { Flag: false, FlagCategoryText: 'appliedBeforeApril302024' },
           ],
         ],
@@ -206,7 +206,7 @@ export function getPowerPlatformApiMockHandlers() {
         [
           '10000000003',
           [
-            { Flag: false, FlagCategoryText: 'isCraAssessed' },
+            { Flag: true, FlagCategoryText: 'isCraAssessed' },
             { Flag: false, FlagCategoryText: 'appliedBeforeApril302024' },
           ],
         ],

--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -26,7 +26,7 @@ export interface RenewState {
     hasBeenAssessedByCRA: boolean;
     lastName: string;
     sin: string;
-  };
+  } | null;
   readonly children: {
     readonly id: string;
     readonly dentalBenefits?: {

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
@@ -6,7 +6,6 @@ import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
-import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../page-ids.json';
@@ -50,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:applicant-information.page-title') }) };
 
-  return json({ id: state.id, csrfToken, meta, defaultState: state.applicantInformation, clientApplication: state.clientApplication, editMode: state.editMode });
+  return json({ id: state.id, csrfToken, meta, defaultState: state.applicantInformation, editMode: state.editMode });
 }
 
 export async function action({ context: { session, serviceProvider }, params, request }: ActionFunctionArgs) {
@@ -138,8 +137,9 @@ export async function action({ context: { session, serviceProvider }, params, re
   // Fetch client application data using ClientApplicationService
   const clientApplication = await clientApplicationService.findClientApplicationByBasicInfo(parsedDataResult.data);
 
-  // TODO: handle when clientApplication is not found (null)
-  invariant(clientApplication, 'Expected clientApplication to be found (not null).');
+  if (!clientApplication) {
+    return { status: 'status-not-found' } as const;
+  }
 
   saveRenewState({ params, session, state: { applicantInformation: parsedDataResult.data, clientApplication } });
 
@@ -157,12 +157,13 @@ export async function action({ context: { session, serviceProvider }, params, re
 
 export default function RenewApplicationInformation() {
   const { i18n, t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, clientApplication, editMode, csrfToken } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const errors = fetcher.data?.errors;
+  const fetcherStatus = typeof fetcher.data === 'object' && 'status' in fetcher.data ? fetcher.data.status : undefined;
+  const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
@@ -175,19 +176,9 @@ export default function RenewApplicationInformation() {
 
   const eligibilityLink = <InlineLink to={t('renew:applicant-information.eligibility-link')} className="external-link" newTabIndicator target="_blank" />;
 
-  useEffect(() => {
-    if (clientApplication === null) {
-      const targetElement = document.getElementById('status-not-found');
-      if (targetElement) {
-        targetElement.scrollIntoView({ behavior: 'smooth' });
-        targetElement.focus();
-      }
-    }
-  }, [clientApplication]);
-
   return (
     <>
-      {clientApplication === null && <StatusNotFound />}
+      {fetcherStatus === 'status-not-found' && <StatusNotFound />}
       <div className="my-6 sm:my-8">
         <Progress value={25} size="lg" label={t('apply:progress.label')} />
       </div>
@@ -306,8 +297,17 @@ export default function RenewApplicationInformation() {
 function StatusNotFound() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const noWrap = <span className="whitespace-nowrap" />;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.scrollIntoView({ behavior: 'smooth' });
+      wrapperRef.current.focus();
+    }
+  }, []);
+
   return (
-    <div id="status-not-found" className="mb-4">
+    <div ref={wrapperRef} id="status-not-found" className="mb-4">
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew:applicant-information.status-not-found.heading')}</h2>
         <p className="mb-2">{t('renew:applicant-information.status-not-found.please-review')}</p>


### PR DESCRIPTION
### Description
Further improve the mock api response for the client application endpoint. The Flags field in the response now conditionally changes based on the IdentificationID (clientNumber) provided in the request. The response also return `status-not-found` if a specific client number is entered.

If clientNumber is "10000000000",
return 404, display `status-not-found` alert

If clientNumber is "10000000001", Flags will be set to:
isCraAssessed: false
appliedBeforeApril302024: true
Go to `ita` flow

If clientNumber is "10000000002", Flags will be set to:
isCraAssessed: true
appliedBeforeApril302024: false
Skip `tax-filing` and go to `adult-child` flow


For any other client number entered, go to `adult-child` flow

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
go to /renew/$id/applicant-information, input 3 client numbers to test the flow. Input a client number not listed in the description to trigger the `status-not-found` alert

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->