### PR TITLE
Mapping from adult/child renewal state to benefit renewal DTO

### DIFF
--- a/frontend/app/.server/container-modules/mappers.container-module.ts
+++ b/frontend/app/.server/container-modules/mappers.container-module.ts
@@ -20,7 +20,7 @@ import {
   ProvinceTerritoryStateDtoMapperImpl,
   ProvincialGovernmentInsurancePlanDtoMapperImpl,
 } from '~/.server/domain/mappers';
-import { BenefitApplicationStateMapperImpl } from '~/.server/routes/mappers';
+import { BenefitApplicationStateMapperImpl, BenefitRenewalStateMapperImpl } from '~/.server/routes/mappers';
 import { HCaptchaDtoMapperImpl } from '~/.server/web/mappers';
 
 /**
@@ -44,6 +44,7 @@ export const mappersContainerModule = new ContainerModule((bind) => {
   bind(TYPES.domain.mappers.PreferredLanguageDtoMapper).to(PreferredLanguageDtoMapperImpl);
   bind(TYPES.domain.mappers.ProvinceTerritoryStateDtoMapper).to(ProvinceTerritoryStateDtoMapperImpl);
   bind(TYPES.domain.mappers.ProvincialGovernmentInsurancePlanDtoMapper).to(ProvincialGovernmentInsurancePlanDtoMapperImpl);
+  bind(TYPES.routes.mappers.BenefitRenewalStateMapper).to(BenefitRenewalStateMapperImpl);
   bind(TYPES.routes.mappers.BenefitApplicationStateMapper).to(BenefitApplicationStateMapperImpl);
   bind(TYPES.web.mappers.HCaptchaDtoMapper).to(HCaptchaDtoMapperImpl);
 });

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -4,16 +4,7 @@ import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, Co
 
 export type ClientApplicationDto = ReadonlyDeep<{
   applicantInformation: ApplicantInformationDto & { clientNumber?: string };
-  children: (Omit<ChildDto, 'information'> & {
-    information: {
-      firstName: string;
-      lastName: string;
-      dateOfBirth: string;
-      isParent: boolean;
-      clientNumber?: string;
-      socialInsuranceNumber: string;
-    };
-  })[];
+  children: ClientChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;
   dateOfBirth: string;
@@ -25,6 +16,17 @@ export type ClientApplicationDto = ReadonlyDeep<{
   livingIndependently?: boolean;
   partnerInformation?: PartnerInformationDto;
 }>;
+
+export type ClientChildDto = Omit<ChildDto, 'information'> & {
+  information: {
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    isParent: boolean;
+    clientNumber?: string;
+    socialInsuranceNumber: string;
+  };
+};
 
 export type ClientApplicationBasicInfoRequestDto = Readonly<{
   clientNumber: string;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -1,9 +1,11 @@
 import { injectable } from 'inversify';
+import invariant from 'tiny-invariant';
+import { ReadonlyObjectDeep } from 'type-fest/source/readonly-deep';
+import validator from 'validator';
 
-import type { BenefitRenewalDto, ClientApplicationDto } from '~/.server/domain/dtos';
+import type { ApplicantInformationDto, BenefitRenewalDto, ClientApplicationDto, ClientChildDto, ContactInformationDto, PartnerInformationDto } from '~/.server/domain/dtos';
 import type {
   AddressInformationState,
-  ApplicantInformationState,
   ChildState,
   ConfirmDentalBenefitsState,
   ContactInformationState,
@@ -15,7 +17,6 @@ import type {
 
 export interface RenewAdultChildState {
   addressInformation?: AddressInformationState;
-  applicantInformation: ApplicantInformationState;
   children: ChildState[];
   clientApplication: ClientApplicationDto;
   confirmDentalBenefits: ConfirmDentalBenefitsState;
@@ -33,10 +34,223 @@ export interface BenefitRenewalStateMapper {
   mapRenewAdultChildStateToBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): BenefitRenewalDto;
 }
 
+interface ToApplicantInformationArgs {
+  existingApplicantInformation: ReadonlyObjectDeep<ApplicantInformationDto>;
+  hasMaritalStatusChanged: boolean;
+  renewedMaritalStatus?: string;
+}
+
+interface ToChildrenArgs {
+  existingChildren: readonly ReadonlyObjectDeep<ClientChildDto>[];
+  renewedChildren: ChildState[];
+}
+
+interface ToContactInformationArgs {
+  existingContactInformation: ReadonlyObjectDeep<ContactInformationDto>;
+  hasAddressChanged: boolean;
+  hasEmailChanged: boolean;
+  hasPhoneChanged: boolean;
+  renewedAddressInformation?: AddressInformationState;
+  renewedContactInformation: ContactInformationState;
+}
+
+interface ToDentalBenefitsArgs {
+  existingDentalBenefits: readonly string[];
+  hasFederalBenefitsChanged: boolean;
+  hasProvincialTerritorialBenefitsChanged: boolean;
+  renewedDentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+}
+
+interface ToPartnerInformationArgs {
+  existingPartnerInformation?: ReadonlyObjectDeep<PartnerInformationDto>;
+  hasMaritalStatusChanged: boolean;
+  renewedPartnerInformation?: PartnerInformationState;
+}
+
 @injectable()
 export class BenefitRenewalStateMapperImpl implements BenefitRenewalStateMapper {
-  mapRenewAdultChildStateToBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): BenefitRenewalDto {
-    // TODO use the clientApplicationDto with the 'State' objects to form the BenefitRenewalDto somehow
-    throw new Error('Method not implemented.');
+  mapRenewAdultChildStateToBenefitRenewalDto({
+    addressInformation,
+    children,
+    clientApplication,
+    confirmDentalBenefits,
+    contactInformation,
+    dentalBenefits,
+    dentalInsurance,
+    hasAddressChanged,
+    hasMaritalStatusChanged,
+    maritalStatus,
+    partnerInformation,
+  }: RenewAdultChildState): BenefitRenewalDto {
+    const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
+    if (hasEmailChanged === undefined) {
+      throw Error('Expected hasEmailChanged to be defined');
+    }
+
+    const hasPhoneChanged = contactInformation.isNewOrUpdatedPhoneNumber;
+    if (hasPhoneChanged === undefined) {
+      throw Error('Expected hasPhoneChanged to be defined');
+    }
+
+    const hasFederalBenefitsChanged = confirmDentalBenefits.federalBenefitsChanged;
+    const hasProvincialTerritorialBenefitsChanged = confirmDentalBenefits.provincialTerritorialBenefitsChanged;
+
+    return {
+      ...clientApplication,
+      applicantInformation: this.toApplicantInformation({
+        existingApplicantInformation: clientApplication.applicantInformation,
+        hasMaritalStatusChanged,
+        renewedMaritalStatus: maritalStatus,
+      }),
+      children: this.toChildren({
+        existingChildren: clientApplication.children,
+        renewedChildren: children,
+      }),
+      changeIndicators: {
+        hasAddressChanged,
+        hasEmailChanged,
+        hasMaritalStatusChanged,
+        hasPhoneChanged,
+        hasFederalBenefitsChanged,
+        hasProvincialTerritorialBenefitsChanged,
+      },
+      contactInformation: this.toContactInformation({
+        renewedAddressInformation: addressInformation,
+        renewedContactInformation: contactInformation,
+        existingContactInformation: clientApplication.contactInformation,
+        hasAddressChanged,
+        hasEmailChanged,
+        hasPhoneChanged,
+      }),
+      dentalBenefits: this.toDentalBenefits({
+        existingDentalBenefits: clientApplication.dentalBenefits,
+        hasFederalBenefitsChanged,
+        hasProvincialTerritorialBenefitsChanged,
+        renewedDentalBenefits: dentalBenefits,
+      }),
+      dentalInsurance,
+      partnerInformation: this.toPartnerInformation({
+        existingPartnerInformation: clientApplication.partnerInformation,
+        hasMaritalStatusChanged,
+        renewedPartnerInformation: partnerInformation,
+      }),
+      typeOfApplication: children.length === 0 ? 'adult' : 'adult-child',
+      userId: 'anonymous',
+    };
+  }
+
+  private toApplicantInformation({ existingApplicantInformation, hasMaritalStatusChanged, renewedMaritalStatus }: ToApplicantInformationArgs) {
+    if (!hasMaritalStatusChanged) return existingApplicantInformation;
+    invariant(renewedMaritalStatus, 'Expected renewedMaritalStatus to be defined when hasMaritalStatusChanged is true');
+
+    return {
+      ...existingApplicantInformation,
+      maritalStatus: renewedMaritalStatus,
+    };
+  }
+
+  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs) {
+    return renewedChildren.map((renewedChild) => {
+      const existingChild = existingChildren.find((existingChild) => existingChild.information.clientNumber === renewedChild.information?.clientNumber);
+      invariant(existingChild, 'Expected existingChild to exist');
+
+      invariant(renewedChild.confirmDentalBenefits, 'Expected renewedChild.confirmDentalBenefits to exist');
+      invariant(renewedChild.dentalInsurance, 'Expected renewedChild.dentalInsurance to exist');
+      invariant(renewedChild.information, 'Expected renewedChild.information to exist');
+
+      return {
+        ...renewedChild,
+        dentalInsurance: renewedChild.dentalInsurance,
+        information: {
+          ...renewedChild.information,
+          socialInsuranceNumber: existingChild.information.socialInsuranceNumber,
+        },
+        dentalBenefits: this.toDentalBenefits({
+          existingDentalBenefits: existingChild.dentalBenefits,
+          hasFederalBenefitsChanged: renewedChild.confirmDentalBenefits.federalBenefitsChanged,
+          hasProvincialTerritorialBenefitsChanged: renewedChild.confirmDentalBenefits.provincialTerritorialBenefitsChanged,
+          renewedDentalBenefits: renewedChild.dentalBenefits,
+        }),
+      };
+    });
+  }
+
+  private toContactInformation({ renewedAddressInformation, renewedContactInformation, existingContactInformation, hasAddressChanged, hasEmailChanged, hasPhoneChanged }: ToContactInformationArgs) {
+    return {
+      ...existingContactInformation,
+      ...(hasAddressChanged && renewedAddressInformation
+        ? {
+            copyMailingAddress: renewedAddressInformation.copyMailingAddress,
+            ...this.toHomeAddress(renewedAddressInformation),
+            mailingAddress: renewedAddressInformation.mailingAddress,
+            mailingApartment: renewedAddressInformation.mailingApartment,
+            mailingCity: renewedAddressInformation.mailingCity,
+            mailingCountry: renewedAddressInformation.mailingCountry,
+            mailingPostalCode: renewedAddressInformation.mailingPostalCode,
+            mailingProvince: renewedAddressInformation.mailingProvince,
+          }
+        : {}),
+      ...(hasPhoneChanged
+        ? {
+            phoneNumber: renewedContactInformation.phoneNumber,
+            phoneNumberAlt: renewedContactInformation.phoneNumberAlt,
+          }
+        : {}),
+      ...(hasEmailChanged
+        ? {
+            email: renewedContactInformation.email,
+          }
+        : {}),
+    };
+  }
+
+  private toHomeAddress({ copyMailingAddress, homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince, mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: AddressInformationState) {
+    if (copyMailingAddress) {
+      return {
+        homeAddress: mailingAddress,
+        homeApartment: mailingApartment,
+        homeCity: mailingCity,
+        homeCountry: mailingCountry,
+        homePostalCode: mailingPostalCode,
+        homeProvince: mailingProvince,
+      };
+    }
+
+    invariant(homeAddress, 'Expected homeAddress to be defined when copyMailingAddress is false.');
+    invariant(homeCity, 'Expected homeCity to be defined when copyMailingAddress is false.');
+    invariant(homeCountry, 'Expected homeCountry to be defined when copyMailingAddress is false.');
+
+    return {
+      homeAddress,
+      homeApartment,
+      homeCity,
+      homeCountry,
+      homePostalCode,
+      homeProvince,
+    };
+  }
+
+  private toDentalBenefits({ hasFederalBenefitsChanged, hasProvincialTerritorialBenefitsChanged, existingDentalBenefits, renewedDentalBenefits: dentalBenefits }: ToDentalBenefitsArgs) {
+    if (!hasFederalBenefitsChanged && !hasProvincialTerritorialBenefitsChanged) return existingDentalBenefits;
+    if (!dentalBenefits) return [];
+
+    const dentalBenefitsDto = [];
+
+    if (dentalBenefits.hasFederalBenefits && dentalBenefits.federalSocialProgram && !validator.isEmpty(dentalBenefits.federalSocialProgram)) {
+      dentalBenefitsDto.push(dentalBenefits.federalSocialProgram);
+    }
+
+    if (dentalBenefits.hasProvincialTerritorialBenefits && dentalBenefits.provincialTerritorialSocialProgram && !validator.isEmpty(dentalBenefits.provincialTerritorialSocialProgram)) {
+      dentalBenefitsDto.push(dentalBenefits.provincialTerritorialSocialProgram);
+    }
+
+    return dentalBenefitsDto;
+  }
+
+  private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs) {
+    if (!hasMaritalStatusChanged) return existingPartnerInformation;
+
+    // TODO figure out how to map this since renewal doesn't have first name, last name and date of birth fields
+    return existingPartnerInformation;
   }
 }


### PR DESCRIPTION
### Description
Incremental PR that adds a preliminary implementation to the interfaces defined in #2559.
Unit tests and mapping from DTO to Entity will be done in a future PR.
`TODO` has been left until there is clarity on how to map partner information.

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Screenshots (if applicable)
Logged the benefit renewal DTO on the last step of the `/renew` flow:
![image](https://github.com/user-attachments/assets/2e1352aa-71b1-49c9-9705-156c518c6d39)


### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Add the following to `/review-adult-information` and/or `/review-child-information` and complete the renewal (adult/child) flow.
```typescript
const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewAdultChildStateToBenefitRenewalDto(state);
```
- Log the resulting `benefitRenewalDto` to inspect its structure. 
- Depending on whether you chose to change information during the renewal process, the DTO will reflect those changes. 
- If no changes were made to specific information, the data from the stub resource file located at `/app/.server/resources/power-platform/client-application.json` will be used.