### PR TITLE
[gitops] Configure OAuth Proxy to allow health auth tokens through

### DIFF
--- a/gitops/overlays/dev/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/dev/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/int1/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/int1/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/int2/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/int2/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/perf/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/perf/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/prod/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/prod/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/staging/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/staging/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/uat1/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/uat1/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"

--- a/gitops/overlays/uat2/configs/oauth-proxy/config.conf
+++ b/gitops/overlays/uat2/configs/oauth-proxy/config.conf
@@ -37,6 +37,7 @@ skip_auth_preflight = "true"
 ## OIDC settings
 provider = "oidc"
 client_id = "cd8251d3-562e-4125-b37f-c444c8b9735f"
+oidc_extra_audiences = [ "78748871-b90d-4594-a738-8f7a9528a3db" ]
 oidc_issuer_url = "https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0"
 skip_jwt_bearer_tokens = "true"
 skip_provider_button = "false"


### PR DESCRIPTION
### Description

To allow access tokens through OAuth Proxy when calling the `/api/health` endpoint, OAuth Proxy must be configured to be aware of the correct token audience.
