### PR TITLE
Adding benefit application state mapper to map from apply state to benefit application dto

### DIFF
--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -59,6 +59,7 @@ import type {
   SessionService,
 } from '~/.server/domain/services';
 import type { ConfigFactory, LogFactory } from '~/.server/factories';
+import type { BenefitApplicationStateMapper } from '~/.server/remix/domain/mappers';
 import { assignServiceIdentifiers, serviceIdentifier as serviceId } from '~/.server/utils/service-identifier.utils';
 import type { HCaptchaDtoMapper } from '~/.server/web/mappers';
 import type { HCaptchaRepository } from '~/.server/web/repositories';
@@ -120,6 +121,7 @@ export const TYPES = assignServiceIdentifiers({
   ApplicationStatusRepository: serviceId<ApplicationStatusRepository>(),
   ApplicationStatusService: serviceId<ApplicationStatusService>(),
   AuditService: serviceId<AuditService>(),
+  BenefitApplicationStateMapper: serviceId<BenefitApplicationStateMapper>(),
   BenefitRenewalDtoMapper: serviceId<BenefitRenewalDtoMapper>(),
   BenefitRenewalRepository: serviceId<BenefitRenewalRepository>(),
   BenefitRenewalService: serviceId<BenefitRenewalService>(),

--- a/frontend/app/.server/container-modules/mappers.container-module.ts
+++ b/frontend/app/.server/container-modules/mappers.container-module.ts
@@ -19,6 +19,7 @@ import {
   ProvinceTerritoryStateDtoMapperImpl,
   ProvincialGovernmentInsurancePlanDtoMapperImpl,
 } from '~/.server/domain/mappers';
+import { BenefitApplicationStateMapperImpl } from '~/.server/remix/domain/mappers';
 import { HCaptchaDtoMapperImpl } from '~/.server/web/mappers';
 
 /**
@@ -28,6 +29,7 @@ export const mappersContainerModule = new ContainerModule((bind) => {
   bind(TYPES.AddressValidationDtoMapper).to(AddressValidationDtoMapperImpl);
   bind(TYPES.ApplicantDtoMapper).to(ApplicantDtoMapperImpl);
   bind(TYPES.ApplicationStatusDtoMapper).to(ApplicationStatusDtoMapperImpl);
+  bind(TYPES.BenefitApplicationStateMapper).to(BenefitApplicationStateMapperImpl);
   bind(TYPES.BenefitRenewalDtoMapper).to(BenefitRenewalDtoMapperImpl);
   bind(TYPES.ClientApplicationDtoMapper).to(ClientApplicationDtoMapperImpl);
   bind(TYPES.ClientFriendlyStatusDtoMapper).to(ClientFriendlyStatusDtoMapperImpl);

--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -1,0 +1,70 @@
+export type BenefitApplicationDto = Readonly<{
+  applicantInformation: Readonly<{
+    firstName: string;
+    lastName: string;
+    maritalStatus: string;
+    socialInsuranceNumber: string;
+  }>;
+  children: ReadonlyArray<
+    Readonly<{
+      readonly dentalBenefits: Readonly<{
+        hasFederalBenefits: boolean;
+        federalSocialProgram?: string;
+        hasProvincialTerritorialBenefits: boolean;
+        provincialTerritorialSocialProgram?: string;
+        // province?: string; TODO verify if this is needed when mapping to entity
+      }>;
+      dentalInsurance: boolean;
+      information: Readonly<{
+        firstName: string;
+        lastName: string;
+        dateOfBirth: string;
+        isParent: boolean;
+        hasSocialInsuranceNumber: boolean;
+        socialInsuranceNumber?: string;
+      }>;
+    }>
+  >;
+  communicationPreferences: Readonly<{
+    email?: string;
+    preferredLanguage: string;
+    preferredMethod: string;
+  }>;
+  contactInformation: Readonly<{
+    copyMailingAddress: boolean;
+    homeAddress: string;
+    homeApartment?: string;
+    homeCity: string;
+    homeCountry: string;
+    homePostalCode?: string;
+    homeProvince?: string;
+    mailingAddress: string;
+    mailingApartment?: string;
+    mailingCity: string;
+    mailingCountry: string;
+    mailingPostalCode?: string;
+    mailingProvince?: string;
+    phoneNumber?: string;
+    phoneNumberAlt?: string;
+    email?: string;
+  }>;
+  dateOfBirth: string;
+  dentalBenefits?: Readonly<{
+    hasFederalBenefits: boolean;
+    federalSocialProgram?: string;
+    hasProvincialTerritorialBenefits: boolean;
+    provincialTerritorialSocialProgram?: string;
+    // province?: string; TODO verify if this is needed when mapping to entity
+  }>;
+  dentalInsurance?: boolean;
+  disabilityTaxCredit?: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: Readonly<{
+    // confirm: boolean; TODO verify if this is needed when mapping to entity
+    dateOfBirth: string;
+    firstName: string;
+    lastName: string;
+    socialInsuranceNumber: string;
+  }>;
+  typeOfApplication: 'adult' | 'adult-child' | 'child';
+}>;

--- a/frontend/app/.server/domain/dtos/index.ts
+++ b/frontend/app/.server/domain/dtos/index.ts
@@ -2,6 +2,7 @@ export type * from './address-validation.dto';
 export type * from './applicant.dto';
 export type * from './application-status.dto';
 export type * from './audit.dto';
+export type * from './benefit-application.dto';
 export type * from './benefit-renewal.dto';
 export type * from './client-application.dto';
 export type * from './client-friendly-status.dto';

--- a/frontend/app/.server/remix/domain/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/remix/domain/mappers/benefit-application.state.mapper.ts
@@ -1,0 +1,178 @@
+import { injectable } from 'inversify';
+import invariant from 'tiny-invariant';
+
+import type { BenefitApplicationDto } from '~/.server/domain/dtos';
+import { getAgeCategoryFromDateString } from '~/route-helpers/apply-route-helpers.server';
+import type {
+  ApplicantInformationState,
+  ChildState,
+  CommunicationPreferencesState,
+  ContactInformationState,
+  DentalFederalBenefitsState,
+  DentalProvincialTerritorialBenefitsState,
+  PartnerInformationState,
+  TypeOfApplicationState,
+} from '~/route-helpers/apply-route-helpers.server';
+
+export interface ApplyAdultState {
+  applicantInformation: ApplicantInformationState;
+  communicationPreferences: CommunicationPreferencesState;
+  contactInformation: ContactInformationState;
+  dateOfBirth: string;
+  dentalBenefits: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+  dentalInsurance: boolean;
+  disabilityTaxCredit?: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: PartnerInformationState;
+  typeOfApplication: Extract<TypeOfApplicationState, 'adult'>;
+}
+
+export interface ApplyAdultChildState {
+  applicantInformation: ApplicantInformationState;
+  children: Required<ChildState>[];
+  communicationPreferences: CommunicationPreferencesState;
+  contactInformation: ContactInformationState;
+  dateOfBirth: string;
+  dentalBenefits: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+  dentalInsurance: boolean;
+  disabilityTaxCredit?: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: PartnerInformationState;
+  typeOfApplication: Extract<TypeOfApplicationState, 'adult-child'>;
+}
+
+export interface ApplyChildState {
+  applicantInformation: ApplicantInformationState;
+  children: Required<ChildState>[];
+  communicationPreferences: CommunicationPreferencesState;
+  contactInformation: ContactInformationState;
+  dateOfBirth: string;
+  disabilityTaxCredit?: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: PartnerInformationState;
+  typeOfApplication: Extract<TypeOfApplicationState, 'child'>;
+}
+
+interface ToBenefitApplicationDtoArgs {
+  applicantInformation: ApplicantInformationState;
+  children?: Required<ChildState>[];
+  communicationPreferences: CommunicationPreferencesState;
+  dateOfBirth: string;
+  dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+  dentalInsurance?: boolean;
+  disabilityTaxCredit?: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: PartnerInformationState;
+  contactInformation: ContactInformationState;
+  typeOfApplication: Extract<TypeOfApplicationState, 'adult' | 'adult-child' | 'child'>;
+}
+
+export interface BenefitApplicationStateMapper {
+  mapApplyAdultStateToBenefitApplicationDto(applyAdultState: ApplyAdultState): BenefitApplicationDto;
+
+  mapApplyAdultChildStateToBenefitApplicationDto(applyAdultChildState: ApplyAdultChildState): BenefitApplicationDto;
+
+  mapApplyChildStateToBenefitApplicationDto(applyChildState: ApplyChildState): BenefitApplicationDto;
+}
+
+@injectable()
+export class BenefitApplicationStateMapperImpl implements BenefitApplicationStateMapper {
+  mapApplyAdultStateToBenefitApplicationDto(applyAdultState: ApplyAdultState): BenefitApplicationDto {
+    const ageCategory = getAgeCategoryFromDateString(applyAdultState.dateOfBirth);
+    if (ageCategory === 'adults' && applyAdultState.disabilityTaxCredit === undefined) {
+      throw Error('Expected disabilityTaxCredit to be defined');
+    }
+
+    if (ageCategory === 'youth' && applyAdultState.livingIndependently === undefined) {
+      throw Error('Expected livingIndependently to be defined');
+    }
+
+    return this.toBenefitApplicationDto({
+      ...applyAdultState,
+      disabilityTaxCredit: ageCategory === 'adults' ? applyAdultState.disabilityTaxCredit : undefined,
+      livingIndependently: ageCategory === 'youth' ? applyAdultState.livingIndependently : undefined,
+    });
+  }
+
+  mapApplyAdultChildStateToBenefitApplicationDto(applyAdultChildState: ApplyAdultChildState): BenefitApplicationDto {
+    const ageCategory = getAgeCategoryFromDateString(applyAdultChildState.dateOfBirth);
+    if (ageCategory === 'adults' && applyAdultChildState.disabilityTaxCredit === undefined) {
+      throw Error('Expected disabilityTaxCredit to be defined');
+    }
+
+    if (ageCategory === 'youth' && applyAdultChildState.livingIndependently === undefined) {
+      throw Error('Expected livingIndependently to be defined');
+    }
+
+    return this.toBenefitApplicationDto({
+      ...applyAdultChildState,
+      disabilityTaxCredit: ageCategory === 'adults' ? applyAdultChildState.disabilityTaxCredit : undefined,
+      livingIndependently: ageCategory === 'youth' ? applyAdultChildState.livingIndependently : undefined,
+    });
+  }
+
+  mapApplyChildStateToBenefitApplicationDto(applyChildState: ApplyChildState): BenefitApplicationDto {
+    return this.toBenefitApplicationDto(applyChildState);
+  }
+
+  private toBenefitApplicationDto({
+    applicantInformation,
+    children,
+    communicationPreferences,
+    dateOfBirth,
+    dentalBenefits,
+    dentalInsurance,
+    disabilityTaxCredit,
+    livingIndependently,
+    partnerInformation,
+    contactInformation,
+    typeOfApplication,
+  }: ToBenefitApplicationDtoArgs) {
+    return {
+      applicantInformation,
+      children: children ?? [],
+      communicationPreferences,
+      contactInformation: this.toContactInformation(contactInformation),
+      dateOfBirth,
+      dentalBenefits,
+      dentalInsurance,
+      disabilityTaxCredit,
+      livingIndependently,
+      partnerInformation,
+      typeOfApplication,
+    };
+  }
+
+  private toContactInformation(contactInformation: ContactInformationState) {
+    return {
+      ...contactInformation,
+      ...this.toHomeAddress(contactInformation),
+    };
+  }
+
+  private toHomeAddress({ copyMailingAddress, homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince, mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: ContactInformationState) {
+    if (copyMailingAddress) {
+      return {
+        homeAddress: mailingAddress,
+        homeApartment: mailingApartment,
+        homeCity: mailingCity,
+        homeCountry: mailingCountry,
+        homePostalCode: mailingPostalCode,
+        homeProvince: mailingProvince,
+      };
+    }
+
+    invariant(homeAddress, 'Expected homeAddress to be defined when copyMailingAddress is false.');
+    invariant(homeCity, 'Expected homeCity to be defined when copyMailingAddress is false.');
+    invariant(homeCountry, 'Expected homeCountry to be defined when copyMailingAddress is false.');
+
+    return {
+      homeAddress,
+      homeApartment,
+      homeCity,
+      homeCountry,
+      homePostalCode,
+      homeProvince,
+    };
+  }
+}

--- a/frontend/app/.server/remix/domain/mappers/index.ts
+++ b/frontend/app/.server/remix/domain/mappers/index.ts
@@ -1,0 +1,1 @@
+export * from './benefit-application.state.mapper';


### PR DESCRIPTION
### Description
Incremental PR to ultimately make benefit application service injectable.

The proposed DTO is based off [ApplyState](https://github.com/DTS-STN/canadian-dental-care-plan/blob/d434faf2afdf79c3775660dccbeebc479e357fff/frontend/app/route-helpers/apply-route-helpers.server.ts#L16), with:
- fields that are specific to the state/form removed
- fields made mandatory/optional depending on the service submission requirements

The proposed state mapper is based off [benefit-application-service-mappers](https://github.com/DTS-STN/canadian-dental-care-plan/blob/main/frontend/app/mappers/benefit-application-service-mappers.server.ts) but excludes any mapping from DTO to entity (the Interop request), which will be in a future PR.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Use the `appContainer` to inject the benefit application state mapper on any `/review-information` route to any of the `/apply` flows. 
- Pass the `state` to any of the mapper methods and proceed with the application for the flow to verify that the mapping behaves as expected.