### PR TITLE
add dental-insurance route to protected renew application

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -9,6 +9,7 @@ export const pageIds = {
       termsAndConditions: 'CDCP-PROT-RENW-0002',
       taxFiling: 'CDCP-PROT-RENW-0003',
       fileYourTaxes: 'CDCP-PROT-RENW-0004',
+      dentalInsurance: 'CDCP-PROT-RENW-0006',
     },
     dataUnavailable: 'CDCP-PROT-0099',
   },

--- a/frontend/app/route-helpers/protected-renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/protected-renew-route-helpers.server.ts
@@ -17,6 +17,7 @@ export interface ProtectedRenewState {
     readonly acknowledgePrivacy: boolean;
     readonly shareData: boolean;
   };
+  readonly dentalInsurance?: boolean;
   // TODO Add remaining states
 }
 

--- a/frontend/app/routes/protected/renew/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/dental-insurance.tsx
@@ -1,0 +1,209 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { Button, ButtonLink } from '~/components/buttons';
+import { Collapsible } from '~/components/collapsible';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { loadProtectedRenewState, saveProtectedRenewState } from '~/route-helpers/protected-renew-route-helpers.server';
+import { getRaoidcService } from '~/services/raoidc-service.server';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getFixedT } from '~/utils/locale-utils.server';
+import { getLogger } from '~/utils/logging.server';
+import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { transformFlattenedError } from '~/utils/zod-utils.server';
+
+enum FormAction {
+  Continue = 'continue',
+  Save = 'save',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.dentalInsurance,
+  pageTitleI18nKey: 'protected-renew:dental-insurance.title',
+};
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const raoidcService = await getRaoidcService();
+  await raoidcService.handleSessionValidation(request, session);
+
+  const state = loadProtectedRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // TODO: get name of primary applicant from state and pass it into the page title and heading
+
+  const csrfToken = String(session.get('csrfToken'));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.title') }) };
+
+  return { id: state, csrfToken, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const log = getLogger('protected/renew/dental-insurance');
+
+  const raoidcService = await getRaoidcService();
+  await raoidcService.handleSessionValidation(request, session);
+
+  const state = loadProtectedRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // state validation schema
+  const dentalInsuranceSchema = z.object({
+    dentalInsurance: z.boolean({ errorMap: () => ({ message: t('protected-renew:dental-insurance.error-message.dental-insurance-required') }) }),
+  });
+
+  const formData = await request.formData();
+  const expectedCsrfToken = String(session.get('csrfToken'));
+  const submittedCsrfToken = String(formData.get('_csrf'));
+
+  if (expectedCsrfToken !== submittedCsrfToken) {
+    log.warn('Invalid CSRF token detected; expected: [%s], submitted: [%s]', expectedCsrfToken, submittedCsrfToken);
+    throw new Response('Invalid CSRF token', { status: 400 });
+  }
+
+  const data = { dentalInsurance: formData.get('dentalInsurance') ? formData.get('dentalInsurance') === 'yes' : undefined };
+  const parsedDataResult = dentalInsuranceSchema.safeParse(data);
+
+  if (!parsedDataResult.success) {
+    return Response.json(
+      {
+        errors: transformFlattenedError(parsedDataResult.error.flatten()),
+      },
+      { status: 400 },
+    );
+  }
+
+  saveProtectedRenewState({ params, session, state: { dentalInsurance: parsedDataResult.data.dentalInsurance } });
+
+  if (state.editMode) {
+    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+  }
+
+  return redirect(getPathById('protected/renew/$id/demographic-survey', params));
+}
+
+export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, { dentalInsurance: 'input-radio-dental-insurance-option-0' });
+
+  const helpMessage = (
+    <div className="my-4 space-y-4">
+      <ul className="list-disc pl-7">
+        <li>{t('dental-insurance.list.employment')}</li>
+        <li>{t('dental-insurance.list.pension')}</li>
+        <li>{t('dental-insurance.list.purchased')}</li>
+        <li>{t('dental-insurance.list.professional')}</li>
+      </ul>
+      <Collapsible summary={t('dental-insurance.detail.additional-info.title')}>
+        <div className="space-y-4">
+          <p>{t('dental-insurance.detail.additional-info.not-eligible')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('dental-insurance.detail.additional-info.not-eligible-employer')}</li>
+            <li>{t('dental-insurance.detail.additional-info.not-eligible-pension')}</li>
+            <li>{t('dental-insurance.detail.additional-info.not-eligible-organization')}</li>
+          </ul>
+          <p>{t('dental-insurance.detail.additional-info.not-eligible-note')}</p>
+          <p>{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
+          <p>{t('dental-insurance.detail.additional-info.eligible')}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
+            <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
+          </ul>
+        </div>
+      </Collapsible>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="max-w-prose">
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <input type="hidden" name="_csrf" value={csrfToken} />
+          <div className="my-6">
+            <InputRadios
+              id="dental-insurance"
+              name="dentalInsurance"
+              legend={t('dental-insurance.legend')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance.option-yes" />,
+                  value: 'yes',
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="dental-insurance.option-no" />,
+                  value: 'no',
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              helpMessagePrimary={helpMessage}
+              helpMessagePrimaryClassName="text-black"
+              errorMessage={errors?.dentalInsurance}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental insurance click">
+                {t('dental-insurance.button.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="protected/renew/$id/review-adult-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental insurance click"
+              >
+                {t('dental-insurance.button.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Access to other dental insurance click"
+              >
+                {t('dental-insurance.button.continue')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="protected/renew/$id/member-selection"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to other dental insurance click"
+              >
+                {t('dental-insurance.button.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -52,6 +52,11 @@ export const routes = [
         file: 'routes/protected/renew/file-taxes.tsx',
         paths: { en: '/:lang/protected/renew/:id/file-taxes', fr: '/:lang/protected/renew/:id/file-taxes' },
       },
+      {
+        id: 'protected/renew/$id/dental-insurance',
+        file: 'routes/protected/renew/dental-insurance.tsx',
+        paths: { en: '/:lang/protected/renew/:id/dental-insurance', fr: '/:lang/protected/renew/:id/dental-insurance' },
+      },
     ],
   },
 ] as const satisfies I18nRoute[];

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -111,5 +111,42 @@
     "back-btn": "Back",
     "return-btn": "Return to dashboard",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "dental-insurance": {
+    "title": "{{name}}: Access to other dental insurance",
+    "legend": "Do you have access to dental insurance or coverage:",
+    "list": {
+      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
+      "pension": "Through your pension benefits or a family member's pension benefits",
+      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "professional": "Through a professional or student organization"
+    },
+    "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
+    "option-no": "<strong>No</strong>, I do not have access to dental insurance or coverage",
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "detail": {
+      "additional-info": {
+        "title": "Additional information",
+        "eligible": "Exception: You may still be eligible if you are retired and:",
+        "list": {
+          "opted": "you opted out of pension benefits before December 11, 2023, and",
+          "cannot-opt": "you can't opt back in under the pension rules"
+        },
+        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
+        "not-eligible-employer": "employer",
+        "not-eligible-pension": "pension (see exception)",
+        "not-eligible-organization": "professional or student organization.",
+        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
+        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+      }
+    },
+    "error-message": {
+      "dental-insurance-required": "Select whether you have access to dental insurance"
+    }
   }
 }

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -111,5 +111,42 @@
     "back-btn": "Back",
     "return-btn": "Return to dashboard",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "dental-insurance": {
+    "title": "{{name}}\u00a0: Access to other dental insurance",
+    "legend": "Do you have access to dental insurance or coverage:",
+    "list": {
+      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
+      "pension": "Through your pension benefits or a family member's pension benefits",
+      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "professional": "Through a professional or student organization"
+    },
+    "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
+    "option-no": "<strong>No</strong>, I do not have access to dental insurance or coverage",
+    "button": {
+      "back": "Back",
+      "continue": "Continue",
+      "cancel-btn": "Cancel",
+      "save-btn": "Save"
+    },
+    "detail": {
+      "additional-info": {
+        "title": "Additional information",
+        "eligible": "Exception: You may still be eligible if you are retired and:",
+        "list": {
+          "opted": "you opted out of pension benefits before December 11, 2023, and",
+          "cannot-opt": "you can't opt back in under the pension rules"
+        },
+        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
+        "not-eligible-employer": "employer",
+        "not-eligible-pension": "pension (see exception)",
+        "not-eligible-organization": "professional or student organization.",
+        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
+        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+      }
+    },
+    "error-message": {
+      "dental-insurance-required": "Select whether you have access to dental insurance"
+    }
   }
 }


### PR DESCRIPTION
### Description
adds 
- `protected/renew/dental-insurance` 
- a todo mentioning we'll need to fetch the primary applicant's name to pass to the page title/heading


### Related Azure Boards Work Items
AB#4822
