### PR TITLE
Tighten up return types in locale-utils and update tests

### DIFF
--- a/frontend/__tests__/utils/locale-utils.test.ts
+++ b/frontend/__tests__/utils/locale-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { APP_LOCALES, getAltLanguage, getNamespaces, getTypedI18nNamespaces, isAppLocale, removeLanguageFromPath, useAppLocale } from '~/utils/locale-utils';
+import { APP_LOCALES, getAltLanguage, getLanguage, getNamespaces, getTypedI18nNamespaces, isAppLocale, removeLanguageFromPath, useAppLocale } from '~/utils/locale-utils';
 
 /*
  * @vitest-environment jsdom
@@ -29,16 +29,30 @@ describe('locale-utils', () => {
   });
 
   describe('getAltLanguage', () => {
-    it('should return "fr" for "en"', () => {
-      expect(getAltLanguage('en')).toBe('fr');
-    });
-
-    it('should return "en" for "fr"', () => {
-      expect(getAltLanguage('fr')).toBe('en');
+    it.each([
+      { language: 'en', expected: 'fr' },
+      { language: 'fr', expected: 'en' },
+    ])('should return $expected for language $language', ({ language, expected }) => {
+      expect(getAltLanguage(language)).toBe(expected);
     });
 
     it('should throw an error for invalid language', () => {
-      expect(() => getAltLanguage('es')).toThrowError('Unexpected language: es');
+      expect(() => getAltLanguage('es')).toThrowError(`Could not determine altLanguage for language: es.`);
+    });
+  });
+
+  describe('getLanguage', () => {
+    it.each([
+      { pathname: '/en', expected: 'en' },
+      { pathname: '/en/foo', expected: 'en' },
+      { pathname: '/fr', expected: 'fr' },
+      { pathname: '/fr/foo', expected: 'fr' },
+    ])('should return $expected for pathname $pathname', ({ pathname, expected }) => {
+      expect(getLanguage(pathname)).toBe(expected);
+    });
+
+    it('should throw an error for invalid pathname', () => {
+      expect(() => getLanguage('/es')).toThrowError(`Could not determine language for pathname: /es.`);
     });
   });
 

--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -17,6 +17,11 @@ export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) 
   const params = useParams();
   const [searchParams] = useSearchParams();
 
+  // can't toggle language if we don't know our current language
+  if (params.lang === undefined) {
+    return <></>;
+  }
+
   const altLang = getAltLanguage(params.lang);
   const currentRoute = matches[matches.length - 1];
   const routeId = currentRoute.id.replace(/-(en|fr)$/, '');

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
+import { useEffect } from 'react';
 
 import { Link } from '@remix-run/react';
 
@@ -15,7 +15,7 @@ import { SkipNavigationLinks } from '~/components/skip-navigation-links';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
-import { getAltLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { useI18nNamespaces, usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
@@ -138,12 +138,6 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
   const en = i18n.getFixedT('en');
   const fr = i18n.getFixedT('fr');
 
-  const altLanguage = getAltLanguage(i18n.language);
-  const altLogoContent = <span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>;
-
-  const englishCdcpLink = <InlineLink to={en('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" />;
-  const frenchCdcpLink = <InlineLink to={fr('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" />;
-
   useEffect(() => {
     if (adobeAnalytics.isConfigured()) {
       adobeAnalytics.pushErrorEvent(404);
@@ -158,7 +152,9 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
             <div property="publisher" typeof="GovernmentOrganization">
               <Link to="https://canada.ca/" property="url">
                 <img className="h-8 w-auto" src="/assets/sig-blk-en.svg" alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
-                <span className="sr-only">/ {altLogoContent}</span>
+                <span className="sr-only">
+                  / <span lang="fr">{fr('gcweb:header.govt-of-canada.text')}</span>
+                </span>
               </Link>
               <meta property="name" content={`${en('gcweb:header.govt-of-canada.text')} / ${fr('gcweb:header.govt-of-canada.text')}`} />
               <meta property="areaServed" typeof="Country" content="Canada" />
@@ -177,7 +173,7 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
             <p className="mb-8 text-lg text-gray-500">{en('gcweb:public-not-found.page-message')}</p>
             <ul className="list-disc space-y-2 pl-10">
               <li>
-                <Trans t={en} ns={['gcweb']} i18nKey="gcweb:public-not-found.return-cdcp" components={{ englishCdcpLink }} />
+                <Trans t={en} ns={['gcweb']} i18nKey="gcweb:public-not-found.return-cdcp" components={{ englishCdcpLink: <InlineLink to={en('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" /> }} />
               </li>
             </ul>
           </div>
@@ -189,7 +185,7 @@ export function BilingualNotFoundError({ error }: BilingualNotFoundErrorProps) {
             <p className="mb-8 text-lg text-gray-500">{fr('gcweb:public-not-found.page-message')}</p>
             <ul className="list-disc space-y-2 pl-10">
               <li>
-                <Trans t={fr} ns={['gcweb']} i18nKey="gcweb:public-not-found.return-cdcp" components={{ frenchCdcpLink }} />
+                <Trans t={fr} ns={['gcweb']} i18nKey="gcweb:public-not-found.return-cdcp" components={{ frenchCdcpLink: <InlineLink to={fr('gcweb:public-not-found.cdcp-link')} className="external-link" newTabIndicator target="_blank" /> }} />
               </li>
             </ul>
           </div>

--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -15,15 +15,15 @@ export interface PageHeaderBrandProps {
 
 export function PageHeaderBrand({ headerLogoUrl }: PageHeaderBrandProps) {
   const { i18n, t } = useTranslation(['gcweb']);
-
   const altLanguage = getAltLanguage(i18n.language);
-  const altLogoContent = <span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>;
+
   const headerLogo = (
     <>
       <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
-      <span className="sr-only">{altLogoContent}</span>
+      <span className="sr-only">{<span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>}</span>
     </>
   );
+
   return (
     <div id="wb-bnr">
       <div className="container flex items-center justify-between gap-6 py-2.5 sm:py-3.5">

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -36,16 +36,31 @@ export function isAppLocale(value: unknown): value is AppLocale {
  * Returns the alternate language for the given input language.
  * (ie: 'en' → 'fr'; 'fr' → 'en')
  */
-export function getAltLanguage(language?: string) {
-  if (!isAppLocale(language)) {
-    throw new Error(`Unexpected language: ${language}`);
-  }
-
+export function getAltLanguage(language: string): AppLocale {
   switch (language) {
     case 'en':
       return 'fr';
     case 'fr':
       return 'en';
+    default:
+      throw new Error(`Could not determine altLanguage for language: ${language}.`);
+  }
+}
+
+/**
+ * Extracts the language code from a given pathname.
+ *
+ * @param pathname - The pathname to extract the language from.
+ * @returns The language code ('en' or 'fr') if found, otherwise undefined.
+ */
+export function getLanguage(pathname: string): AppLocale {
+  switch (true) {
+    case pathname === '/en' || pathname.startsWith('/en/'):
+      return 'en';
+    case pathname === '/fr' || pathname.startsWith('/fr/'):
+      return 'fr';
+    default:
+      throw new Error(`Could not determine language for pathname: ${pathname}.`);
   }
 }
 
@@ -124,8 +139,6 @@ export function getTypedI18nNamespaces<const T extends Readonly<FlatNamespace>, 
 /**
  * Returns translation based off provided locale
  *
- * @param language
- * @param { english translation, french translation}
  * @returns either the english translation or the french translation.
  */
 export function getNameByLanguage<T extends { nameEn: string; nameFr: string } | { nameEn?: string; nameFr?: string }>(language: string, obj: T): T extends { nameEn: infer N; nameFr: infer F } ? (typeof language extends 'fr' ? F : N) : never {


### PR DESCRIPTION
### Description

An iterative PR to prepare for eventually replacing `/:lang/` in our routes with `/en/` and `/fr/`.

This PR adds a `getLanguage(pathname)` function to determine the language from a given URL path, and makes `language` a required parameter of `getAltLanguage(language)`.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

I didn't run the tests before pushing.. if my build fails I'll push a fixup commit.