### PR TITLE
refactor(frontend): change service identifier generation pattern

### DIFF
--- a/frontend/__tests__/.server/constants/types.constant.test.ts
+++ b/frontend/__tests__/.server/constants/types.constant.test.ts
@@ -1,16 +1,26 @@
-import type { interfaces } from 'inversify';
+import { flatKeys } from 'moderndash';
 import { describe, expect, it } from 'vitest';
 
 import { TYPES } from '~/.server/constants';
 
-describe('TYPES', () => {
-  it('should have unique Symbol values', () => {
-    const uniqueIdentifiers: interfaces.ServiceIdentifier[] = [];
+/**
+ * Generic tests for the `TYPES` constant
+ */
+describe('TYPES constant', () => {
+  it('should contain unique service identifiers', () => {
+    const flattenedKeys = flatKeys(TYPES);
+    const allIdentifiers = Object.values(flattenedKeys);
+    const uniqueIdentifiers = new Set(allIdentifiers);
+    expect(uniqueIdentifiers.size).toBe(allIdentifiers.length);
+  });
 
-    for (const key in TYPES) {
-      const identifier = TYPES[key as keyof typeof TYPES];
-      expect(uniqueIdentifiers.includes(identifier)).toBe(false);
-      uniqueIdentifiers.push(identifier);
-    }
+  it('should contain unique service identifiers for each entry', () => {
+    const flattenedKeys = flatKeys(TYPES);
+    expect.hasAssertions();
+    Object.keys(flattenedKeys).forEach((identifierKey) => {
+      const identifier = flattenedKeys[identifierKey as keyof typeof flattenedKeys];
+      expect(identifier).toBeTypeOf('symbol');
+      expect((identifier as symbol).description).toBe(identifierKey);
+    });
   });
 });

--- a/frontend/__tests__/.server/remix/security/validate-csrf-token.test.ts
+++ b/frontend/__tests__/.server/remix/security/validate-csrf-token.test.ts
@@ -13,7 +13,7 @@ describe('validateCsrfToken', () => {
     const mockValidateCsrfToken = vi.fn();
     const mockRequest = mock<ActionFunctionArgs['request']>();
     const mockContext = mockDeep<ActionFunctionArgs['context']>();
-    mockContext.appContainer.get.calledWith(TYPES.Web_CsrfTokenValidator).mockReturnValueOnce({
+    mockContext.appContainer.get.calledWith(TYPES.web.validators.CsrfTokenValidator).mockReturnValueOnce({
       validateCsrfToken: mockValidateCsrfToken,
     } satisfies Partial<CsrfTokenValidator>);
 
@@ -28,7 +28,7 @@ describe('validateCsrfToken', () => {
     });
     const mockRequest = mock<ActionFunctionArgs['request']>();
     const mockContext = mockDeep<ActionFunctionArgs['context']>();
-    mockContext.appContainer.get.calledWith(TYPES.Web_CsrfTokenValidator).mockReturnValueOnce({
+    mockContext.appContainer.get.calledWith(TYPES.web.validators.CsrfTokenValidator).mockReturnValueOnce({
       validateCsrfToken: mockValidateCsrfToken,
     } satisfies Partial<CsrfTokenValidator>);
 
@@ -43,7 +43,7 @@ describe('validateCsrfToken', () => {
     });
     const mockRequest = mock<ActionFunctionArgs['request']>();
     const mockContext = mockDeep<ActionFunctionArgs['context']>();
-    mockContext.appContainer.get.calledWith(TYPES.Web_CsrfTokenValidator).mockReturnValueOnce({
+    mockContext.appContainer.get.calledWith(TYPES.web.validators.CsrfTokenValidator).mockReturnValueOnce({
       validateCsrfToken: mockValidateCsrfToken,
     } satisfies Partial<CsrfTokenValidator>);
 

--- a/frontend/__tests__/.server/utils/service-identifier.utils.test.ts
+++ b/frontend/__tests__/.server/utils/service-identifier.utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ServiceIdentifier } from '~/.server/constants';
+import { assignServiceIdentifiers, serviceIdentifier } from '~/.server/utils/service-identifier.utils';
+
+describe('serviceIdentifier function', () => {
+  it('should return a unique symbol when called with an identifier', () => {
+    const result = serviceIdentifier('TestService');
+    expect(result).toBeTypeOf('symbol');
+    expect(String(result)).toBe('Symbol(TestService)');
+  });
+
+  it('should return a default symbol when no identifier is provided', () => {
+    const result = serviceIdentifier();
+    expect(result).toBeTypeOf('symbol');
+    expect(String(result)).toBe('Symbol(unknown)');
+  });
+});
+
+describe('assignServiceIdentifiers function', () => {
+  it('should recursively assign unique service identifiers to each key in the types object', () => {
+    type CsrfTokenValidatorMock = unknown;
+    const TYPES = {
+      web: {
+        validators: {
+          CsrfTokenValidator: Symbol.for('CsrfTokenValidator') as unknown as ServiceIdentifier<CsrfTokenValidatorMock>,
+        },
+      },
+    };
+
+    const serviceIdentifiers = assignServiceIdentifiers(TYPES);
+
+    expect(serviceIdentifiers.web.validators.CsrfTokenValidator).toBeTypeOf('symbol');
+    expect(String(serviceIdentifiers.web.validators.CsrfTokenValidator)).toBe('Symbol(web.validators.CsrfTokenValidator)');
+  });
+});

--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -59,86 +59,120 @@ import type {
   SessionService,
 } from '~/.server/domain/services';
 import type { ConfigFactory, LogFactory } from '~/.server/factories';
+import { assignServiceIdentifiers, serviceIdentifier as serviceId } from '~/.server/utils/service-identifier.utils';
 import type { HCaptchaDtoMapper } from '~/.server/web/mappers';
 import type { HCaptchaRepository } from '~/.server/web/repositories';
 import type { HCaptchaService } from '~/.server/web/services';
 import type { CsrfTokenValidator } from '~/.server/web/validators';
 
 /**
- * A type representing a service identifier for dependency injection purposes.
- * The identifier excludes `string` and `symbol` types, allowing only specific types
- * from the `interfaces.ServiceIdentifier`.
+ * Represents a service identifier for dependency injection purposes.
+ * The identifier restricts the use of `string` and `symbol` types, allowing only specific types
+ * from `interfaces.ServiceIdentifier` to be used for registering and resolving dependencies.
  *
  * @template T - The type associated with the service identifier.
+ * @example
+ * ```typescript
+ * const identifier: ServiceIdentifier<ExampleService> = serviceIdentifier('ExampleService');
+ * ```
  */
-export type ServiceIdentifier<T = unknown> = Exclude<interfaces.ServiceIdentifier<T>, string | symbol>;
+export type ServiceIdentifier<T> = Exclude<interfaces.ServiceIdentifier<T>, string | symbol>;
 
 /**
- * A constant object defining various service identifiers for dependency injection.
- * These identifiers are used to register and resolve services in a dependency container.
+ * Recursive type defining the structure of the service identifier registry.
+ * Allows nesting of `Types` objects to create hierarchical structures.
+ *
+ * @template T - Type associated with each key in the registry.
+ * @example
+ * ```typescript
+ * const exampleRegistry: Types = {
+ *   ExampleService: serviceId<ExampleService>(),
+ *   nested: {
+ *     NestedService: serviceId<NestedService>()
+ *   }
+ * };
+ * ```
  */
-export const TYPES = {
-  AddressValidationDtoMapper: serviceIdentifier<AddressValidationDtoMapper>('AddressValidationDtoMapper'),
-  AddressValidationRepository: serviceIdentifier<AddressValidationRepository>('AddressValidationRepository'),
-  AddressValidationService: serviceIdentifier<AddressValidationService>('AddressValidationService'),
-  ApplicantDtoMapper: serviceIdentifier<ApplicantDtoMapper>('ApplicantDtoMapper'),
-  ApplicantRepository: serviceIdentifier<ApplicantRepository>('ApplicantRepository'),
-  ApplicantService: serviceIdentifier<ApplicantService>('ApplicantService'),
-  ApplicationStatusDtoMapper: serviceIdentifier<ApplicationStatusDtoMapper>('ApplicationStatusDtoMapper'),
-  ApplicationStatusRepository: serviceIdentifier<ApplicationStatusRepository>('ApplicationStatusRepository'),
-  ApplicationStatusService: serviceIdentifier<ApplicationStatusService>('ApplicationStatusService'),
-  AuditService: serviceIdentifier<AuditService>('AuditService'),
-  BenefitRenewalDtoMapper: serviceIdentifier<BenefitRenewalDtoMapper>('BenefitRenewalDtoMapper'),
-  BenefitRenewalRepository: serviceIdentifier<BenefitRenewalRepository>('BenefitRenewalRepository'),
-  BenefitRenewalService: serviceIdentifier<BenefitRenewalService>('BenefitRenewalService'),
-  ClientApplicationDtoMapper: serviceIdentifier<ClientApplicationDtoMapper>('ClientApplicationDtoMapper'),
-  ClientApplicationRepository: serviceIdentifier<ClientApplicationRepository>('ClientApplicationRepository'),
-  ClientApplicationService: serviceIdentifier<ClientApplicationService>('ClientApplicationService'),
-  ClientConfig: serviceIdentifier<ClientConfig>('ClientConfig'),
-  ClientFriendlyStatusDtoMapper: serviceIdentifier<ClientFriendlyStatusDtoMapper>('ClientFriendlyStatusDtoMapper'),
-  ClientFriendlyStatusRepository: serviceIdentifier<ClientFriendlyStatusRepository>('ClientFriendlyStatusRepository'),
-  ClientFriendlyStatusService: serviceIdentifier<ClientFriendlyStatusService>('ClientFriendlyStatusService'),
-  ConfigFactory: serviceIdentifier<ConfigFactory>('ConfigFactory'),
-  CountryDtoMapper: serviceIdentifier<CountryDtoMapper>('CountryDtoMapper'),
-  CountryRepository: serviceIdentifier<CountryRepository>('CountryRepository'),
-  CountryService: serviceIdentifier<CountryService>('CountryService'),
-  DemographicSurveyDtoMapper: serviceIdentifier<DemographicSurveyDtoMapper>('DemographicSurveyDtoMapper'),
-  DemographicSurveyRepository: serviceIdentifier<DemographicSurveyRepository>('DemographicSurveyRepository'),
-  DemographicSurveyService: serviceIdentifier<DemographicSurveyService>('DemographicSurveyService'),
-  FederalGovernmentInsurancePlanDtoMapper: serviceIdentifier<FederalGovernmentInsurancePlanDtoMapper>('FederalGovernmentInsurancePlanDtoMapper'),
-  FederalGovernmentInsurancePlanRepository: serviceIdentifier<FederalGovernmentInsurancePlanRepository>('FederalGovernmentInsurancePlanRepository'),
-  FederalGovernmentInsurancePlanService: serviceIdentifier<FederalGovernmentInsurancePlanService>('FederalGovernmentInsurancePlanService'),
-  HCaptchaDtoMapper: serviceIdentifier<HCaptchaDtoMapper>('HCaptchaDtoMapper'),
-  HCaptchaRepository: serviceIdentifier<HCaptchaRepository>('HCaptchaRepository'),
-  HCaptchaService: serviceIdentifier<HCaptchaService>('HCaptchaService'),
-  LetterDtoMapper: serviceIdentifier<LetterDtoMapper>('LetterDtoMapper'),
-  LetterRepository: serviceIdentifier<LetterRepository>('LetterRepository'),
-  LetterService: serviceIdentifier<LetterService>('LetterService'),
-  LetterTypeDtoMapper: serviceIdentifier<LetterTypeDtoMapper>('LetterTypeDtoMapper'),
-  LetterTypeRepository: serviceIdentifier<LetterTypeRepository>('LetterTypeRepository'),
-  LetterTypeService: serviceIdentifier<LetterTypeService>('LetterTypeService'),
-  LogFactory: serviceIdentifier<LogFactory>('LogFactory'),
-  MaritalStatusDtoMapper: serviceIdentifier<MaritalStatusDtoMapper>('MaritalStatusDtoMapper'),
-  MaritalStatusRepository: serviceIdentifier<MaritalStatusRepository>('MaritalStatusRepository'),
-  MaritalStatusService: serviceIdentifier<MaritalStatusService>('MaritalStatusService'),
-  PreferredCommunicationMethodDtoMapper: serviceIdentifier<PreferredCommunicationMethodDtoMapper>('PreferredCommunicationMethodDtoMapper'),
-  PreferredCommunicationMethodRepository: serviceIdentifier<PreferredCommunicationMethodRepository>('PreferredCommunicationMethodRepository'),
-  PreferredCommunicationMethodService: serviceIdentifier<PreferredCommunicationMethodService>('PreferredCommunicationMethodService'),
-  PreferredLanguageDtoMapper: serviceIdentifier<PreferredLanguageDtoMapper>('PreferredLanguageDtoMapper'),
-  PreferredLanguageRepository: serviceIdentifier<PreferredLanguageRepository>('PreferredLanguageRepository'),
-  PreferredLanguageService: serviceIdentifier<PreferredLanguageService>('PreferredLanguageService'),
-  ProvinceTerritoryStateDtoMapper: serviceIdentifier<ProvinceTerritoryStateDtoMapper>('ProvinceTerritoryStateDtoMapper'),
-  ProvinceTerritoryStateRepository: serviceIdentifier<ProvinceTerritoryStateRepository>('ProvinceTerritoryStateRepository'),
-  ProvinceTerritoryStateService: serviceIdentifier<ProvinceTerritoryStateService>('ProvinceTerritoryStateService'),
-  ProvincialGovernmentInsurancePlanDtoMapper: serviceIdentifier<ProvincialGovernmentInsurancePlanDtoMapper>('ProvincialGovernmentInsurancePlanDtoMapper'),
-  ProvincialGovernmentInsurancePlanRepository: serviceIdentifier<ProvincialGovernmentInsurancePlanRepository>('ProvincialGovernmentInsurancePlanRepository'),
-  ProvincialGovernmentInsurancePlanService: serviceIdentifier<ProvincialGovernmentInsurancePlanService>('ProvincialGovernmentInsurancePlanService'),
-  RedisService: serviceIdentifier<RedisService>('RedisService'),
-  ServerConfig: serviceIdentifier<ServerConfig>('ServerConfig'),
-  SessionService: serviceIdentifier<SessionService>('SessionService'),
-  Web_CsrfTokenValidator: serviceIdentifier<CsrfTokenValidator>('WebCsrfTokenValidator'),
-} as const satisfies Record<string, ServiceIdentifier>;
+export type TypesContant<T = unknown> = Readonly<{
+  // The index signature ensures that the registry can hold a string key with either a
+  // service identifier or another nested `Types` object.
+  [key: string]: ServiceIdentifier<T> | TypesContant<T>;
+}>;
 
-function serviceIdentifier<T>(identifier: string): ServiceIdentifier<T> {
-  return Symbol.for(identifier) as unknown as ServiceIdentifier<T>;
-}
+/**
+ * Contains service identifiers for dependency injection, structured by categories for easier organization.
+ * This constant provides unique identifiers for each service, repository, and mapper used in the application.
+ *
+ * @example
+ * ```typescript
+ * const addressValidationService = container.get(TYPES.AddressValidationService);
+ * const applicantDtoMapper = container.get(TYPES.ApplicantDtoMapper);
+ * ```
+ */
+export const TYPES = assignServiceIdentifiers({
+  AddressValidationDtoMapper: serviceId<AddressValidationDtoMapper>(),
+  AddressValidationRepository: serviceId<AddressValidationRepository>(),
+  AddressValidationService: serviceId<AddressValidationService>(),
+  ApplicantDtoMapper: serviceId<ApplicantDtoMapper>(),
+  ApplicantRepository: serviceId<ApplicantRepository>(),
+  ApplicantService: serviceId<ApplicantService>(),
+  ApplicationStatusDtoMapper: serviceId<ApplicationStatusDtoMapper>(),
+  ApplicationStatusRepository: serviceId<ApplicationStatusRepository>(),
+  ApplicationStatusService: serviceId<ApplicationStatusService>(),
+  AuditService: serviceId<AuditService>(),
+  BenefitRenewalDtoMapper: serviceId<BenefitRenewalDtoMapper>(),
+  BenefitRenewalRepository: serviceId<BenefitRenewalRepository>(),
+  BenefitRenewalService: serviceId<BenefitRenewalService>(),
+  ClientApplicationDtoMapper: serviceId<ClientApplicationDtoMapper>(),
+  ClientApplicationRepository: serviceId<ClientApplicationRepository>(),
+  ClientApplicationService: serviceId<ClientApplicationService>(),
+  ClientConfig: serviceId<ClientConfig>(),
+  ClientFriendlyStatusDtoMapper: serviceId<ClientFriendlyStatusDtoMapper>(),
+  ClientFriendlyStatusRepository: serviceId<ClientFriendlyStatusRepository>(),
+  ClientFriendlyStatusService: serviceId<ClientFriendlyStatusService>(),
+  ConfigFactory: serviceId<ConfigFactory>(),
+  CountryDtoMapper: serviceId<CountryDtoMapper>(),
+  CountryRepository: serviceId<CountryRepository>(),
+  CountryService: serviceId<CountryService>(),
+  DemographicSurveyDtoMapper: serviceId<DemographicSurveyDtoMapper>(),
+  DemographicSurveyRepository: serviceId<DemographicSurveyRepository>(),
+  DemographicSurveyService: serviceId<DemographicSurveyService>(),
+  FederalGovernmentInsurancePlanDtoMapper: serviceId<FederalGovernmentInsurancePlanDtoMapper>(),
+  FederalGovernmentInsurancePlanRepository: serviceId<FederalGovernmentInsurancePlanRepository>(),
+  FederalGovernmentInsurancePlanService: serviceId<FederalGovernmentInsurancePlanService>(),
+  HCaptchaDtoMapper: serviceId<HCaptchaDtoMapper>(),
+  HCaptchaRepository: serviceId<HCaptchaRepository>(),
+  HCaptchaService: serviceId<HCaptchaService>(),
+  LetterDtoMapper: serviceId<LetterDtoMapper>(),
+  LetterRepository: serviceId<LetterRepository>(),
+  LetterService: serviceId<LetterService>(),
+  LetterTypeDtoMapper: serviceId<LetterTypeDtoMapper>(),
+  LetterTypeRepository: serviceId<LetterTypeRepository>(),
+  LetterTypeService: serviceId<LetterTypeService>(),
+  LogFactory: serviceId<LogFactory>(),
+  MaritalStatusDtoMapper: serviceId<MaritalStatusDtoMapper>(),
+  MaritalStatusRepository: serviceId<MaritalStatusRepository>(),
+  MaritalStatusService: serviceId<MaritalStatusService>(),
+  PreferredCommunicationMethodDtoMapper: serviceId<PreferredCommunicationMethodDtoMapper>(),
+  PreferredCommunicationMethodRepository: serviceId<PreferredCommunicationMethodRepository>(),
+  PreferredCommunicationMethodService: serviceId<PreferredCommunicationMethodService>(),
+  PreferredLanguageDtoMapper: serviceId<PreferredLanguageDtoMapper>(),
+  PreferredLanguageRepository: serviceId<PreferredLanguageRepository>(),
+  PreferredLanguageService: serviceId<PreferredLanguageService>(),
+  ProvinceTerritoryStateDtoMapper: serviceId<ProvinceTerritoryStateDtoMapper>(),
+  ProvinceTerritoryStateRepository: serviceId<ProvinceTerritoryStateRepository>(),
+  ProvinceTerritoryStateService: serviceId<ProvinceTerritoryStateService>(),
+  ProvincialGovernmentInsurancePlanDtoMapper: serviceId<ProvincialGovernmentInsurancePlanDtoMapper>(),
+  ProvincialGovernmentInsurancePlanRepository: serviceId<ProvincialGovernmentInsurancePlanRepository>(),
+  ProvincialGovernmentInsurancePlanService: serviceId<ProvincialGovernmentInsurancePlanService>(),
+  RedisService: serviceId<RedisService>(),
+  ServerConfig: serviceId<ServerConfig>(),
+  SessionService: serviceId<SessionService>(),
+  web: {
+    validators: {
+      CsrfTokenValidator: serviceId<CsrfTokenValidator>(),
+    },
+  },
+} as const satisfies TypesContant);
+
+export default { TYPES };

--- a/frontend/app/.server/container-modules/web-validators.container-module.ts
+++ b/frontend/app/.server/container-modules/web-validators.container-module.ts
@@ -7,5 +7,5 @@ import { CsrfTokenValidatorImpl } from '~/.server/web/validators';
  * Container module for web validators.
  */
 export const webValidatorsContainerModule = new ContainerModule((bind) => {
-  bind(TYPES.Web_CsrfTokenValidator).to(CsrfTokenValidatorImpl);
+  bind(TYPES.web.validators.CsrfTokenValidator).to(CsrfTokenValidatorImpl);
 });

--- a/frontend/app/.server/remix/security/validate-csrf-token.ts
+++ b/frontend/app/.server/remix/security/validate-csrf-token.ts
@@ -32,7 +32,7 @@ import { CsrfTokenInvalidException } from '~/.server/web/exceptions';
  */
 export async function validateCsrfToken({ context, request }: PickDeep<ActionFunctionArgs, 'context.appContainer' | 'request'>): Promise<void> {
   try {
-    const csrfTokenValidator = context.appContainer.get(TYPES.Web_CsrfTokenValidator);
+    const csrfTokenValidator = context.appContainer.get(TYPES.web.validators.CsrfTokenValidator);
     await csrfTokenValidator.validateCsrfToken(request);
   } catch (err) {
     if (err instanceof CsrfTokenInvalidException) {

--- a/frontend/app/.server/utils/service-identifier.utils.ts
+++ b/frontend/app/.server/utils/service-identifier.utils.ts
@@ -1,0 +1,62 @@
+import assert from 'assert';
+import { flatKeys, set } from 'moderndash';
+
+import type { ServiceIdentifier, TypesContant } from '~/.server/constants';
+
+/**
+ * Generates a unique `ServiceIdentifier` for dependency injection, using a string identifier.
+ * The identifier is globally unique, thanks to the use of `Symbol.for`.
+ * If no identifier is provided, the default value `'unknown'` is used.
+ *
+ * @param identifier - The name for the identifier. Defaults to `'unknown'` if not provided.
+ * @returns A unique `ServiceIdentifier` symbol for the specified type.
+ * @template T - The type associated with the service identifier.
+ * @example
+ * ```typescript
+ * const applicantServiceId = serviceIdentifier<ApplicantService>('ApplicantService');
+ * const defaultServiceId = serviceIdentifier<DefaultService>(); // Uses 'unknown' as identifier
+ * ```
+ */
+export function serviceIdentifier<T>(identifier: string = 'unknown'): ServiceIdentifier<T> {
+  return Symbol.for(identifier) as unknown as ServiceIdentifier<T>;
+}
+
+/**
+ * Recursively assigns service identifiers to each key path in the provided types object.
+ * This function traverses the nested structure of `types`, converting each key path into
+ * a service identifier using the `serviceIdentifier` function. The result is a new object
+ * where each key corresponds to a `ServiceIdentifier` symbol that uniquely identifies a service.
+ *
+ * @param {T} types - The original types object to be transformed.
+ * @returns {T} A new object with transformed service identifiers, where each key path is replaced
+ *              with a unique `ServiceIdentifier` symbol.
+ * @template T - The type of the input `types` object, which can contain nested structures.
+ * @example
+ * const types = {
+ *   UserService: {},
+ *   ProductService: {},
+ *   web: {
+ *     validators: {
+ *       CsrfTokenValidator: {},
+ *     },
+ *   },
+ * };
+ *
+ * const serviceIdentifiers = assignServiceIdentifiers(types);
+ *
+ * console.log(serviceIdentifiers.UserService); // Symbol(UserService)
+ * console.log(serviceIdentifiers.web.validators.CsrfTokenValidator); // Symbol(web.validators.CsrfTokenValidator)
+ * ```
+ */
+export function assignServiceIdentifiers<T extends TypesContant>(types: T): T {
+  const newTypes = { ...types }; // Shallow copy of the original types structure.
+  const flattenedKeys = flatKeys(types); // Get all nested key paths as an object.
+
+  // Map each key of the flattenedKeys object to a service identifier.
+  Object.keys(flattenedKeys).forEach((identifierKey) => {
+    assert(typeof flattenedKeys[identifierKey as keyof typeof flattenedKeys] === 'symbol', `Expected "${identifierKey}" to be a symbol`);
+    set(newTypes, identifierKey, serviceIdentifier(identifierKey));
+  });
+
+  return newTypes;
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This code defines `TYPES`, a centralized registry of service identifiers for dependency injection, organized to provide clear structure and type safety. Each identifier is generated using `serviceIdentifier`, creating a `Symbol` for each service, repository, or mapper, represented by the full key path (e.g., `"AddressValidationService"` or `"web.validators.CsrfTokenValidator"`). This unique `Symbol` ensures safe, collision-free access across the app.

#### Core Components

1. **ServiceIdentifier Type**:
   - A custom type restricting identifiers to specific non-primitive types, enhancing type safety by excluding `string` and `symbol` types directly.

2. **TypesContant Type**:
   - A recursive structure allowing nested categories of identifiers for improved organization.

3. **TYPES Constant**:
   - Built with `assignServiceIdentifiers`, `TYPES` dynamically maps the full key paths (e.g., `"ClientApplicationService"`) to unique `Symbol` identifiers, ensuring each path is transformed into a `Symbol` accessible via `TYPES`.

#### Usage
Example:
```typescript
const clientService = container.get(TYPES.ClientApplicationService); // retrieves Symbol(ClientApplicationService)
const validator = container.get(TYPES.web.validators.CsrfTokenValidator); // retrieves Symbol(web.validators.CsrfTokenValidator)
```

#### Benefit
By associating each key path with a unique `Symbol`, `TYPES` ensures collision-free, type-safe service identifiers. The full path as the `Symbol` description aids debugging by making the origin of each identifier explicit.