### PR TITLE
AB#4802 -- Fixed mailing address label for renewal flows

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
@@ -283,7 +283,7 @@ export default function RenewAdultChildUpdateAddress() {
                 id="mailing-address"
                 name="mailingAddress"
                 className="w-full"
-                label={t('renew-adult-child:update-address.address-field.address')}
+                label={t('renew-adult-child:update-address.address-field.mailing-address')}
                 maxLength={30}
                 helpMessagePrimary={t('renew-adult-child:update-address.address-field.address-note')}
                 helpMessagePrimaryClassName="text-black"

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -290,7 +290,7 @@ export default function RenewItaUpdateAddress() {
                 id="mailing-address"
                 name="mailingAddress"
                 className="w-full"
-                label={t('renew-ita:update-address.address-field.address')}
+                label={t('renew-ita:update-address.address-field.mailing-address')}
                 maxLength={30}
                 helpMessagePrimary={t('renew-ita:update-address.address-field.address-note')}
                 helpMessagePrimaryClassName="text-black"

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -102,6 +102,7 @@
     },
     "address-field": {
       "address": "Address",
+      "mailing-address": "Mailing address",
       "address-note": "Include apartment number (if applicable), street number, street name. For example: 4B - 123 Main St.",
       "country": "Country",
       "province": "Province, territory, state, or region",

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -92,6 +92,7 @@
     },
     "address-field": {
       "address": "Address",
+      "mailing-address": "Mailing address",
       "address-note": "Include street number and name",
       "apartment": "Apartment, suite, etc. (optional)",
       "country": "Country",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -102,6 +102,7 @@
     },
     "address-field": {
       "address": "Adresse postale",
+      "mailing-address": "Adresse postale",
       "apartment": "Inclure le numéro d'appartement (s'il y a lieu), le numéro municipal et le nom de la rue. Par exemple : 4B - 123 Rue Main",
       "country": "Pays",
       "province": "Province, territoire, État ou région",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -93,6 +93,7 @@
     },
     "address-field": {
       "address": "Adresse postale",
+      "mailing-address": "Adresse postale",
       "address-note": "Inclure le numéro municipal et le nom de rue",
       "apartment": "Appartement, suite, etc. (facultatif)",
       "country": "Pays",


### PR DESCRIPTION
### Description
Fixed mailing address label for adult-child/ita renewal flows from figma

### Related Azure Boards Work Items
[AB#4802](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4802)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d46edfc4-83ae-4f8d-b167-bf30d27a3019)