### PR TITLE
Adding unit tests for benefit renewal state mapper and fixing mapping issues

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -300,6 +300,9 @@ YUKON_PROVINCE_ID=8fef32b7-39b3-eb11-8236-0022486d8d5f
 # id for 'Email' communication method
 # (optional; default: 775170000)
 COMMUNICATION_METHOD_EMAIL_ID=775170000
+# id for 'Mail' communication method
+# (optional; default: 775170002)
+COMMUNICATION_METHOD_MAIL_ID=775170002
 ## id for 'United States of America'
 # (optional; default: fcf7389e-97ae-eb11-8236-000d3af4bfc3)
 USA_COUNTRY_ID=fcf7389e-97ae-eb11-8236-000d3af4bfc3

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ServerConfig } from '~/.server/configs';
+import type { AdultChildBenefitRenewalDto, ClientApplicationDto } from '~/.server/domain/dtos';
+import type { FederalGovernmentInsurancePlanService, ProvincialGovernmentInsurancePlanService } from '~/.server/domain/services';
+import { BenefitRenewalStateMapperImpl } from '~/.server/routes/mappers';
+import type { RenewAdultChildState } from '~/.server/routes/mappers';
+
+describe('BenefitRenewalStateMapperImpl', () => {
+  const mockFederalGovernmentInsurancePlanService = mock<FederalGovernmentInsurancePlanService>();
+  mockFederalGovernmentInsurancePlanService.listFederalGovernmentInsurancePlans.mockReturnValue([
+    {
+      id: 'Original federal benefit',
+      nameEn: 'English example name',
+      nameFr: 'French example name',
+    },
+
+    {
+      id: 'New federal benefit',
+      nameEn: 'English example name',
+      nameFr: 'French example name',
+    },
+  ]);
+
+  const mockProvincialGovernmentInsurancePlanService = mock<ProvincialGovernmentInsurancePlanService>();
+  mockProvincialGovernmentInsurancePlanService.listProvincialGovernmentInsurancePlans.mockReturnValue([
+    {
+      id: 'Original provincial benefit',
+      nameEn: 'English example name',
+      nameFr: 'French example name',
+      provinceTerritoryStateId: 'Example province id',
+    },
+    {
+      id: 'New provincial benefit',
+      nameEn: 'English example name',
+      nameFr: 'French example name',
+      provinceTerritoryStateId: 'Example province id',
+    },
+  ]);
+
+  const mockServerConfig = mock<ServerConfig>();
+  mockServerConfig.COMMUNICATION_METHOD_EMAIL_ID = 'Email';
+  mockServerConfig.COMMUNICATION_METHOD_MAIL_ID = 'Mail';
+
+  const mapper = new BenefitRenewalStateMapperImpl(mockFederalGovernmentInsurancePlanService, mockProvincialGovernmentInsurancePlanService, mockServerConfig);
+
+  const mockClientApplication: ClientApplicationDto = {
+    applicantInformation: {
+      firstName: 'John',
+      lastName: 'Doe',
+      maritalStatus: 'Married',
+      socialInsuranceNumber: '800000002',
+      clientNumber: '00000000000',
+    },
+    children: [
+      {
+        dentalBenefits: ['Original federal benefit', 'Original provincial benefit'],
+        dentalInsurance: false,
+        information: {
+          clientNumber: '11111111111',
+          dateOfBirth: '2020-01-01',
+          firstName: 'John Jr.',
+          lastName: 'Doe',
+          isParent: true,
+          socialInsuranceNumber: '800000010',
+        },
+      },
+    ],
+    communicationPreferences: {
+      preferredLanguage: 'English',
+      preferredMethod: 'Mail',
+    },
+    contactInformation: {
+      copyMailingAddress: false,
+      homeAddress: '123 Original Fake Street',
+      homeApartment: 'Unit 1',
+      homeCity: 'Home City',
+      homeCountry: 'Canada',
+      homePostalCode: 'H0H0H0',
+      homeProvince: 'ON',
+      mailingAddress: '456 Original Fake Street',
+      mailingApartment: 'Unit 2',
+      mailingCity: 'Mailing City',
+      mailingCountry: 'Canada',
+      mailingPostalCode: 'H0H0H0',
+      mailingProvince: 'ON',
+      phoneNumber: '555-555-5555',
+      phoneNumberAlt: '555-555-6666',
+      email: 'test@example.com',
+    },
+    dateOfBirth: '1970-01-01',
+    dentalBenefits: ['Original federal benefit', 'Original provincial benefit'],
+    dentalInsurance: false,
+    hasFiledTaxes: true,
+    isInvitationToApplyClient: false,
+    partnerInformation: {
+      confirm: true,
+      dateOfBirth: '1970-01-01',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      socialInsuranceNumber: '800011819',
+    },
+  };
+
+  describe('mapRenewAdultChildStateToAdultChildBenefitRenewalDto', () => {
+    it('should map a valid RenewAdultChildState to AdultChildBenefitRenewalDto with information changed', () => {
+      const renewAdultChildState: RenewAdultChildState = {
+        addressInformation: {
+          copyMailingAddress: false,
+          homeAddress: '123 New Fake Street',
+          homeCity: 'Home City',
+          homeCountry: 'United States',
+          homePostalCode: '90210',
+          homeProvince: 'LA',
+          mailingAddress: '456 New Fake Street',
+          mailingCity: 'Mailing City',
+          mailingCountry: 'United States',
+          mailingPostalCode: '90210',
+          mailingProvince: 'LA',
+        },
+        children: [
+          {
+            id: '1',
+            confirmDentalBenefits: {
+              federalBenefitsChanged: true,
+              provincialTerritorialBenefitsChanged: true,
+            },
+            dentalBenefits: {
+              hasFederalBenefits: true,
+              hasProvincialTerritorialBenefits: true,
+              federalSocialProgram: 'New federal program',
+              provincialTerritorialSocialProgram: 'New provincial program',
+            },
+            dentalInsurance: true,
+            information: {
+              clientNumber: '11111111111',
+              dateOfBirth: '2020-01-01',
+              firstName: 'John Jr.',
+              lastName: 'Doe',
+              isParent: true,
+            },
+          },
+        ],
+        clientApplication: mockClientApplication,
+        confirmDentalBenefits: {
+          federalBenefitsChanged: true,
+          provincialTerritorialBenefitsChanged: false,
+        },
+        contactInformation: {
+          email: 'new@example.com',
+          phoneNumber: '555-555-1234',
+          phoneNumberAlt: '555-555-5678',
+          isNewOrUpdatedEmail: true,
+          isNewOrUpdatedPhoneNumber: true,
+          shouldReceiveEmailCommunication: true,
+        },
+        dentalBenefits: {
+          hasFederalBenefits: true,
+          hasProvincialTerritorialBenefits: false,
+          federalSocialProgram: 'New federal program',
+        },
+        dentalInsurance: true,
+        hasAddressChanged: true,
+        hasMaritalStatusChanged: true,
+        maritalStatus: 'Single',
+      };
+
+      const adultChildBenefitRenewalDto = mapper.mapRenewAdultChildStateToAdultChildBenefitRenewalDto(renewAdultChildState);
+
+      const expectedResult: AdultChildBenefitRenewalDto = {
+        ...mockClientApplication,
+        applicantInformation: {
+          firstName: 'John',
+          lastName: 'Doe',
+          maritalStatus: 'Single',
+          socialInsuranceNumber: '800000002',
+        },
+        contactInformation: {
+          copyMailingAddress: false,
+          homeAddress: '123 New Fake Street',
+          homeApartment: undefined,
+          homeCity: 'Home City',
+          homeCountry: 'United States',
+          homePostalCode: '90210',
+          homeProvince: 'LA',
+          mailingAddress: '456 New Fake Street',
+          mailingApartment: undefined,
+          mailingCity: 'Mailing City',
+          mailingCountry: 'United States',
+          mailingPostalCode: '90210',
+          mailingProvince: 'LA',
+          email: 'new@example.com',
+          phoneNumber: '555-555-1234',
+          phoneNumberAlt: '555-555-5678',
+        },
+        changeIndicators: {
+          hasAddressChanged: true,
+          hasEmailChanged: true,
+          hasMaritalStatusChanged: true,
+          hasPhoneChanged: true,
+          hasFederalBenefitsChanged: true,
+          hasProvincialTerritorialBenefitsChanged: false,
+        },
+        children: [
+          {
+            dentalBenefits: ['New federal program', 'New provincial program'],
+            dentalInsurance: true,
+            information: {
+              dateOfBirth: '2020-01-01',
+              firstName: 'John Jr.',
+              lastName: 'Doe',
+              isParent: true,
+              socialInsuranceNumber: '800000010',
+            },
+          },
+        ],
+        communicationPreferences: {
+          preferredLanguage: 'English',
+          preferredMethod: 'Email',
+          email: 'new@example.com',
+        },
+        dateOfBirth: '1970-01-01',
+        dentalBenefits: ['New federal program', 'Original provincial benefit'],
+        dentalInsurance: true,
+        typeOfApplication: 'adult-child',
+        userId: 'anonymous',
+      };
+
+      expect(adultChildBenefitRenewalDto).toEqual(expectedResult);
+    });
+  });
+});

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -48,6 +48,7 @@ const serverEnv = clientEnvSchema.extend({
   CANADA_COUNTRY_ID: z.string().trim().min(1).default('0cf5389e-97ae-eb11-8236-000d3af4bfc3'),
   USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
   COMMUNICATION_METHOD_EMAIL_ID: z.string().trim().min(1).default('775170000'),
+  COMMUNICATION_METHOD_MAIL_ID: z.string().trim().min(1).default('775170002'),
   CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
   INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
 


### PR DESCRIPTION
### Description
Single unit test added for adult child benefit renewal to keep PR manageable. Issues discovered and fixed:
- `communicationPreferences` in the DTO now being mapped based on the value of `renewedReceiveEmailCommunication` from the state, which includes adding an environment variable for the mail communication method identifier
- `toDentalBenefits(..)` modified to support unchanged federal and provincial/territorial dental benefits from existing dental benefits
- Explicitly mapping fields where appropriate to prevent additional fields from being added to mapping result

### Related Azure Boards Work Items
[AB#4786](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4786)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`