### PR TITLE
Mapping from ITA renewal state to benefit renewal DTO

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -2,7 +2,7 @@ import type { ReadonlyDeep } from 'type-fest';
 
 import type { BenefitApplicationDto } from './benefit-application.dto';
 
-export type BenefitRenewalDto = BenefitApplicationDto &
+export type BenefitRenewalAdultChildDto = BenefitApplicationDto &
   ReadonlyDeep<{
     changeIndicators: {
       hasAddressChanged: boolean;
@@ -11,6 +11,13 @@ export type BenefitRenewalDto = BenefitApplicationDto &
       hasPhoneChanged: boolean;
       hasFederalBenefitsChanged: boolean;
       hasProvincialTerritorialBenefitsChanged: boolean;
+    };
+  }>;
+
+export type BenefitRenewalItaDto = BenefitApplicationDto &
+  ReadonlyDeep<{
+    changeIndicators: {
+      hasAddressChanged: boolean;
     };
   }>;
 

--- a/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
+++ b/frontend/app/route-helpers/renew-ita-route-helpers.server.ts
@@ -78,7 +78,7 @@ interface ValidateRenewItaStateForReviewArgs {
 }
 
 export function validateRenewItaStateForReview({ params, state }: ValidateRenewItaStateForReviewArgs) {
-  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, addressInformation, applicantInformation, dentalBenefits, dentalInsurance, hasAddressChanged } = state;
+  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, addressInformation, applicantInformation, clientApplication, dentalBenefits, dentalInsurance, hasAddressChanged } = state;
 
   if (typeOfRenewal === undefined) {
     throw redirect(getPathById('public/renew/$id/type-renewal', params));
@@ -96,12 +96,20 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     throw redirect(getPathById('public/renew/$id/applicant-information', params));
   }
 
+  if (clientApplication === undefined) {
+    throw redirect(getPathById('public/renew/$id/applicant-information', params));
+  }
+
   if (maritalStatus === undefined) {
     throw redirect(getPathById('public/renew/$id/ita/marital-status', params));
   }
 
   if (contactInformation === undefined) {
     throw redirect(getPathById('public/renew/$id/ita/confirm-email', params));
+  }
+
+  if (hasAddressChanged === undefined) {
+    throw redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
   }
 
   if (hasAddressChanged && addressInformation === undefined) {
@@ -122,6 +130,7 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     id,
     submissionInfo,
     typeOfRenewal,
+    clientApplication,
     contactInformation,
     applicantInformation,
     dentalBenefits,


### PR DESCRIPTION
### Description
Leverages mapper methods introduced in #2598 to map from the ITA state to `BenefitRenewalDTO`.

Introduced required checks for `clientApplication` and `hasAddressChanged` in the ITA route helper, which are mandatory for ITA renewal submission.

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Screenshots (if applicable)
Logged the benefit renewal DTO on the last step of the `/renew/$id/ita` flow:

![image](https://github.com/user-attachments/assets/e6fdb1d8-a241-4687-9812-25171e2eb52a)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Add the following to `/review-information` and complete the renewal ITA flow (use client number `10000000001` locally).
```typescript
const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewItaStateToBenefitRenewalDto(state);
```
- Log the resulting `benefitRenewalDto` to inspect its structure. 
- Depending on whether you chose to change information during the renewal process, the DTO will reflect those changes. 
- If no changes were made to specific information, the data from the stub resource file located at `/app/.server/resources/power-platform/client-application.json` will be used.

### Additional Notes
Unit tests and mapping to Entity to be introduced in future PR.