### PR TITLE
[gitops] Bumping prototype environment to `0.0.0-6f4bc39e-0075e`

### DIFF
--- a/gitops/overlays/prototype/configs/frontend/config.conf
+++ b/gitops/overlays/prototype/configs/frontend/config.conf
@@ -42,8 +42,3 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 # Interop API configuration
 #
 INTEROP_API_BASE_URI=https://interop.api.example.com/
-
-#
-# CDCP back end api
-#
-CDCP_API_BASE_URI=https://cdcp.api.example.com

--- a/gitops/overlays/prototype/patches/deployments.yaml
+++ b/gitops/overlays/prototype/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.5.0
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-6f4bc39e-0075e
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
Also removing unused config.

![image](https://github.com/user-attachments/assets/1b057bd4-c1a0-488f-ab7c-9ca1959cd88f)
