### PR TITLE
Fix broken language switcher on 404 page

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -2,8 +2,9 @@ import { useMatches, useParams, useSearchParams } from '@remix-run/react';
 
 import type { InlineLinkProps } from '~/components/inline-link';
 import { InlineLink } from '~/components/inline-link';
+import { isI18nPageRoute } from '~/routes/routes';
 import { getAltLanguage } from '~/utils/locale-utils';
-import { getPathById } from '~/utils/route-utils';
+import { findRouteById, getPathById } from '~/utils/route-utils';
 
 export type LanguageSwitcherProps = OmitStrict<InlineLinkProps, 'to' | 'reloadDocument'>;
 
@@ -19,8 +20,11 @@ export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) 
   const altLang = getAltLanguage(params.lang);
   const currentRoute = matches[matches.length - 1];
   const routeId = currentRoute.id.replace(/-(en|fr)$/, '');
+  const route = findRouteById(routeId);
+  const pathname = isI18nPageRoute(route) //
+    ? getPathById(routeId, { ...params, lang: altLang })
+    : switchLanguage(currentRoute.pathname);
 
-  const pathname = getPathById(routeId, { ...params, lang: altLang });
   const search = searchParams.toString();
 
   return (
@@ -28,4 +32,11 @@ export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) 
       {children}
     </InlineLink>
   );
+}
+
+/**
+ * Switches /en → /fr and vice versa.
+ */
+function switchLanguage(pathname: string): string {
+  return pathname.replace(/^\/(en|fr)/, (substring) => `${substring === '/en' ? '/fr' : '/en'}`);
 }

--- a/frontend/app/routes/routes.ts
+++ b/frontend/app/routes/routes.ts
@@ -27,15 +27,15 @@ type ExtractI18nRouteIds<T, Filter = void> = T extends I18nLayoutRoute //
 /**
  * Type guard to determine if a route is an I18nLayoutRoute.
  */
-export function isI18nLayoutRoute(i18nRoute: I18nRoute): i18nRoute is I18nLayoutRoute {
-  return 'children' in i18nRoute;
+export function isI18nLayoutRoute(obj: unknown): obj is I18nLayoutRoute {
+  return obj !== null && typeof obj === 'object' && 'file' in obj && 'children' in obj;
 }
 
 /**
  * Type guard to determine if a route is an I18nPageRoute.
  */
-export function isI18nPageRoute(i18nRoute: I18nRoute): i18nRoute is I18nPageRoute {
-  return isI18nLayoutRoute(i18nRoute) === false;
+export function isI18nPageRoute(obj: unknown): obj is I18nPageRoute {
+  return obj !== null && typeof obj === 'object' && 'file' in obj && 'id' in obj && 'paths' in obj;
 }
 
 export const routes = [

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -7,7 +7,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import type { I18nPageRoute, I18nRoute, Language } from '~/routes/routes';
-import { isI18nLayoutRoute, isI18nPageRoute, routes } from '~/routes/routes';
+import { routes as i18nRoutes, isI18nLayoutRoute, isI18nPageRoute } from '~/routes/routes';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type ParsedKeysByNamespaces<TOpt extends TOptions = {}> = ParseKeysByNamespaces<Namespace, KeysByTOptions<TOpt>>;
@@ -131,21 +131,17 @@ export function usePageTitleI18nOptions() {
     .reduce(coalesce);
 }
 
-export function findRouteById(id: string): I18nPageRoute | undefined {
-  function search(id: string, routes: I18nRoute[]): I18nPageRoute | undefined {
-    for (const route of routes) {
-      if (isI18nPageRoute(route) && route.id === id) {
-        return route;
-      }
+export function findRouteById(id: string, routes: I18nRoute[] = i18nRoutes): I18nPageRoute | undefined {
+  for (const route of routes) {
+    if (isI18nPageRoute(route) && route.id === id) {
+      return route;
+    }
 
-      if (isI18nLayoutRoute(route)) {
-        const matchingRoute = search(id, route.children);
-        if (matchingRoute) return matchingRoute;
-      }
+    if (isI18nLayoutRoute(route)) {
+      const matchingRoute = findRouteById(id, route.children);
+      if (matchingRoute) return matchingRoute;
     }
   }
-
-  return search(id, routes);
 }
 
 export function getPathById(id: string, params: Params = {}): string {

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -131,26 +131,29 @@ export function usePageTitleI18nOptions() {
     .reduce(coalesce);
 }
 
-export function findRouteById(id: string, routes: I18nRoute[] = []): I18nPageRoute | undefined {
-  for (const route of routes) {
-    if (isI18nPageRoute(route) && route.id === id) {
-      return route;
-    }
+export function findRouteById(id: string): I18nPageRoute | undefined {
+  function search(id: string, routes: I18nRoute[]): I18nPageRoute | undefined {
+    for (const route of routes) {
+      if (isI18nPageRoute(route) && route.id === id) {
+        return route;
+      }
 
-    if (isI18nLayoutRoute(route)) {
-      const matchingRoute = findRouteById(id, route.children);
-      if (matchingRoute) return matchingRoute;
+      if (isI18nLayoutRoute(route)) {
+        const matchingRoute = search(id, route.children);
+        if (matchingRoute) return matchingRoute;
+      }
     }
   }
+
+  return search(id, routes);
 }
 
-export function getPathById(id: string, params: Params = {}) {
+export function getPathById(id: string, params: Params = {}): string {
   const { lang = 'en' } = params as { lang?: Language };
 
-  const route = findRouteById(id, routes);
+  const route = findRouteById(id);
   const path = route?.paths[lang];
   invariant(path, `path not found for route [${id}] and language [${lang}]`);
 
-  // replace any path params with the provided params
   return generatePath(path, params);
 }


### PR DESCRIPTION
### Description

Since there is no i18n route associated with 404-inducing URLs, the language switcher needs to fall back to the current path to toggle language.

### Screenshots

![image](https://github.com/user-attachments/assets/055893b7-fdcb-4917-afde-bf185b5be8f1)

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Navigate to <http://localhost:3000/en/foo> and toggle the language.
