### PR TITLE
Adding interface for benefit renewal state mapper and fixing resulting issues with state in route helper

### DIFF
--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -62,7 +62,7 @@ import type {
   ProvincialGovernmentInsurancePlanService,
 } from '~/.server/domain/services';
 import type { ConfigFactory, LogFactory } from '~/.server/factories';
-import type { BenefitApplicationStateMapper } from '~/.server/routes/mappers';
+import type { BenefitApplicationStateMapper, BenefitRenewalStateMapper } from '~/.server/routes/mappers';
 import type { MailingAddressValidatorFactory } from '~/.server/routes/public/address-validation';
 import type { AddressValidatorFactory } from '~/.server/routes/validators';
 import { assignServiceIdentifiers, serviceIdentifier as serviceId } from '~/.server/utils/service-identifier.utils';
@@ -196,6 +196,7 @@ export const TYPES = assignServiceIdentifiers({
   routes: {
     mappers: {
       BenefitApplicationStateMapper: serviceId<BenefitApplicationStateMapper>(),
+      BenefitRenewalStateMapper: serviceId<BenefitRenewalStateMapper>(),
     },
     public: {
       addressValidation: {

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -1,3 +1,20 @@
+import type { ReadonlyDeep } from 'type-fest';
+
+import type { BenefitApplicationDto } from './benefit-application.dto';
+
+export type BenefitRenewalDto = BenefitApplicationDto &
+  ReadonlyDeep<{
+    changeIndicators: {
+      hasAddressChanged: boolean;
+      hasEmailChanged: boolean;
+      hasMaritalStatusChanged: boolean;
+      hasPhoneChanged: boolean;
+      hasFederalBenefitsChanged: boolean;
+      hasProvincialTerritorialBenefitsChanged: boolean;
+    };
+  }>;
+
+// TODO remove this when mapping to BenefitRenewalDto is complete
 export type BenefitRenewalRequestDto = Readonly<{
   applicantInformation: Readonly<{
     firstName: string;
@@ -47,6 +64,7 @@ export type BenefitRenewalRequestDto = Readonly<{
   }>;
 }>;
 
+// TODO remove this when mapping to application code is complete
 export type BenefitRenewalResponseDto = Readonly<{
   confirmationCode: string;
   submittedOn: string;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -1,0 +1,44 @@
+import { injectable } from 'inversify';
+
+import type { BenefitRenewalDto, ClientApplicationDto } from '~/.server/domain/dtos';
+import type {
+  AddressInformationState,
+  ApplicantInformationState,
+  ChildState,
+  CommunicationPreferenceState,
+  ConfirmDentalBenefitsState,
+  ContactInformationState,
+  DentalFederalBenefitsState,
+  DentalProvincialTerritorialBenefitsState,
+  PartnerInformationState,
+  TypeOfRenewalState,
+} from '~/route-helpers/renew-route-helpers.server';
+
+export interface RenewAdultChildState {
+  addressInformation?: AddressInformationState;
+  applicantInformation: ApplicantInformationState;
+  children: ChildState[];
+  clientApplication: ClientApplicationDto;
+  communicationPreferences?: CommunicationPreferenceState;
+  confirmDentalBenefits: ConfirmDentalBenefitsState;
+  contactInformation: ContactInformationState;
+  dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+  dentalInsurance: boolean;
+  hasAddressChanged: boolean;
+  hasMaritalStatusChanged: boolean;
+  maritalStatus?: string;
+  partnerInformation?: PartnerInformationState;
+  typeOfRenewal: Extract<TypeOfRenewalState, 'adult-child'>;
+}
+
+export interface BenefitRenewalStateMapper {
+  mapRenewAdultChildStateToBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): BenefitRenewalDto;
+}
+
+@injectable()
+export class BenefitRenewalStateMapperImpl implements BenefitRenewalStateMapper {
+  mapRenewAdultChildStateToBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): BenefitRenewalDto {
+    // TODO use the clientApplicationDto with the 'State' objects to form the BenefitRenewalDto somehow
+    throw new Error('Method not implemented.');
+  }
+}

--- a/frontend/app/.server/routes/mappers/index.ts
+++ b/frontend/app/.server/routes/mappers/index.ts
@@ -1,1 +1,2 @@
 export * from './benefit-application.state.mapper';
+export * from './benefit-renewal.state.mapper';

--- a/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-adult-child-route-helpers.server.ts
@@ -135,6 +135,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     communicationPreference,
     addressInformation,
     applicantInformation,
+    clientApplication,
     dentalBenefits,
     confirmDentalBenefits,
     dentalInsurance,
@@ -156,8 +157,20 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/renew/$id/applicant-information', params));
   }
 
+  if (clientApplication === undefined) {
+    throw redirect(getPathById('public/renew/$id/applicant-information', params));
+  }
+
+  if (hasMaritalStatusChanged === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
+  }
+
   if (hasMaritalStatusChanged && maritalStatus === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
+  }
+
+  if (hasAddressChanged === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
   }
 
   if (hasAddressChanged && addressInformation === undefined) {
@@ -193,6 +206,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     id,
     submissionInfo,
     typeOfRenewal,
+    clientApplication,
     contactInformation,
     communicationPreference,
     applicantInformation,

--- a/frontend/app/route-helpers/renew-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.server.ts
@@ -4,6 +4,7 @@ import type { Params } from '@remix-run/react';
 
 import { z } from 'zod';
 
+import type { ClientApplicationDto } from '~/.server/domain/dtos';
 import { getEnv } from '~/utils/env-utils.server';
 import { getLocaleFromParams } from '~/utils/locale-utils.server';
 import { getLogger } from '~/utils/logging.server';
@@ -18,23 +19,7 @@ export interface RenewState {
     dateOfBirth: string;
     clientNumber: string;
   };
-  readonly clientApplication?: {
-    clientNumber: string;
-    dateOfBirth: string;
-    firstName: string;
-    hasAppliedBeforeApril302024: boolean;
-    hasBeenAssessedByCRA: boolean;
-    lastName: string;
-    sin: string;
-    children: {
-      information: {
-        firstName: string;
-        lastName: string;
-        dateOfBirth: string;
-        clientNumber: string;
-      };
-    }[];
-  } | null;
+  readonly clientApplication?: ClientApplicationDto;
   readonly children: {
     readonly id: string;
     readonly dentalBenefits?: {


### PR DESCRIPTION
### Description
Incremental PR to map from renewal state to DTO. 

When attempting to use this mapper, some missing checks were found in the `renew-adult-child-route-helpers.server.ts`, which have been added.

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Tto ensure types were correct in this PR, add the following to the `/adult-child/review-child-information`:

```typescript
appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewAdultChildStateToBenefitRenewalDto(state);
```