### PR TITLE
refactor(frontend): remove redundant 'ErrorBoundary'

### DIFF
--- a/frontend/app/routes/public/apply/_route.tsx
+++ b/frontend/app/routes/public/apply/_route.tsx
@@ -1,8 +1,8 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, isRouteErrorResponse, useLoaderData, useParams, useRouteError } from '@remix-run/react';
+import { Outlet, useLoaderData, useParams } from '@remix-run/react';
 
 import { TYPES } from '~/.server/constants';
-import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/apply-route-helpers';
 import { useApiApplyState } from '~/utils/api-apply-state-utils';
@@ -21,16 +21,6 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return <NotFoundError error={error} />;
-  }
-
-  return <ServerError error={error} />;
 }
 
 export default function Layout() {

--- a/frontend/app/routes/public/demographic-survey/$id/_route.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/_route.tsx
@@ -1,8 +1,8 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
+import { Outlet, useLoaderData } from '@remix-run/react';
 
 import { TYPES } from '~/.server/constants';
-import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -18,16 +18,6 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return <NotFoundError error={error} />;
-  }
-
-  return <ServerError error={error} />;
 }
 
 export default function Route() {

--- a/frontend/app/routes/public/renew/_route.tsx
+++ b/frontend/app/routes/public/renew/_route.tsx
@@ -1,8 +1,8 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
+import { Outlet, useLoaderData } from '@remix-run/react';
 
 import { TYPES } from '~/.server/constants';
-import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -18,16 +18,6 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return <NotFoundError error={error} />;
-  }
-
-  return <ServerError error={error} />;
 }
 
 export default function Route() {

--- a/frontend/app/routes/public/status/_route.tsx
+++ b/frontend/app/routes/public/status/_route.tsx
@@ -1,8 +1,8 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { Outlet, isRouteErrorResponse, useLoaderData, useRouteError } from '@remix-run/react';
+import { Outlet, useLoaderData } from '@remix-run/react';
 
 import { TYPES } from '~/.server/constants';
-import { NotFoundError, PublicLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
+import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -18,16 +18,6 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return <NotFoundError error={error} />;
-  }
-
-  return <ServerError error={error} />;
 }
 
 export default function Route() {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title, since the `ErrorBoundary` is the same as the parent public layout, any error thrown in the layout's child routes will bubble up to it.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->