### PR TITLE
Disable fog of war

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -101,7 +101,10 @@ export default defineConfig({
             // https://remix.run/docs/en/main/guides/dependency-optimization
             unstable_optimizeDeps: true,
             v3_fetcherPersist: true,
-            v3_lazyRouteDiscovery: true,
+            // XXX  :: GjB :: lazy route discovery breaks navigation from the language switcher when running in devmode
+            //                strangely, when running in production mode, it works perfectly fine 🤷
+            // TODO :: GjB :: figure out why this doesn't work in devmode and hopefully fix it.
+            v3_lazyRouteDiscovery: false,
             v3_relativeSplatPath: true,
             v3_singleFetch: true,
             v3_throwAbortReason: true,


### PR DESCRIPTION
### Description

When fog of war is enabled, navigating from the language chooser page is broken when running the server in devmode.

It initially looks like the navigation works, but after a slight pause the page renders a 404 with an "unhandled thrown response" error.

I suspect that the terms-and-conditions route isn't being added to the index/layout's route manifest, but I'm not yet sure how to fix that. I've disabled the flag for now until we can find time to investigate.

### Additional Notes

- <https://remix.run/docs/en/main/guides/lazy-route-discovery>