### PR TITLE
Refactoring implementations of benefit renewal service and DTO mapper

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -1,25 +1,27 @@
-import type { ReadonlyDeep } from 'type-fest';
-
 import type { BenefitApplicationDto } from './benefit-application.dto';
 
-export type BenefitRenewalAdultChildDto = BenefitApplicationDto &
-  ReadonlyDeep<{
-    changeIndicators: {
-      hasAddressChanged: boolean;
-      hasEmailChanged: boolean;
-      hasMaritalStatusChanged: boolean;
-      hasPhoneChanged: boolean;
-      hasFederalBenefitsChanged: boolean;
-      hasProvincialTerritorialBenefitsChanged: boolean;
-    };
+export type AdultChildBenefitRenewalDto = BenefitApplicationDto &
+  Readonly<{
+    changeIndicators: AdultChildChangeIndicators;
   }>;
 
-export type BenefitRenewalItaDto = BenefitApplicationDto &
-  ReadonlyDeep<{
-    changeIndicators: {
-      hasAddressChanged: boolean;
-    };
+export type AdultChildChangeIndicators = Readonly<{
+  hasAddressChanged: boolean;
+  hasEmailChanged: boolean;
+  hasMaritalStatusChanged: boolean;
+  hasPhoneChanged: boolean;
+  hasFederalBenefitsChanged: boolean;
+  hasProvincialTerritorialBenefitsChanged: boolean;
+}>;
+
+export type ItaBenefitRenewalDto = BenefitApplicationDto &
+  Readonly<{
+    changeIndicators: ItaChangeIndicators;
   }>;
+
+export type ItaChangeIndicators = Readonly<{
+  hasAddressChanged: boolean;
+}>;
 
 // TODO remove this when mapping to BenefitRenewalDto is complete
 export type BenefitRenewalRequestDto = Readonly<{

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -1,125 +1,116 @@
-export type BenefitRenewalRequestEntity = Readonly<{
-  BenefitApplication: Readonly<{
-    Applicant: Readonly<{
-      ApplicantDetail: Readonly<{
+import type { ReadonlyDeep } from 'type-fest';
+
+export type BenefitRenewalRequestEntity = ReadonlyDeep<{
+  BenefitApplication: {
+    Applicant: {
+      ApplicantDetail: {
         PrivateDentalInsuranceIndicator?: boolean;
         DisabilityTaxCreditIndicator?: boolean;
         LivingIndependentlyIndicator?: boolean;
-        InsurancePlan?: ReadonlyArray<
-          Readonly<{
-            InsurancePlanIdentification?: ReadonlyArray<
-              Readonly<{
-                IdentificationID?: string;
-              }>
-            >;
-          }>
-        >;
-      }>;
-      PersonBirthDate: Readonly<{
+        InsurancePlan?: {
+          InsurancePlanIdentification?: {
+            IdentificationID?: string;
+          }[];
+        }[];
+      };
+      ChangedInformation: string[]; // TODO subject to change - specifications not yet provided
+      PersonBirthDate: {
         date: string;
-      }>;
-      PersonContactInformation: ReadonlyArray<
-        Readonly<{
-          Address: ReadonlyArray<
-            Readonly<{
-              AddressCategoryCode: Readonly<{
-                ReferenceDataName: string;
-              }>;
-              AddressCityName: string;
-              AddressCountry: Readonly<{
-                CountryCode: Readonly<{
-                  ReferenceDataID: string;
-                }>;
-              }>;
-              AddressPostalCode: string;
-              AddressProvince: Readonly<{
-                ProvinceCode: Readonly<{
-                  ReferenceDataID: string;
-                }>;
-              }>;
-              AddressSecondaryUnitText: string;
-              AddressStreet: Readonly<{
-                StreetName: string;
-              }>;
-            }>
-          >;
-          EmailAddress: ReadonlyArray<
-            Readonly<{
-              EmailAddressID: string;
-            }>
-          >;
-          TelephoneNumber: ReadonlyArray<
-            Readonly<{
-              TelephoneNumberCategoryCode: Readonly<{
-                ReferenceDataID: string;
-                ReferenceDataName: string;
-              }>;
-            }>
-          >;
-        }>
-      >;
-      PersonMaritalStatus: Readonly<{
-        StatusCode: Readonly<{
-          ReferenceDataID?: string;
-        }>;
-      }>;
-      PersonName: ReadonlyArray<
-        Readonly<{
-          PersonGivenName: ReadonlyArray<string>;
-          PersonSurName: string;
-        }>
-      >;
-      PersonClientIdentification: Readonly<{
-        IdentificationID: string;
-      }>;
-      RelatedPerson: ReadonlyArray<
-        Readonly<{
-          PersonBirthDate: Readonly<{
-            date: string;
-          }>;
-          PersonRelationshipCode: Readonly<{
+      };
+      PersonContactInformation: {
+        Address: {
+          AddressCategoryCode: {
             ReferenceDataName: string;
-          }>;
-          PersonSINIdentification: Readonly<{
-            IdentificationID: string;
-          }>;
-          ApplicantDetail: Readonly<{
-            ConsentToSharePersonalInformationIndicator?: boolean;
-            AttestParentOrGuardianIndicator?: boolean;
-            PrivateDentalInsuranceIndicator?: boolean;
-            InsurancePlan?: ReadonlyArray<
-              Readonly<{
-                InsurancePlanIdentification?: ReadonlyArray<
-                  Readonly<{
-                    IdentificationID?: string;
-                  }>
-                >;
-              }>
-            >;
-          }>;
-        }>
-      >;
+          };
+          AddressCityName: string;
+          AddressCountry: {
+            CountryCode: {
+              ReferenceDataID: string;
+            };
+          };
+          AddressPostalCode: string;
+          AddressProvince: {
+            ProvinceCode: {
+              ReferenceDataID: string;
+            };
+          };
+          AddressSecondaryUnitText: string;
+          AddressStreet: {
+            StreetName: string;
+          };
+        }[];
+        EmailAddress: {
+          EmailAddressID: string;
+        }[];
+        TelephoneNumber: {
+          TelephoneNumberCategoryCode: {
+            ReferenceDataID: string;
+            ReferenceDataName: string;
+          };
+        }[];
+      }[];
+      PersonLanguage: {
+        CommunicationCategoryCode: {
+          ReferenceDataID: string;
+        };
+        PreferredIndicator: boolean;
+      }[];
+      PersonMaritalStatus: {
+        StatusCode: {
+          ReferenceDataID: string;
+        };
+      };
+      PersonName: {
+        PersonGivenName: string[];
+        PersonSurName: string;
+      }[];
+      PersonSINIdentification: {
+        IdentificationID: string;
+      };
+      RelatedPerson: {
+        ApplicantDetail: {
+          PrivateDentalInsuranceIndicator?: boolean;
+          InsurancePlan?: {
+            InsurancePlanIdentification?: {
+              IdentificationID?: string;
+            }[];
+          }[];
+          ConsentToSharePersonalInformationIndicator?: boolean;
+          AttestParentOrGuardianIndicator?: boolean;
+        };
+        PersonBirthDate: {
+          date: string;
+        };
+        PersonName: {
+          PersonGivenName: string[];
+          PersonSurName: string;
+        }[];
+        PersonRelationshipCode: {
+          ReferenceDataName: string;
+        };
+        PersonSINIdentification: {
+          IdentificationID: string;
+        };
+      }[];
       MailingSameAsHomeIndicator: boolean;
-      PreferredMethodCommunicationCode?: Readonly<{
-        ReferenceDataID?: string;
-      }>;
-    }>;
-    BenefitRenewalCategoryCode: Readonly<{
+      PreferredMethodCommunicationCode: {
+        ReferenceDataID: string;
+      };
+    };
+    BenefitApplicationCategoryCode: {
       ReferenceDataID: string;
-    }>;
-    BenefitRenewalChannelCode: Readonly<{
+    };
+    BenefitApplicationChannelCode: {
       ReferenceDataID: string;
-    }>;
-  }>;
+    };
+  };
 }>;
 
-export type BenefitRenewalResponseEntity = Readonly<{
-  BenefitApplication: Readonly<{
-    BenefitRenewalIdentification: ReadonlyArray<
-      Readonly<{
-        IdentificationID: string;
-        IdentificationCategoryText: string;
-      }>
-    >;
-  }>;
+export type BenefitRenewalResponseEntity = ReadonlyDeep<{
+  BenefitApplication: {
+    BenefitApplicationIdentification: {
+      IdentificationID: string;
+      IdentificationCategoryText: string;
+    }[];
+  };
 }>;

--- a/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
+++ b/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
@@ -74,7 +74,7 @@ export class MockBenefitRenewalRepository implements BenefitRenewalRepository {
 
     const benefitRenewalResponseEntity: BenefitRenewalResponseEntity = {
       BenefitApplication: {
-        BenefitRenewalIdentification: [
+        BenefitApplicationIdentification: [
           {
             IdentificationID: '2476124092174',
             IdentificationCategoryText: 'Confirmation Number',

--- a/frontend/app/.server/domain/services/benefit-renewal.service.ts
+++ b/frontend/app/.server/domain/services/benefit-renewal.service.ts
@@ -1,19 +1,26 @@
 import { inject, injectable } from 'inversify';
 
 import { TYPES } from '~/.server/constants';
-import { BenefitRenewalRequestDto, BenefitRenewalResponseDto } from '~/.server/domain/dtos';
+import { AdultChildBenefitRenewalDto, ItaBenefitRenewalDto } from '~/.server/domain/dtos';
 import type { BenefitRenewalDtoMapper } from '~/.server/domain/mappers';
 import type { BenefitRenewalRepository } from '~/.server/domain/repositories';
+import type { AuditService } from '~/.server/domain/services';
 import type { LogFactory, Logger } from '~/.server/factories';
 
 export interface BenefitRenewalService {
   /**
-   * Submits benefit renewal request.
+   * Submits an adult child benefit renewal request.
    *
-   * @param benefitRenewalState The renewal state stored in session.
-   * @returns A Promise that resolves to the renewal response if successful, or `null` otherwise.
+   * @param adultChildBenefitRenewalDto The adult child benefit renewal request dto
    */
-  createBenefitRenewal(benefitRenewalRequestDto: BenefitRenewalRequestDto): Promise<BenefitRenewalResponseDto>;
+  createAdultChildBenefitRenewal(adultChildBenefitRenewalDto: AdultChildBenefitRenewalDto): Promise<void>;
+
+  /**
+   * Submits an ITA benefit renewal request.
+   *
+   * @param adultChildBenefitRenewalDto The adult child benefit renewal request dto
+   */
+  createItaBenefitRenewal(itaBenefitRenewalDto: ItaBenefitRenewalDto): Promise<void>;
 }
 
 @injectable()
@@ -22,20 +29,32 @@ export class BenefitRenewalServiceImpl implements BenefitRenewalService {
 
   constructor(
     @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
-    @inject(TYPES.domain.mappers.BenefitRenewalDtoMapper) private readonly BenefitRenewalDtoMapper: BenefitRenewalDtoMapper,
-    @inject(TYPES.domain.repositories.BenefitRenewalRepository) private readonly BenefitRenewalRepository: BenefitRenewalRepository,
+    @inject(TYPES.domain.mappers.BenefitRenewalDtoMapper) private readonly benefitRenewalDtoMapper: BenefitRenewalDtoMapper,
+    @inject(TYPES.domain.repositories.BenefitRenewalRepository) private readonly benefitRenewalRepository: BenefitRenewalRepository,
+    @inject(TYPES.domain.services.AuditService) private readonly auditService: AuditService,
   ) {
     this.log = logFactory.createLogger('BenefitRenewalServiceImpl');
   }
 
-  async createBenefitRenewal(benefitRenewalRequestDto: BenefitRenewalRequestDto): Promise<BenefitRenewalResponseDto> {
-    this.log.debug('Submit benefit renewal request');
-    this.log.trace('Submit benefit renewal request with: [%j]', benefitRenewalRequestDto);
+  async createAdultChildBenefitRenewal(adultChildBenefitRenewalDto: AdultChildBenefitRenewalDto): Promise<void> {
+    this.log.trace('Creating adult child benefit renewal for request [%j]', adultChildBenefitRenewalDto);
 
-    const benefitRenewalRequest = this.BenefitRenewalDtoMapper.mapBenefitRenewalRequestDtoToBenefitRenewalRequestEntity(benefitRenewalRequestDto);
-    const benefitRenewalResponseEntity = await this.BenefitRenewalRepository.createBenefitRenewal(benefitRenewalRequest);
-    const benefitRenewalResponse = this.BenefitRenewalDtoMapper.mapBenefitRenewalResponseEntityToBenefitRenewalResponseDto(benefitRenewalResponseEntity);
-    this.log.trace('Returning client application: [%j]', benefitRenewalResponse);
-    return benefitRenewalResponse;
+    this.auditService.createAudit('adult-child-renewal-submit.post', { userId: adultChildBenefitRenewalDto.userId });
+
+    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(adultChildBenefitRenewalDto);
+    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+
+    this.log.trace('Successfully created adult child benefit renewal for request [%j]', adultChildBenefitRenewalDto);
+  }
+
+  async createItaBenefitRenewal(itaBenefitRenewalDto: ItaBenefitRenewalDto): Promise<void> {
+    this.log.trace('Creating ITA benefit renewal for request [%j]', itaBenefitRenewalDto);
+
+    this.auditService.createAudit('ita-renewal-submit.post', { userId: itaBenefitRenewalDto.userId });
+
+    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapItaBenefitRenewalDtoToBenefitRenewalRequestEntity(itaBenefitRenewalDto);
+    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+
+    this.log.trace('Successfully created ITA benefit renewal for request [%j]', itaBenefitRenewalDto);
   }
 }

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant';
 import { ReadonlyObjectDeep } from 'type-fest/source/readonly-deep';
 import validator from 'validator';
 
-import type { ApplicantInformationDto, BenefitRenewalAdultChildDto, BenefitRenewalItaDto, ClientApplicationDto, ClientChildDto, ContactInformationDto, PartnerInformationDto } from '~/.server/domain/dtos';
+import type { AdultChildBenefitRenewalDto, ApplicantInformationDto, ClientApplicationDto, ClientChildDto, ContactInformationDto, ItaBenefitRenewalDto, PartnerInformationDto } from '~/.server/domain/dtos';
 import type { AddressInformationState, ChildState, ConfirmDentalBenefitsState, ContactInformationState, DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, PartnerInformationState } from '~/.server/routes/helpers/renew-route-helpers';
 
 export interface RenewAdultChildState {
@@ -32,8 +32,8 @@ export interface RenewItaState {
 }
 
 export interface BenefitRenewalStateMapper {
-  mapRenewAdultChildStateToBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): BenefitRenewalAdultChildDto;
-  mapRenewItaStateToBenefitRenewalDto(renewItaState: RenewItaState): BenefitRenewalItaDto;
+  mapRenewAdultChildStateToAdultChildBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): AdultChildBenefitRenewalDto;
+  mapRenewItaStateToItaBenefitRenewalDto(renewItaState: RenewItaState): ItaBenefitRenewalDto;
 }
 
 interface ToApplicantInformationArgs {
@@ -71,7 +71,7 @@ interface ToPartnerInformationArgs {
 
 @injectable()
 export class BenefitRenewalStateMapperImpl implements BenefitRenewalStateMapper {
-  mapRenewAdultChildStateToBenefitRenewalDto({
+  mapRenewAdultChildStateToAdultChildBenefitRenewalDto({
     addressInformation,
     children,
     clientApplication,
@@ -83,7 +83,7 @@ export class BenefitRenewalStateMapperImpl implements BenefitRenewalStateMapper 
     hasMaritalStatusChanged,
     maritalStatus,
     partnerInformation,
-  }: RenewAdultChildState): BenefitRenewalAdultChildDto {
+  }: RenewAdultChildState): AdultChildBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
       throw Error('Expected hasEmailChanged to be defined');
@@ -141,7 +141,7 @@ export class BenefitRenewalStateMapperImpl implements BenefitRenewalStateMapper 
     };
   }
 
-  mapRenewItaStateToBenefitRenewalDto({ addressInformation, clientApplication, contactInformation, dentalBenefits, dentalInsurance, hasAddressChanged, maritalStatus, partnerInformation }: RenewItaState): BenefitRenewalItaDto {
+  mapRenewItaStateToItaBenefitRenewalDto({ addressInformation, clientApplication, contactInformation, dentalBenefits, dentalInsurance, hasAddressChanged, maritalStatus, partnerInformation }: RenewItaState): ItaBenefitRenewalDto {
     return {
       ...clientApplication,
       applicantInformation: this.toApplicantInformation({

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -5,6 +5,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remi
 import { redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
+import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
@@ -187,8 +188,12 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (getChildrenState(state).length === 0) {
-    const submissionInfo = await appContainer.get(TYPES.domain.services.BenefitRenewalService).createBenefitRenewal(state);
+    const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewAdultChildStateToAdultChildBenefitRenewalDto(state);
+    await appContainer.get(TYPES.domain.services.BenefitRenewalService).createAdultChildBenefitRenewal(benefitRenewalDto);
+
+    const submissionInfo = { submittedOn: new UTCDate().toISOString() };
     saveRenewState({ params, session, state: { submissionInfo } });
+
     return redirect(getPathById('public/renew/$id/adult-child/confirmation', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -5,6 +5,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remi
 import { redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
+import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
@@ -142,8 +143,10 @@ export async function action({ context: { appContainer, session }, params, reque
     }
   }
 
-  const submissionInfo = await appContainer.get(TYPES.domain.services.BenefitRenewalService).createBenefitRenewal(state);
+  const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewAdultChildStateToAdultChildBenefitRenewalDto(state);
+  await appContainer.get(TYPES.domain.services.BenefitRenewalService).createAdultChildBenefitRenewal(benefitRenewalDto);
 
+  const submissionInfo = { submittedOn: new UTCDate().toISOString() };
   saveRenewState({ params, session, state: { submissionInfo } });
 
   return redirect(getPathById('public/renew/$id/adult-child/confirmation', params));

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -5,6 +5,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remi
 import { redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
+import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
@@ -185,8 +186,10 @@ export async function action({ context: { appContainer, session }, params, reque
     }
   }
 
-  const submissionInfo = await appContainer.get(TYPES.domain.services.BenefitRenewalService).createBenefitRenewal(state);
+  const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewItaStateToItaBenefitRenewalDto(state);
+  await appContainer.get(TYPES.domain.services.BenefitRenewalService).createItaBenefitRenewal(benefitRenewalDto);
 
+  const submissionInfo = { submittedOn: new UTCDate().toISOString() };
   saveRenewState({ params, session, state: { submissionInfo } });
 
   return redirect(getPathById('public/renew/$id/ita/confirmation', params));


### PR DESCRIPTION
### Description
This PR introduces updates and additions to support the renewal flow, ensuring backward compatibility by breaking changes into multiple commits instead of separate PRs:

- Renamed DTOs and state mapper methods and introduced new types for `changedIndicators`
- `BenefitRenewalRequestEntity` and `BenefitRenewalResponseEntity` are based off `BenefitApplicationRequestEntity` and `BenefitApplicationResponseEntity` introduced in #2531
- Added a DTO mapper (based off of benefit application DTO mapper introduced in #2531) and integrated it into the service layer
- Updated `/review-information` routes to utilize the new service for the renewal flow

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Screenshots (if applicable)
Log of ITA renewal submission:
![image](https://github.com/user-attachments/assets/3909e253-423f-41a6-a6d7-e46d1f430147)

Log of adult/child renewal submission:
![image](https://github.com/user-attachments/assets/a33b5791-60e5-4039-96d9-4f570a27e795)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/renew`. Submit a renewal application for ITA and adult/child flows.