### PR TITLE
AB#4799 Add confirm marital status screen in renew adult-child flow

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -10,7 +10,7 @@ export type BenefitRenewalRequestDto = Readonly<{
     yearOfBirth: string;
     socialInsuranceNumber: string;
   }>;
-  maritalStatus: string;
+  maritalStatus?: string;
   contactInformation?: Readonly<{
     phoneNumber?: string;
     phoneNumberAlt?: string;

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -60,7 +60,7 @@ export type BenefitRenewalRequestEntity = Readonly<{
       >;
       PersonMaritalStatus: Readonly<{
         StatusCode: Readonly<{
-          ReferenceDataID: string;
+          ReferenceDataID?: string;
         }>;
       }>;
       PersonName: ReadonlyArray<

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -82,7 +82,7 @@ interface ToBenefitRenewalRequestArgs {
   partnerInformation?: PartnerInformationState | undefined;
   contactInformation?: ContactInformationState;
   typeOfRenewal: TypeOfRenewalState;
-  maritalStatus: string;
+  maritalStatus?: string;
   addressInformation?: AddressInformationState;
 }
 

--- a/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
+++ b/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
@@ -61,7 +61,7 @@ export interface ToBenefitRenewRequestFromRenewAdultChildStateArgs {
   partnerInformation: PartnerInformationState | undefined;
   contactInformation: ContactInformationState;
   typeOfRenewal: Extract<TypeOfRenewalState, 'adult-child'>;
-  maritalStatus: string | undefined;
+  maritalStatus?: string;
 }
 
 export function toBenefitRenewRequestFromRenewAdultChildState({

--- a/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
+++ b/frontend/app/mappers/benefit-renewal-service-mappers.server.ts
@@ -61,7 +61,7 @@ export interface ToBenefitRenewRequestFromRenewAdultChildStateArgs {
   partnerInformation: PartnerInformationState | undefined;
   contactInformation: ContactInformationState;
   typeOfRenewal: Extract<TypeOfRenewalState, 'adult-child'>;
-  maritalStatus: string;
+  maritalStatus: string | undefined;
 }
 
 export function toBenefitRenewRequestFromRenewAdultChildState({
@@ -96,7 +96,7 @@ interface ToBenefitRenewalRequestArgs {
   partnerInformation: PartnerInformationState | undefined;
   contactInformation: ContactInformationState;
   typeOfRenewal: TypeOfRenewalState;
-  maritalStatus: string;
+  maritalStatus?: string;
   addressInformation?: AddressInformationState;
   children?: ChildState[];
 }

--- a/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
@@ -142,7 +142,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
   }
 
   if (maritalStatus === undefined) {
-    throw redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
+    throw redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
   }
 
   if (hasAddressChanged && addressInformation === undefined) {

--- a/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
@@ -122,8 +122,23 @@ interface ValidateRenewAdultChildStateForReviewArgs {
 }
 
 export function validateRenewAdultChildStateForReview({ params, state }: ValidateRenewAdultChildStateForReviewArgs) {
-  const { hasAddressChanged, maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, communicationPreference, addressInformation, applicantInformation, dentalBenefits, confirmDentalBenefits, dentalInsurance } =
-    state;
+  const {
+    hasMaritalStatusChanged,
+    hasAddressChanged,
+    maritalStatus,
+    partnerInformation,
+    contactInformation,
+    editMode,
+    id,
+    submissionInfo,
+    typeOfRenewal,
+    communicationPreference,
+    addressInformation,
+    applicantInformation,
+    dentalBenefits,
+    confirmDentalBenefits,
+    dentalInsurance,
+  } = state;
 
   if (typeOfRenewal === undefined) {
     throw redirect(getPathById('public/renew/$id/type-renewal', params));
@@ -141,7 +156,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/renew/$id/applicant-information', params));
   }
 
-  if (maritalStatus === undefined) {
+  if (hasMaritalStatusChanged && maritalStatus === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
   }
 
@@ -172,6 +187,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
   const children = getChildrenState(state).length > 0 ? validateChildrenStateForReview({ childrenState: state.children, params }) : [];
 
   return {
+    hasMaritalStatusChanged,
     maritalStatus,
     editMode,
     id,

--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -62,6 +62,7 @@ export interface RenewState {
     yearOfBirth: string;
     socialInsuranceNumber: string;
   };
+  readonly hasMaritalStatusChanged?: boolean;
   readonly maritalStatus?: string;
   readonly contactInformation?: {
     isNewOrUpdatedPhoneNumber?: boolean;

--- a/frontend/app/routes.json
+++ b/frontend/app/routes.json
@@ -838,6 +838,14 @@
                 }
               },
               {
+                "id": "public/renew/$id/adult-child/confirm-marital-status",
+                "file": "routes/public/renew/$id/adult-child/confirm-marital-status.tsx",
+                "paths": {
+                  "en": "/:lang/renew/:id/adult-child/confirm-marital-status",
+                  "fr": "/:lang/renew/:id/adult-child/confirm-marital-status"
+                }
+              },
+              {
                 "id": "public/renew/$id/adult-child/marital-status",
                 "file": "routes/public/renew/$id/adult-child/marital-status.tsx",
                 "paths": {

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -101,20 +101,21 @@
         "exitApplication": "CDCP-RENw-ITA-0010"
       },
       "adultChild": {
-        "maritalStatus": "CDCP-RENW-ADCH-0001",
-        "confirmPhone": "CDCP-RENW-ADCH-0002",
-        "confirmEmail": "CDCP-RENW-ADCH-0003",
-        "confirmAddress": "CDCP-RENW-ADCH-0004",
-        "updateAddress": "CDCP-RENW-ADCH-0005",
-        "dentalInsurance": "CDCP-RENW-ADCH-0006",
-        "confirmFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0007",
-        "updateFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0008",
-        "childInformation": "CDCP-RENW-ADCH-0009",
-        "parentOrGuardian": "CDCP-RENW-ADCH-0010",
-        "reviewChildInformation": "CDCP-RENW-ADCH-0011",
-        "exitApplication": "CDCP-RENW-ADCH-0012",
-        "confirmation": "CDCP-RENW-ADCH-0013",
-        "reviewAdultInformation": "CDCP-APPL-ADCH-0014"
+        "confirmMaritalStatus": "CDCP-RENW-ADCH-001",
+        "maritalStatus": "CDCP-RENW-ADCH-0002",
+        "confirmPhone": "CDCP-RENW-ADCH-0003",
+        "confirmEmail": "CDCP-RENW-ADCH-0004",
+        "confirmAddress": "CDCP-RENW-ADCH-0005",
+        "updateAddress": "CDCP-RENW-ADCH-0006",
+        "dentalInsurance": "CDCP-RENW-ADCH-0007",
+        "confirmFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0008",
+        "updateFederalProvincialTerritorialBenefits": "CDCP-RENW-ADCH-0009",
+        "childInformation": "CDCP-RENW-ADCH-00010",
+        "parentOrGuardian": "CDCP-RENW-ADCH-0011",
+        "reviewChildInformation": "CDCP-RENW-ADCH-0012",
+        "exitApplication": "CDCP-RENW-ADCH-0013",
+        "confirmation": "CDCP-RENW-ADCH-0014",
+        "reviewAdultInformation": "CDCP-APPL-ADCH-0015"
       }
     },
     "demographicSurvey": {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -1,0 +1,155 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
+import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+enum MaritalStatusRadioOptions {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adultChild.confirmMaritalStatus,
+  pageTitleI18nKey: 'renew-adult-child:confirm-marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-marital-status.page-title') }) };
+
+  return json({ id: state.id, csrfToken, meta, defaultState: { hasMaritalStatusChanged: state.hasMaritalStatusChanged } });
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('renew/adult-child/confirm-marital-status');
+  const state = loadRenewAdultChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const confirmMaritalStatusSchema = z.object({
+    hasMaritalStatusChanged: z.boolean({
+      errorMap: () => ({ message: t('renew-adult-child:confirm-marital-status.error-message.has-marital-status-changed-required') }),
+    }),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = { hasMaritalStatusChanged: formData.get('hasMaritalStatusChanged') ? formData.get('hasMaritalStatusChanged') === 'yes' : undefined };
+  const parsedDataResult = confirmMaritalStatusSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return json({
+      errors: transformFlattenedError(parsedDataResult.error.flatten()),
+    });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      hasMaritalStatusChanged: parsedDataResult.data.hasMaritalStatusChanged,
+    },
+  });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
+  }
+
+  if (parsedDataResult.data.hasMaritalStatusChanged) {
+    return redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/confirm-phone', params));
+}
+
+export default function RenewAdultChildConfirmMaritalStatus() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasMaritalStatusChanged: 'input-radio-has-marital-status-changed-option-0',
+  });
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={22} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="space-y-6">
+            <InputRadios
+              id="has-marital-status-changed"
+              name="hasMaritalStatusChanged"
+              legend={t('renew-adult-child:confirm-marital-status.has-marital-status-changed')}
+              options={[
+                { value: MaritalStatusRadioOptions.Yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState.hasMaritalStatusChanged === true },
+                { value: MaritalStatusRadioOptions.No, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState.hasMaritalStatusChanged === false },
+              ]}
+              helpMessagePrimary={t('renew-adult-child:confirm-marital-status.help-message')}
+              errorMessage={errors?.hasMaritalStatusChanged}
+              required
+            />
+          </div>
+
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Confirm marital status click">
+              {t('renew-adult-child:confirm-marital-status.continue-btn')}
+            </LoadingButton>
+            <ButtonLink
+              id="back-button"
+              routeId="public/renew/$id/adult-child/type-renewal"
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Confirm marital status click"
+            >
+              {t('renew-adult-child:confirm-marital-status.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -118,7 +118,7 @@ export default function RenewAdultChildConfirmMaritalStatus() {
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <input type="hidden" name="_csrf" value={csrfToken} />
-          <div className="space-y-6">
+          <div className="mb-6">
             <InputRadios
               id="has-marital-status-changed"
               name="hasMaritalStatusChanged"
@@ -135,7 +135,7 @@ export default function RenewAdultChildConfirmMaritalStatus() {
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button name="_action" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Confirm marital status click">
-                {t('renew-adult-child:marital-status.save-btn')}
+                {t('renew-adult-child:marital-status.continue-btn')}
               </Button>
               <ButtonLink
                 id="back-button"

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import pageIds from '../../../../page-ids.json';
-import { ButtonLink } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-marital-status.page-title') }) };
 
-  return json({ id: state.id, csrfToken, meta, defaultState: { hasMaritalStatusChanged: state.hasMaritalStatusChanged } });
+  return json({ id: state.id, csrfToken, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode });
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -99,7 +99,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewAdultChildConfirmMaritalStatus() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -124,30 +124,46 @@ export default function RenewAdultChildConfirmMaritalStatus() {
               name="hasMaritalStatusChanged"
               legend={t('renew-adult-child:confirm-marital-status.has-marital-status-changed')}
               options={[
-                { value: MaritalStatusRadioOptions.Yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState.hasMaritalStatusChanged === true },
-                { value: MaritalStatusRadioOptions.No, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState.hasMaritalStatusChanged === false },
+                { value: MaritalStatusRadioOptions.Yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
+                { value: MaritalStatusRadioOptions.No, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
               helpMessagePrimary={t('renew-adult-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
               required
             />
           </div>
-
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Confirm marital status click">
-              {t('renew-adult-child:confirm-marital-status.continue-btn')}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              routeId="public/renew/$id/adult-child/type-renewal"
-              params={params}
-              disabled={isSubmitting}
-              startIcon={faChevronLeft}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Confirm marital status click"
-            >
-              {t('renew-adult-child:confirm-marital-status.back-btn')}
-            </ButtonLink>
-          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button name="_action" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Confirm marital status click">
+                {t('renew-adult-child:marital-status.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/review-adult-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Confirm marital status click"
+              >
+                {t('dental-insurance.button.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Confirm marital status click">
+                {t('renew-adult-child:confirm-marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/type-renewal"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Confirm marital status click"
+              >
+                {t('renew-adult-child:confirm-marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
         </fetcher.Form>
       </div>
     </>

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -64,6 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       phoneNumber: state.contactInformation?.phoneNumber,
       phoneNumberAlt: state.contactInformation?.phoneNumberAlt,
     },
+    hasMaritalStatusChanged: state.hasMaritalStatusChanged,
     maritalStatus: state.maritalStatus,
     editMode: state.editMode,
   });
@@ -138,7 +139,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewAdultChildConfirmPhone() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -247,7 +248,7 @@ export default function RenewAdultChildConfirmPhone() {
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/adult-child/marital-status"
+                routeId={hasMaritalStatusChanged ? 'public/renew/$id/adult-child/marital-status' : 'public/renew/$id/adult-child/confirm-marital-status'}
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -223,7 +223,14 @@ export default function RenewAdultChildMaritalStatus() {
               >
                 {t('renew-adult-child:marital-status.continue-btn')}
               </LoadingButton>
-              <ButtonLink id="back-button" routeId="public/renew/$id/type-renewal" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Marital status click">
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/confirm-marital-status"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Marital status click"
+              >
                 {t('renew-adult-child:marital-status.back-btn')}
               </ButtonLink>
             </div>

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -65,7 +65,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeProvinceTerritoryStateAbbr = state.addressInformation?.homeProvince ? appContainer.get(TYPES.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
   const countryMailing = state.addressInformation?.mailingCountry ? appContainer.get(TYPES.CountryService).getLocalizedCountryById(state.addressInformation.mailingCountry, locale) : undefined;
   const countryHome = state.addressInformation?.homeCountry ? appContainer.get(TYPES.CountryService).getLocalizedCountryById(state.addressInformation.homeCountry, locale) : undefined;
-  const maritalStatus = appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
+  const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,
@@ -74,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     clientNumber: state.applicantInformation.clientNumber,
-    maritalStatus: maritalStatus.name,
+    maritalStatus: maritalStatus ? maritalStatus.name : undefined,
     contactInformationEmail: state.contactInformation.email,
     communicationPreferenceEmail: state.communicationPreference?.email,
   };
@@ -250,9 +250,9 @@ export default function RenewAdultChildReviewAdultInformation() {
                 <p>{userInfo.clientNumber}</p>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult-child:review-adult-information.marital-title')}>
-                <p>{userInfo.maritalStatus}</p>
+                <p>{userInfo.maritalStatus ? userInfo.maritalStatus : t('renew-adult-child:review-adult-information.no-change')}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-martial-status" routeId="public/renew/$id/adult-child/marital-status" params={params}>
+                  <InlineLink id="change-martial-status" routeId="public/renew/$id/adult-child/confirm-marital-status" params={params}>
                     {t('renew-adult-child:review-adult-information.marital-change')}
                   </InlineLink>
                 </div>

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -93,7 +93,7 @@ export async function action({ context: { appContainer, session }, params, reque
     if (state.clientApplication?.hasAppliedBeforeApril302024) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
-    return redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
+    return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
   }
 
   if (parsedDataResult.data.typeOfRenewal === RenewalType.Child) {

--- a/frontend/app/schemas/benefit-renewal-service-schemas.server.ts
+++ b/frontend/app/schemas/benefit-renewal-service-schemas.server.ts
@@ -64,7 +64,7 @@ export const benefitRenewalRequestSchema = z.object({
       ),
       PersonMaritalStatus: z.object({
         StatusCode: z.object({
-          ReferenceDataID: z.string(),
+          ReferenceDataID: z.string().optional(),
         }),
       }),
       PersonName: z.array(

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -5,6 +5,8 @@
     "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Back",
     "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
     "radio-options": {
       "yes": "Yes",
       "no": "No"
@@ -572,6 +574,7 @@
     "dental-benefit-title": "Access to government dental benefits",
     "dental-benefit-change": "Change answer to government dental benefits",
     "dental-benefit-has-access": "Has access to the following benefits:",
+    "no-change": "No update",
     "submit-button": "Submit Application",
     "exit-button": "Exit application",
     "back-button": "Back",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -1,6 +1,6 @@
 {
   "confirm-marital-status": {
-    "page-title": "Marital-status",
+    "page-title": "Marital status",
     "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
     "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Back",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -1,4 +1,18 @@
 {
+  "confirm-marital-status": {
+    "page-title": "Marital-status",
+    "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
+    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "has-marital-status-changed-required": "Please indicate if your marital status has changed"
+    }
+  },
   "marital-status": {
     "page-title": "Marital status",
     "marital-status": "What is your current marital status?",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -1,6 +1,6 @@
 {
   "confirm-marital-status": {
-    "page-title": "Marital-status",
+    "page-title": "État civil",
     "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
     "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Retour",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -5,9 +5,11 @@
     "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Sauvegarder",
     "radio-options": {
-      "yes": "Yes",
-      "no": "No"
+      "yes": "Oui",
+      "no": "Non"
     },
     "error-message": {
       "has-marital-status-changed-required": "Please indicate if your marital status has changed"
@@ -573,6 +575,7 @@
     "dental-benefit-title": "Accès à des prestations dentaires gouvernementales",
     "dental-benefit-change": "Modifier la réponse à «\u00a0soins dentaires gouvernementaux\u00a0»",
     "dental-benefit-has-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
+    "no-change": "Aucun changement",
     "submit-button": "Soumettre la demande",
     "exit-button": "Quitter la demande",
     "back-button": "Retour",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -1,4 +1,18 @@
 {
+  "confirm-marital-status": {
+    "page-title": "Marital-status",
+    "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
+    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "has-marital-status-changed-required": "Please indicate if your marital status has changed"
+    }
+  },
   "marital-status": {
     "page-title": "État civil",
     "marital-status": "Quel est votre état civil actuel?",


### PR DESCRIPTION
### Description
Added `confirm-marital-status` page as the first screen in renew adult-child flow. If user select `yes`, go to `marital-status` page, if no, skip `marital-status` page, go to `confirm-phone`

### Related Azure Boards Work Items
[AB#4799](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4799)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->