### PR TITLE
feature(frontend): add address validation review route

### DIFF
--- a/frontend/app/.server/remix/domain/routes/address-validation/mailing-address.validator.ts
+++ b/frontend/app/.server/remix/domain/routes/address-validation/mailing-address.validator.ts
@@ -1,0 +1,46 @@
+import type { ServerConfig } from '~/.server/configs';
+import type { Address, AddressValidatorErrorMessages } from '~/.server/remix/domain/validators/address.validator';
+import { AddressValidator } from '~/.server/remix/domain/validators/address.validator';
+import type { InvalidResult, ValidResult } from '~/.server/remix/domain/validators/types.validator';
+import { getFixedT } from '~/utils/locale-utils.server';
+
+export class MailingAddressValidator implements MailingAddressValidator {
+  constructor(
+    private readonly locale: AppLocale,
+    private readonly serverConfig: Pick<ServerConfig, 'CANADA_COUNTRY_ID' | 'USA_COUNTRY_ID'>,
+  ) {}
+
+  async validateMailingAddress(data: Partial<Address>): Promise<InvalidResult<Address> | ValidResult<Address>> {
+    const errorMessages = await this.getMailingAddressSchemaErrorMessages();
+    const addressValidator = new AddressValidator(errorMessages, this.serverConfig);
+    return addressValidator.validateAddress(data);
+  }
+
+  private async getMailingAddressSchemaErrorMessages(): Promise<AddressValidatorErrorMessages> {
+    const t = await getFixedT(this.locale, ['address-validation']);
+    return {
+      address: {
+        invalidCharacters: t('address-validation:index.error-message.characters-valid'),
+        required: t('address-validation:index.error-message.address-required'),
+      },
+      city: {
+        required: t('address-validation:index.error-message.city-required'),
+        invalidCharacters: t('address-validation:index.error-message.characters-valid'),
+      },
+      country: {
+        required: t('address-validation:index.error-message.country-required'),
+      },
+      provinceState: {
+        required: t('address-validation:index.error-message.province-state-required'),
+      },
+      postalZipCode: {
+        invalidCharacters: t('address-validation:index.error-message.characters-valid'),
+        invalidPostalCode: t('address-validation:index.error-message.postal-zip-code-valid'),
+        invalidPostalCodeForProvince: t('address-validation:index.error-message.invalid-postal-zip-code-for-province'),
+        invalidPostalZipCodeForCountry: t('address-validation:index.error-message.invalid-postal-zip-code-for-country'),
+        invalidZipCode: t('address-validation:index.error-message.zip-code-valid'),
+        required: t('address-validation:index.error-message.postal-zip-code-required'),
+      },
+    };
+  }
+}

--- a/frontend/app/.server/remix/domain/validators/address.validator.ts
+++ b/frontend/app/.server/remix/domain/validators/address.validator.ts
@@ -1,0 +1,148 @@
+import validator from 'validator';
+import { z } from 'zod';
+
+import type { ServerConfig } from '~/.server/configs';
+import type { InvalidResult, ValidResult } from '~/.server/remix/domain/validators/types.validator';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+/**
+ * Interface for Address input data.
+ */
+export interface Address {
+  address: string;
+  city: string;
+  country: string;
+  postalZipCode?: string;
+  provinceState?: string;
+}
+
+/**
+ * Error messages configuration for AddressValidator.
+ */
+export interface AddressValidatorErrorMessages {
+  address: {
+    invalidCharacters: string;
+    required: string;
+  };
+  city: {
+    invalidCharacters: string;
+    required: string;
+  };
+  country: {
+    required: string;
+  };
+  postalZipCode: {
+    invalidCharacters: string;
+    invalidPostalCode: string;
+    invalidPostalCodeForProvince: string;
+    invalidPostalZipCodeForCountry: string;
+    invalidZipCode: string;
+    required: string;
+  };
+  provinceState: {
+    required: string;
+  };
+}
+
+/**
+ * Validates address input data against specific country and format requirements.
+ */
+export class AddressValidator {
+  constructor(
+    private readonly errorMessages: AddressValidatorErrorMessages,
+    private readonly serverConfig: Pick<ServerConfig, 'CANADA_COUNTRY_ID' | 'USA_COUNTRY_ID'>,
+  ) {}
+
+  /**
+   * Validates address data. Returns validation success and either parsed data or errors.
+   * @param data - Partial address input data to validate.
+   */
+  validateAddress(data: Partial<Address>): InvalidResult<Address> | ValidResult<Address> {
+    const addressSchema = this.getAddressSchema();
+    const parsedDataResult = addressSchema.safeParse(data);
+
+    if (parsedDataResult.success) {
+      return { success: true, data: parsedDataResult.data };
+    }
+
+    return {
+      success: false,
+      errors: transformFlattenedError(parsedDataResult.error.flatten()),
+    };
+  }
+
+  /**
+   * Returns a Zod schema for validating Address input data.
+   * This schema validates required fields and specific country-based requirements.
+   */
+  private getAddressSchema(): z.ZodType<Address> {
+    const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = this.serverConfig;
+
+    return z
+      .object({
+        address: z.string().trim().min(1, this.errorMessages.address.required).max(30).refine(isAllValidInputCharacters, this.errorMessages.address.invalidCharacters),
+        country: z.string().trim().min(1, this.errorMessages.country.required),
+        provinceState: z.string().trim().min(1, this.errorMessages.provinceState.required).optional(),
+        city: z.string().trim().min(1, this.errorMessages.city.required).max(100).refine(isAllValidInputCharacters, this.errorMessages.city.invalidCharacters),
+        postalZipCode: z.string().trim().max(100).refine(isAllValidInputCharacters, this.errorMessages.postalZipCode.invalidCharacters).optional(),
+      })
+      .superRefine((val, ctx) => {
+        const { country, provinceState, postalZipCode } = val;
+        const isCanada = country === CANADA_COUNTRY_ID;
+        const isUSA = country === USA_COUNTRY_ID;
+
+        // Province/State validation for Canada and USA
+        if ((isCanada || isUSA) && (!provinceState || validator.isEmpty(provinceState))) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: this.errorMessages.provinceState.required,
+            path: ['provinceState'],
+          });
+        }
+
+        // Postal/Zip Code validation for Canada and USA
+        if ((isCanada || isUSA) && (!postalZipCode || validator.isEmpty(postalZipCode))) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: this.errorMessages.postalZipCode.required,
+            path: ['postalZipCode'],
+          });
+        } else if (isUSA && postalZipCode && !isValidPostalCode(country, postalZipCode)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: this.errorMessages.postalZipCode.invalidZipCode,
+            path: ['postalZipCode'],
+          });
+        } else if (isCanada && postalZipCode) {
+          if (!isValidPostalCode(CANADA_COUNTRY_ID, postalZipCode)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: this.errorMessages.postalZipCode.invalidPostalCode,
+              path: ['postalZipCode'],
+            });
+          } else if (provinceState && !isValidCanadianPostalCode(provinceState, postalZipCode)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: this.errorMessages.postalZipCode.invalidPostalCodeForProvince,
+              path: ['postalZipCode'],
+            });
+          }
+        }
+
+        // Ensure postal code does not match Canadian format for non-Canadian addresses
+        if (!isCanada && postalZipCode && isValidPostalCode(CANADA_COUNTRY_ID, postalZipCode)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: this.errorMessages.postalZipCode.invalidPostalZipCodeForCountry,
+            path: ['country'],
+          });
+        }
+      })
+      .transform((val) => ({
+        ...val,
+        postalZipCode: val.country && val.postalZipCode ? formatPostalCode(val.country, val.postalZipCode) : val.postalZipCode,
+      }));
+  }
+}

--- a/frontend/app/.server/remix/domain/validators/types.validator.ts
+++ b/frontend/app/.server/remix/domain/validators/types.validator.ts
@@ -1,0 +1,20 @@
+/**
+ * Result type for an unsuccessful validation, containing detailed error messages
+ * for each invalid field in the validated object.
+ *
+ * @template T - The type of object being validated.
+ */
+export interface InvalidResult<T extends object> {
+  success: false;
+  errors: Readonly<Partial<Record<keyof T, string | undefined>>>;
+}
+
+/**
+ * Result type for a successful validation, containing the validated object data.
+ *
+ * @template T - The type of object being validated.
+ */
+export interface ValidResult<T extends object> {
+  success: true;
+  data: T;
+}

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -90,11 +90,20 @@
         }
       },
       {
-        "id": "public/address-validation",
-        "file": "routes/public/address-validation.tsx",
+        "id": "public/address-validation/index",
+        "index": true,
+        "file": "routes/public/address-validation/index.tsx",
         "paths": {
           "en": "/:lang/address-validation",
           "fr": "/:lang/validation-adresse"
+        }
+      },
+      {
+        "id": "public/address-validation/review",
+        "file": "routes/public/address-validation/review.tsx",
+        "paths": {
+          "en": "/:lang/address-validation/review",
+          "fr": "/:lang/validation-adresse/revue"
         }
       },
       {

--- a/frontend/app/routes/public/address-validation/review.tsx
+++ b/frontend/app/routes/public/address-validation/review.tsx
@@ -1,0 +1,77 @@
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect, useLoaderData, useParams } from '@remix-run/react';
+
+import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import { SERVICE_IDENTIFIER } from '~/.server/constants';
+import { MailingAddressValidator } from '~/.server/remix/domain/routes/address-validation/mailing-address.validator';
+import { Address } from '~/components/address';
+import { ButtonLink } from '~/components/buttons';
+import { PublicLayout } from '~/components/layouts/public-layout';
+import { featureEnabled } from '~/utils/env-utils.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('address-validation', 'gcweb'),
+  pageTitleI18nKey: 'address-validation:review.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+  featureEnabled('address-validation');
+
+  const mailingAddressValidator = new MailingAddressValidator(getLocale(request), appContainer.get(SERVICE_IDENTIFIER.SERVER_CONFIG));
+  const validationResult = await mailingAddressValidator.validateMailingAddress(session.get('route.address-validation'));
+
+  if (!validationResult.success) {
+    session.unset('route.address-validation');
+    return redirect('public/address-validation/index');
+  }
+
+  const validatedMailingAddress = validationResult.data;
+  const locale = getLocale(request);
+  const formattedMailingAddress = {
+    address: validatedMailingAddress.address,
+    city: validatedMailingAddress.city,
+    country: appContainer.get(SERVICE_IDENTIFIER.COUNTRY_SERVICE).getLocalizedCountryById(validatedMailingAddress.country, locale).name,
+    postalZipCode: validatedMailingAddress.postalZipCode,
+    provinceState: validatedMailingAddress.provinceState && appContainer.get(SERVICE_IDENTIFIER.PROVINCE_TERRITORY_STATE_SERVICE).getLocalizedProvinceTerritoryStateById(validatedMailingAddress.provinceState, locale).abbr,
+  };
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('address-validation:review.page-title') }) };
+
+  return {
+    meta,
+    mailingAddress: formattedMailingAddress,
+  };
+}
+
+export default function AddressValidationReviewRoute() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { mailingAddress } = useLoaderData<typeof loader>();
+  const params = useParams();
+
+  return (
+    <PublicLayout>
+      <div className="mb-6 max-w-prose space-y-4">
+        <h2 className="font-lato text-2xl font-bold">{t('address-validation:review.address-header')}</h2>
+        <p>{t('address-validation:review.address-sub-header')}</p>
+        <hr className="h-px border-0 bg-gray-200" />
+        <Address address={mailingAddress} />
+        <hr className="h-px border-0 bg-gray-200" />
+      </div>
+      <ButtonLink startIcon={faEdit} id="edit-button-link" routeId="public/address-validation/index" params={params}>
+        {t('address-validation:review.edit-button')}
+      </ButtonLink>
+    </PublicLayout>
+  );
+}

--- a/frontend/public/locales/en/address-validation.json
+++ b/frontend/public/locales/en/address-validation.json
@@ -1,54 +1,52 @@
 {
-  "address-field": {
-    "address": "Address",
-    "address-note": "Include street number and name",
-    "city": "City or town",
-    "country": "Country",
-    "postal-zip-code": "Postal code or ZIP code",
-    "postal-zip-code-optional": "Postal code or ZIP code (optional)",
-    "province-state": "Province, territory, state, or region"
-  },
-  "address-header": "Mailing address",
-  "dialog": {
-    "address-suggestion": {
-      "address-selection-legend": "Please select an address option below:",
-      "cancel-button": "Cancel",
-      "description": "We found a suggested correction for the address you entered.",
-      "entered-address-option": "Entered address:",
-      "header": "Address correction suggestion",
-      "suggested-address-option": "Suggested corrected address:",
-      "use-selected-address-button": "Use selected address"
+  "index": {
+    "address-field": {
+      "address": "Address",
+      "address-note": "Include street number and name",
+      "city": "City or town",
+      "country": "Country",
+      "postal-zip-code": "Postal code or ZIP code",
+      "postal-zip-code-optional": "Postal code or ZIP code (optional)",
+      "province-state": "Province, territory, state, or region"
     },
-    "international-address": {
-      "close-button": "Close",
-      "description": "Please double-check the international mailing address details below:",
-      "header": "International mailing address"
+    "address-header": "Mailing address",
+    "dialog": {
+      "address-suggestion": {
+        "address-selection-legend": "Please select an address option below:",
+        "cancel-button": "Cancel",
+        "description": "We found a suggested correction for the address you entered.",
+        "entered-address-option": "Entered address:",
+        "header": "Address correction suggestion",
+        "suggested-address-option": "Suggested corrected address:",
+        "use-selected-address-button": "Use selected address"
+      },
+      "not-correct-address": {
+        "close-button": "Close",
+        "description": "There seems to be an issue with the mailing address you entered. Please verify the information below:",
+        "header": "Mailing address error"
+      }
     },
-    "not-correct-address": {
-      "close-button": "Close",
-      "description": "There seems to be an issue with the mailing address you entered. Please verify the information below:",
-      "header": "Mailing address error"
+    "error-message": {
+      "address-required": "Enter mailing address, typically number and street",
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
+      "city-required": "Enter a city or town for your mailing address",
+      "country-required": "Select a country for your mailing address",
+      "invalid-postal-zip-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+      "invalid-postal-zip-code-for-province": "The postal code does not match the province or territory you selected",
+      "postal-zip-code-required": "Enter postal code or zip code for your mailing address",
+      "postal-zip-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
+      "province-state-required": "Select a province, territory, state or region for your mailing address",
+      "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789"
     },
-    "valid-address": {
-      "close-button": "Close",
-      "description": "Your mailing address is valid! Please review the confirmed details below:",
-      "header": "Mailing address confirmed"
-    }
+    "optional-label": "Complete all fields unless marked as optional.",
+    "page-title": "Address validation",
+    "reset-button": "Reset",
+    "submit-button": "Validate address"
   },
-  "error-message": {
-    "address-required": "Enter mailing address, typically number and street",
-    "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-    "city-required": "Enter a city or town for your mailing address",
-    "country-required": "Select a country for your mailing address",
-    "invalid-postal-zip-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
-    "invalid-postal-zip-code-for-province": "The postal code does not match the province or territory you selected",
-    "postal-zip-code-required": "Enter postal code or zip code for your mailing address",
-    "postal-zip-code-valid": "Enter mailing address postal code in the correct format, such as A1A 1A1",
-    "province-state-required": "Select a province, territory, state or region for your mailing address",
-    "zip-code-valid": "Enter mailing address zip code in the correct format, such as 12345 or 12345-6789"
-  },
-  "optional-label": "Complete all fields unless marked as optional.",
-  "page-title": "Address validation",
-  "reset-button": "Reset",
-  "submit-button": "Validate address"
+  "review": {
+    "address-header": "Review your mailing address",
+    "address-sub-header": "Thank you for validating your mailing address! Please review the information below to ensure it's correct.",
+    "edit-button": "Edit mailing address",
+    "page-title": "Address validation review"
+  }
 }

--- a/frontend/public/locales/fr/address-validation.json
+++ b/frontend/public/locales/fr/address-validation.json
@@ -1,59 +1,57 @@
 {
-  "address-field": {
-    "address": "Adresse",
-    "address-note": "Inclure le numéro et le nom de la rue",
-    "city": "Ville ou village",
-    "country": "Pays",
-    "postal-zip-code": "Code postal",
-    "postal-zip-code-optional": "Code postal (facultatif)",
-    "province-state": "Province, territoire, état ou région"
-  },
-  "address-header": "Adresse postale",
-  "dialog": {
-    "address-suggestion": {
-      "address-selection-legend": "Veuillez sélectionner une option d'adresse ci\u2011dessous\u00a0:",
-      "cancel-button": "Annuler",
-      "description": "Nous avons trouvé une correction suggérée pour l'adresse que vous avez saisie.",
-      "entered-address-option": "Adresse saisie\u00a0:",
-      "header": "Suggestion de correction d'adresse",
-      "suggested-address-option": "Adresse corrigée suggérée\u00a0:",
-      "use-selected-address-button": "Utiliser l'adresse sélectionnée"
+  "index": {
+    "address-field": {
+      "address": "Adresse",
+      "address-note": "Inclure le numéro et le nom de la rue",
+      "city": "Ville ou village",
+      "country": "Pays",
+      "postal-zip-code": "Code postal",
+      "postal-zip-code-optional": "Code postal (facultatif)",
+      "province-state": "Province, territoire, état ou région"
     },
-    "international-address": {
-      "close-button": "Fermer",
-      "description": "Veuillez vérifier les détails de l'adresse postale internationale ci\u2011dessous\u00a0:",
-      "header": "Adresse postale internationale"
+    "address-header": "Adresse postale",
+    "dialog": {
+      "address-suggestion": {
+        "address-selection-legend": "Veuillez sélectionner une option d'adresse ci\u2011dessous\u00a0:",
+        "cancel-button": "Annuler",
+        "description": "Nous avons trouvé une correction suggérée pour l'adresse que vous avez saisie.",
+        "entered-address-option": "Adresse saisie\u00a0:",
+        "header": "Suggestion de correction d'adresse",
+        "suggested-address-option": "Adresse corrigée suggérée\u00a0:",
+        "use-selected-address-button": "Utiliser l'adresse sélectionnée"
+      },
+      "not-correct-address": {
+        "close-button": "Fermer",
+        "description": "Il semble y avoir un problème avec l'adresse postale que vous avez saisie. Veuillez vérifier les informations ci\u2011dessous\u00a0:",
+        "header": "Erreur d'adresse postale"
+      }
     },
-    "not-correct-address": {
-      "close-button": "Fermer",
-      "description": "Il semble y avoir un problème avec l'adresse postale que vous avez saisie. Veuillez vérifier les informations ci\u2011dessous\u00a0:",
-      "header": "Erreur d'adresse postale"
+    "error-message": {
+      "address-required": "Entrez l'adresse postale, normalement le numéro et le nom de la rue",
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
+      "city-required": "Entrez une ville ou une municipalité pour votre adresse postale",
+      "country-required": "Sélectionnez un pays pour votre adresse postale",
+      "invalid-postal-zip-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
+      "invalid-postal-zip-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné",
+      "postal-zip-code-required": "Entrez un code postal ou un code postal américain pour votre adresse postale",
+      "postal-zip-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
+      "province-state-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
+      "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789"
     },
-    "valid-address": {
+    "optional-label": "Veuillez remplir tous les champs, sauf ceux indiqués comme facultatifs.",
+    "page-title": "Validation d'adresse",
+    "reset-button": "Réinitialiser",
+    "submit-button": "Valider l'adresse",
+    "valid-address-dialog": {
       "close-button": "Fermer",
-      "description": "Votre adresse postale est valide! Veuillez vérifier les détails confirmés ci\u2011dessous\u00a0:",
-      "header": "Adresse postale confirmée"
+      "description": "L'adresse postale fournie a été validée avec succès et est valide. Veuillez vérifier l'adresse formatée ci\u2011dessous\u00a0:",
+      "header": "Adresse postale validée"
     }
   },
-  "error-message": {
-    "address-required": "Entrez l'adresse postale, normalement le numéro et le nom de la rue",
-    "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-    "city-required": "Entrez une ville ou une municipalité pour votre adresse postale",
-    "country-required": "Sélectionnez un pays pour votre adresse postale",
-    "invalid-postal-zip-code-for-country": "Un code postal canadien a été entré dans l'adresse postale mais le Canada n'a pas été choisi comme pays. Veuillez choisir Canada, et la bonne province, ou changer le code postal",
-    "invalid-postal-zip-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné",
-    "postal-zip-code-required": "Entrez un code postal ou un code postal américain pour votre adresse postale",
-    "postal-zip-code-valid": "Entrez un code postal pour l'adresse postale dans le bon format, par exemple A1A 1A1",
-    "province-state-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse postale",
-    "zip-code-valid": "Entrez un code postal américain pour l'adresse postale dans le bon format, par exemple 12345 ou 12345-6789"
-  },
-  "optional-label": "Veuillez remplir tous les champs, sauf ceux indiqués comme facultatifs.",
-  "page-title": "Validation d'adresse",
-  "reset-button": "Réinitialiser",
-  "submit-button": "Valider l'adresse",
-  "valid-address-dialog": {
-    "close-button": "Fermer",
-    "description": "L'adresse postale fournie a été validée avec succès et est valide. Veuillez vérifier l'adresse formatée ci\u2011dessous\u00a0:",
-    "header": "Adresse postale validée"
+  "review": {
+    "address-header": "Vérifiez votre adresse de correspondance",
+    "address-sub-header": "Merci d'avoir validé votre adresse de correspondance! Veuillez vérifier les informations ci-dessous pour vous assurer qu'elles sont correctes.",
+    "edit-button": "Modifier l'adresse postale",
+    "page-title": "Révision de la validation d'adresse"
   }
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Add an address validation review route for this proof of concept. Additionally, I created two `domain` Remix validators:

- `~/.server/remix/domain/validators/address.validator` – a reusable address validator for the Remix business domain.
- `~/.server/remix/domain/routes/address-validation/mailing-address.validator` – a route-specific mailing address validator for the Remix business domain. It uses the `address.validator` and provides custom error messages tailored to the mailing address validation context.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4696](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4696)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

English Review
![image](https://github.com/user-attachments/assets/96197e2c-afe1-42de-940e-933e03f80adb)

French Review
![image](https://github.com/user-attachments/assets/5e3ad200-ba78-44df-8ea1-5344c22999bc)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->