### PR TITLE
add Adobe Analytics URL transformer helpers for protected renew application

### DIFF
--- a/frontend/app/route-helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/route-helpers/protected-renew-route-helpers.ts
@@ -1,0 +1,35 @@
+import { removePathSegment } from '~/utils/url-utils';
+
+/**
+ * Adobe Analytics needs us to clean up URLs before sending event data. This ensures their reports focus
+ * on the core content, not things like tracking codes, because they don't want those to mess up their
+ * website visitor categories.
+ * @param url
+ * @returns
+ */
+export function transformAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  // TODO: add translated route segments
+  const protectedRenewRouteRegex = /^\/(en|fr)\/protected\/(renew)\//i;
+  if (!protectedRenewRouteRegex.test(urlObj.pathname)) return urlObj;
+  return new URL(removePathSegment(urlObj, 3));
+}
+
+/**
+ * Adobe Analytics needs us to clean up URLs before sending event data. This ensures their reports focus
+ * on the core content, not things like tracking codes, because they don't want those to mess up their
+ * website visitor categories.
+ * @param url
+ * @returns
+ */
+export function transformChildrenRouteAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  // TODO: add translated route segments
+  const protectedRenewRouteRegex = /^\/(en|fr)\/protected\/(renew)\//i;
+  if (!protectedRenewRouteRegex.test(urlObj.pathname)) return urlObj;
+  // remove protected renew state id
+  let transofrmedUrl = removePathSegment(urlObj, 3);
+  // remove protected renew child state id
+  transofrmedUrl = removePathSegment(transofrmedUrl, 3);
+  return new URL(transofrmedUrl);
+}

--- a/frontend/app/routes/api/protected-renew-state.ts
+++ b/frontend/app/routes/api/protected-renew-state.ts
@@ -1,0 +1,51 @@
+/**
+ * An API route that can be used to perform actions with user's protected renew state.
+ */
+import type { ActionFunctionArgs } from '@remix-run/node';
+
+import { z } from 'zod';
+
+import { saveProtectedRenewState } from '~/route-helpers/protected-renew-route-helpers.server';
+import { getLogger } from '~/utils/logging.server';
+
+const API_PROTECTED_RENEW_STATE_ACTIONS = ['extend'] as const;
+export type ApiProtectedRenewStateAction = (typeof API_PROTECTED_RENEW_STATE_ACTIONS)[number];
+
+export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+  const log = getLogger('routes/api/protected-renew-state');
+  const sessionId = session.id;
+  log.debug("Action with with user's protected renew state; sessionId: [%s]", sessionId);
+
+  if (request.method !== 'POST') {
+    log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
+    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
+  }
+
+  const bodySchema = z.object({
+    action: z.enum(API_PROTECTED_RENEW_STATE_ACTIONS),
+    id: z.string(),
+  });
+
+  const requestBody = await request.json();
+  const parsedBody = bodySchema.safeParse(requestBody);
+
+  if (!parsedBody.success) {
+    log.debug('Invalid request body [%j]; sessionId: [%s]', requestBody, sessionId);
+    return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
+  }
+
+  const params = { id: parsedBody.data.id };
+
+  switch (parsedBody.data.action) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    case 'extend': {
+      log.debug("Extending user's protected renew state; id: [%s], sessionId: [%s]", params.id, sessionId);
+      saveProtectedRenewState({ params, session, state: {} });
+      return new Response(null, { status: 204 });
+    }
+
+    default: {
+      throw Error(`Action '${parsedBody.data.action}' not implemented; sessionId: [${sessionId}]`);
+    }
+  }
+}

--- a/frontend/app/routes/protected/renew/$id/$childId/layout.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from '@remix-run/react';
+
+import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/protected-renew-route-helpers';
+import type { RouteHandleData } from '~/utils/route-utils';
+
+export const handle = {
+  transformAdobeAnalyticsUrl: transformChildrenRouteAdobeAnalyticsUrl,
+} as const satisfies RouteHandleData;
+
+/**
+ * Do-nothing parent route.
+ * (placeholder for future code)
+ */
+export default function Route() {
+  return <Outlet />;
+}

--- a/frontend/app/routes/protected/renew/layout.tsx
+++ b/frontend/app/routes/protected/renew/layout.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+
+import type { LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet, useLoaderData, useNavigate, useParams } from '@remix-run/react';
+
+import { TYPES } from '~/.server/constants';
+import { i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
+import SessionTimeout from '~/components/session-timeout';
+import { transformAdobeAnalyticsUrl } from '~/route-helpers/protected-renew-route-helpers';
+import { useApiProtectedRenewState } from '~/utils/api-protected-renew-state.utils';
+import { useApiSession } from '~/utils/api-session-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getLocale } from '~/utils/locale-utils.server';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
+  transformAdobeAnalyticsUrl,
+} as const satisfies RouteHandleData;
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+  const locale = getLocale(request);
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
+  return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
+}
+
+export default function Layout() {
+  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const path = getPathById('protected/renew/index', params);
+
+  useEffect(() => {
+    // redirect to start if the flow has not yet been initialized
+    const protectedRenewState = sessionStorage.getItem('protected.renew.state');
+
+    if (protectedRenewState !== 'active') {
+      navigate(path, { replace: true });
+    }
+  }, [navigate, path]);
+
+  const apiProtectedRenewState = useApiProtectedRenewState();
+  const apiSession = useApiSession();
+
+  function handleOnSessionEnd() {
+    apiSession.submit({ action: 'end', locale, redirectTo: 'cdcp-website-apply' });
+  }
+
+  function handleOnSessionExtend() {
+    // extends the protected renew state if 'id' param exists
+    const id = params.id;
+    if (typeof id === 'string') {
+      apiProtectedRenewState.submit({ action: 'extend', id });
+      return;
+    }
+
+    // extends the user's session
+    apiSession.submit({ action: 'extend' });
+  }
+
+  return (
+    <>
+      <SessionTimeout promptBeforeIdle={SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={SESSION_TIMEOUT_SECONDS * 1000} onSessionEnd={handleOnSessionEnd} onSessionExtend={handleOnSessionExtend} />
+      <Outlet />
+    </>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -30,79 +30,89 @@ export const routes = [
         paths: { en: '/:lang/stub-login', fr: '/:lang/stub-login' },
       },
       {
-        id: 'protected/renew/index',
-        file: 'routes/protected/renew/index.tsx',
-        paths: { en: '/:lang/protected/renew', fr: '/:lang/protected/renew' },
-      },
-      {
-        id: 'protected/renew/$id/terms-and-conditions',
-        file: 'routes/protected/renew/$id/terms-and-conditions.tsx',
-        paths: { en: '/:lang/protected/renew/:id/terms-and-conditions', fr: '/:lang/protected/renew/:id/terms-and-conditions' },
-      },
-      {
-        id: 'protected/renew/$id/tax-filing',
-        file: 'routes/protected/renew/$id/tax-filing.tsx',
-        paths: { en: '/:lang/protected/renew/:id/tax-filing', fr: '/:lang/protected/renew/:id/tax-filing' },
-      },
-      {
-        id: 'protected/renew/$id/file-taxes',
-        file: 'routes/protected/renew/$id/file-taxes.tsx',
-        paths: { en: '/:lang/protected/renew/:id/file-taxes', fr: '/:lang/protected/renew/:id/file-taxes' },
-      },
-      {
-        id: 'protected/renew/$id/dental-insurance',
-        file: 'routes/protected/renew/$id/dental-insurance.tsx',
-        paths: { en: '/:lang/protected/renew/:id/dental-insurance', fr: '/:lang/protected/renew/:id/dental-insurance' },
-      },
-      {
-        id: 'protected/renew/$id/demographic-survey',
-        file: 'routes/protected/renew/$id/demographic-survey.tsx',
-        paths: { en: '/:lang/protected/renew/:id/demographic-survey', fr: '/:lang/protected/renew/:id/demographic-survey' },
-      },
-      {
-        id: 'protected/renew/$id/marital-status',
-        file: 'routes/protected/renew/$id/marital-status.tsx',
-        paths: { en: '/:lang/protected/renew/:id/marital-status', fr: '/:lang/protected/renew/:id/etat-civil' },
-      },
-      {
-        id: 'protected/renew/$id/$childId/parent-or-guardian',
-        file: 'routes/protected/renew/$id/$childId/parent-or-guardian.tsx',
-        paths: { en: '/:lang/protected/renew/:id/:childId/parent-or-guardian', fr: '/:lang/protected/renew/:id/:childId/parent-or-guardian' },
-      },
-      {
-        id: 'protected/renew/$id/$childId/dental-insurance',
-        file: 'routes/protected/renew/$id/$childId/dental-insurance.tsx',
-        paths: { en: '/:lang/protected/renew/:id/:childId/dental-insurance', fr: '/:lang/protected/renew/:id/:childId/dental-insurance' },
-      },
-      {
-        id: 'protected/renew/$id/$childId/demographic-survey',
-        file: 'routes/protected/renew/$id/$childId/demographic-survey.tsx',
-        paths: { en: '/:lang/protected/renew/:id/:childId/demographic-survey', fr: '/:lang/protected/renew/:id/:childId/demographic-survey' },
-      },
-      {
-        id: 'protected/renew/$id/confirm-phone',
-        file: 'routes/protected/renew/$id/confirm-phone.tsx',
-        paths: { en: '/:lang/protected/renew/:id/confirm-phone', fr: '/:lang/protected/renew/:id/confirmer-telephone' },
-      },
-      {
-        id: 'protected/renew/$id/confirm-email',
-        file: 'routes/protected/renew/$id/confirm-email.tsx',
-        paths: { en: '/:lang/protected/renew/:id/confirm-email', fr: '/:lang/protected/renew/:id/confirmer-courriel' },
-      },
-      {
-        id: 'protected/renew/$id/communication-preference',
-        file: 'routes/protected/renew/$id/communication-preference.tsx',
-        paths: { en: '/:lang/protected/renew/:id/communication-preference', fr: '/:lang/protected/renew/:id/communication-preference' },
-      },
-      {
-        id: 'protected/renew/$id/confirm-address',
-        file: 'routes/protected/renew/$id/confirm-address.tsx',
-        paths: { en: '/:lang/protected/renew/:id/confirm-address', fr: '/:lang/protected/renew/:id/confirmer-adresse' },
-      },
-      {
-        id: 'protected/renew/$id/update-address',
-        file: 'routes/protected/renew/$id/update-address.tsx',
-        paths: { en: '/:lang/protected/renew/:id/update-address', fr: '/:lang/protected/renew/:id/mise-a-jour-adresse' },
+        file: 'routes/protected/renew/layout.tsx',
+        children: [
+          {
+            id: 'protected/renew/index',
+            file: 'routes/protected/renew/index.tsx',
+            paths: { en: '/:lang/protected/renew', fr: '/:lang/protected/renew' },
+          },
+          {
+            id: 'protected/renew/$id/terms-and-conditions',
+            file: 'routes/protected/renew/$id/terms-and-conditions.tsx',
+            paths: { en: '/:lang/protected/renew/:id/terms-and-conditions', fr: '/:lang/protected/renew/:id/terms-and-conditions' },
+          },
+          {
+            id: 'protected/renew/$id/tax-filing',
+            file: 'routes/protected/renew/$id/tax-filing.tsx',
+            paths: { en: '/:lang/protected/renew/:id/tax-filing', fr: '/:lang/protected/renew/:id/tax-filing' },
+          },
+          {
+            id: 'protected/renew/$id/file-taxes',
+            file: 'routes/protected/renew/$id/file-taxes.tsx',
+            paths: { en: '/:lang/protected/renew/:id/file-taxes', fr: '/:lang/protected/renew/:id/file-taxes' },
+          },
+          {
+            id: 'protected/renew/$id/dental-insurance',
+            file: 'routes/protected/renew/$id/dental-insurance.tsx',
+            paths: { en: '/:lang/protected/renew/:id/dental-insurance', fr: '/:lang/protected/renew/:id/dental-insurance' },
+          },
+          {
+            id: 'protected/renew/$id/demographic-survey',
+            file: 'routes/protected/renew/$id/demographic-survey.tsx',
+            paths: { en: '/:lang/protected/renew/:id/demographic-survey', fr: '/:lang/protected/renew/:id/demographic-survey' },
+          },
+          {
+            id: 'protected/renew/$id/marital-status',
+            file: 'routes/protected/renew/$id/marital-status.tsx',
+            paths: { en: '/:lang/protected/renew/:id/marital-status', fr: '/:lang/protected/renew/:id/etat-civil' },
+          },
+          {
+            file: 'routes/protected/renew/$id/$childId/layout.tsx',
+            children: [
+              {
+                id: 'protected/renew/$id/$childId/parent-or-guardian',
+                file: 'routes/protected/renew/$id/$childId/parent-or-guardian.tsx',
+                paths: { en: '/:lang/protected/renew/:id/:childId/parent-or-guardian', fr: '/:lang/protected/renew/:id/:childId/parent-or-guardian' },
+              },
+              {
+                id: 'protected/renew/$id/$childId/dental-insurance',
+                file: 'routes/protected/renew/$id/$childId/dental-insurance.tsx',
+                paths: { en: '/:lang/protected/renew/:id/:childId/dental-insurance', fr: '/:lang/protected/renew/:id/:childId/dental-insurance' },
+              },
+              {
+                id: 'protected/renew/$id/$childId/demographic-survey',
+                file: 'routes/protected/renew/$id/$childId/demographic-survey.tsx',
+                paths: { en: '/:lang/protected/renew/:id/:childId/demographic-survey', fr: '/:lang/protected/renew/:id/:childId/demographic-survey' },
+              },
+            ],
+          },
+          {
+            id: 'protected/renew/$id/confirm-phone',
+            file: 'routes/protected/renew/$id/confirm-phone.tsx',
+            paths: { en: '/:lang/protected/renew/:id/confirm-phone', fr: '/:lang/protected/renew/:id/confirmer-telephone' },
+          },
+          {
+            id: 'protected/renew/$id/confirm-email',
+            file: 'routes/protected/renew/$id/confirm-email.tsx',
+            paths: { en: '/:lang/protected/renew/:id/confirm-email', fr: '/:lang/protected/renew/:id/confirmer-courriel' },
+          },
+          {
+            id: 'protected/renew/$id/communication-preference',
+            file: 'routes/protected/renew/$id/communication-preference.tsx',
+            paths: { en: '/:lang/protected/renew/:id/communication-preference', fr: '/:lang/protected/renew/:id/communication-preference' },
+          },
+          {
+            id: 'protected/renew/$id/confirm-address',
+            file: 'routes/protected/renew/$id/confirm-address.tsx',
+            paths: { en: '/:lang/protected/renew/:id/confirm-address', fr: '/:lang/protected/renew/:id/confirmer-adresse' },
+          },
+          {
+            id: 'protected/renew/$id/update-address',
+            file: 'routes/protected/renew/$id/update-address.tsx',
+            paths: { en: '/:lang/protected/renew/:id/update-address', fr: '/:lang/protected/renew/:id/mise-a-jour-adresse' },
+          },
+        ],
       },
     ],
   },

--- a/frontend/app/utils/api-protected-renew-state.utils.ts
+++ b/frontend/app/utils/api-protected-renew-state.utils.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+import { useSubmit } from '@remix-run/react';
+
+import type { ApiProtectedRenewStateAction } from '~/routes/api/protected-renew-state';
+
+interface ApiProtectedRenewStateSubmitFuncArgs {
+  action: ApiProtectedRenewStateAction;
+  id: string;
+}
+
+/**
+ * A custom hook for submitting API requests to the protected renew state endpoint.
+ */
+export function useApiProtectedRenewState() {
+  const remixSubmit = useSubmit();
+
+  /**
+   * Submits a request to the protected renew state API endpoint.
+   *
+   * @example
+   * submit({ action: ApiProtectedRenewStateAction.Extend, id: '00000000-0000-0000-0000-000000000000' });
+   */
+  const submit = useCallback(
+    ({ action, id }: ApiProtectedRenewStateSubmitFuncArgs) => {
+      remixSubmit(
+        { action, id },
+        {
+          action: '/api/protected-renew-state',
+          encType: 'application/json',
+          method: 'POST',
+          navigate: false,
+        },
+      );
+    },
+    [remixSubmit],
+  );
+
+  return { submit };
+}


### PR DESCRIPTION
### Description
adds helpers to transform the URL (strip UUIDs) for Adobe Analytics for the protected renew application.  This is similar to how it's done in the public Apply Online application.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`