### PR TITLE
refactor(frontend): remove ContainerConfigProvider

### DIFF
--- a/frontend/__tests__/routes/protected/letters/index.test.tsx
+++ b/frontend/__tests__/routes/protected/letters/index.test.tsx
@@ -2,8 +2,9 @@ import type { AppLoadContext } from '@remix-run/node';
 import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
+import { mockDeep } from 'vitest-mock-extended';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { loader } from '~/routes/protected/letters/index';
 
 vi.mock('~/services/instrumentation-service.server', () => ({
@@ -53,8 +54,7 @@ describe('Letters Page', () => {
       session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
       session.set('userInfoToken', { sin: '999999999', sub: '1111111' });
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
+      const mockAppLoadContext = mockDeep<AppLoadContext>({
         serviceProvider: {
           getApplicantService: vi.fn().mockReturnValue({ findClientNumberBySin: vi.fn().mockReturnValue('some-client-number') }),
           getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }),
@@ -72,6 +72,9 @@ describe('Letters Page', () => {
             ]),
           }),
         },
+      });
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.CLIENT_CONFIG).mockReturnValueOnce({
+        SCCH_BASE_URI: 'https://api.example.com',
       });
 
       const response = await loader({
@@ -95,8 +98,7 @@ describe('Letters Page', () => {
     session.set('idToken', { sub: '00000000-0000-0000-0000-000000000000' });
     session.set('userInfoToken', { sin: '999999999' });
 
-    const mockAppLoadContext = mock<AppLoadContext>({
-      configProvider: { getClientConfig: vi.fn().mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' }) },
+    const mockAppLoadContext = mockDeep<AppLoadContext>({
       serviceProvider: {
         getApplicantService: vi.fn().mockReturnValue({ findClientNumberBySin: vi.fn().mockReturnValue('some-client-number') }),
         getAuditService: vi.fn().mockReturnValue({ createAudit: vi.fn() }),
@@ -115,6 +117,7 @@ describe('Letters Page', () => {
         }),
       },
     });
+    mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.CLIENT_CONFIG).mockReturnValue({ SCCH_BASE_URI: 'https://api.example.com' });
 
     const response = await loader({
       request: new Request('http://localhost/letters'),

--- a/frontend/__tests__/routes/public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/public/communication-preference.test.tsx
@@ -2,8 +2,9 @@ import type { AppLoadContext } from '@remix-run/node';
 import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
+import { mockDeep } from 'vitest-mock-extended';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { action, loader } from '~/routes/public/apply/$id/adult/communication-preference';
 
 vi.mock('~/route-helpers/apply-adult-route-helpers.server', () => ({
@@ -31,12 +32,7 @@ describe('_public.apply.id.communication-preference', () => {
     it('should id, state, country list and region list', async () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: {
-          getServerConfig: vi.fn().mockReturnValue({
-            COMMUNICATION_METHOD_EMAIL_ID: 'email',
-          }),
-        },
+      const mockAppLoadContext = mockDeep<AppLoadContext>({
         serviceProvider: {
           getPreferredCommunicationMethodService: () => ({
             listPreferredCommunicationMethods: vi.fn(),
@@ -60,6 +56,9 @@ describe('_public.apply.id.communication-preference', () => {
             ],
           }),
         },
+      });
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.SERVER_CONFIG).mockReturnValueOnce({
+        COMMUNICATION_METHOD_EMAIL_ID: 'email',
       });
 
       const response = await loader({
@@ -99,12 +98,9 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('_csrf', 'csrfToken');
       formData.append('preferredLanguage', 'fr');
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: {
-          getServerConfig: vi.fn().mockReturnValue({
-            COMMUNICATION_METHOD_EMAIL_ID: 'email',
-          }),
-        },
+      const mockAppLoadContext = mockDeep<AppLoadContext>();
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.SERVER_CONFIG).mockReturnValueOnce({
+        COMMUNICATION_METHOD_EMAIL_ID: 'email',
       });
 
       const response = await action({
@@ -128,12 +124,9 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('email', '');
       formData.append('preferredLanguage', 'fr');
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: {
-          getServerConfig: vi.fn().mockReturnValue({
-            COMMUNICATION_METHOD_EMAIL_ID: 'email',
-          }),
-        },
+      const mockAppLoadContext = mockDeep<AppLoadContext>();
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.SERVER_CONFIG).mockReturnValueOnce({
+        COMMUNICATION_METHOD_EMAIL_ID: 'email',
       });
 
       const response = await action({
@@ -158,12 +151,9 @@ describe('_public.apply.id.communication-preference', () => {
       formData.append('confirmEmail', 'johndoe@example.com');
       formData.append('preferredLanguage', 'fr');
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: {
-          getServerConfig: vi.fn().mockReturnValue({
-            COMMUNICATION_METHOD_EMAIL_ID: 'email',
-          }),
-        },
+      const mockAppLoadContext = mockDeep<AppLoadContext>();
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.SERVER_CONFIG).mockReturnValueOnce({
+        COMMUNICATION_METHOD_EMAIL_ID: 'email',
       });
 
       const response = await action({

--- a/frontend/__tests__/routes/public/contact-information.test.tsx
+++ b/frontend/__tests__/routes/public/contact-information.test.tsx
@@ -2,8 +2,9 @@ import type { AppLoadContext } from '@remix-run/node';
 import { createMemorySessionStorage } from '@remix-run/node';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
+import { mockDeep } from 'vitest-mock-extended';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { loader } from '~/routes/public/apply/$id/adult/contact-information';
 
 vi.mock('~/route-helpers/apply-adult-route-helpers.server', () => ({
@@ -31,15 +32,7 @@ describe('_public.apply.id.contact-information', () => {
     it('should id, state, country list and region list', async () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
-      const mockAppLoadContext = mock<AppLoadContext>({
-        configProvider: {
-          getServerConfig: vi.fn().mockReturnValue({
-            MARITAL_STATUS_CODE_COMMONLAW: 'COMMONLAW',
-            MARITAL_STATUS_CODE_MARRIED: 'MARRIED',
-            CANADA_COUNTRY_ID: 'CAN',
-            USA_COUNTRY_ID: 'USA',
-          }),
-        },
+      const mockAppLoadContext = mockDeep<AppLoadContext>({
         serviceProvider: {
           getCountryService: () => ({
             getCountryById: vi.fn(),
@@ -55,6 +48,12 @@ describe('_public.apply.id.contact-information', () => {
             listAndSortLocalizedProvinceTerritoryStatesByCountryId: vi.fn(),
           }),
         },
+      });
+      mockAppLoadContext.appContainer.get.calledWith(SERVICE_IDENTIFIER.SERVER_CONFIG).mockReturnValueOnce({
+        MARITAL_STATUS_CODE_COMMONLAW: 'COMMONLAW',
+        MARITAL_STATUS_CODE_MARRIED: 'MARRIED',
+        CANADA_COUNTRY_ID: 'CAN',
+        USA_COUNTRY_ID: 'USA',
       });
 
       const response = await loader({

--- a/frontend/app/.server/app.container.ts
+++ b/frontend/app/.server/app.container.ts
@@ -5,7 +5,7 @@ import { makeLoggerMiddleware, textSerializer } from 'inversify-logger-middlewar
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { configsContainerModule, containerProvidersContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, servicesContainerModule, webValidatorsContainerModule } from '~/.server/container-modules';
-import type { AppContainerProvider, ContainerConfigProvider, ContainerServiceProvider } from '~/.server/providers';
+import type { AppContainerProvider, ContainerServiceProvider } from '~/.server/providers';
 import { AppContainerProviderImpl } from '~/.server/providers';
 import { getLogger } from '~/utils/logging.server';
 
@@ -25,7 +25,6 @@ import { getLogger } from '~/utils/logging.server';
 
 let appContainerInstance: interfaces.Container | undefined;
 let appContainerProviderInstance: AppContainerProvider | undefined;
-let containerConfigProviderInstance: ContainerConfigProvider | undefined;
 let containerServiceProviderInstance: ContainerServiceProvider | undefined;
 
 /**
@@ -44,15 +43,6 @@ function getAppContainer(): interfaces.Container {
  */
 export function getAppContainerProvider(): AppContainerProvider {
   return (appContainerProviderInstance ??= new AppContainerProviderImpl(getAppContainer()));
-}
-
-/**
- * Returns the ContainerConfigProvider singleton instance.
- *
- * @returns The ContainerConfigProvider singleton instance.
- */
-export function getContainerConfigProvider(): ContainerConfigProvider {
-  return (containerConfigProviderInstance ??= getAppContainer().get(SERVICE_IDENTIFIER.CONTAINER_CONFIG_PROVIDER));
 }
 
 /**

--- a/frontend/app/.server/constants/service-identifier.constant.ts
+++ b/frontend/app/.server/constants/service-identifier.constant.ts
@@ -56,7 +56,7 @@ import type {
   SessionService,
 } from '~/.server/domain/services';
 import type { ConfigFactory, LogFactory } from '~/.server/factories';
-import type { ContainerConfigProvider, ContainerServiceProvider } from '~/.server/providers';
+import type { ContainerServiceProvider } from '~/.server/providers';
 import type { HCaptchaDtoMapper } from '~/.server/web/mappers';
 import type { HCaptchaRepository } from '~/.server/web/repositories';
 import type { HCaptchaService } from '~/.server/web/services';
@@ -83,7 +83,6 @@ export const SERVICE_IDENTIFIER = {
   CLIENT_FRIENDLY_STATUS_REPOSITORY: serviceIdentifier<ClientFriendlyStatusRepository>('ClientFriendlyStatusRepository'),
   CLIENT_FRIENDLY_STATUS_SERVICE: serviceIdentifier<ClientFriendlyStatusService>('ClientFriendlyStatusService'),
   CONFIG_FACTORY: serviceIdentifier<ConfigFactory>('ConfigFactory'),
-  CONTAINER_CONFIG_PROVIDER: serviceIdentifier<ContainerConfigProvider>('ContainerConfigProvider'),
   CONTAINER_SERVICE_PROVIDER: serviceIdentifier<ContainerServiceProvider>('ContainerServiceProvider'),
   COUNTRY_DTO_MAPPER: serviceIdentifier<CountryDtoMapper>('CountryDtoMapper'),
   COUNTRY_REPOSITORY: serviceIdentifier<CountryRepository>('CountryRepository'),

--- a/frontend/app/.server/container-modules/container-providers.container-module.ts
+++ b/frontend/app/.server/container-modules/container-providers.container-module.ts
@@ -1,12 +1,11 @@
 import { ContainerModule } from 'inversify';
 
 import { SERVICE_IDENTIFIER } from '~/.server/constants';
-import { ContainerConfigProviderImpl, ContainerServiceProviderImpl } from '~/.server/providers';
+import { ContainerServiceProviderImpl } from '~/.server/providers';
 
 /**
  * Container module for container providers.
  */
 export const containerProvidersContainerModule = new ContainerModule((bind) => {
-  bind(SERVICE_IDENTIFIER.CONTAINER_CONFIG_PROVIDER).to(ContainerConfigProviderImpl);
   bind(SERVICE_IDENTIFIER.CONTAINER_SERVICE_PROVIDER).to(ContainerServiceProviderImpl);
 });

--- a/frontend/app/express.server.ts
+++ b/frontend/app/express.server.ts
@@ -15,7 +15,7 @@ import type { SetOptional } from 'type-fest';
 
 import { getEnv } from './utils/env-utils.server';
 import { randomString } from './utils/string-utils';
-import { getAppContainerProvider, getContainerConfigProvider, getContainerServiceProvider } from '~/.server/app.container';
+import { getAppContainerProvider, getContainerServiceProvider } from '~/.server/app.container';
 import { getLogger } from '~/utils/logging.server';
 
 const { NODE_ENV } = getEnv();
@@ -114,7 +114,6 @@ const expressApp = await createExpressApp({
 
     const partialAppLoadContext = {
       appContainer: getAppContainerProvider(),
-      configProvider: getContainerConfigProvider(),
       serviceProvider: getContainerServiceProvider(),
     } as const satisfies SetOptional<AppLoadContext, 'session'>;
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import reactPhoneNumberInputStyleSheet from 'react-phone-number-input/style.css?url';
 import invariant from 'tiny-invariant';
 
+import { SERVICE_IDENTIFIER } from './.server/constants';
 import { getDynatraceService } from './services/dynatrace-service.server';
 import type { FeatureName } from './utils/env-utils';
 import { ClientEnv } from '~/components/client-env';
@@ -59,7 +60,7 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => {
   };
 };
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const buildInfoService = getBuildInfoService();
   const dynatraceService = getDynatraceService();
   const requestUrl = new URL(request.url);
@@ -68,7 +69,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
 
   const buildInfo = buildInfoService.getBuildInfo();
   const dynatraceRumScript = await dynatraceService.retrieveRumScript();
-  const env = configProvider.getClientConfig();
+  const env = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   const meta = {
     author: t('gcweb:meta.author'),
     description: t('gcweb:meta.description'),

--- a/frontend/app/routes/$lang-$.tsx
+++ b/frontend/app/routes/$lang-$.tsx
@@ -17,7 +17,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('gcweb:public-not-found.document-title') }) };
   return json({ meta }, { status: 404 });

--- a/frontend/app/routes/$lang-index.tsx
+++ b/frontend/app/routes/$lang-index.tsx
@@ -5,12 +5,12 @@ import { BilingualNotFoundError, NotFoundError } from '~/components/layouts/publ
 import { isAppLocale } from '~/utils/locale-utils';
 import { getLogger } from '~/utils/logging.server';
 
-export function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   // Return a 404 status response because the displayed content is "not found"
   return new Response(null, { status: 404 });
 }
 
-export function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('$lang/index');
   const lang = params.lang;
 

--- a/frontend/app/routes/$lang-layout.tsx
+++ b/frontend/app/routes/$lang-layout.tsx
@@ -6,7 +6,7 @@ import { BilingualNotFoundError, NotFoundError, ServerError } from '~/components
 import { isAppLocale } from '~/utils/locale-utils';
 import { getLogger } from '~/utils/logging.server';
 
-export function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const log = getLogger('$lang/_route');
   const lang = params.lang;
 

--- a/frontend/app/routes/[.]well-known.jwks[.]json.tsx
+++ b/frontend/app/routes/[.]well-known.jwks[.]json.tsx
@@ -4,6 +4,7 @@ import { json } from '@remix-run/node';
 import { subtle } from 'node:crypto';
 
 import type { ServerConfig } from '~/.server/configs';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { generateCryptoKey, generateJwkId } from '~/utils/crypto-utils.server';
 import { getLogger } from '~/utils/logging.server';
 
@@ -37,9 +38,9 @@ async function getJwks(serverConfig: Pick<ServerConfig, 'AUTH_JWT_PUBLIC_KEY'>) 
  * A JSON endpoint that contains a list of the application's public keys that
  * can be used by an auth provider to verify private key JWTs.
  */
-export async function loader({ context: { configProvider } }: LoaderFunctionArgs) {
-  const serverConfig = configProvider.getServerConfig();
-  const keys = await getJwks(serverConfig);
+export async function loader({ context: { appContainer } }: LoaderFunctionArgs) {
+  const { AUTH_JWT_PUBLIC_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
+  const keys = await getJwks({ AUTH_JWT_PUBLIC_KEY });
   const headers = { 'Content-Type': 'application/json' };
 
   return json({ keys }, { headers: headers });

--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -12,7 +12,7 @@ import { getLogger } from '~/utils/logging.server';
 const API_APPLY_STATE_ACTIONS = ['extend'] as const;
 export type ApiApplyStateAction = (typeof API_APPLY_STATE_ACTIONS)[number];
 
-export async function action({ context: { configProvider, serviceProvider, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request }: ActionFunctionArgs) {
   const log = getLogger('routes/api/apply-state');
   const sessionId = session.id;
   log.debug("Action with with user's apply state; sessionId: [%s]", sessionId);

--- a/frontend/app/routes/api/readyz.ts
+++ b/frontend/app/routes/api/readyz.ts
@@ -6,6 +6,6 @@ import { json } from '@remix-run/node';
  *
  * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
  */
-export function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   return json({ ready: true });
 }

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -16,7 +16,7 @@ export type ApiSessionAction = (typeof API_SESSION_ACTIONS)[number];
 const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', 'cdcp-website-status'] as const;
 export type ApiSessionRedirectTo = (typeof API_SESSION_REDIRECT_TO_OPTIONS)[number];
 
-export async function action({ context: { configProvider, serviceProvider, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request }: ActionFunctionArgs) {
   const log = getLogger('routes/api/session');
   const sessionId = session.id;
   log.debug("Action with user's server-side session; sessionId: [%s]", sessionId);

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -3,6 +3,7 @@ import { redirect } from '@remix-run/node';
 
 import { z } from 'zod';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { getAuditService } from '~/services/audit-service.server';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -71,12 +72,12 @@ function handleLoginRequest({ request }: LoaderFunctionArgs) {
 /**
  * Handler for /auth/logout requests
  */
-async function handleLogoutRequest({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+async function handleLogoutRequest({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const log = getLogger('auth.$/handleLogoutRequest');
   log.debug('Handling RAOIDC logout request');
   getInstrumentationService().createCounter('auth.logout.requests').add(1);
 
-  const { AUTH_RASCL_LOGOUT_URL } = configProvider.getServerConfig();
+  const { AUTH_RASCL_LOGOUT_URL } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const sessionService = serviceProvider.getSessionService();
 
@@ -103,7 +104,7 @@ async function handleLogoutRequest({ context: { configProvider, serviceProvider,
 /**
  * Handler for /auth/login/raoidc requests
  */
-async function handleRaoidcLoginRequest({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+async function handleRaoidcLoginRequest({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const log = getLogger('auth.$/handleRaoidcLoginRequest');
   log.debug('Handling RAOIDC login request');
   getInstrumentationService().createCounter('auth.login.raoidc.requests').add(1);
@@ -138,7 +139,7 @@ async function handleRaoidcLoginRequest({ context: { configProvider, serviceProv
 /**
  * Handler for /auth/callback/raoidc requests
  */
-async function handleRaoidcCallbackRequest({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+async function handleRaoidcCallbackRequest({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const log = getLogger('auth.$/handleRaoidcCallbackRequest');
   log.debug('Handling RAOIDC callback request');
   getInstrumentationService().createCounter('auth.callback.raoidc.requests').add(1);
@@ -164,12 +165,12 @@ async function handleRaoidcCallbackRequest({ context: { configProvider, serviceP
 /**
  * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
  */
-function handleMockAuthorizeRequest({ context: { configProvider }, request }: LoaderFunctionArgs) {
+function handleMockAuthorizeRequest({ context: { appContainer }, request }: LoaderFunctionArgs) {
   const log = getLogger('auth.$/handleMockAuthorizeRequest');
   log.debug('Handling (mock) RAOIDC authorize request');
   getInstrumentationService().createCounter('auth.authorize.requests').add(1);
 
-  const { MOCK_AUTH_ALLOWED_REDIRECTS } = configProvider.getServerConfig();
+  const { MOCK_AUTH_ALLOWED_REDIRECTS } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const isValidRedirectUri = (val: string): boolean => MOCK_AUTH_ALLOWED_REDIRECTS.includes(val);
 
   const searchParamsSchema = z.object({

--- a/frontend/app/routes/protected/_route.tsx
+++ b/frontend/app/routes/protected/_route.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { NotFoundError, ProtectedLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
@@ -11,8 +12,8 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = configProvider.getClientConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   return { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -5,6 +5,7 @@ import { useLoaderData, useParams } from '@remix-run/react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import pageIds from '../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -26,14 +27,14 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request, session);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('data-unavailable:page-title') }) };
 
-  const { SCCH_BASE_URI } = configProvider.getClientConfig();
+  const { SCCH_BASE_URI } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
 
   return json({ meta, SCCH_BASE_URI });
 }

--- a/frontend/app/routes/protected/home.tsx
+++ b/frontend/app/routes/protected/home.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const raoidcService = await getRaoidcService();
   await raoidcService.handleSessionValidation(request, session);
 

--- a/frontend/app/routes/protected/letters/$id.download.tsx
+++ b/frontend/app/routes/protected/letters/$id.download.tsx
@@ -10,7 +10,7 @@ import { featureEnabled } from '~/utils/env-utils.server';
 import { getLocale } from '~/utils/locale-utils.server';
 import type { IdToken, UserinfoToken } from '~/utils/raoidc-utils.server';
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
   const instrumentationService = getInstrumentationService();

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -9,6 +9,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { InlineLink } from '~/components/inline-link';
@@ -38,7 +39,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 
 const orderEnumSchema = z.enum(['asc', 'desc']);
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('view-letters');
 
   const instrumentationService = getInstrumentationService();
@@ -72,7 +73,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('letters:index.page-title') }) };
-  const { SCCH_BASE_URI } = configProvider.getClientConfig();
+  const { SCCH_BASE_URI } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
 
   const idToken: IdToken = session.get('idToken');
   serviceProvider.getAuditService().createAudit('page-view.letters', { userId: idToken.sub });

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return { meta, defaultValues };
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('stub-login');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/address-validation.tsx
+++ b/frontend/app/routes/public/address-validation.tsx
@@ -10,6 +10,7 @@ import invariant from 'tiny-invariant';
 import validator from 'validator';
 import { z } from 'zod';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { validateCsrfToken } from '~/.server/remix/security';
 import { Address } from '~/components/address';
 import { AddressDiff } from '~/components/address-diff';
@@ -80,9 +81,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   featureEnabled('address-validation');
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const locale = getLocale(request);
   const countries = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
@@ -100,7 +101,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   };
 }
 
-export async function action({ context: { appContainer, configProvider, serviceProvider, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request }: ActionFunctionArgs) {
   featureEnabled('address-validation');
   await validateCsrfToken({ context: { appContainer }, request });
 
@@ -109,7 +110,7 @@ export async function action({ context: { appContainer, configProvider, serviceP
   }
 
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const locale = getLocale(request);
 
   const addressSchema = z

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -64,7 +64,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, ageCategory, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/applicant-information');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/apply-children');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -40,7 +40,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/apply-yourself');
   loadApplyAdultChildState({ params, request, session });
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +39,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/cannot-apply-child');
 
   loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/dental-insurance');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,13 +48,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const federalSocialPrograms = serviceProvider.getFederalGovernmentInsurancePlanService().listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provinceTerritoryStates = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
@@ -82,7 +83,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/federal-provincial-territorial-benefits');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +66,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/information');
 
   const state = loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -40,7 +40,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/children/parent-or-guardian');
 
   loadApplyAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -76,7 +76,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
 
   const log = getLogger('apply/adult-child/child-summary');

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
@@ -40,8 +41,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,10 +75,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -164,7 +164,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/contact-apply-child');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -45,11 +46,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -73,12 +74,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/contact-information');
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +53,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: { dateOfBirth, allChildrenUnder18 }, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/date-of-birth');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/dental-insurance');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -57,7 +57,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/disability-tax-credit');
   const state = loadApplyAdultChildState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/dob-eligibility');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,8 +48,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -75,7 +76,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/federal-provincial-territorial');
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.livingIndependently });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/living-independently');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, ageCategory });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/parent-or-guardian');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/partner-information');
 
   const state = loadApplyAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -12,6 +12,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -47,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -55,7 +56,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -147,12 +148,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/review-adult-information');
 
   loadApplyAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -13,6 +13,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button } from '~/components/buttons';
 import { DebugPayload } from '~/components/debug-payload';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -50,13 +51,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -110,12 +111,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/review-child-information');
 
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult-child/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -64,7 +64,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ ageCategory, csrfToken, defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, maritalStatuses, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/applicant-information');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
@@ -40,8 +41,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -73,10 +74,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -131,7 +131,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -45,11 +46,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -73,12 +74,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/contact-information');
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
@@ -34,7 +34,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -45,7 +45,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: { dateOfBirth }, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/date-of-birth');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/dental-insurance');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -57,7 +57,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/disability-tax-credit');
   const state = loadApplyAdultState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/dob-eligibility');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,8 +48,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -73,7 +74,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/federal-provincial-territorial');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.livingIndependently, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/living-independently');
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ ageCategory, csrfToken, defaultState: state.disabilityTaxCredit, id: state.id, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/parent-or-guardian');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/partner-information');
 
   const state = loadApplyAdultState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -13,6 +13,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { DebugPayload } from '~/components/debug-payload';
@@ -51,7 +52,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -59,7 +60,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -157,12 +158,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/review-information');
 
   const state = loadApplyAdultStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/adult/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/application-delegate');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -63,7 +63,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, maritalStatuses, csrfToken, meta, defaultState: state.applicantInformation, dateOfBirth: state.dateOfBirth, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/applicant-information');
 
   const state = loadApplyChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -28,7 +28,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/cannot-apply-child');
   loadApplySingleChildState({ params, request, session });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/dental-insurance');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,10 +48,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
 
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -82,7 +83,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/federal-provincial-territorial-benefits');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +66,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/information');
 
   const state = loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/children/parent-or-guardian');
 
   loadApplySingleChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -47,7 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -77,7 +77,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
 
   const log = getLogger('apply/child/child-summary');

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
@@ -40,8 +41,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,10 +75,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -152,7 +152,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/confirmation');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/contact-apply-child');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -45,11 +46,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -73,12 +74,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/contact-information');
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const personalInformationSchema = z
     .object({

--- a/frontend/app/routes/public/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -41,7 +41,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +55,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.partnerInformation, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/partner-information');
 
   const state = loadApplyChildState({ params, request, session });

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -13,6 +13,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { DebugPayload } from '~/components/debug-payload';
@@ -51,7 +52,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -59,7 +60,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -132,12 +133,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/review-adult-information');
 
   const state = loadApplyChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const benefitApplicationService = getBenefitApplicationService();
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -12,6 +12,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button } from '~/components/buttons';
 import { DescriptionListItem } from '~/components/description-list-item';
 import { InlineLink } from '~/components/inline-link';
@@ -46,13 +47,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -102,12 +103,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/review-child-information');
 
   loadApplyChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling2023 });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/child/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/index.tsx
+++ b/frontend/app/routes/public/apply/$id/index.tsx
@@ -5,7 +5,7 @@ import { loadApplyState, saveApplyState } from '~/route-helpers/apply-route-help
 import { getPathById } from '~/utils/route-utils';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadApplyState({ params, session });
   saveApplyState({ params, session, state: {} });
   return redirect(getPathById('public/apply/$id/type-application', params));

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   loadApplyState({ params, session });
   const csrfToken = String(session.get('csrfToken'));
 
@@ -39,7 +39,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('apply/terms-and-conditions');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfApplication });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('apply/type-of-application');
   loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/_route.tsx
+++ b/frontend/app/routes/public/apply/_route.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useLoaderData, useParams, useRouteError } from '@remix-run/react';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/apply-route-helpers';
@@ -16,9 +17,9 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const locale = getLocale(request);
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = configProvider.getClientConfig();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -25,7 +25,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/public/demographic-survey/$id/_route.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/_route.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
@@ -13,9 +14,9 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const locale = getLocale(request);
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = configProvider.getClientConfig();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 

--- a/frontend/app/routes/public/demographic-survey/$id/questions/$memberId.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/questions/$memberId.tsx
@@ -36,7 +36,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   const csrfToken = String(session.get('csrfToken'));
 
   const member = loadDemographicSurveySingleMemberState({ params, session });
@@ -55,7 +55,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, memberName, indigenousStatuses, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState: member.questions });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('demographic-survey/questions');
 
   const state = loadDemographicSurveyState({ params, session });

--- a/frontend/app/routes/public/demographic-survey/$id/submitted.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/submitted.tsx
@@ -24,7 +24,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -33,7 +33,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('demographic-survey/submitted');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/demographic-survey/$id/summary.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/summary.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -44,7 +44,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, members: state.memberInformation });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('demographic-survey/summary');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/demographic-survey/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/terms-and-conditions.tsx
@@ -26,7 +26,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   const csrfToken = String(session.get('csrfToken'));
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -35,7 +35,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('demographic-survey/terms-and-conditions');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -46,7 +46,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -68,7 +68,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/confirm-federal-provincial-territorial');
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const renewState = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/dental-insurance');
 
   const state = loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -44,7 +44,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +60,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/information');
 
   const state = loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +39,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/parent-or-guardian');
 
   loadRenewAdultSingleChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -48,8 +49,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -83,7 +84,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/children/update-federal-provincial-territorial');
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const renewState = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -46,7 +46,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -75,7 +75,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta, children, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
 
   const log = getLogger('renew/adult-child/child-summary');

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress } });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-address');
   const state = loadRenewAdultChildState({ params, request, session });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -48,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -67,7 +67,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-email');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -45,7 +45,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +60,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-federal-provincial-territorial');
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -48,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -69,7 +69,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/confirm-phone');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -43,7 +43,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/dental-insurance');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewAdultChildState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -47,12 +48,12 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = serviceProvider.getMaritalStatusService().listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:marital-status.page-title') }) };
@@ -60,7 +61,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/marital-status');
 
   const state = loadRenewAdultChildState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -12,6 +12,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button } from '~/components/buttons';
 import { DebugPayload } from '~/components/debug-payload';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -47,13 +48,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true
   saveRenewState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -107,12 +108,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/review-child-information');
 
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -42,11 +43,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -67,12 +68,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/update-address');
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const addressInformationSchema = z
     .object({

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,8 +48,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -75,7 +76,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/adult-child/update-federal-provincial-territorial');
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/renew/$id/file-taxes.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/file-taxes');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
@@ -11,6 +11,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
@@ -40,8 +41,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -73,10 +74,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/communication-preference');
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = configProvider.getServerConfig();
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -40,7 +40,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -50,7 +50,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress } });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/confirm-address');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -43,7 +43,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -141,7 +141,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/confirmation');
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/contact-information.tsx
@@ -43,7 +43,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +60,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/contact-information');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -33,7 +33,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -43,7 +43,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/dental-insurance');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
@@ -27,7 +27,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewItaState({ params, request, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -38,7 +38,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/exit-application');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
@@ -47,8 +48,8 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = configProvider.getServerConfig();
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+  const { CANADA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -73,7 +74,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/federal-provincial-territorial');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -47,12 +48,12 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = serviceProvider.getMaritalStatusService().listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = configProvider.getServerConfig();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:marital-status.page-title') }) };
@@ -60,7 +61,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/marital-status');
 
   const state = loadRenewItaState({ params, request, session });

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -12,6 +12,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { DebugPayload } from '~/components/debug-payload';
@@ -49,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaStateForReview({ params, request, session });
 
   // invariant(!state.hasAddressChanged || (state.addressInformation && state.addressInformation.homeCountry), `Unexpected home address country: ${state.addressInformation?.homeCountry}`);
@@ -57,7 +58,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   // renew state is valid then edit mode can be set to true
   saveRenewState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -155,12 +156,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/review-information');
 
   const state = loadRenewItaStateForReview({ params, request, session });
 
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
@@ -42,11 +43,11 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const countryList = serviceProvider.getCountryService().listAndSortLocalizedCountries(locale);
   const regionList = serviceProvider.getProvinceTerritoryStateService().listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -67,12 +68,12 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/ita/update-address');
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = configProvider.getServerConfig();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const addressInformationSchema = z
     .object({

--- a/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
+++ b/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
@@ -29,7 +29,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const { id } = loadRenewState({ params, session });
 
   const csrfToken = String(session.get('csrfToken'));
@@ -40,7 +40,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id, csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/renew-delegate');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +47,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.taxFiling });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/tax-filing');
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -37,7 +37,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request, params }: LoaderFunctionArgs) {
   loadRenewState({ params, session });
   const csrfToken = String(session.get('csrfToken'));
 
@@ -47,7 +47,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, meta });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, request, params }: ActionFunctionArgs) {
   const log = getLogger('renew/terms-and-conditions');
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -38,7 +38,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal, hasBeenAssessedByCRA: state.clientApplication?.hasBeenAssessedByCRA });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/type-of-renewal');
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/_route.tsx
+++ b/frontend/app/routes/public/renew/_route.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
@@ -13,9 +14,9 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const locale = getLocale(request);
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = configProvider.getClientConfig();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -30,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -41,7 +41,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ locale, meta, csrfToken });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   const log = getLogger('renew/index');
 
   const formData = await request.formData();

--- a/frontend/app/routes/public/status/_route.tsx
+++ b/frontend/app/routes/public/status/_route.tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
 
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
@@ -13,9 +14,9 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { configProvider, serviceProvider, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, request }: LoaderFunctionArgs) {
   const locale = getLocale(request);
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = configProvider.getClientConfig();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -12,6 +12,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { DatePickerField } from '~/components/date-picker-field';
@@ -53,9 +54,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const csrfToken = String(session.get('csrfToken'));
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -67,10 +68,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/child/index');
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
 

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -10,6 +10,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../page-ids.json';
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import { Collapsible } from '~/components/collapsible';
 import { useErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
@@ -42,9 +43,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
 
   const csrfToken = String(session.get('csrfToken'));
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -56,10 +57,10 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   return json({ csrfToken, hCaptchaEnabled, meta, siteKey: HCAPTCHA_SITE_KEY });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
   const log = getLogger('status/index');
-  const { ENABLED_FEATURES } = configProvider.getServerConfig();
+  const { ENABLED_FEATURES } = appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
   const hCaptchaRouteHelpers = getHCaptchaRouteHelpers();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const formData = await request.formData();

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -39,7 +39,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
   return data ? getTitleMetaTags(data.meta.title) : [];
 });
 
-export async function loader({ context: { configProvider, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, serviceProvider, session }, params, request }: LoaderFunctionArgs) {
   featureEnabled('status');
 
   const statusStateId = getStatusStateIdFromUrl(request.url);
@@ -63,7 +63,7 @@ export async function loader({ context: { configProvider, serviceProvider, sessi
   });
 }
 
-export async function action({ context: { configProvider, serviceProvider, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, serviceProvider, session }, params, request }: ActionFunctionArgs) {
   featureEnabled('status');
 
   const statusStateId = getStatusStateIdFromUrl(request.url);

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -16,7 +16,7 @@ import type renew from '../public/locales/en/renew.json';
 import type status from '../public/locales/en/status.json';
 import type stubLogin from '../public/locales/en/stub-login.json';
 import type unableToProcessRequest from '../public/locales/en/unable-to-process-request.json';
-import type { AppContainerProvider, ContainerConfigProvider, ContainerServiceProvider } from '~/.server/providers';
+import type { AppContainerProvider, ContainerServiceProvider } from '~/.server/providers';
 import type { ClientEnv } from '~/utils/env-utils.server';
 import type { APP_LOCALES } from '~/utils/locale-utils';
 
@@ -85,7 +85,6 @@ declare module 'i18next' {
 declare module '@remix-run/server-runtime' {
   interface AppLoadContext extends ContainerProvider {
     appContainer: AppContainerProvider;
-    configProvider: ContainerConfigProvider;
     serviceProvider: ContainerServiceProvider;
     session: Session;
   }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Replace `ContainerConfigProvider` with `AppContainerProvider`.

How to get client config from the application container:

```diff
- configProvider.getClientConfig();
+ appContainer.get(SERVICE_IDENTIFIER.CLIENT_CONFIG);
```

How to get server config from the application container:

```diff
- configProvider.getServerConfig();
+ appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG);
```

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->