### PR TITLE
Restructuring and mapping entire client application DTO

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -23,14 +23,14 @@ describe('ClientApplicationDtoMapperImpl', () => {
                     AddressCategoryCode: {
                       ReferenceDataName: 'Home',
                     },
-                    AddressCityName: 'Toronto',
+                    AddressCityName: 'Home City',
                     AddressCountry: {
                       CountryCode: {
                         ReferenceDataID: 'CAN',
                         ReferenceDataName: 'Canada',
                       },
                     },
-                    AddressPostalCode: 'M5H 2N2',
+                    AddressPostalCode: 'H0H 0H0',
                     AddressProvince: {
                       ProvinceCode: {
                         ReferenceDataID: 'ON',
@@ -39,7 +39,30 @@ describe('ClientApplicationDtoMapperImpl', () => {
                     },
                     AddressSecondaryUnitText: 'Unit 101',
                     AddressStreet: {
-                      StreetName: 'Main St',
+                      StreetName: '123 Fake Street',
+                    },
+                  },
+                  {
+                    AddressCategoryCode: {
+                      ReferenceDataName: 'Mailing',
+                    },
+                    AddressCityName: 'Mailing City',
+                    AddressCountry: {
+                      CountryCode: {
+                        ReferenceDataID: 'USA',
+                        ReferenceDataName: 'United States',
+                      },
+                    },
+                    AddressPostalCode: '90210',
+                    AddressProvince: {
+                      ProvinceCode: {
+                        ReferenceDataID: 'LA',
+                        ReferenceDataName: 'Los Angeles',
+                      },
+                    },
+                    AddressSecondaryUnitText: 'Unit 102',
+                    AddressStreet: {
+                      StreetName: '456 Fake Street',
                     },
                   },
                 ],
@@ -54,7 +77,15 @@ describe('ClientApplicationDtoMapperImpl', () => {
                       TelephoneNumberFullID: '555-555-5555',
                     },
                     TelephoneNumberCategoryCode: {
-                      ReferenceDataName: 'Mobile',
+                      ReferenceDataName: 'Primary',
+                    },
+                  },
+                  {
+                    FullTelephoneNumber: {
+                      TelephoneNumberFullID: '555-555-5556',
+                    },
+                    TelephoneNumberCategoryCode: {
+                      ReferenceDataName: 'Alternate',
                     },
                   },
                 ],
@@ -106,12 +137,8 @@ describe('ClientApplicationDtoMapperImpl', () => {
             },
             ClientIdentification: [
               {
-                IdentificationID: '4f35f70b-2f83-ee11-8179-000d3a09d000',
-                IdentificationCategoryText: 'Applicant ID',
-              },
-              {
-                IdentificationID: '1e97fe42-0263-ee11-8df0-000d3a09df08',
-                IdentificationCategoryText: 'Client ID',
+                IdentificationID: '00000000000',
+                IdentificationCategoryText: 'Client Number',
               },
             ],
             Flags: [
@@ -130,7 +157,7 @@ describe('ClientApplicationDtoMapperImpl', () => {
                   },
                 ],
                 PersonRelationshipCode: {
-                  ReferenceDataName: 'Sibling',
+                  ReferenceDataName: 'Spouse',
                 },
                 PersonSINIdentification: {
                   IdentificationID: '80000002',
@@ -174,14 +201,51 @@ describe('ClientApplicationDtoMapperImpl', () => {
       };
 
       const expectedClientApplicationDto: ClientApplicationDto = {
-        clientNumber: '4f35f70b-2f83-ee11-8179-000d3a09d000',
-        dateOfBirth: '2000-01-01',
-        firstName: 'John',
-        hasAppliedBeforeApril302024: false,
-        hasBeenAssessedByCRA: true,
-        lastName: 'Doe',
-        sin: '80000002',
+        applicantInformation: {
+          firstName: 'John',
+          lastName: 'Doe',
+          maritalStatus: 'MARRIED',
+          socialInsuranceNumber: '80000002',
+          clientNumber: '00000000000',
+        },
         children: [],
+        communicationPreferences: {
+          email: 'email@example.com',
+          preferredLanguage: 'ENG',
+          preferredMethod: 'EMAIL',
+        },
+        contactInformation: {
+          copyMailingAddress: true,
+          email: 'email@example.com',
+          homeAddress: '123 Fake Street',
+          homeApartment: 'Unit 101',
+          homeCity: 'Home City',
+          homeCountry: 'CAN',
+          homePostalCode: 'H0H 0H0',
+          homeProvince: 'ON',
+          mailingAddress: '456 Fake Street',
+          mailingApartment: 'Unit 102',
+          mailingCity: 'Mailing City',
+          mailingCountry: 'USA',
+          mailingPostalCode: '90210',
+          mailingProvince: 'LA',
+          phoneNumber: '555-555-5555',
+          phoneNumberAlt: '555-555-5556',
+        },
+        dateOfBirth: '2000-01-01',
+        dentalBenefits: ['ID-123456'],
+        dentalInsurance: true,
+        disabilityTaxCredit: true,
+        hasFiledTaxes: true,
+        isInvitationToApplyClient: false,
+        livingIndependently: true,
+        partnerInformation: {
+          confirm: false,
+          dateOfBirth: '2000-01-01',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          socialInsuranceNumber: '80000002',
+        },
       };
 
       // Act

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -178,23 +178,30 @@ describe('ClientApplicationServiceImpl', () => {
 
   // Mock for ClientApplicationDto
   const mockClientApplicationDto: ClientApplicationDto = {
-    clientNumber: 'ABC123',
+    applicantInformation: {
+      firstName: 'John',
+      lastName: 'Doe',
+      maritalStatus: 'MARRIED',
+      socialInsuranceNumber: '80000002',
+    },
+    children: [],
+    communicationPreferences: {
+      preferredLanguage: 'ENG',
+      preferredMethod: 'EMAIL',
+    },
+    contactInformation: {
+      copyMailingAddress: true,
+      homeAddress: '123 Fake Street',
+      homeCity: 'Home City',
+      homeCountry: 'CAN',
+      mailingAddress: '456 Fake Street',
+      mailingCity: 'Mailing City',
+      mailingCountry: 'USA',
+    },
     dateOfBirth: '2000-01-01',
-    firstName: 'John',
-    hasAppliedBeforeApril302024: false,
-    hasBeenAssessedByCRA: true,
-    lastName: 'Doe',
-    sin: '80000002',
-    children: [
-      {
-        information: {
-          firstName: 'John',
-          lastName: 'Doe',
-          dateOfBirth: '2000-01-01',
-          clientNumber: '123456789',
-        },
-      },
-    ],
+    dentalBenefits: ['ID-123456'],
+    hasFiledTaxes: true,
+    isInvitationToApplyClient: false,
   };
 
   describe('findClientApplicationBySin', () => {

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -1,19 +1,30 @@
-export type ClientApplicationDto = Readonly<{
-  clientNumber: string;
-  dateOfBirth: string;
-  firstName: string;
-  hasAppliedBeforeApril302024: boolean;
-  hasBeenAssessedByCRA: boolean;
-  lastName: string;
-  sin: string;
-  children: {
+import type { ReadonlyDeep } from 'type-fest';
+
+import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, ContactInformationDto, PartnerInformationDto } from './benefit-application.dto';
+
+export type ClientApplicationDto = ReadonlyDeep<{
+  applicantInformation: ApplicantInformationDto & { clientNumber?: string };
+  children: (Omit<ChildDto, 'dentalBenefits' | 'information'> & {
+    dentalBenefits: string[]; // TODO this structure should be switched in BenefitApplicationDto as well
     information: {
       firstName: string;
       lastName: string;
       dateOfBirth: string;
+      isParent: boolean;
       clientNumber?: string;
+      socialInsuranceNumber: string;
     };
-  }[];
+  })[];
+  communicationPreferences: CommunicationPreferencesDto;
+  contactInformation: ContactInformationDto;
+  dateOfBirth: string;
+  dentalBenefits: string[]; // TODO this structure should be switched in BenefitApplicationDto as well
+  dentalInsurance?: boolean;
+  disabilityTaxCredit?: boolean;
+  hasFiledTaxes: boolean;
+  isInvitationToApplyClient: boolean;
+  livingIndependently?: boolean;
+  partnerInformation?: PartnerInformationDto;
 }>;
 
 export type ClientApplicationBasicInfoRequestDto = Readonly<{

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -144,8 +144,8 @@ export type ClientApplicationEntity = Readonly<{
                 >;
               }>
             >;
-            ConsentToSharePersonalInformationIndicator?: boolean;
-            AttestParentOrGuardianIndicator?: boolean;
+            ConsentToSharePersonalInformationIndicator: boolean;
+            AttestParentOrGuardianIndicator: boolean;
           }>;
           ClientIdentification: ReadonlyArray<
             Readonly<{

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -1,37 +1,17 @@
 import { injectable } from 'inversify';
+import invariant from 'tiny-invariant';
 
 import type { ClientApplicationBasicInfoRequestDto, ClientApplicationDto, ClientApplicationSinRequestDto } from '~/.server/domain/dtos';
 import type { ClientApplicationBasicInfoRequestEntity, ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
 
 export interface ClientApplicationDtoMapper {
-  mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto;
   mapClientApplicationBasicInfoRequestDtoToClientApplicationBasicInfoRequestEntity(clientApplicationBasicInfoRequestDto: ClientApplicationBasicInfoRequestDto): ClientApplicationBasicInfoRequestEntity;
   mapClientApplicationSinRequestDtoToClientApplicationSinRequestEntity(clientApplicationSinRequestDto: ClientApplicationSinRequestDto): ClientApplicationSinRequestEntity;
+  mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto;
 }
 
 @injectable()
 export class ClientApplicationDtoMapperImpl implements ClientApplicationDtoMapper {
-  mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto {
-    const { Flags } = clientApplicationEntity.BenefitApplication.Applicant;
-    return {
-      clientNumber: clientApplicationEntity.BenefitApplication.Applicant.ClientIdentification[0].IdentificationID,
-      dateOfBirth: clientApplicationEntity.BenefitApplication.Applicant.PersonBirthDate.date,
-      firstName: clientApplicationEntity.BenefitApplication.Applicant.PersonName[0].PersonGivenName[0],
-      hasAppliedBeforeApril302024: this.resolveFlagValue(Flags, 'appliedBeforeApril302024'),
-      hasBeenAssessedByCRA: this.resolveFlagValue(Flags, 'isCraAssessed'),
-      lastName: clientApplicationEntity.BenefitApplication.Applicant.PersonName[0].PersonSurName,
-      sin: clientApplicationEntity.BenefitApplication.Applicant.PersonSINIdentification.IdentificationID,
-      children: clientApplicationEntity.BenefitApplication.Applicant.RelatedPerson.filter((person) => person.PersonRelationshipCode.ReferenceDataName === ('Dependant' as const)).map((person) => ({
-        information: {
-          dateOfBirth: person.PersonBirthDate.date,
-          firstName: person.PersonName[0].PersonGivenName[0],
-          lastName: person.PersonName[0].PersonSurName,
-          clientNumber: person.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
-        },
-      })),
-    };
-  }
-
   mapClientApplicationBasicInfoRequestDtoToClientApplicationBasicInfoRequestEntity(clientApplicationBasicInfoRequestDto: ClientApplicationBasicInfoRequestDto) {
     return {
       Applicant: {
@@ -60,6 +40,88 @@ export class ClientApplicationDtoMapperImpl implements ClientApplicationDtoMappe
           IdentificationID: clientApplicationSinRequestDto.sin,
         },
       },
+    };
+  }
+
+  mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto {
+    const applicant = clientApplicationEntity.BenefitApplication.Applicant;
+
+    const applicantInformation = {
+      firstName: applicant.PersonName[0].PersonGivenName[0],
+      lastName: applicant.PersonName[0].PersonSurName,
+      maritalStatus: applicant.PersonMaritalStatus.StatusCode.ReferenceDataID,
+      clientNumber: applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
+      socialInsuranceNumber: applicant.PersonSINIdentification.IdentificationID,
+    };
+
+    const children = applicant.RelatedPerson.filter((person) => person.PersonRelationshipCode.ReferenceDataName === 'Dependant').map((child) => ({
+      dentalBenefits: child.ApplicantDetail.InsurancePlan?.[0].InsurancePlanIdentification.map((insurancePlan) => insurancePlan.IdentificationID) ?? [],
+      dentalInsurance: child.ApplicantDetail.PrivateDentalInsuranceIndicator,
+      information: {
+        firstName: child.PersonName[0].PersonGivenName[0],
+        lastName: child.PersonName[0].PersonSurName,
+        dateOfBirth: child.PersonBirthDate.date,
+        isParent: child.ApplicantDetail.AttestParentOrGuardianIndicator,
+        clientNumber: child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
+        socialInsuranceNumber: child.PersonSINIdentification.IdentificationID,
+      },
+    }));
+
+    const communicationPreferences = {
+      email: applicant.PersonContactInformation[0].EmailAddress.at(0)?.EmailAddressID,
+      preferredLanguage: applicant.PersonLanguage[0].CommunicationCategoryCode.ReferenceDataID,
+      preferredMethod: applicant.PreferredMethodCommunicationCode.ReferenceDataID,
+    };
+
+    const homeAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');
+    invariant(homeAddress, 'Expected homeAddress to be defined');
+
+    const mailingAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
+    invariant(mailingAddress, 'Expected mailingAddress to be defined');
+
+    const contactInformation = {
+      copyMailingAddress: applicant.MailingSameAsHomeIndicator,
+      homeAddress: homeAddress.AddressStreet.StreetName,
+      homeApartment: homeAddress.AddressSecondaryUnitText,
+      homeCity: homeAddress.AddressCityName,
+      homeCountry: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
+      homePostalCode: homeAddress.AddressPostalCode,
+      homeProvince: homeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
+      mailingAddress: mailingAddress.AddressStreet.StreetName,
+      mailingApartment: mailingAddress.AddressSecondaryUnitText,
+      mailingCity: mailingAddress.AddressCityName,
+      mailingCountry: mailingAddress.AddressCountry.CountryCode.ReferenceDataID,
+      mailingPostalCode: mailingAddress.AddressPostalCode,
+      mailingProvince: mailingAddress.AddressProvince.ProvinceCode.ReferenceDataID,
+      phoneNumber: applicant.PersonContactInformation[0].TelephoneNumber.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Primary')?.FullTelephoneNumber.TelephoneNumberFullID,
+      phoneNumberAlt: applicant.PersonContactInformation[0].TelephoneNumber.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Alternate')?.FullTelephoneNumber.TelephoneNumberFullID,
+      email: applicant.PersonContactInformation[0].EmailAddress.at(0)?.EmailAddressID,
+    };
+
+    const partner = applicant.RelatedPerson.find((person) => person.PersonRelationshipCode.ReferenceDataName === 'Spouse');
+    const partnerInformation = partner
+      ? {
+          confirm: partner.ApplicantDetail.ConsentToSharePersonalInformationIndicator,
+          dateOfBirth: partner.PersonBirthDate.date,
+          firstName: partner.PersonName[0].PersonGivenName[0],
+          lastName: partner.PersonName[0].PersonSurName,
+          socialInsuranceNumber: partner.PersonSINIdentification.IdentificationID,
+        }
+      : undefined;
+
+    return {
+      applicantInformation,
+      children,
+      communicationPreferences,
+      contactInformation,
+      dateOfBirth: applicant.PersonBirthDate.date,
+      dentalBenefits: applicant.ApplicantDetail.InsurancePlan?.[0].InsurancePlanIdentification.map((insurancePlan) => insurancePlan.IdentificationID) ?? [],
+      dentalInsurance: applicant.ApplicantDetail.PrivateDentalInsuranceIndicator,
+      disabilityTaxCredit: applicant.ApplicantDetail.DisabilityTaxCreditIndicator,
+      hasFiledTaxes: this.resolveFlagValue(applicant.Flags, 'isCraAssessed'),
+      isInvitationToApplyClient: this.resolveFlagValue(applicant.Flags, 'appliedBeforeApril302024'),
+      livingIndependently: applicant.ApplicantDetail.LivingIndependentlyIndicator,
+      partnerInformation,
     };
   }
 

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -157,8 +157,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/review-information', params));
   }
 
-  // If isCraAssessed flag is true, skip tax-filing and go to type-renewal
-  if (clientApplication.hasBeenAssessedByCRA) {
+  if (clientApplication.hasFiledTaxes) {
     return redirect(getPathById('public/renew/$id/type-renewal', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const csrfToken = String(session.get('csrfToken'));
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:type-of-renewal.page-title') }) };
 
-  return { id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal, hasBeenAssessedByCRA: state.clientApplication?.hasBeenAssessedByCRA };
+  return { id: state.id, csrfToken, meta, defaultState: state.typeOfRenewal, hasFiledTaxes: state.clientApplication?.hasFiledTaxes };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -93,7 +93,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (parsedDataResult.data.typeOfRenewal === RenewalType.AdultChild) {
-    if (state.clientApplication?.hasAppliedBeforeApril302024) {
+    if (state.clientApplication?.isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
@@ -108,7 +108,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewTypeOfRenewal() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { csrfToken, defaultState, hasBeenAssessedByCRA } = useLoaderData<typeof loader>();
+  const { csrfToken, defaultState, hasFiledTaxes } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -156,7 +156,7 @@ export default function RenewTypeOfRenewal() {
             </LoadingButton>
             <ButtonLink
               id="back-button"
-              routeId={hasBeenAssessedByCRA ? 'public/renew/$id/applicant-information' : 'public/renew/$id/tax-filing'}
+              routeId={hasFiledTaxes ? 'public/renew/$id/applicant-information' : 'public/renew/$id/tax-filing'}
               params={params}
               disabled={isSubmitting}
               startIcon={faChevronLeft}


### PR DESCRIPTION
### Description
This incremental PR adds the rest of the fields for the client application DTO and also renames the indicators to better match its uses in our application. The DTO mapper has been modified to map the corresponding entity to these DTO fields.

Currently the client application DTO returns only what is required to verify an applicant and their children during the renewal process. However, all fields are required when submitting a renewal application.

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/feef4ffb-6cd8-4ead-a95f-74c516cccf9d)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/renew`. Complete a renewal application.

### Additional Notes
Didn't split mapper into multiple methods to avoid dealing with introducing new types/interfaces only used for mapping.