### PR TITLE
fix(frontend): DI Ambiguous match found 'domain.mappers.AddressValidationDtoMapper

### DIFF
--- a/frontend/app/.server/container-modules/mappers.container-module.ts
+++ b/frontend/app/.server/container-modules/mappers.container-module.ts
@@ -27,9 +27,7 @@ import { HCaptchaDtoMapperImpl } from '~/.server/web/mappers';
  */
 export const mappersContainerModule = new ContainerModule((bind) => {
   bind(TYPES.domain.mappers.AddressValidationDtoMapper).to(AddressValidationDtoMapperImpl);
-  bind(TYPES.domain.mappers.AddressValidationDtoMapper).to(AddressValidationDtoMapperImpl);
   bind(TYPES.domain.mappers.ApplicantDtoMapper).to(ApplicantDtoMapperImpl);
-  bind(TYPES.domain.mappers.ApplicationStatusDtoMapper).to(ApplicationStatusDtoMapperImpl);
   bind(TYPES.domain.mappers.ApplicationStatusDtoMapper).to(ApplicationStatusDtoMapperImpl);
   bind(TYPES.domain.mappers.BenefitApplicationStateMapper).to(BenefitApplicationStateMapperImpl);
   bind(TYPES.domain.mappers.BenefitRenewalDtoMapper).to(BenefitRenewalDtoMapperImpl);


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fixes DI error `Ambiguous match found for serviceIdentifier: Symbol(domain.mappers.AddressValidationDtoMapper)`

```
2024-11-12T16:05:36.884Z   ERROR --- [ entry.server/handleError]: Ambiguous match found for serviceIdentifier: Symbol(domain.mappers.AddressValidationDtoMapper) --- {
  name: 'Error',
  stack: 'Error: Ambiguous match found for serviceIdentifier: Symbol(domain.mappers.AddressValidationDtoMapper)\n' +
    '    at _validateActiveBindingCount (/home/node/node_modules/inversify/lib/planning/planner.js:109:23)\n' +
    '    at _getActiveBindings (/home/node/node_modules/inversify/lib/planning/planner.js:73:5)\n' +
    '    at _createSubRequests (/home/node/node_modules/inversify/lib/planning/planner.js:126:26)\n' +
    '    at /home/node/node_modules/inversify/lib/planning/planner.js:151:17\n' +
    '    at Array.forEach (<anonymous>)\n' +
    '    at /home/node/node_modules/inversify/lib/planning/planner.js:150:26\n' +
    '    at Array.forEach (<anonymous>)\n' +
    '    at _createSubRequests (/home/node/node_modules/inversify/lib/planning/planner.js:129:20)\n' +
    '    at plan (/home/node/node_modules/inversify/lib/planning/planner.js:172:9)\n' +
    '    at /home/node/node_modules/inversify/lib/container/container.js:663:46'
}
```

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->