### PR TITLE
Fix broken `shouldSkipSessionHandling()`

### DIFF
--- a/frontend/app/express.server.ts
+++ b/frontend/app/express.server.ts
@@ -55,9 +55,9 @@ function securityHeadersRequestHandler(request: Request, response: Response, nex
  * Returns `true` if session handling should be skipped for the current request.
  * Typically, this rule applies to stateless API endpoints.
  */
-function shouldSkipSessionHandling({ url: pathname }: Request) {
+function shouldSkipSessionHandling({ path }: Request) {
   const statelessPaths = ['/api/buildinfo', '/api/health', '/api/readyz'];
-  return statelessPaths.includes(pathname);
+  return statelessPaths.includes(path);
 }
 
 export const expressApp = await createExpressApp({


### PR DESCRIPTION
### Description

The `shouldSkipSessionHandling()` function was comparing the request URL, which contains search params. The fix changes this to `request.path` which does not include the params.

### Checklist

- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
