### PR TITLE
Add `vite.config.ts.timestamp-*` to `.gitignore`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -178,3 +178,4 @@ playwright-report/
 test-results/
 
 build-info.json
+vite.config.ts.timestamp-*


### PR DESCRIPTION
### Description

In some rare situations, vite doesn't properly delete the generated `vite.config.ts.timestamp-{timestamp}.js` file that is generated when transpiling `vite.config.ts`.

Adding `vite.config.ts.timestamp-*` to `.gitignore` will ensure these files do not accidentally get committed to the repository. 
