### PR TITLE
fix: broken terraform version

### DIFF
--- a/infrastructure/terraform/azure-ad-application/terraform.tf
+++ b/infrastructure/terraform/azure-ad-application/terraform.tf
@@ -4,7 +4,7 @@
 ###############################################################################
 
 terraform {
-  required_version = ">= 1.7.0, < 2.0.0"
+  required_version = ">= 1.7.0, < 1.10.0"
 
   required_providers {
     azuread = {


### PR DESCRIPTION
### Description

Terraform v1.10.x adds ephemeral variables, which breaks Terragrunt. This PR pins the version to a maximum of v1.9.x until a fix is released.
