### PR TITLE
fix(frontend): resource routes Remix warnings

### DIFF
--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -1,7 +1,6 @@
 /**
  * An API route that can be used to perform actions with user's apply state.
  */
-import { data } from '@remix-run/node';
 import type { ActionFunctionArgs } from '@remix-run/node';
 
 import { z } from 'zod';
@@ -19,7 +18,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (request.method !== 'POST') {
     log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw data({ message: 'Method not allowed' }, { status: 405 });
+    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
   }
 
   const bodySchema = z.object({
@@ -32,7 +31,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (!parsedBody.success) {
     log.debug('Invalid request body [%j]; sessionId: [%s]', requestBody, sessionId);
-    return data({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
+    return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
   const params = { id: parsedBody.data.id };
@@ -42,7 +41,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
     case 'extend': {
       log.debug("Extending user's apply state; id: [%s], sessionId: [%s]", params.id, sessionId);
       saveApplyState({ params, session, state: {} });
-      return data(null, { status: 204 });
+      return new Response(null, { status: 204 });
     }
 
     default: {

--- a/frontend/app/routes/api/buildinfo.ts
+++ b/frontend/app/routes/api/buildinfo.ts
@@ -9,5 +9,5 @@ export function loader({ context, params, request }: LoaderFunctionArgs) {
   const buildInfo = getBuildInfoService().getBuildInfo();
   const imageTag = `${buildInfo.buildVersion}-${buildInfo.buildRevision}-${buildInfo.buildId}`;
 
-  return { ...buildInfo, imageTag };
+  return Response.json({ ...buildInfo, imageTag });
 }

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -1,5 +1,4 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { data } from '@remix-run/node';
 
 import type { HealthCheck, HealthCheckOptions } from '@dts-stn/health-checks';
 import { HealthCheckConfig, execute, getHttpStatusCode } from '@dts-stn/health-checks';
@@ -57,7 +56,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // execute the health checks
   const systemHealthSummary = await execute([redisHealthCheck], healthCheckOptions);
 
-  return data(systemHealthSummary, {
+  return Response.json(systemHealthSummary, {
     headers: { 'Content-Type': HealthCheckConfig.responses.contentType },
     status: getHttpStatusCode(systemHealthSummary.status),
   });

--- a/frontend/app/routes/api/jwks.ts
+++ b/frontend/app/routes/api/jwks.ts
@@ -1,5 +1,4 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
-import { data } from '@remix-run/node';
 
 import { subtle } from 'node:crypto';
 
@@ -43,5 +42,5 @@ export async function loader({ context: { appContainer } }: LoaderFunctionArgs) 
   const keys = await getJwks({ AUTH_JWT_PUBLIC_KEY });
   const headers = { 'Content-Type': 'application/json' };
 
-  return data({ keys }, { headers: headers });
+  return Response.json({ keys }, { headers: headers });
 }

--- a/frontend/app/routes/api/protected-renew-state.ts
+++ b/frontend/app/routes/api/protected-renew-state.ts
@@ -1,7 +1,6 @@
 /**
  * An API route that can be used to perform actions with user's protected renew state.
  */
-import { data } from '@remix-run/node';
 import type { ActionFunctionArgs } from '@remix-run/node';
 
 import { z } from 'zod';
@@ -19,7 +18,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (request.method !== 'POST') {
     log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw data({ message: 'Method not allowed' }, { status: 405 });
+    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
   }
 
   const bodySchema = z.object({
@@ -32,7 +31,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (!parsedBody.success) {
     log.debug('Invalid request body [%j]; sessionId: [%s]', requestBody, sessionId);
-    return data({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
+    return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
   const params = { id: parsedBody.data.id };
@@ -42,7 +41,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
     case 'extend': {
       log.debug("Extending user's protected renew state; id: [%s], sessionId: [%s]", params.id, sessionId);
       saveProtectedRenewState({ params, session, state: {} });
-      return data(null, { status: 204 });
+      return Response.json(null, { status: 204 });
     }
 
     default: {

--- a/frontend/app/routes/api/readyz.ts
+++ b/frontend/app/routes/api/readyz.ts
@@ -6,5 +6,5 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
  * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
  */
 export function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
-  return { ready: true };
+  return Response.json({ ready: true });
 }

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -2,7 +2,7 @@
  * An API route that can be used to perform actions with user's server-side session.
  */
 import type { ActionFunctionArgs } from '@remix-run/node';
-import { data, redirectDocument } from '@remix-run/node';
+import { redirectDocument } from '@remix-run/node';
 
 import { z } from 'zod';
 
@@ -24,7 +24,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (request.method !== 'POST') {
     log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw data({ message: 'Method not allowed' }, { status: 405 });
+    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
   }
 
   const bodySchema = z.object({
@@ -38,7 +38,7 @@ export async function action({ context: { appContainer, session }, request }: Ac
 
   if (!parsedBody.success) {
     log.debug('Invalid request body [%j]; sessionId: [%s]', requestBody, sessionId);
-    return data({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
+    return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
   const { action, locale = 'en', redirectTo } = parsedBody.data;
@@ -54,12 +54,12 @@ export async function action({ context: { appContainer, session }, request }: Ac
         return redirectDocument(redirectToUrl, { headers });
       }
 
-      return data(null, { headers, status: 204 });
+      return Response.json(null, { headers, status: 204 });
     }
 
     case 'extend': {
       log.debug("Extending user's server-side session lifetime; sessionId: [%s]", sessionId);
-      return data(null, { status: 204 });
+      return Response.json(null, { status: 204 });
     }
 
     default: {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix resource routes `REMIX FUTURE CHANGE` warnings.

> ⚠️ REMIX FUTURE CHANGE: Externally-accessed resource routes will no longer be able to return raw JavaScript objects or `null` in React Router v7 when Single Fetch becomes the default. You can prepare for this change at your connvenience by wrapping the data returned from your `loader` function in the `api/readyz-en` route with `json()`.  For instructions on making this change, see https://remix.run/docs/en/v2.13.1/guides/single-fetch#resource-routes  

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->