### PR TITLE
feature(frontend): handle unexpected address validation service error

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/address-validation.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/address-validation.dto.mapper.test.ts
@@ -1,21 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { AddressCorrectionResultDto, AddressCorrectionStatus } from '~/.server/domain/dtos';
+import type { ServerConfig } from '~/.server/configs';
+import type { AddressCorrectionRequestDto, AddressCorrectionResultDto, AddressCorrectionStatus } from '~/.server/domain/dtos';
 import type { AddressCorrectionResultEntity } from '~/.server/domain/entities';
-import { AddressValidationDtoMapperImpl } from '~/.server/domain/mappers';
+import { DefaultAddressValidationDtoMapper } from '~/.server/domain/mappers';
+import { formatPostalCode, isValidPostalCode } from '~/utils/postal-zip-code-utils.server';
 
-describe('AddressValidationDtoMapperImpl', () => {
+vi.mock('~/utils/postal-zip-code-utils.server');
+
+describe('DefaultAddressValidationDtoMapper', () => {
+  const mockServerConfig: Pick<ServerConfig, 'CANADA_COUNTRY_ID'> = { CANADA_COUNTRY_ID: 'CA' };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
   describe('mapAddressCorrectionResultEntityToAddressCorrectionResultDto', () => {
     it.each([
-      { statusCode: 'Corrected', expectedStatus: 'Corrected' as AddressCorrectionStatus },
-      { statusCode: 'NotCorrect', expectedStatus: 'NotCorrect' as AddressCorrectionStatus },
-      { statusCode: 'Valid', expectedStatus: 'Valid' as AddressCorrectionStatus },
-    ])('should map AddressCorrectionResultEntity to AddressCorrectionResultDto with correct status', ({ statusCode, expectedStatus }) => {
+      { statusCode: 'Corrected', expectedStatus: 'corrected' as AddressCorrectionStatus },
+      { statusCode: 'NotCorrect', expectedStatus: 'not-correct' as AddressCorrectionStatus },
+      { statusCode: 'Valid', expectedStatus: 'valid' as AddressCorrectionStatus },
+    ])('should map AddressCorrectionResultEntity to AddressCorrectionResultDto with correct status and format postal code', ({ statusCode, expectedStatus }) => {
+      vi.mocked(isValidPostalCode).mockReturnValue(true);
+      vi.mocked(formatPostalCode).mockReturnValue('H0H 0H0');
+
       const mockEntity: AddressCorrectionResultEntity = {
         'wsaddr:CorrectionResults': {
           'nc:AddressFullText': '123 Fake St',
           'nc:AddressCityName': 'North Pole',
-          'nc:AddressPostalCode': 'H0H 0H0',
+          'nc:AddressPostalCode': 'h0h0h0',
           'can:ProvinceCode': 'ON',
           'wsaddr:Information': {
             'wsaddr:StatusCode': statusCode,
@@ -31,18 +45,23 @@ describe('AddressValidationDtoMapperImpl', () => {
         provinceCode: 'ON',
       };
 
-      const mapper = new AddressValidationDtoMapperImpl();
+      const mapper = new DefaultAddressValidationDtoMapper(mockServerConfig);
       const dto = mapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(mockEntity);
 
       expect(dto).toEqual(expectedDto);
+      expect(isValidPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'h0h0h0');
+      expect(formatPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'h0h0h0');
     });
 
     it('should throw error for unknown status', () => {
+      vi.mocked(isValidPostalCode).mockReturnValue(true);
+      vi.mocked(formatPostalCode).mockReturnValue('H0H 0H0');
+
       const mockEntity: AddressCorrectionResultEntity = {
         'wsaddr:CorrectionResults': {
           'nc:AddressFullText': '123 Fake St',
           'nc:AddressCityName': 'North Pole',
-          'nc:AddressPostalCode': 'H0H 0H0',
+          'nc:AddressPostalCode': 'H0H0H0',
           'can:ProvinceCode': 'ON',
           'wsaddr:Information': {
             'wsaddr:StatusCode': 'Invalid status',
@@ -50,8 +69,67 @@ describe('AddressValidationDtoMapperImpl', () => {
         },
       };
 
-      const mapper = new AddressValidationDtoMapperImpl();
+      const mapper = new DefaultAddressValidationDtoMapper(mockServerConfig);
       expect(() => mapper.mapAddressCorrectionResultEntityToAddressCorrectionResultDto(mockEntity)).toThrowError();
+      expect(isValidPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'H0H0H0');
+      expect(formatPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'H0H0H0');
+    });
+  });
+
+  describe('mapAddressCorrectionRequestDtoToAddressCorrectionResultDto', () => {
+    it('should map AddressCorrectionRequestDto to AddressCorrectionResultDto with service unavailable status and format postal code', () => {
+      vi.mocked(isValidPostalCode).mockReturnValue(true);
+      vi.mocked(formatPostalCode).mockReturnValue('H0H 0H0');
+
+      const mockDto: AddressCorrectionRequestDto = {
+        address: '123 fake st',
+        city: 'north pole',
+        postalCode: 'h0h0h0',
+        provinceCode: 'ON',
+        userId: 'test user',
+      };
+
+      const expectedResult: AddressCorrectionResultDto = {
+        address: '123 FAKE ST',
+        city: 'NORTH POLE',
+        postalCode: 'H0H0H0',
+        provinceCode: 'H0H 0H0',
+        status: 'service-unavailable',
+      };
+
+      const mapper = new DefaultAddressValidationDtoMapper(mockServerConfig);
+      const result = mapper.mapAddressCorrectionRequestDtoToAddressCorrectionResultDto(mockDto, 'service-unavailable');
+
+      expect(result).toEqual(expectedResult);
+      expect(isValidPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'h0h0h0');
+      expect(formatPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'h0h0h0');
+    });
+
+    it('should handle invalid postal code', () => {
+      vi.mocked(isValidPostalCode).mockReturnValue(false);
+      vi.mocked(formatPostalCode).mockReturnValue('INVALID');
+
+      const mockDto: AddressCorrectionRequestDto = {
+        address: '123 fake st',
+        city: 'north pole',
+        postalCode: 'invalid',
+        provinceCode: 'ON',
+        userId: 'test user',
+      };
+
+      const expectedResult: AddressCorrectionResultDto = {
+        address: '123 FAKE ST',
+        city: 'NORTH POLE',
+        postalCode: 'INVALID',
+        provinceCode: 'INVALID',
+        status: 'service-unavailable',
+      };
+
+      const mapper = new DefaultAddressValidationDtoMapper(mockServerConfig);
+      const result = mapper.mapAddressCorrectionRequestDtoToAddressCorrectionResultDto(mockDto, 'service-unavailable');
+      expect(result).toEqual(expectedResult);
+      expect(isValidPostalCode).toHaveBeenCalledWith(mockServerConfig.CANADA_COUNTRY_ID, 'invalid');
+      expect(formatPostalCode).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/app/.server/container-modules/mappers.container-module.ts
+++ b/frontend/app/.server/container-modules/mappers.container-module.ts
@@ -2,7 +2,6 @@ import { ContainerModule } from 'inversify';
 
 import { TYPES } from '~/.server/constants';
 import {
-  AddressValidationDtoMapperImpl,
   ApplicantDtoMapperImpl,
   ApplicationStatusDtoMapperImpl,
   BenefitApplicationDtoMapperImpl,
@@ -10,6 +9,7 @@ import {
   ClientApplicationDtoMapperImpl,
   ClientFriendlyStatusDtoMapperImpl,
   CountryDtoMapperImpl,
+  DefaultAddressValidationDtoMapper,
   DemographicSurveyDtoMapperImpl,
   FederalGovernmentInsurancePlanDtoMapperImpl,
   LetterDtoMapperImpl,
@@ -27,7 +27,7 @@ import { HCaptchaDtoMapperImpl } from '~/.server/web/mappers';
  * Container module for mappers.
  */
 export const mappersContainerModule = new ContainerModule((bind) => {
-  bind(TYPES.domain.mappers.AddressValidationDtoMapper).to(AddressValidationDtoMapperImpl);
+  bind(TYPES.domain.mappers.AddressValidationDtoMapper).to(DefaultAddressValidationDtoMapper);
   bind(TYPES.domain.mappers.ApplicantDtoMapper).to(ApplicantDtoMapperImpl);
   bind(TYPES.domain.mappers.ApplicationStatusDtoMapper).to(ApplicationStatusDtoMapperImpl);
   bind(TYPES.domain.mappers.BenefitApplicationDtoMapper).to(BenefitApplicationDtoMapperImpl);

--- a/frontend/app/.server/container-modules/services.container-module.ts
+++ b/frontend/app/.server/container-modules/services.container-module.ts
@@ -5,7 +5,6 @@ import { RedisServiceImpl } from '../data/services';
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import {
-  AddressValidationServiceImpl,
   ApplicantServiceImpl,
   ApplicationStatusServiceImpl,
   AuditServiceImpl,
@@ -14,6 +13,7 @@ import {
   ClientApplicationServiceImpl,
   ClientFriendlyStatusServiceImpl,
   CountryServiceImpl,
+  DefaultAddressValidationService,
   DemographicSurveyServiceServiceImpl,
   FederalGovernmentInsurancePlanServiceImpl,
   LetterServiceImpl,
@@ -39,7 +39,7 @@ function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
 export const servicesContainerModule = new ContainerModule((bind) => {
   // RedisService bindings depend on the SESSION_STORAGE_TYPE configuration string
   bind(TYPES.data.services.RedisService).to(RedisServiceImpl).when(sessionTypeIs('redis'));
-  bind(TYPES.domain.services.AddressValidationService).to(AddressValidationServiceImpl);
+  bind(TYPES.domain.services.AddressValidationService).to(DefaultAddressValidationService);
   bind(TYPES.domain.services.ApplicantService).to(ApplicantServiceImpl);
   bind(TYPES.domain.services.ApplicationStatusService).to(ApplicationStatusServiceImpl);
   bind(TYPES.domain.services.AuditService).to(AuditServiceImpl);

--- a/frontend/app/.server/domain/dtos/address-validation.dto.ts
+++ b/frontend/app/.server/domain/dtos/address-validation.dto.ts
@@ -23,7 +23,7 @@ export type AddressCorrectionRequestDto = Readonly<{
  */
 export type AddressCorrectionResultDto = Readonly<{
   /** The status of the address correction. */
-  status: AddressCorrectionStatus;
+  status: 'corrected' | 'not-correct' | 'valid' | 'service-unavailable';
 
   /** The full or partial address. */
   address: string;
@@ -41,4 +41,4 @@ export type AddressCorrectionResultDto = Readonly<{
 /**
  * Represents the possible statuses for an address correction result.
  */
-export type AddressCorrectionStatus = 'Corrected' | 'NotCorrect' | 'Valid';
+export type AddressCorrectionStatus = AddressCorrectionResultDto['status'];

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -26,7 +26,6 @@ import { featureEnabled } from '~/utils/env-utils.server';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { getFixedT, getLocale } from '~/utils/locale-utils.server';
 import { mergeMeta } from '~/utils/meta-utils';
-import { formatPostalCode } from '~/utils/postal-zip-code-utils.server';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -160,14 +159,14 @@ export async function action({ context: { appContainer, session }, request, para
     userId: 'anonymous',
   });
 
-  if (addressCorrectionResult.status === 'NotCorrect') {
+  if (addressCorrectionResult.status === 'not-correct') {
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
     } as const satisfies AddressInvalidResponse;
   }
 
-  if (addressCorrectionResult.status === 'Corrected') {
+  if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
@@ -177,7 +176,7 @@ export async function action({ context: { appContainer, session }, request, para
         city: addressCorrectionResult.city,
         country: formattedMailingAddress.country,
         countryId: formattedMailingAddress.countryId,
-        postalZipCode: formatPostalCode(serverConfig.CANADA_COUNTRY_ID, addressCorrectionResult.postalCode),
+        postalZipCode: addressCorrectionResult.postalCode,
         provinceState: provinceTerritoryState.abbr,
         provinceStateId: provinceTerritoryState.id,
       },


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Handle unexpected errors from the address validation service gracefully. CDCP must ensure that any unforeseen issues with the external service (WSAddress) do not impact the user experience. If the service is unavailable, the user's address will be saved without validation. I’ve implemented logic in the `MockAddressValidationRepository` class to simulate various address validation scenarios:

- For the province code `ON` (Ontario), the address validation entity's status code is set to `Corrected`.
- For the province code `QC` (Quebec), the status code is set to `NotCorrect`.
- For the province code `NL` (Newfoundland and Labrador), an error is thrown, and the service should handle it by returning `service-unavailable` in the DTO status field.
- For all other province codes, the status code is set to `Valid`.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#4696](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4696)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->