### PR TITLE
fix(frontend): fix broken i18n

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -99,6 +99,7 @@ WORKDIR /home/node
 # COPY files in order of least → most likely to change to maximize layer caching
 COPY --from=runtime-deps --chown=node:node /home/node/node_modules/ ./node_modules/
 COPY --from=build --chown=node:node /home/node/build/ ./build/
+COPY --from=build --chown=node:node /home/node/public/ ./public/
 COPY --from=build --chown=node:node /home/node/build-info.json ./
 
 # Add labels for OCI compliance, describing the build details and image metadata


### PR DESCRIPTION
### Description

The `dockerfile` had the `./public/` folder removed since these files are copied to `./build/` during the build process.. however, the i18n configuration was not updated to know this. As a workaround for now, I'm putting the `./public/` folder back into the container image.

I will remove it again in a future PR.

### Checklist

- [x] I have tested the changes locally
