### PR TITLE
Clean up token auth

### DIFF
--- a/frontend/__tests__/.server/auth/bearer-token-resolver.test.ts
+++ b/frontend/__tests__/.server/auth/bearer-token-resolver.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { DefaultBearerTokenResolver } from '~/.server/auth/bearer-token-resolver';
+
+describe('DefaultBearerTokenResolver', () => {
+  it('should resolve a bearer token from the authorization header', () => {
+    const bearerTokenResolver = new DefaultBearerTokenResolver();
+
+    const token = '00000000-0000-0000-0000-000000000000';
+    const headers = { authorization: `Bearer ${token}` };
+    const request = new Request('http://example.com', { headers: headers });
+
+    expect(bearerTokenResolver.resolve(request)).toEqual(token);
+  });
+
+  it('should return undefined if the authorization header is not set', () => {
+    const bearerTokenResolver = new DefaultBearerTokenResolver();
+    const request = new Request('http://example.com');
+
+    expect(bearerTokenResolver.resolve(request)).toBeUndefined();
+  });
+
+  it('should return undefined if the authorization header does not contain a bearer token', () => {
+    const bearerTokenResolver = new DefaultBearerTokenResolver();
+
+    const headers = { authorization: 'Basic 00000000-0000-0000-0000-000000000000' };
+    const request = new Request('http://example.com', { headers: headers });
+
+    expect(bearerTokenResolver.resolve(request)).toBeUndefined();
+  });
+});

--- a/frontend/__tests__/.server/auth/token-roles-extractor.test.ts
+++ b/frontend/__tests__/.server/auth/token-roles-extractor.test.ts
@@ -1,0 +1,74 @@
+import type { JWTVerifyResult, ResolvedKey } from 'jose';
+import { decodeJwt, jwtVerify } from 'jose';
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { DefaultTokenRolesExtractor } from '~/.server/auth/token-roles-extractor';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+/*
+ * @vitest-environment node
+ * (see: https://github.com/vitest-dev/vitest/issues/4043)
+ */
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(),
+  decodeJwt: vi.fn(),
+  jwtVerify: vi.fn(),
+}));
+
+describe('DefaultTokenRolesExtractor', () => {
+  const mockLogFactory = mock<LogFactory>({ createLogger: () => mock<Logger>() });
+
+  describe('decodeJwt', () => {
+    const tokenRolesExtractor = new DefaultTokenRolesExtractor(mockLogFactory, 'audience', 'issuer');
+
+    it('should return an empty array if the token does not contain roles', () => {
+      vi.mocked(decodeJwt).mockReturnValue({});
+      const roles = tokenRolesExtractor['decodeJwt']('token');
+      expect(roles).toEqual([]);
+    });
+
+    it('should return the roles from the token', () => {
+      vi.mocked(decodeJwt).mockReturnValue({ roles: ['admin'] });
+      const roles = tokenRolesExtractor['decodeJwt']('token');
+      expect(roles).toEqual(['admin']);
+    });
+  });
+
+  describe('decodeAndVerifyJwt', () => {
+    const tokenRolesExtractor = new DefaultTokenRolesExtractor(mockLogFactory, 'audience', 'issuer');
+
+    it('should return an empty array if the token does not contain roles', async () => {
+      vi.mocked(jwtVerify).mockResolvedValue(
+        mock<JWTVerifyResult & ResolvedKey>({
+          payload: { roles: undefined },
+        }),
+      );
+
+      const roles = await tokenRolesExtractor['decodeAndVerifyJwt']('https://auth.example.com/jwks.json', 'token');
+      expect(roles).toEqual([]);
+    });
+
+    it('should return the roles from the token', async () => {
+      vi.mocked(jwtVerify).mockResolvedValue(
+        mock<JWTVerifyResult & ResolvedKey>({
+          payload: {
+            roles: ['admin'],
+          },
+        }),
+      );
+
+      const roles = await tokenRolesExtractor['decodeAndVerifyJwt']('https://auth.example.com/jwks.json', 'token');
+      expect([...roles]).toEqual(['admin']);
+    });
+  });
+
+  describe('extract', () => {
+    const tokenRolesExtractor = new DefaultTokenRolesExtractor(mockLogFactory, 'audience', 'issuer');
+
+    it('should return an empty array if the token is undefined', async () => {
+      expect(await tokenRolesExtractor.extract(undefined)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/.server/app.container.ts
+++ b/frontend/app/.server/app.container.ts
@@ -5,7 +5,7 @@ import { makeLoggerMiddleware, textSerializer } from 'inversify-logger-middlewar
 import type { AppContainerProvider } from '~/.server/app-container.provider';
 import { AppContainerProviderImpl } from '~/.server/app-container.provider';
 import { TYPES } from '~/.server/constants';
-import { configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, servicesContainerModule, webValidatorsContainerModule } from '~/.server/container-modules';
+import { authContainerModule, configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, servicesContainerModule, webValidatorsContainerModule } from '~/.server/container-modules';
 import { getLogger } from '~/utils/logging.server';
 
 /**
@@ -55,7 +55,7 @@ function createContainer(): interfaces.Container {
   log.info('Creating IoC container; id: [%s], options: [%j]', container.id, container.options);
 
   // load container modules
-  container.load(configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, servicesContainerModule, webValidatorsContainerModule);
+  container.load(authContainerModule, configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, servicesContainerModule, webValidatorsContainerModule);
 
   // configure container logger middleware
   const serverConfig = container.get(TYPES.configs.ServerConfig);

--- a/frontend/app/.server/auth/bearer-token-resolver.ts
+++ b/frontend/app/.server/auth/bearer-token-resolver.ts
@@ -1,0 +1,19 @@
+import { injectable } from 'inversify';
+
+/**
+ * A strategy for resolving bearer tokens from requests.
+ */
+export interface BearerTokenResolver {
+  resolve(request: Request): string | undefined;
+}
+
+@injectable()
+export class DefaultBearerTokenResolver implements BearerTokenResolver {
+  readonly BEARER_TOKEN_HEADER_NAME = 'authorization';
+
+  resolve(request: Request): string | undefined {
+    const authorization = request.headers.get(this.BEARER_TOKEN_HEADER_NAME) ?? '';
+    const [scheme, token] = authorization.split(' ');
+    if (scheme.toLowerCase() === 'bearer') return token;
+  }
+}

--- a/frontend/app/.server/auth/index.ts
+++ b/frontend/app/.server/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './bearer-token-resolver';

--- a/frontend/app/.server/auth/index.ts
+++ b/frontend/app/.server/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './bearer-token-resolver';
+export * from './token-roles-extractor';

--- a/frontend/app/.server/auth/token-roles-extractor.ts
+++ b/frontend/app/.server/auth/token-roles-extractor.ts
@@ -1,0 +1,64 @@
+import { inject, injectable } from 'inversify';
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
+
+import { TYPES } from '~/.server/constants';
+import type { LogFactory } from '~/.server/factories';
+import { Logger } from '~/.server/factories';
+
+export interface TokenRolesExtractor {
+  extract(jwt?: string): Promise<string[]>;
+}
+
+@injectable()
+export class DefaultTokenRolesExtractor implements TokenRolesExtractor {
+  private readonly log: Logger;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    private readonly audience: string,
+    private readonly issuer: string,
+    private readonly jwksUrl?: string,
+  ) {
+    this.log = logFactory.createLogger('DefaultTokenRolesExtractor');
+  }
+
+  async extract(jwt?: string): Promise<string[]> {
+    this.log.trace('Extracting roles from token [%s]', jwt);
+
+    if (jwt === undefined) {
+      this.log.warn('Could not extract roles from token; Reason: no token provided');
+      return [];
+    }
+
+    const roles = this.jwksUrl ? await this.decodeAndVerifyJwt(this.jwksUrl, jwt) : this.decodeJwt(jwt);
+    this.log.debug('Extracted roles: %j', roles);
+    return roles;
+  }
+
+  private decodeJwt(jwt: string): string[] {
+    this.log.warn('JWT verification cannot be performed; Reason: JWK endpoint not configured');
+
+    try {
+      const { roles } = decodeJwt<{ roles?: string[] }>(jwt);
+      return roles ?? [];
+    } catch (error) {
+      this.log.error('Could not extract roles from token', error);
+      return [];
+    }
+  }
+
+  private async decodeAndVerifyJwt(jwksUrl: string, jwt: string): Promise<string[]> {
+    this.log.debug('JWK endpoint configured; Performing JWT verification');
+
+    const getKey = createRemoteJWKSet(new URL(jwksUrl));
+    const options = { audience: this.audience, issuer: this.issuer };
+
+    try {
+      const { payload } = await jwtVerify<{ roles?: string[] }>(jwt, getKey, options);
+      return payload.roles ?? [];
+    } catch (error) {
+      this.log.error('Could not extract roles from token', error);
+      return [];
+    }
+  }
+}

--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -1,5 +1,6 @@
 import type { interfaces } from 'inversify';
 
+import type { BearerTokenResolver } from '~/.server/auth';
 import type { ClientConfig, ServerConfig } from '~/.server/configs';
 import type { RedisService } from '~/.server/data/services';
 import type {
@@ -110,6 +111,9 @@ export type TypesContant<T = unknown> = Readonly<{
  * ```
  */
 export const TYPES = assignServiceIdentifiers({
+  auth: {
+    BearerTokenResolver: serviceId<BearerTokenResolver>(),
+  },
   configs: {
     ClientConfig: serviceId<ClientConfig>(),
     ServerConfig: serviceId<ServerConfig>(),

--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -1,6 +1,6 @@
 import type { interfaces } from 'inversify';
 
-import type { BearerTokenResolver } from '~/.server/auth';
+import type { BearerTokenResolver, TokenRolesExtractor } from '~/.server/auth';
 import type { ClientConfig, ServerConfig } from '~/.server/configs';
 import type { RedisService } from '~/.server/data/services';
 import type {
@@ -113,6 +113,7 @@ export type TypesContant<T = unknown> = Readonly<{
 export const TYPES = assignServiceIdentifiers({
   auth: {
     BearerTokenResolver: serviceId<BearerTokenResolver>(),
+    HealthTokenRolesExtractor: serviceId<TokenRolesExtractor>('HealthTokenRolesExtractor'),
   },
   configs: {
     ClientConfig: serviceId<ClientConfig>(),

--- a/frontend/app/.server/container-modules/auth.container-module.ts
+++ b/frontend/app/.server/container-modules/auth.container-module.ts
@@ -1,6 +1,6 @@
 import { ContainerModule } from 'inversify';
 
-import { DefaultBearerTokenResolver } from '~/.server/auth';
+import { DefaultBearerTokenResolver, DefaultTokenRolesExtractor } from '~/.server/auth';
 import { TYPES } from '~/.server/constants';
 
 /**
@@ -8,4 +8,9 @@ import { TYPES } from '~/.server/constants';
  */
 export const authContainerModule = new ContainerModule((bind) => {
   bind(TYPES.auth.BearerTokenResolver).to(DefaultBearerTokenResolver);
+  bind(TYPES.auth.HealthTokenRolesExtractor).toDynamicValue((context) => {
+    const logFactory = context.container.get(TYPES.factories.LogFactory);
+    const { HEALTH_AUTH_TOKEN_AUDIENCE, HEALTH_AUTH_TOKEN_ISSUER, HEALTH_AUTH_JWKS_URI } = context.container.get(TYPES.configs.ServerConfig);
+    return new DefaultTokenRolesExtractor(logFactory, HEALTH_AUTH_TOKEN_AUDIENCE, HEALTH_AUTH_TOKEN_ISSUER, HEALTH_AUTH_JWKS_URI);
+  });
 });

--- a/frontend/app/.server/container-modules/auth.container-module.ts
+++ b/frontend/app/.server/container-modules/auth.container-module.ts
@@ -1,0 +1,11 @@
+import { ContainerModule } from 'inversify';
+
+import { DefaultBearerTokenResolver } from '~/.server/auth';
+import { TYPES } from '~/.server/constants';
+
+/**
+ * Container module for auth components.
+ */
+export const authContainerModule = new ContainerModule((bind) => {
+  bind(TYPES.auth.BearerTokenResolver).to(DefaultBearerTokenResolver);
+});

--- a/frontend/app/.server/container-modules/index.ts
+++ b/frontend/app/.server/container-modules/index.ts
@@ -1,3 +1,4 @@
+export * from './auth.container-module';
 export * from './configs.container-module';
 export * from './factories.container-module';
 export * from './mappers.container-module';


### PR DESCRIPTION
### Description

Creating standalone components for some auth checks so the code can be reused.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
