### PR TITLE
add first name validation to input fields

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -114,14 +114,20 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult-child:children.information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-adult-child:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:applicant-information.error-message.characters-valid')),
+    firstName: z
+      .string()
+      .trim()
+      .min(1, t('apply-adult-child:applicant-information.error-message.first-name-required'))
+      .max(100)
+      .refine(isAllValidInputCharacters, t('apply-adult-child:applicant-information.error-message.characters-valid'))
+      .refine((firstName) => !hasDigits(firstName), t('apply-adult-child:applicant-information.error-message.first-name-no-digits')),
     lastName: z
       .string()
       .trim()
       .min(1, t('apply-adult-child:applicant-information.error-message.last-name-required'))
       .max(100)
       .refine(isAllValidInputCharacters, t('apply-adult-child:applicant-information.error-message.characters-valid'))
-      .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:applicant-information.error-message.no-digits')),
+      .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:applicant-information.error-message.last-name-no-digits')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-adult-child:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -87,14 +87,20 @@ export async function action({ context: { appContainer, session }, params, reque
   // state validation schema
   const childInformationSchema = z
     .object({
-      firstName: z.string().trim().min(1, t('apply-adult-child:children.information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:children.information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('apply-adult-child:children.information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('apply-adult-child:children.information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('apply-adult-child:children.information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('apply-adult-child:children.information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('apply-adult-child:children.information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:children.information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:children.information.error-message.last-name-no-digits')),
       dateOfBirthYear: z.number({
         required_error: t('apply-adult-child:children.information.error-message.date-of-birth-year-required'),
         invalid_type_error: t('apply-adult-child:children.information.error-message.date-of-birth-year-number'),

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -79,14 +79,20 @@ export async function action({ context: { appContainer, session }, params, reque
         invalid_type_error: t('apply-adult-child:partner-information.error-message.date-of-birth-day-number'),
       }),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-adult-child:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult-child:partner-information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('apply-adult-child:partner-information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('apply-adult-child:partner-information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('apply-adult-child:applicant-information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('apply-adult-child:partner-information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('apply-adult-child:partner-information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:applicant-information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('apply-adult-child:applicant-information.error-message.last-name-no-digits')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -108,14 +108,20 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:applicant-information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-adult:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:applicant-information.error-message.characters-valid')),
+    firstName: z
+      .string()
+      .trim()
+      .min(1, t('apply-adult:applicant-information.error-message.first-name-required'))
+      .max(100)
+      .refine(isAllValidInputCharacters, t('apply-adult:applicant-information.error-message.characters-valid'))
+      .refine((firstName) => !hasDigits(firstName), t('apply-adult:applicant-information.error-message.first-name-no-digits')),
     lastName: z
       .string()
       .trim()
       .min(1, t('apply-adult:applicant-information.error-message.last-name-required'))
       .max(100)
       .refine(isAllValidInputCharacters, t('apply-adult:applicant-information.error-message.characters-valid'))
-      .refine((lastName) => !hasDigits(lastName), t('apply-adult:applicant-information.error-message.no-digits')),
+      .refine((lastName) => !hasDigits(lastName), t('apply-adult:applicant-information.error-message.last-name-no-digits')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-adult:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -78,14 +78,20 @@ export async function action({ context: { appContainer, session }, params, reque
         invalid_type_error: t('apply-adult:partner-information.error-message.date-of-birth-day-number'),
       }),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-adult:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-adult:partner-information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('apply-adult:partner-information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('apply-adult:partner-information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('apply-adult:applicant-information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('apply-adult:partner-information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('apply-adult:partner-information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('apply-adult:applicant-information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('apply-adult:applicant-information.error-message.last-name-no-digits')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -148,14 +148,20 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-child:children.information.error-message.sin-unique') });
         }
       }),
-    firstName: z.string().trim().min(1, t('apply-child:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:applicant-information.error-message.characters-valid')),
+    firstName: z
+      .string()
+      .trim()
+      .min(1, t('apply-child:applicant-information.error-message.first-name-required'))
+      .max(100)
+      .refine(isAllValidInputCharacters, t('apply-child:applicant-information.error-message.characters-valid'))
+      .refine((firstName) => !hasDigits(firstName), t('apply-child:applicant-information.error-message.first-name-no-digits')),
     lastName: z
       .string()
       .trim()
       .min(1, t('apply-child:applicant-information.error-message.last-name-required'))
       .max(100)
       .refine(isAllValidInputCharacters, t('apply-child:applicant-information.error-message.characters-valid'))
-      .refine((lastName) => !hasDigits(lastName), t('apply-child:applicant-information.error-message.no-digits')),
+      .refine((lastName) => !hasDigits(lastName), t('apply-child:applicant-information.error-message.last-name-no-digits')),
     maritalStatus: z
       .string({ errorMap: () => ({ message: t('apply-child:applicant-information.error-message.marital-status-required') }) })
       .trim()

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -87,14 +87,20 @@ export async function action({ context: { appContainer, session }, params, reque
   // state validation schema
   const childInformationSchema = z
     .object({
-      firstName: z.string().trim().min(1, t('apply-child:children.information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:children.information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('apply-child:children.information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('apply-child:children.information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('apply-child:children.information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('apply-child:children.information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('apply-child:children.information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('apply-child:children.information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('apply-child:children.information.error-message.last-name-no-digits')),
       dateOfBirthYear: z.number({
         required_error: t('apply-child:children.information.error-message.date-of-birth-year-required'),
         invalid_type_error: t('apply-child:children.information.error-message.date-of-birth-year-number'),

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -78,14 +78,20 @@ export async function action({ context: { appContainer, session }, params, reque
         invalid_type_error: t('apply-child:partner-information.error-message.date-of-birth-day-number'),
       }),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('apply-child:partner-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('apply-child:partner-information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('apply-child:partner-information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('apply-child:partner-information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('apply-child:partner-information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('apply-child:partner-information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('apply-child:partner-information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('apply-child:partner-information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('apply-child:partner-information.error-message.last-name-no-digits')),
       socialInsuranceNumber: z
         .string()
         .trim()

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -89,14 +89,20 @@ export async function action({ context: { appContainer, session }, params, reque
   // state validation schema
   const childInformationSchema = z
     .object({
-      firstName: z.string().trim().min(1, t('renew-adult-child:children.information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('renew-adult-child:children.information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('renew-adult-child:children.information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('renew-adult-child:children.information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('renew-adult-child:children.information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('renew-adult-child:children.information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('renew-adult-child:children.information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('renew-adult-child:children.information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('renew-adult-child:children.information.error-message.last-name-no-digits')),
       dateOfBirthYear: z.number({
         required_error: t('renew-adult-child:children.information.error-message.date-of-birth-year-required'),
         invalid_type_error: t('renew-adult-child:children.information.error-message.date-of-birth-year-number'),

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -78,14 +78,20 @@ export async function action({ context: { appContainer, session }, params, reque
         invalid_type_error: t('renew:applicant-information.error-message.date-of-birth-day-number'),
       }),
       dateOfBirth: z.string(),
-      firstName: z.string().trim().min(1, t('renew:applicant-information.error-message.first-name-required')).max(100).refine(isAllValidInputCharacters, t('renew:applicant-information.error-message.characters-valid')),
+      firstName: z
+        .string()
+        .trim()
+        .min(1, t('renew:applicant-information.error-message.first-name-required'))
+        .max(100)
+        .refine(isAllValidInputCharacters, t('renew:applicant-information.error-message.characters-valid'))
+        .refine((firstName) => !hasDigits(firstName), t('renew:applicant-information.error-message.first-name-no-digits')),
       lastName: z
         .string()
         .trim()
         .min(1, t('renew:applicant-information.error-message.last-name-required'))
         .max(100)
         .refine(isAllValidInputCharacters, t('renew:applicant-information.error-message.characters-valid'))
-        .refine((lastName) => !hasDigits(lastName), t('renew:applicant-information.error-message.no-digits')),
+        .refine((lastName) => !hasDigits(lastName), t('renew:applicant-information.error-message.last-name-no-digits')),
       clientNumber: z
         .string()
         .trim()

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -25,7 +25,8 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "children": {
@@ -94,7 +95,8 @@
         "has-social-insurance-number": "Select whether the child has a SIN",
         "is-parent": "Select whether you are the parent or legal guardian of the child",
         "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-        "no-digits": "Last name must contain letters only"
+        "first-name-no-digits": "First name must contain letters only",
+        "last-name-no-digits": "Last name must contain letters only"
       }
     },
     "dental-insurance": {
@@ -605,7 +607,8 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "review-adult-information": {

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -25,7 +25,8 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "communication-preference": {
@@ -288,7 +289,8 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -34,7 +34,8 @@
       "date-of-birth-year-number": "Year must be a number, for example 1950",
       "date-of-birth-year-required": "Date of birth must include a year",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "children": {
@@ -102,7 +103,8 @@
         "has-social-insurance-number": "Select whether the child has a SIN",
         "is-parent": "Select whether you are the parent or legal guardian of the child",
         "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-        "no-digits": "Last name must contain letters only"
+        "first-name-no-digits": "First name must contain letters only",
+        "last-name-no-digits": "Last name must contain letters only"
       }
     },
     "dental-insurance": {
@@ -369,7 +371,8 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-      "no-digits": "Last name must contain letters only"
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -332,7 +332,8 @@
         "client-number-valid": "Must be a valid client number. Your input must be 11 or 13 digits long.",
         "is-parent": "Select whether you are the parent or legal guardian of the child",
         "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
-        "no-digits": "Last name must contain letters only"
+        "first-name-no-digits": "First name must contain letters only",
+        "last-name-no-digits": "Last name must contain letters only"
       }
     },
     "parent-or-guardian": {

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -137,7 +137,8 @@
       "date-of-birth-year-required": "Date of birth must include a year",
       "first-name-required": "Enter first name",
       "last-name-required": "Enter last name",
-      "no-digits": "Last name must contain letters only",
+      "first-name-no-digits": "First name must contain letters only",
+      "last-name-no-digits": "Last name must contain letters only",
       "client-number-required": "Enter client number",
       "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()",
       "client-number-valid": "Must be a valid client number. Your input must be 11 or 13 digits long."

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -25,7 +25,8 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "children": {
@@ -94,7 +95,8 @@
         "has-social-insurance-number": "Sélectionnez cet enfant a un NAS",
         "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant",
         "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-        "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+        "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+        "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
       }
     },
     "dental-insurance": {
@@ -605,7 +607,8 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "review-adult-information": {

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -25,7 +25,8 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "communication-preference": {
@@ -288,7 +289,8 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -34,7 +34,8 @@
       "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
       "date-of-birth-year-required": "La date de naissance doit inclure une année",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "children": {
@@ -102,7 +103,8 @@
         "has-social-insurance-number": "Sélectionnez cet enfant a un NAS",
         "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant",
         "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-        "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+        "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+        "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
       }
     },
     "dental-insurance": {
@@ -369,7 +371,8 @@
       "sin-valid": "Le NAS doit être valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres"
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
   "contact-information": {

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -332,7 +332,8 @@
         "client-number-valid": "Doit être un numéro de client valide. Votre saisie doit comporter 11, 13 chiffres",
         "is-parent": "Sélectionnez si vous êtes le parent ou le tuteur légal de l'enfant",
         "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés\u00a0: apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
-        "no-digits": "Le nom de famille doit contenir uniquement des lettres",
+        "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+        "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres",
         "no-record": "Aucun dossier correspondant trouvé pour votre enfant"
       }
     },

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -137,7 +137,8 @@
       "date-of-birth-year-required": "La date de naissance doit inclure une année",
       "first-name-required": "Entrez le prénom",
       "last-name-required": "Entrez le nom de famille",
-      "no-digits": "Le nom de famille doit contenir uniquement des lettres",
+      "first-name-no-digits": "Le prénom doit contenir uniquement des lettres",
+      "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres",
       "client-number-required": "Entrez le numéro de client ",
       "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et parenthèse ()",
       "client-number-valid": "Doit être un numéro de client valide. Votre saisie doit comporter 11, 13 chiffres"


### PR DESCRIPTION
### Description
Ensures digits can't be accepted as input in `first-name` input fields (similar to what's been implemented in the past for `last-name` inputs).

### Related Azure Boards Work Items
[AB#4858](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4858)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`