### PR TITLE
fix(frontend): fix hcaptcha response validation

### DIFF
--- a/frontend/__tests__/.server/web/validators/hcaptcha.validator.test.ts
+++ b/frontend/__tests__/.server/web/validators/hcaptcha.validator.test.ts
@@ -4,7 +4,7 @@ import { mock } from 'vitest-mock-extended';
 
 import type { ServerConfig } from '~/.server/configs';
 import type { LogFactory, Logger } from '~/.server/factories';
-import { HCaptchaInvalidException } from '~/.server/web/exceptions';
+import { HCaptchaInvalidException, HCaptchaResponseNotFoundException } from '~/.server/web/exceptions';
 import type { HCaptchaService } from '~/.server/web/services';
 import { DefaultHCaptchaValidator } from '~/.server/web/validators';
 import { getClientIpAddress } from '~/utils/ip-address-utils.server';
@@ -59,14 +59,14 @@ describe('DefaultHCaptchaValidator', () => {
     });
   });
 
-  it('should throw HCaptchaInvalidException if hCaptcha response is not found in the request', async () => {
+  it('should throw HCaptchaResponseNotFoundException if hCaptcha response is not found in the request', async () => {
     // Mock request with no hCaptcha response
     mockRequest = new Request('https://example.com', {
       method: 'POST',
       body: JSON.stringify({}),
     });
 
-    await expect(validator.validateHCaptchaResponse(mockRequest, userId)).rejects.toThrow(new HCaptchaInvalidException('hCaptcha response validation failed; hCaptcha response not found.'));
+    await expect(validator.validateHCaptchaResponse(mockRequest, userId)).rejects.toThrow(new HCaptchaResponseNotFoundException('hCaptcha response not found in request.'));
   });
 
   it('should throw HCaptchaInvalidException if hCaptcha score exceeds the threshold', async () => {

--- a/frontend/app/.server/web/exceptions/hcaptcha-response-not-found.exception.ts
+++ b/frontend/app/.server/web/exceptions/hcaptcha-response-not-found.exception.ts
@@ -1,0 +1,3 @@
+import { BaseWebException } from './base-web.exception';
+
+export class HCaptchaResponseNotFoundException extends BaseWebException {}

--- a/frontend/app/.server/web/exceptions/index.ts
+++ b/frontend/app/.server/web/exceptions/index.ts
@@ -1,4 +1,5 @@
 export * from './base-web.exception';
 export * from './csrf-token-invalid.exception';
 export * from './hcaptcha-invalid.exception';
+export * from './hcaptcha-response-not-found.exception';
 export * from './raoidc-session-invalid.exception';


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix hcaptcha response validation by throwing an `HCaptchatResponseNotFoundException` instead of `HCaptchatInvalidException` when the response cannot be found in the request.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->