### PR TITLE
4818 renew-adult-child nack navigation on children hub

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -35,6 +35,7 @@ enum FormAction {
   Cancel = 'cancel',
   Save = 'save',
   Remove = 'remove',
+  Back = 'back',
 }
 
 export const handle = {
@@ -91,6 +92,13 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+
+  if (formAction === FormAction.Back) {
+    if (state.confirmDentalBenefits?.federalBenefitsChanged || state.confirmDentalBenefits?.provincialTerritorialBenefitsChanged) {
+      return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
+    }
+    return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
+  }
 
   if (formAction === FormAction.Add) {
     const childId = randomUUID();
@@ -279,16 +287,9 @@ export default function RenewFlowChildSummary() {
               >
                 {t('renew-adult-child:children.index.continue-btn')}
               </LoadingButton>
-              <ButtonLink
-                id="back-button"
-                routeId="public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits"
-                params={params}
-                disabled={isSubmitting}
-                startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Child(ren) application click"
-              >
+              <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Child(ren) application click">
                 {t('renew-adult-child:children.index.back-btn')}
-              </ButtonLink>
+              </Button>
             </div>
           )}
         </fetcher.Form>


### PR DESCRIPTION
### Description
The user should be navigated to `renew/$id/adult-child/update-fpt-benefits` if and only if they have selected that their benefits have changed, otherwise they are navigated to `renew/$id/adult-child/confirm-fpt-benefits` when clicking the back button on the children hub.

### Related Azure Boards Work Items
[AB#4818](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4818)