### PR TITLE
[infra] Update frontend app registration

### DIFF
--- a/infrastructure/terragrunt/nonprod/frontend-aad-application/terragrunt.hcl
+++ b/infrastructure/terragrunt/nonprod/frontend-aad-application/terragrunt.hcl
@@ -11,25 +11,38 @@ include "root" {
 }
 
 inputs = {
-  application_display_name = "Canadian Dental Care Program: Service Principal"
+  application_display_name = "Canadian Dental Care Program: Service Principal (nonprod)"
   application_app_roles = [{
-    id                   = "42a55bc0-5c40-4502-a729-791e1fe9d4e0"
-    display_name         = "HealthCheck Monitor"
-    value                = "HealthCheck.ViewDetails"
-    description          = "HealthCheck monitors can view detailed output of a health check."
-    allowed_member_types = ["Application", "User"]
+    id           = "42a55bc0-5c40-4502-a729-791e1fe9d4e0"
+    display_name = "HealthCheck Monitor"
+    value        = "HealthCheck.ViewDetails"
+    description  = "HealthCheck monitors can view detailed output of a health check."
+    allowed_member_types = [
+      "Application",
+      "User"
+    ]
     members = [
+      "adam.pcolinsky@hrsdc-rhdcc.gc.ca",
+      "amy.wong@hrsdc-rhdcc.gc.ca",
+      "benoit.bc.cloutier@hrsdc-rhdcc.gc.ca",
+      "frank.basham@hrsdc-rhdcc.gc.ca",
       "gregory.j.baker@hrsdc-rhdcc.gc.ca",
+      "guillaume.liddle@hrsdc-rhdcc.gc.ca",
+      "ken.blanchard@hrsdc-rhdcc.gc.ca",
       "nicholas.ly@hrsdc-rhdcc.gc.ca",
+      "sebastien.comeau@hrsdc-rhdcc.gc.ca",
+      "stefan.oconnell@hrsdc-rhdcc.gc.ca",
+      "xuan.zhang@hrsdc-rhdcc.gc.ca",
     ]
   }]
   application_identifier_uris = [
-    "api://cdcp.esdc-edsc.gc.ca/frontend",
+    "api://nonprod.cdcp.esdc-edsc.gc.ca/frontend",
   ]
   application_owners = [
     "amy.wong@hrsdc-rhdcc.gc.ca",
     "gregory.j.baker@hrsdc-rhdcc.gc.ca",
     "nicholas.ly@hrsdc-rhdcc.gc.ca",
+    "sebastien.comeau@hrsdc-rhdcc.gc.ca",
   ]
   application_passwords = [
     "Default secret",


### PR DESCRIPTION
### Description

Update app registration with some new settings:

- change display name to `Canadian Dental Care Program: Service Principal (nonprod)`
- change identifier URI to `api://nonprod.cdcp.esdc-edsc.gc.ca/frontend`
- add CDCP senior team members as application owners
- add all CDCP team members to `HealthCheck.ViewDetails` role
- add DTS prod support team members to `HealthCheck.ViewDetails`

### Additional Notes

⚠️ This change has already been applied to our Microsoft Entra tenant. ⚠️