### PR TITLE
fix: revert request log level to info

### DIFF
--- a/frontend/express-server/middleware.server.ts
+++ b/frontend/express-server/middleware.server.ts
@@ -60,7 +60,7 @@ export function logging(isProduction: boolean): RequestHandler {
   const logFormat = isProduction ? 'tiny' : 'dev';
 
   const middleware = morganMiddleware(logFormat, {
-    stream: { write: (msg) => log.audit(msg.trim()) },
+    stream: { write: (msg) => log.info(msg.trim()) },
   });
 
   return (request, response, next) => {


### PR DESCRIPTION
### Description

Fix regression introduced in #2658 (request logging set to `audit`).