### PR TITLE
Add authorization to `/api/health` endpoint

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -350,3 +350,15 @@ DYNATRACE_API_RUM_SCRIPT_URI_CACHE_TTL_SECONDS=3600
 # How long to cache health check component results (in miliseconds)
 # (optional; default: 10 seconds)
 HEALTH_CACHE_TTL=10000
+# The OpenID Connect JWKs endpoint that hosts the public keys to be used during JWT verification for the /api/health endpoint
+# (optional; default: undefined)
+HEALTH_AUTH_JWKS_URI=
+# RBAC role required to access detailed /api/health endpoint responses
+# (optional; default: HealthCheck.ViewDetails)
+HEALTH_AUTH_ROLE=HealthCheck.ViewDetails
+# Expected audience to be used during JWT verification for the /api/health endpoint
+# (optional; default: 00000000-0000-0000-0000-000000000000)
+HEALTH_AUTH_TOKEN_AUDIENCE=00000000-0000-0000-0000-000000000000
+# Expected issuer to be used during JWT verification for the /api/health endpoint
+# (optional; default: https://auth.example.com/)
+HEALTH_AUTH_TOKEN_ISSUER=https://auth.example.com/

--- a/frontend/app/utils/env-utils.server.ts
+++ b/frontend/app/utils/env-utils.server.ts
@@ -189,6 +189,10 @@ const serverEnv = clientEnvSchema.extend({
 
   // health check configuration
   HEALTH_CACHE_TTL: z.coerce.number().default(10 * 1000),
+  HEALTH_AUTH_JWKS_URI: z.string().url().optional(),
+  HEALTH_AUTH_ROLE: z.string().default('HealthCheck.ViewDetails'),
+  HEALTH_AUTH_TOKEN_AUDIENCE: z.string().default('00000000-0000-0000-0000-000000000000'), // intentional default to enforce an audience check when verifying JWTs
+  HEALTH_AUTH_TOKEN_ISSUER: z.string().default('https://auth.example.com/'), // intentional default to enforce an issuer check when verifying JWTs
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;


### PR DESCRIPTION
### Description

Add JWT token authz to `/api/health/`.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Request to be added to the `HealthCheck.ViewDetails` role in the `api://cdcp.esdc-edsc.gc.ca/frontend` Entra application.
- Acquire an access token using client id `78748871-b90d-4594-a738-8f7a9528a3db`.
- Send a GET request to `/api/health` using the access token.
