### PR TITLE
[gitops] add customizable message to maintenance page

### DIFF
--- a/gitops/base/maintenance/configs/503.html
+++ b/gitops/base/maintenance/configs/503.html
@@ -24,13 +24,6 @@
       href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico"
       crossorigin="anonymous"
     />
-    <noscript>
-      <link
-        rel="stylesheet"
-        href="https://www.canada.ca/etc/designs/canada/wet-boew/css/noscript.min.css"
-        crossorigin="anonymous"
-      />
-    </noscript>
   </head>
   <body>
     <header>
@@ -63,10 +56,11 @@
                       <p class="pagetag"><b>Error 503</b></p>
                     </div>
                   </div>
-                  <p>
-                    The web server that provides this service is currently down
-                    for maintenance.
-                  </p>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p>The CDCP online application system will be closed for maintenance between {{startTimeEn}}, through {{endTimeEn}}.</p>
+                    </div>
+                  </div>
                 </div>
               </div>
             </section>
@@ -84,10 +78,7 @@
                   </div>
                   <div class="row mrgn-bttm-lg">
                     <div class="col-md-12">
-                      <p>
-                        Le serveur Web auquel vous tentez d'accéder est
-                        actuellement hors service à des fins d'entretien.
-                      </p>
+                      <p>Le système de demande en ligne du RCSD sera fermé pour maintenance de {{startTimeFr}} à {{endTimeFr}}.</p>
                     </div>
                   </div>
                 </div>
@@ -118,18 +109,5 @@
         </div>
       </div>
     </footer>
-    <script
-      src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"
-      integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/gitops/base/maintenance/deployments.yaml
+++ b/gitops/base/maintenance/deployments.yaml
@@ -13,6 +13,23 @@ spec:
       labels:
         app.kubernetes.io/name: maintenance
     spec:
+      initContainers:
+        - name: preprocess-html
+          # Note: image tag should be pinned to a specific version in overlays
+          image: docker.io/library/alpine:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              cp /tmp/original/503.html /tmp/processed/503.html
+              sed --in-place "s|{{startTimeEn}}|$(cat /tmp/original/startTimeEn)|g" /tmp/processed/503.html
+              sed --in-place "s|{{startTimeFr}}|$(cat /tmp/original/startTimeFr)|g" /tmp/processed/503.html
+              sed --in-place "s|{{endTimeEn}}|$(cat /tmp/original/endTimeEn)|g"     /tmp/processed/503.html
+              sed --in-place "s|{{endTimeFr}}|$(cat /tmp/original/endTimeFr)|g"     /tmp/processed/503.html
+          volumeMounts:
+            - name: maintenance-conf
+              mountPath: /tmp/original
+            - name: processed-html
+              mountPath: /tmp/processed
       containers:
         - name: nginx
           # Note: image tag should be pinned to a specific version in overlays
@@ -33,10 +50,12 @@ spec:
             - name: maintenance-conf
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: config.conf
-            - name: maintenance-conf
+            - name: processed-html
               mountPath: /usr/share/nginx/html/503.html
               subPath: 503.html
       volumes:
         - name: maintenance-conf
           configMap:
             name: maintenance
+        - name: processed-html
+          emptyDir: {}

--- a/gitops/base/maintenance/kustomization.yaml
+++ b/gitops/base/maintenance/kustomization.yaml
@@ -9,3 +9,8 @@ configMapGenerator:
     files:
       - ./configs/503.html
       - ./configs/config.conf
+    literals:
+      - startTimeEn=12:00am EST January 1, 2000
+      - startTimeFr=00 h 00 HNE le 1 janvier 2000
+      - endTimeEn=12:00am EST January 1, 2000
+      - endTimeFr=00 h 00 HNE le 1 janvier 2000

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -46,6 +46,13 @@ configMapGenerator:
     behavior: create
     files:
       - ./configs/oauth-proxy/config.conf
+  - name: maintenance
+    behavior: merge
+    literals:
+      - startTimeEn=10:00pm EST December 6, 2024
+      - startTimeFr=22 h 00 HNE le 6 décembre 2024
+      - endTimeEn=10:00pm December 8, 2024
+      - endTimeFr=22 h 00 le 8 décembre 2024
 secretGenerator:
   - name: frontend
     behavior: replace

--- a/gitops/overlays/prod/patches/deployments-maintenance.yaml
+++ b/gitops/overlays/prod/patches/deployments-maintenance.yaml
@@ -8,6 +8,9 @@ spec:
       app.kubernetes.io/name: maintenance
   template:
     spec:
+      initContainers:
+        - name: preprocess-html
+          image: docker.io/library/alpine:3.20.3
       containers:
         - name: nginx
           image: docker.io/nginx:1.27.0


### PR DESCRIPTION
### Description

Add a customizable message to the maintenance page that displays the start time and end time of the maintenance window.

### Screenshots

![Screenshot From 2024-12-02 11-00-19](https://github.com/user-attachments/assets/2d6cc387-1c79-4403-a34d-b0be84d6c386)

### Additional Notes

Attached is a .patch file generated by running `kubectl kustomize` in the `overlays/prod/` folder before and after this change. It shows what will be updated in the cluster once applied.

``` patch
diff --git a/tmp/code-stdin-sq4 b/tmp/code-stdin-p5P
index fd8ab56c..8ff9524e 100644
--- a/tmp/code-stdin-sq4
+++ b/tmp/code-stdin-p5P
@@ -123,13 +123,6 @@ data:
           href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico"
           crossorigin="anonymous"
         />
-        <noscript>
-          <link
-            rel="stylesheet"
-            href="https://www.canada.ca/etc/designs/canada/wet-boew/css/noscript.min.css"
-            crossorigin="anonymous"
-          />
-        </noscript>
       </head>
       <body>
         <header>
@@ -162,10 +155,11 @@ data:
                           <p class="pagetag"><b>Error 503</b></p>
                         </div>
                       </div>
-                      <p>
-                        The web server that provides this service is currently down
-                        for maintenance.
-                      </p>
+                      <div class="row mrgn-bttm-lg">
+                        <div class="col-md-12">
+                          <p>The CDCP online application system will be closed for maintenance between {{startTimeEn}}, through {{endTimeEn}}.</p>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </section>
@@ -183,10 +177,7 @@ data:
                       </div>
                       <div class="row mrgn-bttm-lg">
                         <div class="col-md-12">
-                          <p>
-                            Le serveur Web auquel vous tentez d'accéder est
-                            actuellement hors service à des fins d'entretien.
-                          </p>
+                          <p>Le système de demande en ligne du RCSD sera fermé pour maintenance de {{startTimeFr}} à {{endTimeFr}}.</p>
                         </div>
                       </div>
                     </div>
@@ -217,19 +208,6 @@ data:
             </div>
           </div>
         </footer>
-        <script
-          src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"
-          integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
-          crossorigin="anonymous"
-        ></script>
-        <script
-          src="https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js"
-          crossorigin="anonymous"
-        ></script>
-        <script
-          src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"
-          crossorigin="anonymous"
-        ></script>
       </body>
     </html>
   config.conf: |
@@ -247,6 +225,10 @@ data:
         internal;
       }
     }
+  endTimeEn: 10:00pm December 8, 2024
+  endTimeFr: 22 h 00 le 8 décembre 2024
+  startTimeEn: 10:00pm EST December 6, 2024
+  startTimeFr: 22 h 00 HNE le 6 décembre 2024
 kind: ConfigMap
 metadata:
   labels:
@@ -255,7 +237,7 @@ metadata:
     app.kubernetes.io/managed-by: teamcity
     app.kubernetes.io/part-of: canada-dental-care-plan
     app.kubernetes.io/tier: prod
-  name: maintenance-fdbb7cd7b2
+  name: maintenance-mff6gmh2hc
   namespace: canada-dental-care-plan
 ---
 apiVersion: v1
@@ -796,12 +778,32 @@ spec:
           name: maintenance-conf
           subPath: config.conf
         - mountPath: /usr/share/nginx/html/503.html
-          name: maintenance-conf
+          name: processed-html
           subPath: 503.html
+      initContainers:
+      - args:
+        - |
+          cp /tmp/original/503.html /tmp/processed/503.html
+          sed --in-place "s|{{startTimeEn}}|$(cat /tmp/original/startTimeEn)|g" /tmp/processed/503.html
+          sed --in-place "s|{{startTimeFr}}|$(cat /tmp/original/startTimeFr)|g" /tmp/processed/503.html
+          sed --in-place "s|{{endTimeEn}}|$(cat /tmp/original/endTimeEn)|g"     /tmp/processed/503.html
+          sed --in-place "s|{{endTimeFr}}|$(cat /tmp/original/endTimeFr)|g"     /tmp/processed/503.html
+        command:
+        - /bin/sh
+        - -c
+        image: docker.io/library/alpine:3.20.3
+        name: preprocess-html
+        volumeMounts:
+        - mountPath: /tmp/original
+          name: maintenance-conf
+        - mountPath: /tmp/processed
+          name: processed-html
       volumes:
       - configMap:
-          name: maintenance-fdbb7cd7b2
+          name: maintenance-mff6gmh2hc
         name: maintenance-conf
+      - emptyDir: {}
+        name: processed-html
 ---
 apiVersion: apps/v1
 kind: StatefulSet
```
