### PR TITLE
Add `useCurrentLanguage()` hook

### DIFF
--- a/frontend/__tests__/components/language-switcher.test.tsx
+++ b/frontend/__tests__/components/language-switcher.test.tsx
@@ -30,6 +30,13 @@ vi.mock('@remix-run/react', async (actual) => {
   };
 });
 
+vi.mock('~/hooks', () => ({
+  useCurrentLanguage: vi.fn().mockReturnValue({
+    currentLanguage: 'en',
+    altLanguage: 'fr',
+  }),
+}));
+
 vi.mock('~/utils/env-utils', () => ({
   getClientEnv: vi.fn(),
 }));

--- a/frontend/__tests__/components/page-header-brand.test.tsx
+++ b/frontend/__tests__/components/page-header-brand.test.tsx
@@ -19,6 +19,13 @@ vi.mock('~/components/language-switcher', () => ({
   LanguageSwitcher: vi.fn().mockImplementation(({ children }) => <div>{children}</div>),
 }));
 
+vi.mock('~/hooks', () => ({
+  useCurrentLanguage: vi.fn().mockReturnValue({
+    currentLanguage: 'en',
+    altLanguage: 'fr',
+  }),
+}));
+
 vi.mock('~/utils/locale-utils.ts', () => ({
   getAltLanguage: (lang: string) => lang,
 }));

--- a/frontend/__tests__/components/progress.test.tsx
+++ b/frontend/__tests__/components/progress.test.tsx
@@ -4,9 +4,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Progress } from '~/components/progress';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    i18n: { language: 'en' },
+vi.mock('~/hooks', () => ({
+  useCurrentLanguage: vi.fn().mockReturnValue({
+    currentLanguage: 'en',
+    altLanguage: 'fr',
   }),
 }));
 

--- a/frontend/__tests__/hooks/use-current-language.hook.test.ts
+++ b/frontend/__tests__/hooks/use-current-language.hook.test.ts
@@ -1,0 +1,53 @@
+import { useLocation } from '@remix-run/react';
+
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { useCurrentLanguage } from '~/hooks/use-current-language.hook';
+import { getAltLanguage, getLanguage } from '~/utils/locale-utils';
+
+vi.mock('@remix-run/react', () => ({
+  useLocation: vi.fn(),
+}));
+
+vi.mock('~/utils/locale-utils', () => ({
+  getLanguage: vi.fn(),
+  getAltLanguage: vi.fn(),
+}));
+
+describe('useCurrentLanguage', () => {
+  it('should return the current and alternate languages', () => {
+    vi.mocked(useLocation).mockReturnValue(mock({ pathname: '/en/some-route' }));
+    vi.mocked(getLanguage).mockReturnValue('en');
+    vi.mocked(getAltLanguage).mockReturnValue('fr');
+
+    expect(useCurrentLanguage()).toEqual({ currentLanguage: 'en', altLanguage: 'fr' });
+  });
+
+  it('should return the current and alternate languages for french', () => {
+    vi.mocked(useLocation).mockReturnValue(mock({ pathname: '/fr/some-route' }));
+    vi.mocked(getLanguage).mockReturnValue('fr');
+    vi.mocked(getAltLanguage).mockReturnValue('en');
+
+    expect(useCurrentLanguage()).toEqual({ currentLanguage: 'fr', altLanguage: 'en' });
+  });
+
+  it('should throw when no langauge can be detected)', () => {
+    vi.mocked(useLocation).mockReturnValue(mock({ pathname: '/some-route' }));
+    vi.mocked(getLanguage).mockImplementation(() => {
+      throw new Error(`Could not determine language for pathname: /some-route.`);
+    });
+
+    expect(() => useCurrentLanguage()).toThrowError(`Could not determine language for pathname: /some-route.`);
+  });
+
+  it('should throw when no altLangauge can be detected)', () => {
+    vi.mocked(useLocation).mockReturnValue(mock({ pathname: '/some-route' }));
+    vi.mocked(getLanguage).mockReturnValue('en');
+    vi.mocked(getAltLanguage).mockImplementation(() => {
+      throw new Error('Could not determine altLanguage for language: en');
+    });
+
+    expect(() => useCurrentLanguage()).toThrowError('Could not determine altLanguage for language: en');
+  });
+});

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -8,6 +8,7 @@ import { InputHelp } from './input-help';
 import { InputLabel } from './input-label';
 import { InputLegend } from './input-legend';
 import { InputOption } from './input-option';
+import { useCurrentLanguage } from '~/hooks';
 import { extractDateParts, useMonths } from '~/utils/date-utils';
 import { padWithZero } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
@@ -40,7 +41,8 @@ export interface DatePickerFieldProps {
 }
 
 export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, names, required }: DatePickerFieldProps) => {
-  const { i18n, t } = useTranslation(['gcweb']);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(['gcweb']);
   const [value] = useState(extractDateParts(defaultValue));
 
   const inputWrapperId = `date-picker-${id}`;
@@ -171,7 +173,7 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
         {(datePickerErrorMessages.all !== undefined || datePickerErrorMessages.year !== undefined || datePickerErrorMessages.month !== undefined || datePickerErrorMessages.day !== undefined) && (
           <div className="mb-2 space-y-2">
             {datePickerErrorMessages.all && <p>{datePickerErrorMessages.all}</p>}
-            {i18n.language === 'fr' ? (
+            {currentLanguage === 'fr' ? (
               <>
                 {datePickerErrorMessages.day && <p>{datePickerErrorMessages.day}</p>}
                 {datePickerErrorMessages.month && <p>{datePickerErrorMessages.month}</p>}
@@ -192,7 +194,7 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
           </InputHelp>
         )}
         <div className="flex flex-col space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
-          {i18n.language === 'fr' ? (
+          {currentLanguage === 'fr' ? (
             <>
               {datePickerDay}
               {datePickerMonth}
@@ -230,8 +232,8 @@ interface DatePickerMonthProps {
 }
 
 function DatePickerMonth({ ariaDescribedBy, ariaErrorMessage, className, defaultValue, disabled, id, label, name, placeholder, required }: DatePickerMonthProps) {
-  const { i18n } = useTranslation(['gcweb']);
-  const months = useMonths(i18n.language);
+  const { currentLanguage } = useCurrentLanguage();
+  const months = useMonths(currentLanguage);
 
   const selectId = `date-picker-${id}-month`;
   const wrapperId = `date-picker-${id}-month-wrapper`;

--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -2,8 +2,8 @@ import { useMatches, useParams, useSearchParams } from '@remix-run/react';
 
 import type { InlineLinkProps } from '~/components/inline-link';
 import { InlineLink } from '~/components/inline-link';
+import { useCurrentLanguage } from '~/hooks';
 import { isI18nPageRoute } from '~/routes/routes';
-import { getAltLanguage } from '~/utils/locale-utils';
 import { findRouteById, getPathById } from '~/utils/route-utils';
 
 export type LanguageSwitcherProps = OmitStrict<InlineLinkProps, 'to' | 'reloadDocument'>;
@@ -13,21 +13,16 @@ export type LanguageSwitcherProps = OmitStrict<InlineLinkProps, 'to' | 'reloadDo
  * (ie: 'en' → 'fr'; 'fr' → 'en')
  */
 export function LanguageSwitcher({ children, ...props }: LanguageSwitcherProps) {
+  const { altLanguage } = useCurrentLanguage();
   const matches = useMatches();
   const params = useParams();
   const [searchParams] = useSearchParams();
 
-  // can't toggle language if we don't know our current language
-  if (params.lang === undefined) {
-    return <></>;
-  }
-
-  const altLang = getAltLanguage(params.lang);
   const currentRoute = matches[matches.length - 1];
   const routeId = currentRoute.id.replace(/-(en|fr)$/, '');
   const route = findRouteById(routeId);
   const pathname = isI18nPageRoute(route) //
-    ? getPathById(routeId, { ...params, lang: altLang })
+    ? getPathById(routeId, { ...params, lang: altLanguage })
     : switchLanguage(currentRoute.pathname);
 
   const search = searchParams.toString();

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -12,6 +12,7 @@ import { PageDetails } from '~/components/page-details';
 import { PageHeaderBrand } from '~/components/page-header-brand';
 import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
+import { useCurrentLanguage } from '~/hooks';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
@@ -56,11 +57,12 @@ export function AppPageTitle({ children }: PropsWithChildren) {
 }
 
 function PageHeader() {
-  const { t, i18n } = useTranslation(i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(i18nNamespaces);
   const { HEADER_LOGO_URL_EN, HEADER_LOGO_URL_FR } = getClientEnv();
 
   // Select the correct logo URL based on the current language
-  const headerLogoUrl = i18n.language === 'fr' ? HEADER_LOGO_URL_FR : HEADER_LOGO_URL_EN;
+  const headerLogoUrl = currentLanguage === 'fr' ? HEADER_LOGO_URL_FR : HEADER_LOGO_URL_EN;
 
   return (
     <header className="border-b-[3px] border-slate-700 print:hidden">

--- a/frontend/app/components/page-header-brand.tsx
+++ b/frontend/app/components/page-header-brand.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
-import { getAltLanguage } from '~/utils/locale-utils';
+import { useCurrentLanguage } from '~/hooks';
 
 export interface PageHeaderBrandProps {
   /**
@@ -14,12 +14,12 @@ export interface PageHeaderBrandProps {
 }
 
 export function PageHeaderBrand({ headerLogoUrl }: PageHeaderBrandProps) {
+  const { currentLanguage, altLanguage } = useCurrentLanguage();
   const { i18n, t } = useTranslation(['gcweb']);
-  const altLanguage = getAltLanguage(i18n.language);
 
   const headerLogo = (
     <>
-      <img className="h-8 w-auto" src={`/assets/sig-blk-${i18n.language}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
+      <img className="h-8 w-auto" src={`/assets/sig-blk-${currentLanguage}.svg`} alt={t('gcweb:header.govt-of-canada.text')} property="logo" width="300" height="28" decoding="async" />
       <span className="sr-only">{<span lang={altLanguage}>{i18n.getFixedT(altLanguage)('gcweb:header.govt-of-canada.text')}</span>}</span>
     </>
   );

--- a/frontend/app/components/progress.tsx
+++ b/frontend/app/components/progress.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import * as ProgressPrimitive from '@radix-ui/react-progress';
-import { useTranslation } from 'react-i18next';
 
+import { useCurrentLanguage } from '~/hooks';
 import { formatPercent } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
@@ -33,10 +33,10 @@ export interface ProgressProps extends React.ComponentPropsWithoutRef<typeof Pro
 }
 
 const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(({ className, size = 'base', variant = 'default', value, label, ...props }, ref) => {
-  const { i18n } = useTranslation('gcweb');
+  const { currentLanguage } = useCurrentLanguage();
   return (
     <>
-      {label && <p id="progress-label" className="mb-2">{`${label} ${formatPercent(value, i18n.language)}`}</p>}
+      {label && <p id="progress-label" className="mb-2">{`${label} ${formatPercent(value, currentLanguage)}`}</p>}
       <ProgressPrimitive.Root ref={ref} className={cn(rootBaseClassName, sizes[size], className)} data-testid="progress-root" value={value} {...props} aria-labelledby={label && 'progress-label'}>
         <ProgressPrimitive.Indicator className={cn(indicatorBaseClassName, variants[variant])} style={{ transform: `translateX(-${100 - value}%)` }} data-testid="progress-indicator" />
       </ProgressPrimitive.Root>

--- a/frontend/app/hooks/index.ts
+++ b/frontend/app/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from './use-current-language.hook';
 export * from './use-enhanced-fetcher.hook';
 export * from './use-fetcher-key.hook';

--- a/frontend/app/hooks/use-current-language.hook.tsx
+++ b/frontend/app/hooks/use-current-language.hook.tsx
@@ -1,0 +1,21 @@
+import { useLocation } from '@remix-run/react';
+
+import { getAltLanguage, getLanguage } from '~/utils/locale-utils';
+
+type UseCurrentLanguageReturnType = {
+  altLanguage: AppLocale;
+  currentLanguage: AppLocale;
+};
+
+/**
+ * A hook that returns the current language and its alternate language.
+ *
+ * @returns An object containing the current language the alternate language.
+ * @throws {Error} If no language can be detected for the current route.
+ */
+export function useCurrentLanguage(): UseCurrentLanguageReturnType {
+  const { pathname } = useLocation();
+  const currentLanguage = getLanguage(pathname);
+  const altLanguage = getAltLanguage(currentLanguage);
+  return { altLanguage, currentLanguage };
+}

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -12,6 +12,7 @@ import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { InlineLink } from '~/components/inline-link';
 import { InputSelect } from '~/components/input-select';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getInstrumentationService } from '~/services/instrumentation-service.server';
 import { getRaoidcService } from '~/services/raoidc-service.server';
@@ -82,8 +83,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export default function LettersIndex() {
+  const { currentLanguage } = useCurrentLanguage();
   const [, setSearchParams] = useSearchParams();
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { letters, letterTypes, sortOrder, SCCH_BASE_URI } = useLoaderData<typeof loader>();
   const params = useParams();
 
@@ -121,7 +123,7 @@ export default function LettersIndex() {
             {letters.map((letter) => {
               const letterType = letterTypes.find(({ id }) => id === letter.letterTypeId);
               const gcAnalyticsCustomClickValue = `ESDC-EDSC:CDCP Letters Click:${letterType?.nameEn ?? letter.letterTypeId}`;
-              const letterName = letterType ? getNameByLanguage(i18n.language, letterType) : letter.letterTypeId;
+              const letterName = letterType ? getNameByLanguage(currentLanguage, letterType) : letter.letterTypeId;
 
               return (
                 <li key={letter.id} className="py-4 sm:py-6">

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -19,6 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { LoadingButton } from '~/components/loading-button';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { ChildInformationState, ChildSinState } from '~/route-helpers/apply-route-helpers.server';
@@ -221,7 +222,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowChildInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, childName, editMode, isNew } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -232,7 +234,7 @@ export default function ApplyFlowChildInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -17,6 +17,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import { getChildrenState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -119,7 +120,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowChildSummary() {
-  const { t, i18n } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, children, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -154,7 +156,7 @@ export default function ApplyFlowChildSummary() {
           <div className="mt-6 space-y-8">
             {children.map((child) => {
               const childName = `${child.information?.firstName} ${child.information?.lastName}`;
-              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language) : '';
+              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), currentLanguage) : '';
               return (
                 <section key={child.id}>
                   <h2 className="mb-4 font-lato text-2xl font-bold">{childName}</h2>

--- a/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
@@ -14,6 +14,7 @@ import { InlineLink } from '~/components/inline-link';
 import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import { getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -184,7 +185,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowDateOfBirth() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -192,7 +194,7 @@ export default function ApplyFlowDateOfBirth() {
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -15,6 +15,7 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultChildState } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -167,7 +168,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -177,7 +179,7 @@ export default function ApplyFlowApplicationInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -19,6 +19,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultChildStateForReview } from '~/route-helpers/apply-adult-child-route-helpers.server';
 import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -156,8 +157,9 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ReviewInformation() {
+  const { currentLanguage } = useCurrentLanguage();
   const params = useParams();
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { children, csrfToken, siteKey, hCaptchaEnabled, payload } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -200,7 +202,7 @@ export default function ReviewInformation() {
         <div className="space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), i18n.language);
+            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), currentLanguage);
             return (
               <section key={child.id} className="space-y-8">
                 <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>

--- a/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
@@ -11,6 +11,7 @@ import { DatePickerField } from '~/components/date-picker-field';
 import { useErrorSummary } from '~/components/error-summary';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import { getAgeCategoryFromDateString, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -159,7 +160,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowDateOfBirth() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -167,7 +169,7 @@ export default function ApplyFlowDateOfBirth() {
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -15,6 +15,7 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyAdultState } from '~/route-helpers/apply-adult-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -161,7 +162,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -171,7 +173,7 @@ export default function ApplyFlowApplicationInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -20,6 +20,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { ApplicantInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -229,7 +230,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, dateOfBirth, maritalStatuses, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -239,7 +241,7 @@ export default function ApplyFlowApplicationInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -19,6 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { LoadingButton } from '~/components/loading-button';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyChildState, loadApplySingleChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { ChildInformationState, ChildSinState } from '~/route-helpers/apply-route-helpers.server';
@@ -221,7 +222,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowChildInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, childName, editMode, isNew } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -232,7 +234,7 @@ export default function ApplyFlowChildInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -17,6 +17,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import { getChildrenState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -112,7 +113,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowChildSummary() {
-  const { t, i18n } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, children, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -147,7 +149,7 @@ export default function ApplyFlowChildSummary() {
           <div className="mt-6 space-y-8">
             {children.map((child) => {
               const childName = `${child.information?.firstName} ${child.information?.lastName}`;
-              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language) : '';
+              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), currentLanguage) : '';
               return (
                 <section key={child.id}>
                   <h2 className="mb-4 font-lato text-2xl font-bold">{childName}</h2>

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -15,6 +15,7 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyChildState } from '~/route-helpers/apply-child-route-helpers.server';
 import type { PartnerInformationState } from '~/route-helpers/apply-route-helpers.server';
@@ -166,7 +167,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ApplyFlowApplicationInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -176,7 +178,7 @@ export default function ApplyFlowApplicationInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -17,6 +17,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadApplyChildStateForReview } from '~/route-helpers/apply-child-route-helpers.server';
 import { clearApplyState, saveApplyState } from '~/route-helpers/apply-route-helpers.server';
@@ -146,8 +147,9 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function ReviewInformation() {
+  const { currentLanguage } = useCurrentLanguage();
   const params = useParams();
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { children, csrfToken, siteKey, hCaptchaEnabled } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -190,7 +192,7 @@ export default function ReviewInformation() {
         <div className="mb-8 space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), i18n.language);
+            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), currentLanguage);
             return (
               <section key={child.id} className="space-y-10">
                 <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -18,6 +18,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { LoadingButton } from '~/components/loading-button';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import { saveRenewState } from '~/route-helpers/renew-route-helpers.server';
@@ -207,7 +208,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function RenewFlowChildInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, defaultState, childName, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -218,7 +220,7 @@ export default function RenewFlowChildInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -17,6 +17,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { loadRenewAdultChildState } from '~/route-helpers/renew-adult-child-route-helpers.server';
 import { getChildrenState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
@@ -126,7 +127,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function RenewFlowChildSummary() {
-  const { t, i18n } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { csrfToken, children, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -162,7 +164,7 @@ export default function RenewFlowChildSummary() {
           <div className="mt-6 space-y-8">
             {children.map((child) => {
               const childName = `${child.information?.firstName} ${child.information?.lastName}`;
-              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), i18n.language) : '';
+              const dateOfBirth = child.information?.dateOfBirth ? toLocaleDateString(parseDateString(child.information.dateOfBirth), currentLanguage) : '';
               return (
                 <section key={child.id}>
                   <h2 className="mb-4 font-lato text-2xl font-bold">{childName}</h2>

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -18,6 +18,7 @@ import { DescriptionListItem } from '~/components/description-list-item';
 import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { toBenefitRenewRequestFromRenewAdultChildState } from '~/mappers/benefit-renewal-service-mappers.server';
 import { pageIds } from '~/page-ids';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/hcaptcha-route-helpers.server';
@@ -149,8 +150,9 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function RenewAdultChildReviewChildInformation() {
+  const { currentLanguage } = useCurrentLanguage();
   const params = useParams();
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { children, csrfToken, siteKey, hCaptchaEnabled, payload } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -193,7 +195,7 @@ export default function RenewAdultChildReviewChildInformation() {
         <div className="space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), i18n.language);
+            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), currentLanguage);
             return (
               <section key={child.id} className="space-y-8">
                 <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -19,6 +19,7 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import type { ApplicantInformationState } from '~/route-helpers/renew-route-helpers.server';
 import { loadRenewState, saveRenewState } from '~/route-helpers/renew-route-helpers.server';
@@ -165,7 +166,8 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function RenewApplicationInformation() {
-  const { i18n, t } = useTranslation(handle.i18nNamespaces);
+  const { currentLanguage } = useCurrentLanguage();
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, editMode, csrfToken } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -176,7 +178,7 @@ export default function RenewApplicationInformation() {
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -20,6 +20,7 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { LoadingButton } from '~/components/loading-button';
+import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getHCaptchaRouteHelpers } from '~/route-helpers/hcaptcha-route-helpers.server';
 import { getStatusResultUrl, saveStatusState, startStatusState } from '~/route-helpers/status-route-helpers.server';
@@ -227,10 +228,11 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 
 export default function StatusCheckerChild() {
+  const { currentLanguage } = useCurrentLanguage();
   const { csrfToken, hCaptchaEnabled, siteKey } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const { t, i18n } = useTranslation(handle.i18nNamespaces);
+  const { t } = useTranslation(handle.i18nNamespaces);
   const { captchaRef } = useHCaptcha();
   const params = useParams();
   const [childHasSinState, setChildHasSinState] = useState<boolean>();
@@ -242,7 +244,7 @@ export default function StatusCheckerChild() {
     sin: 'sin',
     firstName: 'first-name',
     lastName: 'last-name',
-    ...(i18n.language === 'fr'
+    ...(currentLanguage === 'fr'
       ? { dateOfBirth: 'date-picker-date-of-birth-day', dateOfBirthDay: 'date-picker-date-of-birth-day', dateOfBirthMonth: 'date-picker-date-of-birth-month' }
       : { dateOfBirth: 'date-picker-date-of-birth-month', dateOfBirthMonth: 'date-picker-date-of-birth-month', dateOfBirthDay: 'date-picker-date-of-birth-day' }),
     dateOfBirthYear: 'date-picker-date-of-birth-year',


### PR DESCRIPTION
### Description

Add `useCurrentLanguage()` hook and update routes, components, and tests to use it.

This is an incremental PR intended to refactor or add some code with the hopes of eventually removing the `:lang` parameter from all of our route paths.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`
