### PR TITLE
Add auditing to address validation service

### DIFF
--- a/frontend/__tests__/.server/domain/services/address-validation.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/address-validation.service.test.ts
@@ -6,6 +6,7 @@ import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
 import type { AddressValidationDtoMapper } from '~/.server/domain/mappers';
 import type { AddressValidationRepository } from '~/.server/domain/repositories';
 import { AddressValidationServiceImpl } from '~/.server/domain/services';
+import type { AuditService } from '~/.server/domain/services';
 import type { LogFactory, Logger } from '~/.server/factories';
 
 describe('AddressValidationServiceImpl', () => {
@@ -38,9 +39,11 @@ describe('AddressValidationServiceImpl', () => {
       const mockAddressValidationRepository = mock<AddressValidationRepository>();
       mockAddressValidationRepository.getAddressCorrectionResult.mockResolvedValue(mockAddressCorrectionResultEntity);
 
-      const service = new AddressValidationServiceImpl(mockLogFactory, mockAddressValidationDtoMapper, mockAddressValidationRepository);
+      const mockAuditService = mock<AuditService>();
 
-      const result = await service.getAddressCorrectionResult({ address: '123 Fake Street', city: 'North Pole', provinceCode: 'ON', postalCode: 'H0H 0H0' });
+      const service = new AddressValidationServiceImpl(mockLogFactory, mockAddressValidationDtoMapper, mockAddressValidationRepository, mockAuditService);
+
+      const result = await service.getAddressCorrectionResult({ address: '123 Fake Street', city: 'North Pole', provinceCode: 'ON', postalCode: 'H0H 0H0', userId: 'userId' });
       expect(result).toEqual(mockAddressCorrectionResultDto);
     });
   });

--- a/frontend/app/.server/domain/dtos/address-validation.dto.ts
+++ b/frontend/app/.server/domain/dtos/address-validation.dto.ts
@@ -13,6 +13,9 @@ export type AddressCorrectionRequestDto = Readonly<{
 
   /** The 2-character Canadian province or territorial code. */
   provinceCode: string;
+
+  /** A unique identifier for the user making the request - used for auditing */
+  userId: string;
 }>;
 
 /**

--- a/frontend/app/.server/domain/services/address-validation.service.ts
+++ b/frontend/app/.server/domain/services/address-validation.service.ts
@@ -4,6 +4,7 @@ import { SERVICE_IDENTIFIER } from '~/.server/constants';
 import type { AddressCorrectionRequestDto, AddressCorrectionResultDto } from '~/.server/domain/dtos';
 import type { AddressValidationDtoMapper } from '~/.server/domain/mappers';
 import type { AddressValidationRepository } from '~/.server/domain/repositories';
+import type { AuditService } from '~/.server/domain/services';
 import type { LogFactory, Logger } from '~/.server/factories';
 
 export interface AddressValidationService {
@@ -24,14 +25,19 @@ export class AddressValidationServiceImpl implements AddressValidationService {
     @inject(SERVICE_IDENTIFIER.LOG_FACTORY) logFactory: LogFactory,
     @inject(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_DTO_MAPPER) private readonly addressValidationDtoMapper: AddressValidationDtoMapper,
     @inject(SERVICE_IDENTIFIER.ADDRESS_VALIDATION_REPOSITORY) private readonly addressValidationRepository: AddressValidationRepository,
+    @inject(SERVICE_IDENTIFIER.AUDIT_SERVICE) private readonly auditService: AuditService,
   ) {
     this.log = logFactory.createLogger('AddressValidationServiceImpl');
   }
 
   async getAddressCorrectionResult(addressCorrectionRequestDto: AddressCorrectionRequestDto): Promise<AddressCorrectionResultDto> {
     this.log.trace('Getting address correction results with addressCorrectionRequest: [%j]', addressCorrectionRequestDto);
+
+    this.auditService.createAudit('address-validation.get-address-correction-result', { userId: addressCorrectionRequestDto.userId });
+
     const addressCorrectionResultEntity = await this.addressValidationRepository.getAddressCorrectionResult(addressCorrectionRequestDto);
     const addressCorrectionResultDto = this.addressValidationDtoMapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(addressCorrectionResultEntity);
+
     this.log.trace('Returning address correction result: [%j]', addressCorrectionResultDto);
     return addressCorrectionResultDto;
   }

--- a/frontend/app/routes/public/address-validation.tsx
+++ b/frontend/app/routes/public/address-validation.tsx
@@ -190,6 +190,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
     city: resolvedAddress.city,
     postalCode: resolvedAddress.postalZipCode,
     provinceCode: resolvedAddress.provinceState,
+    userId: 'anonymous',
   });
 
   if (addressCorrectionResult.status === 'NotCorrect') {


### PR DESCRIPTION
### Description
Address validation will eventually be required in the protected space where we need to audit actions from identifiable users.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/114ac68b-d387-4f7f-b9d2-c4059632dab6)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Ensure log level is `audit` or lower. Run application and navigate to `/en/address-validation`. Make a successful request and ensure `AUDIT` is logged.