### PR TITLE
fix(frontend): set vite's hmr port to 3001

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
   server: {
     port: 3000,
     host: true,
+    hmr: {
+      port: 3001,
+    },
   },
   optimizeDeps: {
     esbuildOptions: {


### PR DESCRIPTION
### Description

Remix's dev server automatically set Vite's HMR port on startup. After moving the express server out of `express.server.tsx`, we now have to handle this in `vite.config.ts`.

This fixes a CSP error that would render in the JS console when running on localhost.