### PR TITLE
4809 fix fpt benefits navigation in edit mode

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -103,15 +103,16 @@ export async function action({ context: { appContainer, session }, params, reque
       confirmDentalBenefits: {
         ...parsedDentalBenefitsResult.data,
       },
+      dentalBenefits: parsedDentalBenefitsResult.data.federalBenefitsChanged || parsedDentalBenefitsResult.data.provincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
     },
   });
 
-  if (state.editMode) {
-    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
-  }
-
   if (dentalBenefits.federalBenefitsChanged || dentalBenefits.provincialTerritorialBenefitsChanged) {
     return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
+  }
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -118,6 +118,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
 
   const dentalBenefit = {
+    hasChanged: state.confirmDentalBenefits.federalBenefitsChanged || state.confirmDentalBenefits.provincialTerritorialBenefitsChanged,
     federalBenefit: {
       access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,
@@ -368,18 +369,20 @@ export default function RenewAdultChildReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult-child:review-adult-information.dental-benefit-title')}>
-                {dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
-                  <>
-                    <p>{t('renew-adult-child:review-adult-information.yes')}</p>
-                    <p>{t('renew-adult-child:review-adult-information.dental-benefit-has-access')}</p>
-                    <ul className="ml-6 list-disc">
-                      {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
-                      {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
-                    </ul>
-                  </>
-                ) : (
-                  <p>{t('renew-adult-child:review-adult-information.no')}</p>
-                )}
+                {!dentalBenefit.hasChanged && <p>{t('renew-adult-child:review-adult-information.no-update')}</p>}
+                {dentalBenefit.hasChanged &&
+                  (dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
+                    <>
+                      <p>{t('renew-adult-child:review-adult-information.yes')}</p>
+                      <p>{t('renew-adult-child:review-adult-information.dental-benefit-has-access')}</p>
+                      <ul className="ml-6 list-disc">
+                        {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
+                        {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
+                      </ul>
+                    </>
+                  ) : (
+                    <p>{t('renew-adult-child:review-adult-information.no')}</p>
+                  ))}
                 <div className="mt-4">
                   <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits" params={params}>
                     {t('renew-adult-child:review-adult-information.dental-benefit-change')}


### PR DESCRIPTION
### Description
Navigation is fragile once `editMode` is enabled. State also needs to be correctly handled if they declare that no changes have been made to their benefits and there is a previous entry in state.  Lastly, the "no change" text needs to be displayed if they declare there has been no change to their benefits.  

### Related Azure Boards Work Items
[AB#4809](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4809)