### PR TITLE
fix renew-adult-child nav/state issues

### DIFF
--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -246,7 +246,7 @@ export function renewStateHasPartner(maritalStatus: string) {
 }
 
 export function isNewChildState(child: ChildState) {
-  return child.dentalBenefits === undefined || child.dentalInsurance === undefined || child.information === undefined;
+  return child.dentalInsurance === undefined || child.information === undefined;
 }
 
 export function getChildrenState<TState extends Pick<RenewState, 'children'>>(state: TState, includesNewChildState: boolean = false) {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -51,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   // prettier-ignore
   if (state.applicantInformation === undefined ||
-    state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
     (state.hasAddressChanged && state.addressInformation === undefined) ||
     state.submissionInfo === undefined ||
@@ -61,10 +60,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
 
-  const selectedFederalBenefit = state.dentalBenefits.federalSocialProgram
+  const selectedFederalBenefit = state.dentalBenefits?.federalSocialProgram
     ? appContainer.get(SERVICE_IDENTIFIER.FEDERAL_GOVERNMENT_INSURANCE_PLAN_SERVICE).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
     : undefined;
-  const selectedProvincialBenefits = state.dentalBenefits.provincialTerritorialSocialProgram
+  const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
     ? appContainer.get(SERVICE_IDENTIFIER.PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_SERVICE).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
   const mailingProvinceTerritoryStateAbbr = state.addressInformation?.mailingProvince ? appContainer.get(SERVICE_IDENTIFIER.PROVINCE_TERRITORY_STATE_SERVICE).getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
@@ -119,16 +118,15 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const children = getChildrenState(state).map((child) => {
     // prettier-ignore
-    if (child.dentalBenefits === undefined ||
-      child.dentalInsurance === undefined ||
+    if (child.dentalInsurance === undefined ||
       child.information === undefined) {
       throw new Error(`Incomplete application "${state.id}" child "${child.id}" state!`);
     }
 
-    const federalBenefit = child.dentalBenefits.federalSocialProgram
+    const federalBenefit = child.dentalBenefits?.federalSocialProgram
       ? appContainer.get(SERVICE_IDENTIFIER.FEDERAL_GOVERNMENT_INSURANCE_PLAN_SERVICE).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
-    const provincialTerritorialSocialProgram = child.dentalBenefits.provincialTerritorialSocialProgram
+    const provincialTerritorialSocialProgram = child.dentalBenefits?.provincialTerritorialSocialProgram
       ? appContainer.get(SERVICE_IDENTIFIER.PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_SERVICE).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
@@ -142,12 +140,12 @@ export async function loader({ context: { appContainer, session }, params, reque
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
         federalBenefit: {
-          access: child.dentalBenefits.hasFederalBenefits,
+          access: child.dentalBenefits?.hasFederalBenefits,
           benefit: federalBenefit?.name,
         },
         provTerrBenefit: {
-          access: child.dentalBenefits.hasProvincialTerritorialBenefits,
-          province: child.dentalBenefits.province,
+          access: child.dentalBenefits?.hasProvincialTerritorialBenefits,
+          province: child.dentalBenefits?.province,
           benefit: provincialTerritorialSocialProgram?.name,
         },
       },


### PR DESCRIPTION
### Description
doing some tests of the renew-adult-child flow and found that if you select "No" to both has Federal/Provincial benefits changed on `/confirm-federal-provincial-territorial-benefits`, the state of the child doesn't save.  This also impacts the confirmation screen because the loader will throw an "Incomplete application" error even though dental benefits is optional if the user selects that they haven't changed.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`