### PR TITLE
Splitting renew/ita/update-address to update-mailing-address and upda…

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
@@ -113,7 +113,7 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
   }
 
   if (hasAddressChanged && addressInformation === undefined) {
-    throw redirect(getPathById('public/renew/$id/ita/update-address', params));
+    throw redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
   }
 
   if (dentalInsurance === undefined) {

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -2,6 +2,7 @@ import type { Session } from '@remix-run/node';
 import { redirectDocument } from '@remix-run/node';
 import type { Params } from '@remix-run/react';
 
+import { merge } from 'moderndash';
 import { z } from 'zod';
 
 import type { ClientApplicationDto } from '~/.server/domain/dtos';
@@ -60,17 +61,20 @@ export interface RenewState {
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly addressInformation?: {
-    copyMailingAddress: boolean;
+    // All properties made optional since we are potentially saving mailing and home from two different pages (update-mailing-address/update-home-address).
+    // Refactoring solution: split addressInformation into two: homeAddress, and mailingAddress.
+    // Following Figma, after implementation, 'copyMailingAddress' might be useless.
+    copyMailingAddress?: boolean;
     homeAddress?: string;
     homeApartment?: string;
     homeCity?: string;
     homeCountry?: string;
     homePostalCode?: string;
     homeProvince?: string;
-    mailingAddress: string;
+    mailingAddress?: string;
     mailingApartment?: string;
-    mailingCity: string;
-    mailingCountry: string;
+    mailingCity?: string;
+    mailingCountry?: string;
     mailingPostalCode?: string;
     mailingProvince?: string;
   };
@@ -181,10 +185,9 @@ export function saveRenewState({ params, session, state }: SaveStateArgs) {
   const log = getLogger('renew-route-helpers.server/saveRenewState');
   const currentState = loadRenewState({ params, session });
 
-  const newState = {
-    ...currentState,
-    ...state,
-  } satisfies RenewState;
+  // https://moderndash.io/docs/merge
+  // Merges two objects without overwriting any unmentioned properties
+  const newState = merge({}, currentState, state) satisfies RenewState;
 
   const sessionName = getSessionName(currentState.id);
   session.set(sessionName, newState);

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -291,8 +291,8 @@ export default function RenewAdultChildConfirm() {
               {mailingAddressInfo ? (
                 <Address
                   address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
+                    address: mailingAddressInfo.address ?? '',
+                    city: mailingAddressInfo.city ?? '',
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -99,7 +99,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
   }
 
-  return redirect(getPathById('public/renew/$id/ita/update-address', params));
+  return redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
 }
 
 export default function RenewItaConfirmAddress() {

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -269,8 +269,8 @@ export default function RenewFlowConfirm() {
               {mailingAddressInfo ? (
                 <Address
                   address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
+                    address: mailingAddressInfo.address ?? '',
+                    city: mailingAddressInfo.city ?? '',
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -295,8 +295,8 @@ export default function RenewItaReviewInformation() {
                 {mailingAddressInfo ? (
                   <Address
                     address={{
-                      address: mailingAddressInfo.address,
-                      city: mailingAddressInfo.city,
+                      address: mailingAddressInfo.address ?? '',
+                      city: mailingAddressInfo.city ?? '',
                       provinceState: mailingAddressInfo.province,
                       postalZipCode: mailingAddressInfo.postalCode,
                       country: mailingAddressInfo.country?.name ?? '',
@@ -307,7 +307,7 @@ export default function RenewItaReviewInformation() {
                   t('renew-ita:review-information.no-change')
                 )}
                 <div className="mt-4">
-                  <InlineLink id="change-mailing-address" routeId="public/renew/$id/ita/update-address" params={params}>
+                  <InlineLink id="change-mailing-address" routeId="public/renew/$id/ita/update-mailing-address" params={params}>
                     {t('renew-ita:review-information.mailing-change')}
                   </InlineLink>
                 </div>
@@ -328,7 +328,7 @@ export default function RenewItaReviewInformation() {
                   t('renew-ita:review-information.no-change')
                 )}
                 <div className="mt-4">
-                  <InlineLink id="change-home-address" routeId="public/renew/$id/ita/update-address" params={params}>
+                  <InlineLink id="change-home-address" routeId="public/renew/$id/ita/update-home-address" params={params}>
                     {t('renew-ita:review-information.home-change')}
                   </InlineLink>
                 </div>

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
+import type { AddressInformationState } from '~/.server/routes/helpers/renew-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/.server/utils/postal-zip-code.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import type { InputOptionProps } from '~/components/input-option';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+import { InputSelect } from '~/components/input-select';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.ita.updateAddress,
+  pageTitleI18nKey: 'renew-ita:update-address.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewItaState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.page-title') }) };
+
+  return {
+    id: state.id,
+    meta,
+    defaultState: state.addressInformation,
+    countryList,
+    regionList,
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewItaState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
+
+  const addressInformationSchema = z
+    .object({
+      homeAddress: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
+      homeApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
+      homeCountry: z.string().trim().optional(),
+      homeProvince: z.string().trim().optional(),
+      homeCity: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
+      homePostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.address-required'), path: ['homeAddress'] });
+      }
+
+      if (!val.homeCountry || validator.isEmpty(val.homeCountry)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.country-required'), path: ['homeCountry'] });
+      }
+
+      if (!val.homeCity || validator.isEmpty(val.homeCity)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.city-required'), path: ['homeCity'] });
+      }
+
+      if (val.homeCountry === CANADA_COUNTRY_ID || val.homeCountry === USA_COUNTRY_ID) {
+        if (!val.homeProvince || validator.isEmpty(val.homeProvince)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.province-required'), path: ['homeProvince'] });
+        }
+        if (!val.homePostalCode || validator.isEmpty(val.homePostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.postal-code-required'), path: ['homePostalCode'] });
+        } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
+          const message = val.homeCountry === CANADA_COUNTRY_ID ? t('renew-ita:update-address.error-message.home-address.postal-code-valid') : t('renew-ita:update-address.error-message.home-address.zip-code-valid');
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
+        } else if (val.homeCountry === CANADA_COUNTRY_ID && val.homeProvince && !isValidCanadianPostalCode(val.homeProvince, val.homePostalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.invalid-postal-code-for-province'), path: ['homePostalCode'] });
+        }
+      }
+
+      if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.invalid-postal-code-for-country'), path: ['homeCountry'] });
+      }
+    })
+    .transform((val) => ({
+      ...val,
+      homePostalCode: val.homeCountry && val.homePostalCode ? formatPostalCode(val.homeCountry, val.homePostalCode) : val.homePostalCode,
+    })) satisfies z.ZodType<AddressInformationState>;
+
+  const parsedDataResult = addressInformationSchema.safeParse({
+    homeAddress: formData.get('homeAddress') ? String(formData.get('homeAddress')) : undefined,
+    homeApartment: formData.get('homeApartment') ? String(formData.get('homeApartment')) : undefined,
+    homeCountry: formData.get('homeCountry') ? String(formData.get('homeCountry')) : undefined,
+    homeProvince: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
+    homeCity: formData.get('homeCity') ? String(formData.get('homeCity')) : undefined,
+    homePostalCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({ params, session, state: { addressInformation: parsedDataResult.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/ita/review-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
+}
+
+export default function RenewItaUpdateAddress() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
+  const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    homeAddress: 'home-address',
+    homeApartment: 'home-apartment',
+    homeProvince: 'home-province',
+    homeCountry: 'home-country',
+    homeCity: 'home-city',
+    homePostalCode: 'home-postal-code',
+  });
+
+  const countries = useMemo<InputOptionProps[]>(() => {
+    return countryList.map(({ id, name }) => ({ children: name, value: id }));
+  }, [countryList]);
+
+  useEffect(() => {
+    const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedHomeCountry);
+    setHomeCountryRegions(filteredProvinceTerritoryStates);
+  }, [selectedHomeCountry, regionList]);
+
+  const homeCountryChangeHandler = (event: React.SyntheticEvent<HTMLSelectElement>) => {
+    setSelectedHomeCountry(event.currentTarget.value);
+  };
+
+  // populate home region/province/state list with selected country or current address country
+  const homeRegions: InputOptionProps[] = homeCountryRegions.map(({ id, name }) => ({ children: name, value: id }));
+
+  const dummyOption: InputOptionProps = { children: t('renew-ita:update-address.address-field.select-one'), value: '' };
+
+  const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
+  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={55} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:optional-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <fieldset className="mb-8">
+            <legend className="mb-4 font-lato text-2xl font-bold">{t('renew-ita:update-address.home-address.header')}</legend>
+            <div className="space-y-6">
+              <>
+                <InputSanitizeField
+                  id="home-address"
+                  name="homeAddress"
+                  className="w-full"
+                  label={t('renew-ita:update-address.address-field.address')}
+                  helpMessagePrimary={t('renew-ita:update-address.address-field.address-note')}
+                  helpMessagePrimaryClassName="text-black"
+                  maxLength={30}
+                  autoComplete="address-line1"
+                  defaultValue={defaultState?.homeAddress ?? ''}
+                  errorMessage={errors?.homeAddress}
+                  required
+                />
+                <InputSanitizeField
+                  id="home-apartment"
+                  name="homeApartment"
+                  className="w-full"
+                  label={t('renew-ita:update-address.address-field.apartment')}
+                  maxLength={30}
+                  autoComplete="address-line2"
+                  defaultValue={defaultState?.homeApartment ?? ''}
+                  errorMessage={errors?.homeApartment}
+                />
+                <InputSelect
+                  id="home-country"
+                  name="homeCountry"
+                  className="w-full sm:w-1/2"
+                  label={t('renew-ita:update-address.address-field.country')}
+                  autoComplete="country"
+                  defaultValue={defaultState?.homeCountry ?? ''}
+                  errorMessage={errors?.homeCountry}
+                  options={countries}
+                  onChange={homeCountryChangeHandler}
+                  required
+                />
+                {homeRegions.length > 0 && (
+                  <InputSelect
+                    id="home-province"
+                    name="homeProvince"
+                    className="w-full sm:w-1/2"
+                    label={t('renew-ita:update-address.address-field.province')}
+                    defaultValue={defaultState?.homeProvince ?? ''}
+                    errorMessage={errors?.homeProvince}
+                    options={[dummyOption, ...homeRegions]}
+                    required
+                  />
+                )}
+                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+                  <InputSanitizeField
+                    id="home-city"
+                    name="homeCity"
+                    className="w-full"
+                    label={t('renew-ita:update-address.address-field.city')}
+                    maxLength={100}
+                    autoComplete="address-level2"
+                    defaultValue={defaultState?.homeCity ?? ''}
+                    errorMessage={errors?.homeCity}
+                    required
+                  />
+                  <InputSanitizeField
+                    id="home-postal-code"
+                    name="homePostalCode"
+                    className="w-full"
+                    label={homePostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
+                    maxLength={100}
+                    autoComplete="postal-code"
+                    defaultValue={defaultState?.homePostalCode ?? ''}
+                    errorMessage={errors?.homePostalCode}
+                    required={homePostalCodeRequired}
+                  />
+                </div>
+              </>
+            </div>
+          </fieldset>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Update address click">
+                {t('renew-ita:update-address.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Update address click">
+                {t('renew-ita:update-address.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Update address click">
+                {t('renew-ita:update-address.continue')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/ita/update-mailing-address"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Update home address click"
+              >
+                {t('renew-ita:update-address.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -19,7 +19,6 @@ import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { useErrorSummary } from '~/components/error-summary';
-import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
@@ -82,13 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
       mailingProvince: z.string().trim().min(1, t('renew-ita:update-address.error-message.mailing-address.province-required')).optional(),
       mailingCity: z.string().trim().min(1, t('renew-ita:update-address.error-message.mailing-address.city-required')).max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')),
       mailingPostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
-      copyMailingAddress: z.boolean(),
-      homeAddress: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
-      homeApartment: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
-      homeCountry: z.string().trim().optional(),
-      homeProvince: z.string().trim().optional(),
-      homeCity: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
-      homePostalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-ita:update-address.error-message.characters-valid')).optional(),
     })
     .superRefine((val, ctx) => {
       if (val.mailingCountry === CANADA_COUNTRY_ID || val.mailingCountry === USA_COUNTRY_ID) {
@@ -108,42 +100,9 @@ export async function action({ context: { appContainer, session }, params, reque
       if (val.mailingCountry && val.mailingCountry !== CANADA_COUNTRY_ID && val.mailingPostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.mailingPostalCode)) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.mailing-address.invalid-postal-code-for-country'), path: ['mailingCountry'] });
       }
-
-      if (val.copyMailingAddress === false) {
-        if (!val.homeAddress || validator.isEmpty(val.homeAddress)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.address-required'), path: ['homeAddress'] });
-        }
-
-        if (!val.homeCountry || validator.isEmpty(val.homeCountry)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.country-required'), path: ['homeCountry'] });
-        }
-
-        if (!val.homeCity || validator.isEmpty(val.homeCity)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.city-required'), path: ['homeCity'] });
-        }
-
-        if (val.homeCountry === CANADA_COUNTRY_ID || val.homeCountry === USA_COUNTRY_ID) {
-          if (!val.homeProvince || validator.isEmpty(val.homeProvince)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.province-required'), path: ['homeProvince'] });
-          }
-          if (!val.homePostalCode || validator.isEmpty(val.homePostalCode)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.postal-code-required'), path: ['homePostalCode'] });
-          } else if (!isValidPostalCode(val.homeCountry, val.homePostalCode)) {
-            const message = val.homeCountry === CANADA_COUNTRY_ID ? t('renew-ita:update-address.error-message.home-address.postal-code-valid') : t('renew-ita:update-address.error-message.home-address.zip-code-valid');
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['homePostalCode'] });
-          } else if (val.homeCountry === CANADA_COUNTRY_ID && val.homeProvince && !isValidCanadianPostalCode(val.homeProvince, val.homePostalCode)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.invalid-postal-code-for-province'), path: ['homePostalCode'] });
-          }
-        }
-
-        if (val.homeCountry && val.homeCountry !== CANADA_COUNTRY_ID && val.homePostalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.homePostalCode)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:update-address.error-message.home-address.invalid-postal-code-for-country'), path: ['homeCountry'] });
-        }
-      }
     })
     .transform((val) => ({
       ...val,
-      homePostalCode: val.homeCountry && val.homePostalCode ? formatPostalCode(val.homeCountry, val.homePostalCode) : val.homePostalCode,
       mailingPostalCode: val.mailingCountry && val.mailingPostalCode ? formatPostalCode(val.mailingCountry, val.mailingPostalCode) : val.mailingPostalCode,
     })) satisfies z.ZodType<AddressInformationState>;
 
@@ -154,38 +113,32 @@ export async function action({ context: { appContainer, session }, params, reque
     mailingProvince: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
     mailingCity: String(formData.get('mailingCity') ?? ''),
     mailingPostalCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
-    copyMailingAddress: formData.get('copyMailingAddress') === 'copy',
-    homeAddress: formData.get('homeAddress') ? String(formData.get('homeAddress')) : undefined,
-    homeApartment: formData.get('homeApartment') ? String(formData.get('homeApartment')) : undefined,
-    homeCountry: formData.get('homeCountry') ? String(formData.get('homeCountry')) : undefined,
-    homeProvince: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
-    homeCity: formData.get('homeCity') ? String(formData.get('homeCity')) : undefined,
-    homePostalCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  const updatedData = parsedDataResult.data.copyMailingAddress
-    ? {
-        ...parsedDataResult.data,
-        homeAddress: parsedDataResult.data.mailingAddress,
-        homeApartment: parsedDataResult.data.mailingApartment,
-        homeCountry: parsedDataResult.data.mailingCountry,
-        homeProvince: parsedDataResult.data.mailingProvince,
-        homeCity: parsedDataResult.data.mailingCity,
-        homePostalCode: parsedDataResult.data.mailingPostalCode,
-      }
-    : parsedDataResult.data;
+  // If home address is the same as mailing address, populate home related properties.
+  const updatedAddressInfo = {
+    ...parsedDataResult.data,
+    ...(state.isHomeAddressSameAsMailingAddress && {
+      homeAddress: parsedDataResult.data.mailingAddress,
+      homeApartment: parsedDataResult.data.mailingApartment,
+      homeCountry: parsedDataResult.data.mailingCountry,
+      homeProvince: parsedDataResult.data.mailingProvince,
+      homeCity: parsedDataResult.data.mailingCity,
+      homePostalCode: parsedDataResult.data.mailingPostalCode,
+    }),
+  };
 
-  saveRenewState({ params, session, state: { addressInformation: updatedData } });
+  saveRenewState({ params, session, state: { addressInformation: updatedAddressInfo } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/ita/review-information', params));
   }
-
-  return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
+  // If home addres is not the same as mailing address, redirect to /update-home-address
+  return redirect(state.isHomeAddressSameAsMailingAddress ? getPathById('public/renew/$id/ita/dental-insurance', params) : getPathById('public/renew/$id/ita/update-home-address', params));
 }
 
 export default function RenewItaUpdateAddress() {
@@ -197,34 +150,16 @@ export default function RenewItaUpdateAddress() {
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
-  const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState?.copyMailingAddress === true);
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.homeCountry ?? CANADA_COUNTRY_ID);
-  const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    phoneNumber: 'phone-number',
-    phoneNumberAlt: 'phone-number-alt',
-    email: 'email',
-    confirmEmail: 'confirm-email',
     mailingAddress: 'mailing-address',
     mailingApartment: 'mailing-apartment',
     mailingProvince: 'mailing-province',
     mailingCountry: 'mailing-country',
     mailingCity: 'mailing-city',
     mailingPostalCode: 'mailing-postal-code',
-    copyMailingAddress: 'copy-mailing-address',
-    homeAddress: 'home-address',
-    homeApartment: 'home-apartment',
-    homeProvince: 'home-province',
-    homeCountry: 'home-country',
-    homeCity: 'home-city',
-    homePostalCode: 'home-postal-code',
   });
-
-  const checkHandler = () => {
-    setCopyAddressChecked((curState) => !curState);
-  };
 
   useEffect(() => {
     const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedMailingCountry);
@@ -242,23 +177,10 @@ export default function RenewItaUpdateAddress() {
   // populate mailing region/province/state list with selected country or current address country
   const mailingRegions: InputOptionProps[] = mailingCountryRegions.map(({ id, name }) => ({ children: name, value: id }));
 
-  useEffect(() => {
-    const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedHomeCountry);
-    setHomeCountryRegions(filteredProvinceTerritoryStates);
-  }, [selectedHomeCountry, regionList]);
-
-  const homeCountryChangeHandler = (event: React.SyntheticEvent<HTMLSelectElement>) => {
-    setSelectedHomeCountry(event.currentTarget.value);
-  };
-
-  // populate home region/province/state list with selected country or current address country
-  const homeRegions: InputOptionProps[] = homeCountryRegions.map(({ id, name }) => ({ children: name, value: id }));
-
   const dummyOption: InputOptionProps = { children: t('renew-ita:update-address.address-field.select-one'), value: '' };
 
   const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
   const mailingPostalCodeRequired = postalCodeRequiredContries.includes(selectedMailingCountry);
-  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
 
   return (
     <>
@@ -346,89 +268,6 @@ export default function RenewItaUpdateAddress() {
               </div>
             </div>
           </fieldset>
-          <fieldset className="mb-8">
-            <legend className="mb-4 font-lato text-2xl font-bold">{t('renew-ita:update-address.home-address.header')}</legend>
-            <div className="space-y-6">
-              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
-                {t('renew-ita:update-address.home-address.use-mailing-address')}
-              </InputCheckbox>
-              {!copyAddressChecked && (
-                <>
-                  <InputSanitizeField
-                    id="home-address"
-                    name="homeAddress"
-                    className="w-full"
-                    label={t('renew-ita:update-address.address-field.address')}
-                    helpMessagePrimary={t('renew-ita:update-address.address-field.address-note')}
-                    helpMessagePrimaryClassName="text-black"
-                    maxLength={30}
-                    autoComplete="address-line1"
-                    defaultValue={defaultState?.homeAddress ?? ''}
-                    errorMessage={errors?.homeAddress}
-                    required
-                  />
-                  <InputSanitizeField
-                    id="home-apartment"
-                    name="homeApartment"
-                    className="w-full"
-                    label={t('renew-ita:update-address.address-field.apartment')}
-                    maxLength={30}
-                    autoComplete="address-line2"
-                    defaultValue={defaultState?.homeApartment ?? ''}
-                    errorMessage={errors?.homeApartment}
-                  />
-                  <InputSelect
-                    id="home-country"
-                    name="homeCountry"
-                    className="w-full sm:w-1/2"
-                    label={t('renew-ita:update-address.address-field.country')}
-                    autoComplete="country"
-                    defaultValue={defaultState?.homeCountry ?? ''}
-                    errorMessage={errors?.homeCountry}
-                    options={countries}
-                    onChange={homeCountryChangeHandler}
-                    required
-                  />
-                  {homeRegions.length > 0 && (
-                    <InputSelect
-                      id="home-province"
-                      name="homeProvince"
-                      className="w-full sm:w-1/2"
-                      label={t('renew-ita:update-address.address-field.province')}
-                      defaultValue={defaultState?.homeProvince ?? ''}
-                      errorMessage={errors?.homeProvince}
-                      options={[dummyOption, ...homeRegions]}
-                      required
-                    />
-                  )}
-                  <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                    <InputSanitizeField
-                      id="home-city"
-                      name="homeCity"
-                      className="w-full"
-                      label={t('renew-ita:update-address.address-field.city')}
-                      maxLength={100}
-                      autoComplete="address-level2"
-                      defaultValue={defaultState?.homeCity ?? ''}
-                      errorMessage={errors?.homeCity}
-                      required
-                    />
-                    <InputSanitizeField
-                      id="home-postal-code"
-                      name="homePostalCode"
-                      className="w-full"
-                      label={homePostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
-                      maxLength={100}
-                      autoComplete="postal-code"
-                      defaultValue={defaultState?.homePostalCode ?? ''}
-                      errorMessage={errors?.homePostalCode}
-                      required={homePostalCodeRequired}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
-          </fieldset>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Update address click">
@@ -449,7 +288,7 @@ export default function RenewItaUpdateAddress() {
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Update address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Update mailing address click"
               >
                 {t('renew-ita:update-address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -428,9 +428,14 @@ export const routes = [
             paths: { en: '/:lang/renew/:id/ita/confirm-address', fr: '/:lang/renew/:id/ita/confirmer-adresse' },
           },
           {
-            id: 'public/renew/$id/ita/update-address',
-            file: 'routes/public/renew/$id/ita/update-address.tsx',
-            paths: { en: '/:lang/renew/:id/ita/update-address', fr: '/:lang/renew/:id/ita/mise-a-jour-adresse' },
+            id: 'public/renew/$id/ita/update-mailing-address',
+            file: 'routes/public/renew/$id/ita/update-mailing-address.tsx',
+            paths: { en: '/:lang/renew/:id/ita/update-mailing-address', fr: '/:lang/renew/:id/ita/mise-a-jour-adresse-postale' },
+          },
+          {
+            id: 'public/renew/$id/ita/update-home-address',
+            file: 'routes/public/renew/$id/ita/update-home-address.tsx',
+            paths: { en: '/:lang/renew/:id/ita/update-home-address', fr: '/:lang/renew/:id/ita/mise-a-jour-adresse-domicile' },
           },
           {
             id: 'public/renew/$id/ita/dental-insurance',

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -67,7 +67,7 @@
   },
   "confirm-address": {
     "page-title": "Address",
-    "have-you-moved": "Have you moved or changed your mailing address since you applied for the Canadian Dental Care Plan?",
+    "have-you-moved": "Would you like to update your mailing address?",
     "is-home-address-same-as-mailing-address": "Is your home address the same as your mailing address?",
     "radio-options": {
       "yes": "Yes",
@@ -75,7 +75,7 @@
     },
     "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
-      "has-address-changed-required": "Select whether you have moved or changed your mailing address",
+      "has-address-changed-required": "Select whether or not you want to change your mailing address",
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
     },
     "back-btn": "Back",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -68,7 +68,7 @@
   },
   "confirm-address": {
     "page-title": "Adresse",
-    "have-you-moved": "Avez-vous déménagé ou changé d'adresse postale depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
+    "update-mailing-address": "Souhaitez-vous mettre à jour votre adresse postale?",
     "is-home-address-same-as-mailing-address": "L'adresse de votre domicile est-elle la même que votre adresse postale?",
     "radio-options": {
       "yes": "Oui",
@@ -76,7 +76,7 @@
     },
     "help-message": "L'adresse que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
     "error-message": {
-      "has-address-changed-required": "Sélectionnez si vous avez déménagé ou changé d'adresse postale",
+      "update-mailing-address-required": "Sélectionnez si vous souhaitez ou non modifier votre adresse postale",
       "is-home-address-same-as-mailing-address-required": "Sélectionnez si votre adresse postale et votre adresse domicile sont identiques ou non"
     },
     "back-btn": "Retour",


### PR DESCRIPTION
**Left some comments in the code to get your opinions**
### Description
Renewal Figma changed `update-address` into two pages: `update-mailing-address` and `update-home-address`.

Splitting addressInformation (state) should be considered:
![image](https://github.com/user-attachments/assets/228dc271-0e85-4c7a-aeb9-ed8f60b247a6)


### Related Azure Boards Work Items
AB#4919

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate through the ITA flow and select 'update the mailing address' once on `confirm-address`

### Additional Notes
- Translations will be refactored depending on what we do with this PR.