### PR TITLE
4808 change address bug in edit mode renew-adult-child flow

### DIFF
--- a/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
@@ -186,6 +186,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     addressInformation,
     partnerInformation,
     children,
+    hasAddressChanged,
   };
 }
 

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -85,23 +85,27 @@ export async function loader({ context: { appContainer, session }, params, reque
     consent: state.partnerInformation.confirm,
   };
 
-  const mailingAddressInfo = {
-    address: state.addressInformation?.mailingAddress,
-    city: state.addressInformation?.mailingCity,
-    province: mailingProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation?.mailingPostalCode,
-    country: countryMailing,
-    apartment: state.addressInformation?.mailingApartment,
-  };
+  const mailingAddressInfo = state.hasAddressChanged
+    ? {
+        address: state.addressInformation?.mailingAddress,
+        city: state.addressInformation?.mailingCity,
+        province: mailingProvinceTerritoryStateAbbr,
+        postalCode: state.addressInformation?.mailingPostalCode,
+        country: countryMailing,
+        apartment: state.addressInformation?.mailingApartment,
+      }
+    : undefined;
 
-  const homeAddressInfo = {
-    address: state.addressInformation?.homeAddress,
-    city: state.addressInformation?.homeCity,
-    province: homeProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation?.homePostalCode,
-    country: countryHome,
-    apartment: state.addressInformation?.homeApartment,
-  };
+  const homeAddressInfo = state.hasAddressChanged
+    ? {
+        address: state.addressInformation?.homeAddress,
+        city: state.addressInformation?.homeCity,
+        province: homeProvinceTerritoryStateAbbr,
+        postalCode: state.addressInformation?.homePostalCode,
+        country: countryHome,
+        apartment: state.addressInformation?.homeApartment,
+      }
+    : undefined;
 
   const dentalInsurance = state.dentalInsurance;
 
@@ -309,16 +313,20 @@ export default function RenewAdultChildReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult-child:review-adult-information.mailing-title')}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address ?? '',
-                    city: mailingAddressInfo.city ?? '',
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country?.name ?? '',
-                    apartment: mailingAddressInfo.apartment,
-                  }}
-                />
+                {mailingAddressInfo ? (
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address ?? '',
+                      city: mailingAddressInfo.city ?? '',
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country?.name ?? '',
+                      apartment: mailingAddressInfo.apartment,
+                    }}
+                  />
+                ) : (
+                  <p>{t('renew-adult-child:review-adult-information.no-update')}</p>
+                )}
                 <div className="mt-4">
                   <InlineLink id="change-mailing-address" routeId="public/renew/$id/adult-child/confirm-address" params={params}>
                     {t('renew-adult-child:review-adult-information.mailing-change')}
@@ -326,16 +334,20 @@ export default function RenewAdultChildReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult-child:review-adult-information.home-title')}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address ?? '',
-                    city: homeAddressInfo.city ?? '',
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country?.name ?? '',
-                    apartment: homeAddressInfo.apartment,
-                  }}
-                />
+                {homeAddressInfo ? (
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address ?? '',
+                      city: homeAddressInfo.city ?? '',
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country?.name ?? '',
+                      apartment: homeAddressInfo.apartment,
+                    }}
+                  />
+                ) : (
+                  <p>{t('renew-adult-child:review-adult-information.no-update')}</p>
+                )}
                 <div className="mt-4">
                   <InlineLink id="change-home-address" routeId="public/renew/$id/adult-child/confirm-address" params={params}>
                     {t('renew-adult-child:review-adult-information.home-change')}

--- a/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
@@ -420,7 +420,7 @@ export default function RenewAdultChildUpdateAddress() {
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Update address click">
                 {t('renew-adult-child:update-address.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="public/renew/$id/adult-child/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Update address click">
+              <ButtonLink id="back-button" routeId="public/renew/$id/adult-child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Update address click">
                 {t('renew-adult-child:update-address.cancel-btn')}
               </ButtonLink>
             </div>

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -89,7 +89,9 @@
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
     },
     "back-btn": "Back",
-    "continue-btn": "Continue"
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save"
   },
   "update-address": {
     "page-title": "Update address",
@@ -565,6 +567,7 @@
     "submit-app-title": "Submit your renewal application",
     "submit-p-proceed": "By proceeding with this renewal, you are agreeing to attest truthfully to the information provided.",
     "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
-    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan."
+    "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
+    "no-update": "No update"
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -89,7 +89,9 @@
       "is-home-address-same-as-mailing-address-required": "Sélectionnez si votre adresse postale et votre adresse domicile sont identiques ou non"
     },
     "back-btn": "Retour",
-    "continue-btn": "Continuer"
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer"
   },
   "update-address": {
     "page-title": "Mettez l'adresse à jour",
@@ -566,6 +568,7 @@
     "submit-app-title": "Soumettre votre demande de renouvellement",
     "submit-p-proceed": "En procédant à cette demande de renouvellement, vous acceptez d'attester la véracité des renseignements fournis.",
     "submit-p-false-info": "Si vous fournissez de faux renseignements dans votre demande de renouvellement, vous et les autres personnes pour lesquelles vous avez présenté une demande pourriez être exclus du régime.",
-    "submit-p-repayment": "Si vous ou les membres de votre famille n'étiez pas admissibles au renouvellement, vous pourriez avoir à rembourser la totalité des frais pour les soins reçus par l'intermédiaire du Régime canadien de soins dentaires."
+    "submit-p-repayment": "Si vous ou les membres de votre famille n'étiez pas admissibles au renouvellement, vous pourriez avoir à rembourser la totalité des frais pour les soins reçus par l'intermédiaire du Régime canadien de soins dentaires.",
+    "no-update": "Pas de mise à jour"
   }
 }


### PR DESCRIPTION
### Description
user should now be correctly navigated if they decide to edit their address from the renew-adult-information screen.  

### Related Azure Boards Work Items
[AB#4808](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4808)