### PR TITLE
Reduce logging in `app.container.ts`

### DIFF
--- a/frontend/app/.server/app.container.ts
+++ b/frontend/app/.server/app.container.ts
@@ -97,7 +97,7 @@ function createLoggerMidddlware(): interfaces.Middleware {
         return;
       }
 
-      loggerMiddlewareLog.debug(textSerializer(out));
+      loggerMiddlewareLog.trace(textSerializer(out));
     },
   );
 }


### PR DESCRIPTION
### Description

The container logging is too verbose in `DEBUG`, so I lowered the level to `TRACE`.
