### PR TITLE
[gitops] Removing deprecated `status-checker-redirects` feature flag for prototype

### DIFF
--- a/gitops/overlays/prototype/configs/frontend/config.conf
+++ b/gitops/overlays/prototype/configs/frontend/config.conf
@@ -11,7 +11,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=show-prototype-banner,hcaptcha,status,status-checker-redirects,view-letters,view-letters-online-application
+ENABLED_FEATURES=show-prototype-banner,hcaptcha,status,view-letters,view-letters-online-application
 
 
 #


### PR DESCRIPTION
### Description
As per title. 