### PR TITLE
remove the correct item from session storage

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -67,7 +67,7 @@ export default function RenewFlowParentOrGuardian() {
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     fetcher.submit(event.currentTarget, { method: 'POST' });
-    sessionStorage.removeItem('flow.state');
+    sessionStorage.removeItem('renew.state');
   }
 
   return (

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -369,7 +369,7 @@ export default function RenewFlowConfirm() {
                 size="sm"
                 name="_action"
                 value={FormAction.Close}
-                onClick={() => sessionStorage.removeItem('flow.state')}
+                onClick={() => sessionStorage.removeItem('renew.state')}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Confirmation exit modal - Application successfully submitted click"
               >
                 {t('renew-ita:confirm.modal.close-btn')}


### PR DESCRIPTION
### Description
Noticed there were some leftover copy/paste references that weren't cleaned up in the public renew app.