### PR TITLE
Adding year of birth validation for ITA and Adult-Child

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -84,9 +84,14 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-adult-child:marital-status.error-message.marital-status-required')),
   });
 
+  const currentYear = new Date().getFullYear().toString();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-adult-child:marital-status.error-message.confirm-required')),
-    yearOfBirth: z.string().trim().min(1, t('renew-adult-child:marital-status.error-message.date-of-birth-year-required')),
+    yearOfBirth: z
+      .string()
+      .trim()
+      .min(1, t('renew-adult-child:marital-status.error-message.date-of-birth-year-required'))
+      .refine((year) => year < currentYear, t('renew-adult-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -84,9 +84,14 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-ita:marital-status.error-message.marital-status-required')),
   });
 
+  const currentYear = new Date().getFullYear().toString();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-ita:marital-status.error-message.confirm-required')),
-    yearOfBirth: z.string().trim().min(1, t('renew-ita:marital-status.error-message.date-of-birth-year-required')),
+    yearOfBirth: z
+      .string()
+      .trim()
+      .min(1, t('renew-ita:marital-status.error-message.date-of-birth-year-required'))
+      .refine((year) => year < currentYear, t('renew-ita:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Checkbox must be selected",
       "date-of-birth-year-required": "Year of birth is required",
+      "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique"

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Checkbox must be selected",
       "date-of-birth-year-required": "Year of birth is required",
+      "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique"

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "La case à cocher doit être sélectionnée",
       "date-of-birth-year-required": "L'année de naissance doit être fournie",
+      "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres",
       "sin-valid": "Doit être un NAS valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "La case à cocher doit être sélectionnée",
       "date-of-birth-year-required": "L'année de naissance doit être fournie",
+      "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres",
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"


### PR DESCRIPTION
### Description
Adding a small validation where year must be in the past.

Source: Kaytlin McEachran

### Related Azure Boards Work Items
[AB#4739](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4739)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`