### PR TITLE
Changing type of `dentalBenefits` field to simplify benefit application dto structure

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -6,7 +6,7 @@ export type BenefitApplicationDto = ReadonlyDeep<{
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;
   dateOfBirth: string;
-  dentalBenefits?: DentalBenefitsDto;
+  dentalBenefits: string[];
   dentalInsurance?: boolean;
   disabilityTaxCredit?: boolean;
   livingIndependently?: boolean;
@@ -25,7 +25,7 @@ export type ApplicantInformationDto = ReadonlyDeep<{
 }>;
 
 export type ChildDto = ReadonlyDeep<{
-  dentalBenefits: DentalBenefitsDto;
+  dentalBenefits: string[];
   dentalInsurance: boolean;
   information: {
     firstName: string;
@@ -59,13 +59,6 @@ export type ContactInformationDto = ReadonlyDeep<{
   phoneNumber?: string;
   phoneNumberAlt?: string;
   email?: string;
-}>;
-
-export type DentalBenefitsDto = ReadonlyDeep<{
-  hasFederalBenefits: boolean;
-  federalSocialProgram?: string;
-  hasProvincialTerritorialBenefits: boolean;
-  provincialTerritorialSocialProgram?: string;
 }>;
 
 export type PartnerInformationDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -4,8 +4,7 @@ import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, Co
 
 export type ClientApplicationDto = ReadonlyDeep<{
   applicantInformation: ApplicantInformationDto & { clientNumber?: string };
-  children: (Omit<ChildDto, 'dentalBenefits' | 'information'> & {
-    dentalBenefits: string[]; // TODO this structure should be switched in BenefitApplicationDto as well
+  children: (Omit<ChildDto, 'information'> & {
     information: {
       firstName: string;
       lastName: string;
@@ -18,7 +17,7 @@ export type ClientApplicationDto = ReadonlyDeep<{
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;
   dateOfBirth: string;
-  dentalBenefits: string[]; // TODO this structure should be switched in BenefitApplicationDto as well
+  dentalBenefits: string[];
   dentalInsurance?: boolean;
   disabilityTaxCredit?: boolean;
   hasFiledTaxes: boolean;

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -4,7 +4,7 @@ import validator from 'validator';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { BenefitApplicationDto, ChildDto, ContactInformationDto, DentalBenefitsDto, PartnerInformationDto, TypeOfApplicationDto } from '~/.server/domain/dtos';
+import type { BenefitApplicationDto, ChildDto, ContactInformationDto, PartnerInformationDto, TypeOfApplicationDto } from '~/.server/domain/dtos';
 import type { BenefitApplicationRequestEntity, BenefitApplicationResponseEntity } from '~/.server/domain/entities';
 import { parseDateString } from '~/utils/date-utils';
 
@@ -52,7 +52,7 @@ export class BenefitApplicationDtoMapperImpl implements BenefitApplicationDtoMap
             PrivateDentalInsuranceIndicator: dentalInsurance,
             DisabilityTaxCreditIndicator: disabilityTaxCredit,
             LivingIndependentlyIndicator: livingIndependently,
-            InsurancePlan: dentalBenefits && this.toInsurancePlan(dentalBenefits),
+            InsurancePlan: this.toInsurancePlan(dentalBenefits),
           },
           PersonBirthDate: this.toDate(dateOfBirth),
           PersonContactInformation: [
@@ -100,22 +100,14 @@ export class BenefitApplicationDtoMapperImpl implements BenefitApplicationDtoMap
     };
   }
 
-  private toInsurancePlan({ hasFederalBenefits, federalSocialProgram, hasProvincialTerritorialBenefits, provincialTerritorialSocialProgram }: DentalBenefitsDto) {
-    const insurancePlanIdentification = [];
-
-    if (hasFederalBenefits && federalSocialProgram && !validator.isEmpty(federalSocialProgram)) {
-      insurancePlanIdentification.push({
-        IdentificationID: federalSocialProgram,
-      });
-    }
-
-    if (hasProvincialTerritorialBenefits && provincialTerritorialSocialProgram && !validator.isEmpty(provincialTerritorialSocialProgram)) {
-      insurancePlanIdentification.push({
-        IdentificationID: provincialTerritorialSocialProgram,
-      });
-    }
-
-    return [{ InsurancePlanIdentification: insurancePlanIdentification }];
+  private toInsurancePlan(dentalBenefits: readonly string[]) {
+    return [
+      {
+        InsurancePlanIdentification: dentalBenefits.map((dentalBenefit) => ({
+          IdentificationID: dentalBenefit,
+        })),
+      },
+    ];
   }
 
   private toDate(date: string) {


### PR DESCRIPTION
### Description
This change to the benefit application DTO reduces the complexity of the DTO and ensures consistency with the client application DTO that we use to fetch client application data.

`hasFederalBenefits` and `hasProvincialTerritorialBenefits` are only relevant in the state and not used in the service, therefore they have been removed from the benefit application DTO.

### Screenshots (if applicable)
(same requests as before)
No dental benefits
![image](https://github.com/user-attachments/assets/56742612-0d81-4f70-a56e-dfe7550265b3)

Both federal and provincial benefits
![image](https://github.com/user-attachments/assets/b745e62f-cbe3-4a9e-b645-c254327e2ddc)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
