### PR TITLE
use names in state to display in locales

### DIFF
--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -20,7 +20,7 @@ import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { useBreadcrumbs, useI18nNamespaces, usePageTitleI18nKey } from '~/utils/route-utils';
+import { useBreadcrumbs, useI18nNamespaces, usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -31,12 +31,14 @@ export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 export function ProtectedLayout({ children }: PropsWithChildren) {
   const { t } = useTranslation(useI18nNamespaces());
   const pageTitleI18nKey = usePageTitleI18nKey();
+  const i18nOptions = usePageTitleI18nOptions();
+
   return (
     <>
       <PageHeader />
       <PageBreadcrumbs />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        {pageTitleI18nKey && <AppPageTitle>{t(pageTitleI18nKey)}</AppPageTitle>}
+        {pageTitleI18nKey && <AppPageTitle>{t(pageTitleI18nKey, i18nOptions)}</AppPageTitle>}
         {children}
         <PageDetails />
       </main>

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -20,7 +20,6 @@ import { InputCheckboxes } from '~/components/input-checkboxes';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
@@ -37,6 +36,7 @@ enum FormAction {
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageTitleI18nKey: 'protected-renew:demographic-survey.page-title',
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
@@ -68,7 +68,6 @@ export async function loader({ context: { appContainer, session }, request, para
 
   return {
     meta,
-    memberName,
     indigenousStatuses,
     firstNations,
     disabilityStatuses,
@@ -77,6 +76,7 @@ export async function loader({ context: { appContainer, session }, request, para
     genderStatuses,
     defaultState: state.demographicSurvey,
     editMode: state.editMode,
+    i18nOptions: { memberName },
   };
 }
 
@@ -143,7 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedChildrenDemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -209,7 +209,6 @@ export default function ProtectedChildrenDemographicSurveyQuestions() {
 
   return (
     <>
-      <AppPageTitle>{t('protected-renew:demographic-survey.page-title', { memberName })}</AppPageTitle>
       <div className="max-w-prose">
         <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
         <errorSummary.ErrorSummary />

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
@@ -44,13 +44,15 @@ export async function loader({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
 
   const state = loadProtectedRenewSingleChildState({ params, session });
-  // TODO: get childName from state and pass to title and page heading
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:children.parent-or-guardian.page-title') }) };
+  const childNumber = t('protected-renew:children.child-number', { childNumber: state.childNumber });
+  const childName = state.firstName ?? childNumber;
 
-  return { meta, defaultState: state.isParentOrLegalGuardian };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:children.parent-or-guardian.page-title', { childName }) }) };
+
+  return { meta, defaultState: state.isParentOrLegalGuardian, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -20,7 +20,6 @@ import { InputCheckboxes } from '~/components/input-checkboxes';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
@@ -37,6 +36,7 @@ enum FormAction {
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageTitleI18nKey: 'protected-renew:demographic-survey.page-title',
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
@@ -50,9 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const state = loadProtectedRenewState({ params, session });
 
-  // TODO: get memberName from state to pass to page title and heading
-  // const memberName = `${state.applicantInformation.firstName} ${state.applicantInformation.lastName}`;
-  const memberName = 'todo';
+  const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -68,7 +66,6 @@ export async function loader({ context: { appContainer, session }, request, para
 
   return {
     meta,
-    memberName,
     indigenousStatuses,
     firstNations,
     disabilityStatuses,
@@ -77,6 +74,7 @@ export async function loader({ context: { appContainer, session }, request, para
     genderStatuses,
     defaultState: state.demographicSurvey,
     editMode: state.editMode,
+    i18nOptions: { memberName },
   };
 }
 
@@ -138,7 +136,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedDemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { memberName, indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -204,7 +202,6 @@ export default function ProtectedDemographicSurveyQuestions() {
 
   return (
     <>
-      <AppPageTitle>{t('protected-renew:demographic-survey.page-title', { memberName })}</AppPageTitle>
       <div className="max-w-prose">
         <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
         <errorSummary.ErrorSummary />

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -29,8 +29,8 @@ enum FormAction {
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
+  pageTitleI18nKey: 'protected-renew:dental-insurance.page-title',
   pageIdentifier: pageIds.protected.renew.dentalInsurance,
-  pageTitleI18nKey: 'protected-renew:dental-insurance.title',
 };
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -44,11 +44,11 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  // TODO: get name of primary applicant from state and pass it into the page title and heading
+  const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.page-title', { memberName }) }) };
 
-  return { id: state, meta, defaultState: state.dentalInsurance, hasAddressChanged: state.hasAddressChanged, editMode: state.editMode };
+  return { id: state, meta, defaultState: state.dentalInsurance, hasAddressChanged: state.hasAddressChanged, editMode: state.editMode, i18nOptions: { memberName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -124,7 +124,7 @@
     "save-btn": "Save"
   },
   "dental-insurance": {
-    "title": "{{name}}: Access to other dental insurance",
+    "page-title": "{{memberName}}: Access to other dental insurance",
     "legend": "Do you have access to dental insurance or coverage:",
     "list": {
       "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -124,7 +124,7 @@
     "save-btn": "Save"
   },
   "dental-insurance": {
-    "title": "{{name}}\u00a0: Access to other dental insurance",
+    "page-title": "{{memberName}}\u00a0: Access to other dental insurance",
     "legend": "Do you have access to dental insurance or coverage:",
     "list": {
       "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",


### PR DESCRIPTION
### Description
introduces `.usePageTitleI18nOptions()` to the `ProtectedLayout` (similar to the `PublicLayout`) which allows us to easily interpolate names in the locales.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)
