### PR TITLE
[gitops] Add `ingress-apply-maintenance.yaml` to prod for selective online application maintenance

### DIFF
--- a/gitops/overlays/prod/ingresses-apply-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-apply-maintenance.yaml
@@ -1,0 +1,66 @@
+# This file defines ingress resources that put the online application into "maintenance mode".
+#
+# To enable maintenance mode, reference this file in kustomization.yaml.
+# This will route traffic for the online application to the maintenance and OAuth proxy services,
+# while preserving access to the allowed routes.
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: srv024.service.canada.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(apply|demander)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: maintenance
+                port:
+                  name: http
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-internal
+  labels:
+    app.kubernetes.io/name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k # required for OAuth proxy
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(apply|demander)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: oauth-proxy

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -18,10 +18,13 @@ resources:
   # Note: to enable maintenance mode:
   #
   #   1. comment ./ingresses.yaml
-  #   2. uncomment ./ingresses-maintenance.yaml
+  #   2. uncomment the appropriate maintenance mode file:
+  #      - for full application maintenance, uncomment ./ingresses-maintenance.yaml
+  #      - for online application maintenance, uncomment ./ingresses-apply-maintenance.yaml
   #
-  - ./ingresses.yaml
+  # - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
+  - ./ingresses-apply-maintenance.yaml
 patches:
   - path: ./patches/deployments-frontend.yaml
   - path: ./patches/deployments-maintenance.yaml


### PR DESCRIPTION
- Added new ingress resource to enable maintenance mode for the online application
- Updated `kustomization.yaml` instructions to toggle between full application maintenance and selective maintenance modes
- Marking as draft - to be merged on Friday, December 6 at 10pm Eastern.