### PR TITLE
add protected-renew-route-helper and additional files

### DIFF
--- a/frontend/app/route-helpers/protected-renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/protected-renew-route-helpers.server.ts
@@ -1,0 +1,142 @@
+import type { Session } from '@remix-run/node';
+import { redirectDocument } from '@remix-run/node';
+import type { Params } from '@remix-run/react';
+
+import { z } from 'zod';
+
+import { getLocaleFromParams } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { getCdcpWebsiteApplyUrl } from '~/utils/url-utils.server';
+
+export interface ProtectedRenewState {
+  readonly id: string;
+  readonly editMode: boolean;
+  readonly taxFiling?: boolean;
+  readonly termsAndConditions?: {
+    readonly acknowledgeTerms: boolean;
+    readonly acknowledgePrivacy: boolean;
+    readonly shareData: boolean;
+  };
+  // TODO Add remaining states
+}
+
+/**
+ * Schema for validating UUID.
+ */
+const idSchema = z.string().uuid();
+
+/**
+ * Gets the session name.
+ * @param id - The ID.
+ * @returns The session name.
+ */
+function getSessionName(id: string) {
+  return `protected-renew-flow-${idSchema.parse(id)}`;
+}
+
+export function getProtectedRenewStateIdFromUrl(url: string | URL) {
+  const { searchParams } = new URL(url);
+  return searchParams.get('id');
+}
+
+interface LoadStateArgs {
+  params: Params;
+  session: Session;
+}
+
+/**
+ * Loads protected renew state.
+ * @param args - The arguments.
+ * @returns The loaded state.
+ */
+export function loadProtectedRenewState({ params, session }: LoadStateArgs) {
+  const log = getLogger('protected-renew-route-helpers.server/loadProtectedRenewState');
+  const locale = getLocaleFromParams(params);
+  const cdcpWebsiteApplyUrl = getCdcpWebsiteApplyUrl(locale);
+
+  const parsedId = idSchema.safeParse(params.id);
+
+  if (!parsedId.success) {
+    log.warn('Invalid "id" query string format; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplyUrl, params.id, session.id);
+    throw redirectDocument(cdcpWebsiteApplyUrl);
+  }
+
+  const sessionName = getSessionName(parsedId.data);
+
+  if (!session.has(sessionName)) {
+    log.warn('Protected renew session state has not been found; redirecting to [%s]; sessionName: [%s], sessionId: [%s]', cdcpWebsiteApplyUrl, sessionName, session.id);
+    throw redirectDocument(cdcpWebsiteApplyUrl);
+  }
+
+  const state: ProtectedRenewState = session.get(sessionName);
+  return state;
+}
+
+interface SaveStateArgs {
+  params: Params;
+  session: Session;
+  state: Partial<OmitStrict<ProtectedRenewState, 'id'>>;
+  remove?: keyof OmitStrict<ProtectedRenewState, 'id'>;
+}
+
+/**
+ * Saves protected renew state.
+ * @param args - The arguments.
+ * @returns The new protected renew state.
+ */
+export function saveProtectedRenewState({ params, session, state }: SaveStateArgs) {
+  const log = getLogger('protected-renew-route-helpers.server/saveProtectedRenewState');
+  const currentState = loadProtectedRenewState({ params, session });
+
+  const newState = {
+    ...currentState,
+    ...state,
+  } satisfies ProtectedRenewState;
+
+  const sessionName = getSessionName(currentState.id);
+  session.set(sessionName, newState);
+  log.info('Renew session state saved; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+  return newState;
+}
+
+interface ClearStateArgs {
+  params: Params;
+  session: Session;
+}
+
+/**
+ * Clears protected renew state.
+ * @param args - The arguments.
+ */
+export function clearProtectedRenewState({ params, session }: ClearStateArgs) {
+  const log = getLogger('protected-renew-route-helpers.server/clearProtectedRenewState');
+  const state = loadProtectedRenewState({ params, session });
+  const sessionName = getSessionName(state.id);
+  session.unset(sessionName);
+  log.info('Renew session state cleared; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+}
+
+interface StartArgs {
+  id: string;
+  session: Session;
+}
+
+/**
+ * Starts protected renew state.
+ * @param args - The arguments.
+ * @returns The initial protected renew state.
+ */
+export function startProtectedRenewState({ id, session }: StartArgs) {
+  const log = getLogger('protected-renew-route-helpers.server/startProtectedRenewState');
+  const parsedId = idSchema.parse(id);
+
+  const initialState: ProtectedRenewState = {
+    id: parsedId,
+    editMode: false,
+  };
+
+  const sessionName = getSessionName(parsedId);
+  session.set(sessionName, initialState);
+  log.info('Protected renew session state started; sessionName: [%s], sessionId: [%s]', sessionName, session.id);
+  return initialState;
+}

--- a/frontend/app/routes/page-ids.json
+++ b/frontend/app/routes/page-ids.json
@@ -4,7 +4,11 @@
     "letters": {
       "index": "CDCP-PROT-0015"
     },
-    "renew": {},
+    "renew": {
+      "index": "CDCP-PROT-RENW-0001",
+      "termsAndConditions": "CDCP-PROT-RENW-0002",
+      "taxFiling": "CDCP-PROT-RENW-0003"
+    },
     "dataUnavailable": "CDCP-PROT-0099"
   },
   "public": {

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { useLoaderData, useNavigate, useParams } from '@remix-run/react';
+
+import { randomUUID } from 'crypto';
+
+import pageIds from '../../page-ids.json';
+import { startProtectedRenewState } from '~/route-helpers/protected-renew-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT, getLocale } from '~/utils/locale-utils.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.index,
+  pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-heading',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const id = randomUUID().toString();
+  const state = startProtectedRenewState({ id, session });
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:index.page-title') }) };
+
+  return { id: state.id, locale, meta };
+}
+
+export default function ProtectedRenewIndex() {
+  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const navigate = useNavigate();
+
+  const path = getPathById('protected/renew/$id/terms-and-conditions', { ...params, id });
+
+  useEffect(() => {
+    sessionStorage.setItem('flow.state', 'active');
+    navigate(path, { replace: true });
+  }, [navigate, path]);
+
+  return (
+    <div className="max-w-prose animate-pulse">
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <div className="h-5 w-full rounded bg-gray-200"></div>
+          <div className="h-5 w-full rounded bg-gray-200"></div>
+          <div className="h-5 w-2/3 rounded bg-gray-200"></div>
+        </div>
+        <div className="h-5 w-1/2 rounded bg-gray-200"></div>
+        <div className="h-5 w-1/2 rounded bg-gray-200"></div>
+      </div>
+      <div className="my-8 space-y-2">
+        <div className="h-5 w-full rounded bg-gray-200"></div>
+        <div className="h-5 w-2/3 rounded bg-gray-200"></div>
+      </div>
+      <div className="h-10 w-2/5 rounded bg-gray-200"></div>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/renew/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/tax-filing.tsx
@@ -1,0 +1,135 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import pageIds from '../../page-ids.json';
+import { ButtonLink } from '~/components/buttons';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { loadProtectedRenewState, saveProtectedRenewState } from '~/route-helpers/protected-renew-route-helpers.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+enum TaxFilingOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.taxFiling,
+  pageTitleI18nKey: 'protected-renew:tax-filing.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadProtectedRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:tax-filing.page-title') }) };
+
+  return { id: state.id, csrfToken, meta, defaultState: state.taxFiling };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('protected/renew/tax-filing');
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const taxFilingSchema = z.object({
+    taxFiling: z.nativeEnum(TaxFilingOption, {
+      errorMap: () => ({ message: t('protected-renew:tax-filing.error-message.tax-filing-required') }),
+    }),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = { taxFiling: formData.get('taxFiling') };
+  const parsedDataResult = taxFilingSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return Response.json(
+      {
+        errors: transformFlattenedError(parsedDataResult.error.flatten()),
+      },
+      { status: 400 },
+    );
+  }
+
+  saveProtectedRenewState({ params, session, state: { taxFiling: parsedDataResult.data.taxFiling === TaxFilingOption.Yes } });
+
+  if (parsedDataResult.data.taxFiling === TaxFilingOption.No) {
+    return redirect(getPathById('protected/renew/$id/file-taxes', params));
+  }
+
+  return redirect(getPathById('protected/renew/$id/member-selection', params));
+}
+
+export default function ProtectedRenewFlowTaxFiling() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, { taxFiling: 'input-radio-tax-filing-option-0' });
+
+  return (
+    <>
+      <div className="max-w-prose">
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <InputRadios
+            id="tax-filing"
+            name="taxFiling"
+            legend={t('protected-renew:tax-filing.form-instructions')}
+            options={[
+              { value: TaxFilingOption.Yes, children: t('protected-renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: TaxFilingOption.No, children: t('protected-renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+            ]}
+            errorMessage={errors?.taxFiling}
+            required
+          />
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Continue - Tax filing click">
+              {t('protected-renew:tax-filing.continue-btn')}
+            </LoadingButton>
+            <ButtonLink
+              id="back-button"
+              routeId="protected/renew/$id/terms-and-conditions"
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Back - Tax filing click"
+            >
+              {t('protected-renew:tax-filing.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -32,9 +32,20 @@ export const routes = [
         paths: { en: '/:lang/stub-login', fr: '/:lang/stub-login' },
       },
       {
-        id: 'protected/renew/file-taxes',
-        file: 'routes/protected/renew/file-taxes.tsx',
-        paths: { en: '/:lang/protected/renew/file-taxes', fr: '/:lang/protected/renew/file-taxes' },
+        id: 'protected/renew/index',
+        file: 'routes/protected/renew/index.tsx',
+        index: true,
+        paths: { en: '/:lang/protected/renew', fr: '/:lang/protected/renew' },
+      },
+      {
+        id: 'protected/renew/$id/terms-and-conditions',
+        file: 'routes/protected/renew/terms-and-conditions.tsx',
+        paths: { en: '/:lang/protected/renew/:id/terms-and-conditions', fr: '/:lang/protected/renew/:id/terms-and-conditions' },
+      },
+      {
+        id: 'protected/renew/$id/tax-filing',
+        file: 'routes/protected/renew/tax-filing.tsx',
+        paths: { en: '/:lang/protected/renew/:id/tax-filing', fr: '/:lang/protected/renew/:id/tax-filing' },
       },
     ],
   },

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -1,3 +1,22 @@
 {
-  "file-taxes": {}
+  "index": {
+    "page-title": "Renew"
+  },
+  "terms-and-conditions": {
+    "page-title": "Terms and conditions",
+    "page-heading": "Terms and conditions of use and privacy notice statement"
+  },
+  "tax-filing": {
+    "page-title": "Tax filing",
+    "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2024 and received your Notice of Assessment?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "tax-filing-required": "Select whether or not you have filed your taxes"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
+  }
 }

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -1,3 +1,22 @@
 {
-  "file-taxes": {}
+  "index": {
+    "page-title": "Renew"
+  },
+  "terms-and-conditions": {
+    "page-title": "Terms and conditions",
+    "page-heading": "Terms and conditions of use and privacy notice statement"
+  },
+  "tax-filing": {
+    "page-title": "Tax filing",
+    "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2024 and received your Notice of Assessment?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "tax-filing-required": "Select whether or not you have filed your taxes"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue"
+  }
 }


### PR DESCRIPTION
### Description
adds:
- route helper to manage state in the protected renew application
- `protected/renew/index.tsx` (the `ProtectedRenewState` will be initialized and the user navigated to the terms and conditions route)
- `protected/renew/tax-filing` route (I initially picked this task up, but rolled the state management into this PR because we need state)

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)