### PR TITLE
chore: refactor `locale-utils.getLanguage()`

### DIFF
--- a/frontend/__tests__/utils/locale-utils.test.ts
+++ b/frontend/__tests__/utils/locale-utils.test.ts
@@ -43,12 +43,23 @@ describe('locale-utils', () => {
 
   describe('getLanguage', () => {
     it.each([
-      { pathname: '/en', expected: 'en' },
-      { pathname: '/en/foo', expected: 'en' },
-      { pathname: '/fr', expected: 'fr' },
-      { pathname: '/fr/foo', expected: 'fr' },
-    ])('should return $expected for pathname $pathname', ({ pathname, expected }) => {
-      expect(getLanguage(pathname)).toBe(expected);
+      // pathnames
+      { resource: '/en', expected: 'en' },
+      { resource: '/en/foo', expected: 'en' },
+      { resource: '/fr', expected: 'fr' },
+      { resource: '/fr/foo', expected: 'fr' },
+      // Requests
+      { resource: new Request('https://example.com/en'), expected: 'en' },
+      { resource: new Request('https://example.com/en/foo'), expected: 'en' },
+      { resource: new Request('https://example.com/fr'), expected: 'fr' },
+      { resource: new Request('https://example.com/fr/foo'), expected: 'fr' },
+      // URLs
+      { resource: new URL('https://example.com/en'), expected: 'en' },
+      { resource: new URL('https://example.com/en/foo'), expected: 'en' },
+      { resource: new URL('https://example.com/fr'), expected: 'fr' },
+      { resource: new URL('https://example.com/fr/foo'), expected: 'fr' },
+    ])('should return $expected for resource $resource', ({ resource, expected }) => {
+      expect(getLanguage(resource)).toBe(expected);
     });
 
     it('should throw an error for invalid pathname', () => {

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -48,19 +48,41 @@ export function getAltLanguage(language: string): AppLocale {
 }
 
 /**
- * Extracts the language code from a given pathname.
+ * Extracts the language code from a given resource.
  *
- * @param pathname - The pathname to extract the language from.
+ * @param resource - The resource to extract the language from.
  * @returns The language code ('en' or 'fr') if found, otherwise undefined.
+ * @throws {Error} If the language code cannot be determined.
  */
-export function getLanguage(pathname: string): AppLocale {
+export function getLanguage(resource: Request | URL | string): AppLocale {
   switch (true) {
-    case pathname === '/en' || pathname.startsWith('/en/'):
+    case resource instanceof Request: {
+      return getLanguageFromPathname(new URL(resource.url).pathname);
+    }
+
+    case resource instanceof URL: {
+      return getLanguageFromPathname(resource.pathname);
+    }
+
+    default: {
+      return getLanguageFromPathname(resource);
+    }
+  }
+}
+
+function getLanguageFromPathname(pathname: string): AppLocale {
+  switch (true) {
+    case pathname === '/en' || pathname.startsWith('/en/'): {
       return 'en';
-    case pathname === '/fr' || pathname.startsWith('/fr/'):
+    }
+
+    case pathname === '/fr' || pathname.startsWith('/fr/'): {
       return 'fr';
-    default:
+    }
+
+    default: {
       throw new Error(`Could not determine language for pathname: ${pathname}.`);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

This PR overloads `locale-utils.getLanguage()` so it can be used anywhere that we need to determine the current language.

### Checklist

- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
