### PR TITLE
add additional radio option to receive email communication in renew-adult-child-flow

### DIFF
--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -61,6 +61,7 @@ export interface RenewState {
     phoneNumber?: string;
     phoneNumberAlt?: string;
     email?: string;
+    shouldReceiveEmailCommunication?: boolean;
   };
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -53,6 +53,9 @@
       "legend": "Would you like to update or add your email address?",
       "help-message": "The email address we have on file can also be found on the renewal letter you received from Service Canada."
     },
+    "receive-comms": {
+      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?"
+    },
     "email": "Email address",
     "confirm-email": "Confirm email address",
     "back-btn": "Back",
@@ -67,7 +70,8 @@
       "confirm-email-required": "Confirm email address",
       "email-required": "Enter email address",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
     }
   },
   "confirm-address": {

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -53,6 +53,9 @@
       "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
       "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
     },
+    "receive-comms": {
+      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?"
+    },
     "email": "Adresse courriel",
     "confirm-email": "Confirmer l'adresse courriel",
     "back-btn": "Retour",
@@ -67,7 +70,8 @@
       "confirm-email-required": "Confirmez l'adresse courriel",
       "email-required": "Entrez l'adresse courriel",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
-      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com"
+      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
     }
   },
   "confirm-address": {


### PR DESCRIPTION
### Description
adds an additional radio option to `renew/$id/adult-child/confirm-email`, validation, and state variable.  

NOTE: translations for the error message are not readily available

### Related Azure Boards Work Items
[AB#4785](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4785)
