### PR TITLE
refector(frontend): add 'validateRequestMethod' to routes security handler

### DIFF
--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -5,6 +5,7 @@ import type { ActionFunctionArgs } from '@remix-run/node';
 
 import { z } from 'zod';
 
+import { TYPES } from '~/.server/constants';
 import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 
@@ -12,14 +13,12 @@ const API_APPLY_STATE_ACTIONS = ['extend'] as const;
 export type ApiApplyStateAction = (typeof API_APPLY_STATE_ACTIONS)[number];
 
 export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
+
   const log = getLogger('routes/api/apply-state');
   const sessionId = session.id;
   log.debug("Action with with user's apply state; sessionId: [%s]", sessionId);
-
-  if (request.method !== 'POST') {
-    log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
-  }
 
   const bodySchema = z.object({
     action: z.enum(API_APPLY_STATE_ACTIONS),

--- a/frontend/app/routes/api/protected-renew-state.ts
+++ b/frontend/app/routes/api/protected-renew-state.ts
@@ -5,6 +5,7 @@ import type { ActionFunctionArgs } from '@remix-run/node';
 
 import { z } from 'zod';
 
+import { TYPES } from '~/.server/constants';
 import { saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 
@@ -12,14 +13,12 @@ const API_PROTECTED_RENEW_STATE_ACTIONS = ['extend'] as const;
 export type ApiProtectedRenewStateAction = (typeof API_PROTECTED_RENEW_STATE_ACTIONS)[number];
 
 export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
+
   const log = getLogger('routes/api/protected-renew-state');
   const sessionId = session.id;
   log.debug("Action with with user's protected renew state; sessionId: [%s]", sessionId);
-
-  if (request.method !== 'POST') {
-    log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
-  }
 
   const bodySchema = z.object({
     action: z.enum(API_PROTECTED_RENEW_STATE_ACTIONS),

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -18,14 +18,12 @@ const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', '
 export type ApiSessionRedirectTo = (typeof API_SESSION_REDIRECT_TO_OPTIONS)[number];
 
 export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
+
   const log = getLogger('routes/api/session');
   const sessionId = session.id;
   log.debug("Action with user's server-side session; sessionId: [%s]", sessionId);
-
-  if (request.method !== 'POST') {
-    log.warn('Invalid method requested [%s]; responding with 405; sessionId: [%s]', request.method, sessionId);
-    throw Response.json({ message: 'Method not allowed' }, { status: 405 });
-  }
 
   const bodySchema = z.object({
     action: z.enum(API_SESSION_ACTIONS),

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -2,7 +2,7 @@ import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { data, redirect } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 import { faCheck, faRefresh } from '@fortawesome/free-solid-svg-icons';
@@ -91,11 +91,8 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('address-validation');
+  securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
   securityHandler.validateCsrfToken({ formData, session });
-
-  if (request.method !== 'POST') {
-    throw data({ message: 'Method not allowed' }, { status: 405 });
-  }
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
   const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This PR introduces a new utility function `validateRequestMethod` to enhance the security and maintainability of the routes in the frontend application. The function ensures that incoming HTTP requests use only the allowed HTTP methods, providing a centralized way to validate request methods across the application.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->