### PR TITLE
Add redis health check

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -187,11 +187,14 @@ REDIS_STANDALONE_HOST=localhost
 # (optional; default: localhost)
 REDIS_STANDALONE_PORT=6379
 # redis server username
-# (optional; default undefined)
+# (optional; default: undefined)
 REDIS_USERNAME=username
 # redis server password
-# (optional; default undefined)
+# (optional; default: undefined)
 REDIS_PASSWORD=password
+# number of times to retry a redis request before giving up
+# (optional; default: 3)
+REDIS_MAX_RETRIES_PER_REQUEST=3
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)

--- a/frontend/__tests__/.server/domain/services/redis.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/redis.service.test.ts
@@ -37,6 +37,7 @@ describe('RedisServiceImpl', () => {
           REDIS_STANDALONE_PORT: 8443,
           REDIS_USERNAME: 'redis',
           REDIS_PASSWORD: 'password',
+          REDIS_MAX_RETRIES_PER_REQUEST: 1,
         }),
       );
 
@@ -46,6 +47,7 @@ describe('RedisServiceImpl', () => {
         port: 8443,
         username: 'redis',
         password: 'password',
+        maxRetriesPerRequest: 1,
       });
     });
 
@@ -58,6 +60,7 @@ describe('RedisServiceImpl', () => {
           REDIS_SENTINEL_PORT: 8443,
           REDIS_USERNAME: 'redis',
           REDIS_PASSWORD: 'password',
+          REDIS_MAX_RETRIES_PER_REQUEST: 1,
         }),
       );
 
@@ -67,6 +70,7 @@ describe('RedisServiceImpl', () => {
         sentinels: [{ host: 'example.com', port: 8443 }],
         username: 'redis',
         password: 'password',
+        maxRetriesPerRequest: 1,
       });
     });
   });

--- a/frontend/app/.server/domain/services/redis.service.ts
+++ b/frontend/app/.server/domain/services/redis.service.ts
@@ -25,12 +25,16 @@ export interface RedisService {
    * @see https://redis.io/commands/del/
    */
   del: (key: string) => Promise<number>;
+  /**
+   * @see https://redis.io/commands/ping/
+   */
+  ping: () => Promise<'PONG'>;
 }
 
 @injectable()
 export class RedisServiceImpl implements RedisService {
   private readonly log: Logger;
-  private readonly redisClient: Promise<Redis>;
+  private readonly redisClient: Redis;
 
   constructor(@inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory, @inject(SERVICE_IDENTIFIER.SERVER_CONFIG) serverConfig: ServerConfig) {
     this.log = logFactory.createLogger('RedisServiceImpl');
@@ -38,43 +42,44 @@ export class RedisServiceImpl implements RedisService {
   }
 
   async get<T>(key: string): Promise<T | null> {
-    const redisClient = await this.redisClient;
-    const value = await redisClient.get(key);
+    const value = await this.redisClient.get(key);
     return value ? JSON.parse(value) : null;
   }
 
   async set(key: string, value: unknown, ttlSecs: number): Promise<'OK'> {
-    const redisClient = await this.redisClient;
-    return await redisClient.set(key, JSON.stringify(value), 'EX', ttlSecs);
+    return await this.redisClient.set(key, JSON.stringify(value), 'EX', ttlSecs);
   }
 
   async del(key: string): Promise<number> {
-    const redisClient = await this.redisClient;
-    return await redisClient.del(key);
+    return await this.redisClient.del(key);
   }
 
-  private async newRedisClient(serverConfig: ServerConfig): Promise<Redis> {
+  async ping(): Promise<'PONG'> {
+    return await this.redisClient.ping();
+  }
+
+  private newRedisClient(serverConfig: ServerConfig): Redis {
     const redisClient = new Redis({
       lazyConnect: true,
       host: serverConfig.REDIS_STANDALONE_HOST,
       port: serverConfig.REDIS_STANDALONE_PORT,
       username: serverConfig.REDIS_USERNAME,
       password: serverConfig.REDIS_PASSWORD,
+      maxRetriesPerRequest: serverConfig.REDIS_MAX_RETRIES_PER_REQUEST,
     });
 
     const redisUrl = `redis://${serverConfig.REDIS_STANDALONE_HOST}:${serverConfig.REDIS_STANDALONE_PORT}`;
 
-    await redisClient
+    redisClient
       .on('connect', () => this.log.info(`Redis client initiating connection to [${redisUrl}]`))
       .on('ready', () => this.log.info('Redis client is ready to use'))
       .on('reconnecting', () => this.log.info(`Redis client is reconnecting to [${redisUrl}]`))
-      .on('error', (error: Error) => this.log.error(`Redis client error connecting to [${redisUrl}]: ${error.message}`))
-      .connect();
+      .on('error', (error: Error) => this.log.error(`Redis client error connecting to [${redisUrl}]: ${error.message}`));
 
     return redisClient;
   }
 
-  private async newSentinelClient(serverConfig: ServerConfig): Promise<Redis> {
+  private newSentinelClient(serverConfig: ServerConfig): Redis {
     const sentinelAddress = {
       host: serverConfig.REDIS_SENTINEL_HOST,
       port: serverConfig.REDIS_SENTINEL_PORT,
@@ -82,20 +87,20 @@ export class RedisServiceImpl implements RedisService {
 
     const redisClient = new Redis({
       lazyConnect: true,
-      name: serverConfig.REDIS_SENTINEL_NAME,
       sentinels: [sentinelAddress],
+      name: serverConfig.REDIS_SENTINEL_NAME,
       username: serverConfig.REDIS_USERNAME,
       password: serverConfig.REDIS_PASSWORD,
+      maxRetriesPerRequest: serverConfig.REDIS_MAX_RETRIES_PER_REQUEST,
     });
 
     const redisUrl = `sentinel://${serverConfig.REDIS_SENTINEL_HOST}:${serverConfig.REDIS_SENTINEL_PORT}`;
 
-    await redisClient
+    redisClient
       .on('connect', () => this.log.info(`Redis client initiating connection to [${redisUrl}]`))
       .on('ready', () => this.log.info('Redis client is ready to use'))
       .on('reconnecting', () => this.log.info(`Redis client is reconnecting to [${redisUrl}]`))
-      .on('error', (error: Error) => this.log.error(`Redis client error connecting to [${redisUrl}]: ${error.message}`))
-      .connect();
+      .on('error', (error: Error) => this.log.error(`Redis client error connecting to [${redisUrl}]: ${error.message}`));
 
     return redisClient;
   }

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -51,7 +51,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
 
   // exclude the redis health check if the application is not using it
   const useRedis = configProvider.getServerConfig().SESSION_STORAGE_TYPE === 'redis';
-  if (!useRedis) (healthCheckOptions.excludeComponents ??= []).push(redisHealthCheck.name);
+  if (!useRedis) {
+    healthCheckOptions.excludeComponents ??= [];
+    healthCheckOptions.excludeComponents.push(redisHealthCheck.name);
+  }
 
   // execute the health checks
   const systemHealthSummary = await execute([redisHealthCheck], healthCheckOptions);

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -126,6 +126,7 @@ const serverEnv = clientEnvSchema.extend({
   REDIS_STANDALONE_PORT: z.coerce.number().default(6379),
   REDIS_USERNAME: z.string().trim().min(1).optional(),
   REDIS_PASSWORD: z.string().trim().min(1).optional(),
+  REDIS_MAX_RETRIES_PER_REQUEST: z.coerce.number().default(3),
 
   // mocks settings
   ENABLED_MOCKS: z.string().transform(emptyToUndefined).transform(csvToArray).refine(areValidMockNames).default(''),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@date-fns/utc": "^2.1.0",
-        "@dts-stn/health-checks": "^1.0.0",
+        "@dts-stn/health-checks": "^2.0.0",
         "@faker-js/faker": "^9.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
@@ -929,9 +929,9 @@
       "license": "MIT"
     },
     "node_modules/@dts-stn/health-checks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dts-stn/health-checks/-/health-checks-1.0.0.tgz",
-      "integrity": "sha512-pzkfOW7MYHfNH1RsWD9o+z22YpR/NSe3pwQFCO57Kj5GGjYMiL7GJZjYbTP2xb+PE6skLJo4FUsmLQ/MRvyfqg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dts-stn/health-checks/-/health-checks-2.0.0.tgz",
+      "integrity": "sha512-z6n8HJnPHw4zIIfgj4sra1suTkLnO4iVriYbAGk0aiduelbZkFVLcHl1DBxesMd3Yj44U0+nSGIPcsY1zmNmuw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@date-fns/utc": "^2.1.0",
-    "@dts-stn/health-checks": "^1.0.0",
+    "@dts-stn/health-checks": "^2.0.0",
     "@faker-js/faker": "^9.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-regular-svg-icons": "^6.6.0",


### PR DESCRIPTION
### Description

Add a redis healthcheck that is engaged whenever `SESSION_STORAGE_TYPE=redis`.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Set `SESSION_STORAGE_TYPE=redis` and hit `/api/health`.

```
➜  frontend git:(development) curl  --silent 'http://localhost:3000/api/health'
HTTP/1.1 503 Service Unavailable
content-type: application/health+json

{
  "buildId": "00000000",
  "components": [
    {
      "redis": {
        "status": "UNHEALTHY",
        "responseTimeMs": 398
      }
    }
  ],
  "responseTimeMs": 398,
  "status": "UNHEALTHY",
  "version": "0.0.0"
}
```