### PR TITLE
Fix marital status logic in edit mode

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -83,10 +83,14 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasMaritalStatusChanged: parsedDataResult.data.hasMaritalStatusChanged,
+      maritalStatus: undefined,
     },
   });
 
   if (state.editMode) {
+    if (parsedDataResult.data.hasMaritalStatusChanged) {
+      return redirect(getPathById('public/renew/$id/adult-child/marital-status', params));
+    }
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
@@ -135,7 +139,7 @@ export default function RenewAdultChildConfirmMaritalStatus() {
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button name="_action" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Confirm marital status click">
-                {t('renew-adult-child:marital-status.continue-btn')}
+                {t('renew-adult-child:marital-status.save-btn')}
               </Button>
               <ButtonLink
                 id="back-button"

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -50,6 +50,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
+  if (!state.hasMaritalStatusChanged) {
+    return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
+  }
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = appContainer.get(TYPES.MaritalStatusService).listLocalizedMaritalStatuses(locale);


### PR DESCRIPTION
### Description
Fix the bug where confirm marital status is set to 'no' in edit mode, the marital status field on review information page does not update.
Added a state check in marital-status page loader, if `hasMaritalStatusChanged` is false, redirect to `confirm-marital-status` page to prevent user access marital-status by type url.
updated the `save` button link on `confirm-marital-status` page, if option 'yes' is selected, should navigate to `marital-status` page instead of going back to review-information

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->