### PR TITLE
Update client application mock to handle different client number

### DIFF
--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:type-of-renewal.page-title') }) };
 
-  return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal });
+  return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal, hasBeenAssessedByCRA: state.clientApplication?.hasBeenAssessedByCRA });
 }
 
 export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
@@ -105,7 +105,7 @@ export async function action({ context: { configProvider, serviceProvider, sessi
 
 export default function RenewTypeOfRenewal() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, hasBeenAssessedByCRA } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -151,7 +151,14 @@ export default function RenewTypeOfRenewal() {
             <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Continue - Type of renewal click">
               {t('renew:type-of-renewal.continue-btn')}
             </LoadingButton>
-            <ButtonLink id="back-button" routeId="public/apply/$id/terms-and-conditions" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Back - Type of renewal click">
+            <ButtonLink
+              id="back-button"
+              routeId={hasBeenAssessedByCRA ? 'public/renew/$id/applicant-information' : 'public/renew/$id/tax-filing'}
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form:Back - Type of renewal click"
+            >
               {t('renew:type-of-renewal.back-btn')}
             </ButtonLink>
           </div>


### PR DESCRIPTION
### Description
Update the mock api response for the client application endpoint. The `Flags` field in the response now conditionally changes based on the IdentificationID (clientNumber) provided in the request:

If clientNumber is "`10000000001`", Flags will be set to:
isCraAssessed: true
appliedBeforeApril302024: false
Go to `adult-child` flow

If clientNumber is "`10000000002`", Flags will be set to:
isCraAssessed: false
appliedBeforeApril302024: true
Go to `ita` flow

Right now, for all other clientNumber values, the response will return Flags as defined in the original `clientApplicationJsonDataSource` without modification, which will redirect user to the `adult-child` flow.

Also updated the back button link on the `type-renewal` page, the back button should go either `applicant-information` or `tax-filing` base on the `hasBeenAssessedByCRA` value.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->