### PR TITLE
refactor(frontend): use ClientConfig in routes

### DIFF
--- a/frontend/__tests__/components/client-env.test.tsx
+++ b/frontend/__tests__/components/client-env.test.tsx
@@ -11,15 +11,25 @@ describe('<ClientEnv>', () => {
 
     const env: ClientEnv = {
       ADOBE_ANALYTICS_JQUERY_SRC: 'https://example.com/jquery.min.js',
+      ANOTHER_ETHNIC_GROUP_OPTION: 100000002,
+      CANADA_COUNTRY_ID: 'CAN',
+      CLIENT_STATUS_SUCCESS_ID: 'CLIENT_STATUS_SUCCESS',
+      COMMUNICATION_METHOD_EMAIL_ID: 'EMAIL',
+      COMMUNICATION_METHOD_MAIL_ID: 'MAIL',
       ECAS_BASE_URI: 'https://srv136.services.gc.ca/ecas-seca/rascl/SCL',
       ENABLED_FEATURES: ['feature1', 'feature2'],
       HCAPTCHA_SITE_KEY: 'hcaptcha-site-key',
       HEADER_LOGO_URL_EN: 'https://canada.ca/en',
       HEADER_LOGO_URL_FR: 'https://canada.ca/fr',
       I18NEXT_DEBUG: true,
+      INVALID_CLIENT_FRIENDLY_STATUS: 'INVALID_CLIENT_FRIENDLY_STATUS',
+      IS_APPLICANT_FIRST_NATIONS_YES_OPTION: 100000001,
+      MARITAL_STATUS_CODE_COMMONLAW: 100000004,
+      MARITAL_STATUS_CODE_MARRIED: 100000003,
       SCCH_BASE_URI: 'https://service.canada.ca',
       SESSION_TIMEOUT_PROMPT_SECONDS: 30,
       SESSION_TIMEOUT_SECONDS: 120,
+      USA_COUNTRY_ID: 'USA',
     };
 
     const { container } = render(<ClientEnvComponent env={env} nonce={nonce} />);

--- a/frontend/__tests__/routes/public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/public/communication-preference.test.tsx
@@ -4,7 +4,7 @@ import { createMemorySessionStorage } from '@remix-run/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
-import type { ServerConfig } from '~/.server/configs';
+import type { ClientConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { PreferredCommunicationMethodService, PreferredLanguageService } from '~/.server/domain/services';
 import type { SecurityHandler } from '~/.server/routes/security';
@@ -33,9 +33,9 @@ describe('_public.apply.id.communication-preference', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const mockAppLoadContext = mockDeep<AppLoadContext>();
-      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ServerConfig).mockReturnValueOnce({
+      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ClientConfig).mockReturnValueOnce({
         COMMUNICATION_METHOD_EMAIL_ID: 'email',
-      } satisfies Partial<ServerConfig>);
+      } satisfies Partial<ClientConfig>);
       mockAppLoadContext.appContainer.get.calledWith(TYPES.domain.services.PreferredCommunicationMethodService).mockReturnValueOnce({
         listAndSortLocalizedPreferredCommunicationMethods: () => [
           { id: 'email', name: 'Email' },
@@ -86,9 +86,9 @@ describe('_public.apply.id.communication-preference', () => {
 
       const mockAppLoadContext = mockDeep<AppLoadContext>();
       mockAppLoadContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
-      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ServerConfig).mockReturnValueOnce({
+      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ClientConfig).mockReturnValueOnce({
         COMMUNICATION_METHOD_EMAIL_ID: 'email',
-      } satisfies Partial<ServerConfig>);
+      } satisfies Partial<ClientConfig>);
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
@@ -115,9 +115,9 @@ describe('_public.apply.id.communication-preference', () => {
 
       const mockAppLoadContext = mockDeep<AppLoadContext>();
       mockAppLoadContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
-      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ServerConfig).mockReturnValueOnce({
+      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ClientConfig).mockReturnValueOnce({
         COMMUNICATION_METHOD_EMAIL_ID: 'email',
-      } satisfies Partial<ServerConfig>);
+      } satisfies Partial<ClientConfig>);
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
@@ -146,9 +146,9 @@ describe('_public.apply.id.communication-preference', () => {
 
       const mockAppLoadContext = mockDeep<AppLoadContext>();
       mockAppLoadContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
-      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ServerConfig).mockReturnValueOnce({
+      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ClientConfig).mockReturnValueOnce({
         COMMUNICATION_METHOD_EMAIL_ID: 'email',
-      } satisfies Partial<ServerConfig>);
+      } satisfies Partial<ClientConfig>);
 
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),

--- a/frontend/__tests__/routes/public/contact-information.test.tsx
+++ b/frontend/__tests__/routes/public/contact-information.test.tsx
@@ -4,7 +4,6 @@ import { createMemorySessionStorage } from '@remix-run/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
-import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { CountryService, ProvinceTerritoryStateService } from '~/.server/domain/services';
 import { loader } from '~/routes/public/apply/$id/adult/contact-information';
@@ -32,12 +31,6 @@ describe('_public.apply.id.contact-information', () => {
       const session = await createMemorySessionStorage({ cookie: { secrets: [''] } }).getSession();
 
       const mockAppLoadContext = mockDeep<AppLoadContext>();
-      mockAppLoadContext.appContainer.get.calledWith(TYPES.configs.ServerConfig).mockReturnValueOnce({
-        MARITAL_STATUS_CODE_COMMONLAW: 1,
-        MARITAL_STATUS_CODE_MARRIED: 2,
-        CANADA_COUNTRY_ID: 'CAN',
-        USA_COUNTRY_ID: 'USA',
-      } satisfies Partial<ServerConfig>);
       mockAppLoadContext.appContainer.get.calledWith(TYPES.domain.services.CountryService).mockReturnValueOnce({
         listCountries: () => [{ id: '1', nameEn: 'super country', nameFr: '(FR) super country' }],
         listAndSortLocalizedCountries: () => [{ id: '1', name: 'super country' }],
@@ -56,8 +49,6 @@ describe('_public.apply.id.contact-information', () => {
         id: '123',
         countryList: [{ id: '1', name: 'super country' }],
         regionList: [{ id: 'SP', countryId: 'CAN', name: 'sample', abbr: 'SP' }],
-        CANADA_COUNTRY_ID: 'CAN',
-        USA_COUNTRY_ID: 'USA',
       });
     });
   });

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -46,14 +46,6 @@ const serverEnv = clientEnvSchema.extend({
   APPLICANT_CATEGORY_CODE_FAMILY: z.coerce.number().default(775170001),
   APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: z.coerce.number().default(775170002),
 
-  // lookup identifiers
-  CANADA_COUNTRY_ID: z.string().trim().min(1).default('0cf5389e-97ae-eb11-8236-000d3af4bfc3'),
-  USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
-  COMMUNICATION_METHOD_EMAIL_ID: z.string().trim().min(1).default('775170000'),
-  COMMUNICATION_METHOD_MAIL_ID: z.string().trim().min(1).default('775170002'),
-  CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
-  INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
-
   // province/territory lookup identifiers
   ALBERTA_PROVINCE_ID: z.string().trim().min(1).default("3b17d494-35b3-eb11-8236-0022486d8d5f"),
   BRITISH_COLUMBIA_PROVINCE_ID: z.string().trim().min(1).default("9c440baa-35b3-eb11-8236-0022486d8d5f"),
@@ -72,14 +64,6 @@ const serverEnv = clientEnvSchema.extend({
   // language codes
   ENGLISH_LANGUAGE_CODE: z.coerce.number().default(1033),
   FRENCH_LANGUAGE_CODE: z.coerce.number().default(1036),
-
-  // marital status codes
-  MARITAL_STATUS_CODE_MARRIED: z.coerce.number().default(775170001),
-  MARITAL_STATUS_CODE_COMMONLAW:z.coerce.number().default(775170002),
-
-  // demographic survey codes
-  IS_APPLICANT_FIRST_NATIONS_YES_OPTION: z.coerce.number().default(775170000),
-  ANOTHER_ETHNIC_GROUP_OPTION: z.coerce.number().default(775170009),
 
   // interop api settings
   INTEROP_API_BASE_URI: z.string().url(),

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -23,6 +23,7 @@ import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -46,8 +47,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
-
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -78,8 +77,6 @@ export async function loader({ context: { appContainer, session }, request, para
     genderStatuses,
     defaultState: state.demographicSurvey,
     editMode: state.editMode,
-    IS_APPLICANT_FIRST_NATIONS_YES_OPTION,
-    ANOTHER_ETHNIC_GROUP_OPTION,
   };
 }
 
@@ -93,7 +90,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewSingleChildState({ params, session });
   const protectedRenewState = loadProtectedRenewState({ params, session });
 
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const demographicSurveySchema = z
@@ -146,7 +143,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedChildrenDemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useLoaderData<typeof loader>();
+  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const params = useParams();

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -23,6 +23,7 @@ import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -46,8 +47,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
-
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
 
   const state = loadProtectedRenewState({ params, session });
 
@@ -78,8 +77,6 @@ export async function loader({ context: { appContainer, session }, request, para
     genderStatuses,
     defaultState: state.demographicSurvey,
     editMode: state.editMode,
-    IS_APPLICANT_FIRST_NATIONS_YES_OPTION,
-    ANOTHER_ETHNIC_GROUP_OPTION,
   };
 }
 
@@ -90,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const demographicSurveySchema = z
@@ -141,7 +138,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedDemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useLoaderData<typeof loader>();
+  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const params = useParams();

--- a/frontend/app/routes/protected/renew/$id/marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/marital-status.tsx
@@ -24,6 +24,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -56,11 +57,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
-
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -129,7 +128,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedRenewMaritalStatus() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -8,7 +8,6 @@ import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -19,6 +18,7 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -45,11 +45,10 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const state = loadProtectedRenewState({ params, session });
 
-  const { SCCH_BASE_URI } = getEnv();
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:terms-and-conditions.page-title') }) };
 
-  return { meta, defaultState: state.termsAndConditions, SCCH_BASE_URI };
+  return { meta, defaultState: state.termsAndConditions };
 }
 
 export async function action({ context: { appContainer, session }, request, params }: ActionFunctionArgs) {
@@ -96,7 +95,8 @@ export async function action({ context: { appContainer, session }, request, para
 
 export default function RenewTermsAndConditions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, SCCH_BASE_URI } = useLoaderData<typeof loader>();
+  const { defaultState } = useLoaderData<typeof loader>();
+  const { SCCH_BASE_URI } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/update-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/update-address.tsx
@@ -25,6 +25,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -49,7 +50,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -58,13 +58,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: state.addressInformation,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
     editMode: state.editMode,
   };
 }
@@ -78,7 +75,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const addressInformationSchema = z
     .object({
@@ -191,7 +188,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedRenewUpdateAddress() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -29,6 +29,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -50,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -65,10 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     maritalStatus: state.applicantInformation?.maritalStatus,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
-    MARITAL_STATUS_CODE_COMMONLAW,
-    MARITAL_STATUS_CODE_MARRIED,
     editMode: state.editMode,
   };
 }
@@ -81,7 +77,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const personalInformationSchema = z
     .object({
@@ -242,7 +238,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplyFlowPersonalInformation() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, maritalStatus, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, maritalStatus, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ServerConfig);
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ClientConfig);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -79,7 +79,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
@@ -29,6 +29,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -50,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -59,16 +59,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: state.contactInformation,
     maritalStatus: state.applicantInformation?.maritalStatus,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
-    MARITAL_STATUS_CODE_COMMONLAW,
-    MARITAL_STATUS_CODE_MARRIED,
     editMode: state.editMode,
   };
 }
@@ -81,7 +76,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const personalInformationSchema = z
     .object({
@@ -240,7 +235,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplyFlowPersonalInformation() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, maritalStatus, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, maritalStatus, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -51,7 +51,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
   const state = loadApplySingleChildState({ params, request, session });
 
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -42,7 +42,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -29,6 +29,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -50,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -59,16 +59,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: state.contactInformation,
     maritalStatus: state.applicantInformation?.maritalStatus,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
-    MARITAL_STATUS_CODE_COMMONLAW,
-    MARITAL_STATUS_CODE_MARRIED,
     editMode: state.editMode,
   };
 }
@@ -81,7 +76,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const personalInformationSchema = z
     .object({
@@ -242,7 +237,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplyFlowPersonalInformation() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, maritalStatus, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, maritalStatus, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -23,6 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -53,21 +54,23 @@ export async function loader({ context: { appContainer, session }, params, reque
   // apply state is valid then edit mode can be set to true
   saveApplyState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ServerConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
-
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:review-child-information.page-title') }) };
 
+  const federalGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService);
+  const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService);
+
   const children = state.children.map((child) => {
+    // prettier-ignore
     const selectFederalGovernmentInsurancePlan = child.dentalBenefits.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+      ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
 
+    // prettier-ignore
     const selectedProvincialBenefit = child.dentalBenefits.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+      ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
     return {
@@ -92,14 +95,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  return {
-    id: state.id,
-    children,
-
-    meta,
-    siteKey: HCAPTCHA_SITE_KEY,
-    hCaptchaEnabled,
-  };
+  return { id: state.id, children, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -126,7 +122,9 @@ export default function ReviewInformation() {
   const { currentLanguage } = useCurrentLanguage();
   const params = useParams();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, siteKey, hCaptchaEnabled } = useLoaderData<typeof loader>();
+  const { children } = useLoaderData<typeof loader>();
+  const { HCAPTCHA_SITE_KEY } = useClientEnv();
+  const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const { captchaRef } = useHCaptcha();
@@ -242,7 +240,7 @@ export default function ReviewInformation() {
         </div>
         <fetcher.Form method="post" onSubmit={handleSubmit} className="mt-6 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <CsrfTokenInput />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
           <LoadingButton
             variant="primary"
             id="continue-button"

--- a/frontend/app/routes/public/demographic-survey/$id/questions/$memberId.tsx
+++ b/frontend/app/routes/public/demographic-survey/$id/questions/$memberId.tsx
@@ -23,6 +23,7 @@ import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { AppPageTitle } from '~/components/layouts/public-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -39,8 +40,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
-
   const member = loadDemographicSurveySingleMemberState({ params, session });
   const memberName = `${member.firstName} ${member.lastName}`;
 
@@ -56,7 +55,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const locationBornStatuses = demographicSurveyService.listLocalizedLocationBornStatuses(locale);
   const genderStatuses = demographicSurveyService.listLocalizedGenderStatuses(locale);
 
-  return { meta, memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState: member.questions, IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION };
+  return { meta, memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState: member.questions };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -67,7 +66,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadDemographicSurveyState({ params, session });
 
-  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ServerConfig);
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const demographicSurveySchema = z
@@ -120,7 +119,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function DemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useLoaderData<typeof loader>();
+  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState } = useLoaderData<typeof loader>();
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const params = useParams();

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -50,7 +50,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -25,6 +25,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -57,11 +58,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -129,7 +129,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewAdultChildMaritalStatus() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -25,6 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -54,29 +55,28 @@ export async function loader({ context: { appContainer, session }, params, reque
   // renew state is valid then edit mode can be set to true
   saveRenewState({ params, session, state: { editMode: true } });
 
-  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ServerConfig);
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-
-  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
-  const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
-
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:review-child-information.page-title') }) };
 
-  // prettier-ignore
-  const payload =
-    viewPayloadEnabled &&
-    appContainer.get(TYPES.domain.mappers.BenefitRenewalDtoMapper).mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(
-      appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapRenewAdultChildStateToAdultChildBenefitRenewalDto(state)
-    );
+  const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
+  const benefitRenewalDtoMapper = appContainer.get(TYPES.domain.mappers.BenefitRenewalDtoMapper);
+  const benefitRenewalStateMapper = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper);
+  const payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalStateMapper.mapRenewAdultChildStateToAdultChildBenefitRenewalDto(state));
+
+  const federalGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService);
+  const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService);
 
   const children = state.children.map((child) => {
+    // prettier-ignore
     const selectedFederalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+      ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
 
+    // prettier-ignore
     const selectedProvincialBenefit = child.dentalBenefits?.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+      ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
     return {
@@ -102,15 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  return {
-    id: state.id,
-    children,
-
-    meta,
-    siteKey: HCAPTCHA_SITE_KEY,
-    hCaptchaEnabled,
-    payload,
-  };
+  return { id: state.id, children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -143,7 +135,9 @@ export default function RenewAdultChildReviewChildInformation() {
   const { currentLanguage } = useCurrentLanguage();
   const params = useParams();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, siteKey, hCaptchaEnabled, payload } = useLoaderData<typeof loader>();
+  const { children, payload } = useLoaderData<typeof loader>();
+  const { HCAPTCHA_SITE_KEY } = useClientEnv();
+  const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const { captchaRef } = useHCaptcha();
@@ -246,7 +240,7 @@ export default function RenewAdultChildReviewChildInformation() {
         </div>
         <fetcher.Form method="post" onSubmit={handleSubmit} className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <CsrfTokenInput />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
+          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <LoadingButton
               id="confirm-button"

--- a/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-address.tsx
@@ -26,6 +26,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -47,7 +48,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -56,13 +56,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: state.addressInformation,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
     editMode: state.editMode,
   };
 }
@@ -75,7 +72,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const addressInformationSchema = z
     .object({
@@ -188,7 +185,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewAdultChildUpdateAddress() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -25,6 +25,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -53,11 +54,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
-  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = appContainer.get(TYPES.configs.ServerConfig);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -125,7 +125,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewItaMaritalStatus() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/renew/$id/ita/update-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-address.tsx
@@ -26,6 +26,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -47,7 +48,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
 
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
@@ -56,13 +56,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: state.addressInformation,
     countryList,
     regionList,
-    CANADA_COUNTRY_ID,
-    USA_COUNTRY_ID,
     editMode: state.editMode,
   };
 }
@@ -75,7 +72,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ServerConfig);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const addressInformationSchema = z
     .object({
@@ -193,7 +190,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewItaUpdateAddress() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, CANADA_COUNTRY_ID, USA_COUNTRY_ID, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -39,6 +39,22 @@ export const clientEnvSchema = z.object({
 
   SESSION_TIMEOUT_SECONDS: z.coerce.number().min(0).default(19 * 60),
   SESSION_TIMEOUT_PROMPT_SECONDS: z.coerce.number().min(0).default(5 * 60),
+
+  // demographic survey codes
+  IS_APPLICANT_FIRST_NATIONS_YES_OPTION: z.coerce.number().default(775170000),
+  ANOTHER_ETHNIC_GROUP_OPTION: z.coerce.number().default(775170009),
+
+  // marital status codes
+  MARITAL_STATUS_CODE_MARRIED: z.coerce.number().default(775170001),
+  MARITAL_STATUS_CODE_COMMONLAW:z.coerce.number().default(775170002),
+
+  // lookup identifiers
+  CANADA_COUNTRY_ID: z.string().trim().min(1).default('0cf5389e-97ae-eb11-8236-000d3af4bfc3'),
+  USA_COUNTRY_ID: z.string().trim().min(1).default('fcf7389e-97ae-eb11-8236-000d3af4bfc3'),
+  COMMUNICATION_METHOD_EMAIL_ID: z.string().trim().min(1).default('775170000'),
+  COMMUNICATION_METHOD_MAIL_ID: z.string().trim().min(1).default('775170002'),
+  CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
+  INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
 });
 
 export type ClientEnv = z.infer<typeof clientEnvSchema>;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Refactor the routes to utilize `ClientConfig` instead of `ServerConfig` to reduce the risk of inadvertently exposing sensitive information to the client. On the client side, `useClientEnv` hook should be used to access "client-safe" environment variables. Loaders will no longer return environment variables to the client. In a separate PR, I will decouple `ClientConfig` from `ServerConfig`.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->