### PR TITLE
4810 only display valid members in demographic survey

### DIFF
--- a/frontend/app/route-helpers/demographic-survey-route-helpers.server.ts
+++ b/frontend/app/route-helpers/demographic-survey-route-helpers.server.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto';
 import { z } from 'zod';
 
 import type { RenewState } from './renew-route-helpers.server';
+import { getChildrenState } from './renew-route-helpers.server';
 import { getLocaleFromParams } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
 import { getPathById } from '~/utils/route-utils';
@@ -200,7 +201,7 @@ export function getMemberInformationFromRenewState(state: RenewState) {
 
   const memberInformation = [
     composeMemberInformation(state.applicantInformation?.firstName ?? '', state.applicantInformation?.lastName ?? ''),
-    ...state.children.map((child) => composeMemberInformation(child.information?.firstName ?? '', child.information?.lastName ?? '')),
+    ...getChildrenState(state).map((child) => composeMemberInformation(child.information?.firstName ?? '', child.information?.lastName ?? '')),
   ];
 
   return memberInformation;


### PR DESCRIPTION
### Description
When a user clicks "Renew a child" in `renew/$id/adult-child/children` (the children summary hub), a new entry in state is created for the child.  The user is then brought to the information screen to enter the child's info.  The user can however click back, which keeps this entry in state, and as a consequence, no information for the child has been entered, meaning they're invalid.

There are few ways to handle only displaying valid members in the demographic survey.  I've landed on this approach since it appears to be the simplest (all members need a first and last name)

### Related Azure Boards Work Items
[AB#4810](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4810)