### PR TITLE
Reconfigure vitest environments based on glob matching

### DIFF
--- a/frontend/__tests__/.server/auth/token-roles-extractor.test.ts
+++ b/frontend/__tests__/.server/auth/token-roles-extractor.test.ts
@@ -6,11 +6,6 @@ import { mock } from 'vitest-mock-extended';
 import { DefaultTokenRolesExtractor } from '~/.server/auth/token-roles-extractor';
 import type { LogFactory, Logger } from '~/.server/factories';
 
-/*
- * @vitest-environment node
- * (see: https://github.com/vitest-dev/vitest/issues/4043)
- */
-
 vi.mock('jose', () => ({
   createRemoteJWKSet: vi.fn(),
   decodeJwt: vi.fn(),

--- a/frontend/__tests__/utils/adobe-analytics.client.test.ts
+++ b/frontend/__tests__/utils/adobe-analytics.client.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { isConfigured, pushErrorEvent, pushPageviewEvent, pushValidationErrorEvent } from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 vi.mock('~/utils/env-utils');
 
 describe('isConfigured', () => {

--- a/frontend/__tests__/utils/date-utils.test.ts
+++ b/frontend/__tests__/utils/date-utils.test.ts
@@ -19,6 +19,10 @@ import {
   useMonths,
 } from '~/utils/date-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime('2024-01-01');

--- a/frontend/__tests__/utils/env-utils.test.ts
+++ b/frontend/__tests__/utils/env-utils.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getClientEnv } from '~/utils/env-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 describe('getClientEnv', () => {
   afterEach(() => {
     vi.resetAllMocks();

--- a/frontend/__tests__/utils/link-utils.test.tsx
+++ b/frontend/__tests__/utils/link-utils.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { scrollAndFocusFromAnchorLink } from '~/utils/link-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 const scrollIntoViewMock = vi.fn();
 Element.prototype.scrollIntoView = scrollIntoViewMock;
 

--- a/frontend/__tests__/utils/locale-utils.test.ts
+++ b/frontend/__tests__/utils/locale-utils.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it } from 'vitest';
 
 import { APP_LOCALES, isAppLocale, useAppLocale } from '~/utils/locale-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 describe('locale-utils', () => {
   describe('APP_LOCALES', () => {
     it('should contain only "en" and "fr"', () => {

--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -5,8 +5,12 @@ import { createRemixStub } from '@remix-run/testing';
 
 import { describe, expect, it } from 'vitest';
 
-import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey, useTransformAdobeAnalyticsUrl } from '~/utils/route-utils';
 import type { Breadcrumbs, BuildInfo, RouteHandleData } from '~/utils/route-utils';
+import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey, useTransformAdobeAnalyticsUrl } from '~/utils/route-utils';
+
+/*
+ * @vitest-environment jsdom
+ */
 
 describe('coalesce<T> reducer', () => {
   it('expect undefined from two undefined values', () => {

--- a/frontend/__tests__/utils/seo-utils.test.ts
+++ b/frontend/__tests__/utils/seo-utils.test.ts
@@ -6,6 +6,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getDescriptionMetaTags, getTitleMetaTags, useAlternateLanguages, useCanonicalURL } from '~/utils/seo-utils';
 
+/*
+ * @vitest-environment jsdom
+ */
+
 vi.mock('@remix-run/react');
 vi.mock('react-i18next');
 vi.mock('~/utils/env-utils');

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -116,12 +116,16 @@ export default defineConfig({
     noExternal: ['react-idle-timer', 'fast-json-patch'],
   },
   test: {
-    environment: 'jsdom',
     setupFiles: ['./__tests__/setup-test-env.ts'],
     include: ['./__tests__/**/*.test.{ts,tsx}'],
     coverage: {
       include: ['**/app/**/*.{ts,tsx}'],
       exclude: ['!**/app/[.]client/**', '!**/app/[.]server/**', '**/app/mocks/**', ...coverageConfigDefaults.exclude],
     },
+    environmentMatchGlobs: [
+      ['__tests__/components/**', 'jsdom'],
+      ['__tests__/hooks/**', 'jsdom'],
+      ['__tests__/routes/**', 'jsdom'],
+    ],
   },
 });


### PR DESCRIPTION
### Description

While working on another PR I discovered that jsdom had been configured as the global environment for vitest. While this makes sense for a client-only application, it does not make sense for a Remix application with server-side code.

To fix the issue, I've configured only specific tests to use jsdom (hooks, routes, etc).

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
