### PR TITLE
fix: broken top level awaits

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,10 +9,7 @@ import { coverageConfigDefaults } from 'vitest/config';
 
 export default defineConfig({
   build: {
-    //
-    // build target `esnext` is required for top-level awaits to work
-    //
-    target: 'esnext',
+    target: 'es2022',
   },
   css: {
     postcss: {
@@ -24,6 +21,9 @@ export default defineConfig({
     host: true,
   },
   optimizeDeps: {
+    esbuildOptions: {
+      target: 'es2022',
+    },
     // exclude the otlp-exporter-base package because it causes
     // issues with vite's dependency optimization
     // see: https://github.com/open-telemetry/opentelemetry-js/issues/4794


### PR DESCRIPTION
### Description

Fix error introduced by 417b61b4a284fb699608bdabe0c2f407c28dedd6:

> ✘ [ERROR] Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)

⚠️ I'm not sure if this breaks compatibility with older browsers! ⚠️
