### PR TITLE
fix(frontend): show friendly error page when redis is down

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -192,9 +192,10 @@ REDIS_USERNAME=username
 # redis server password
 # (optional; default: undefined)
 REDIS_PASSWORD=password
-# number of times to retry a redis request before giving up
-# (optional; default: 3)
-REDIS_MAX_RETRIES_PER_REQUEST=3
+# Command timeout for Redis operations in seconds (default: 1).
+# Specifies the maximum time to wait before a command times out.
+REDIS_COMMAND_TIMEOUT_SECONDS=
+
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -113,7 +113,7 @@ const serverEnv = clientEnvSchema.extend({
   REDIS_STANDALONE_PORT: z.coerce.number().default(6379),
   REDIS_USERNAME: z.string().trim().min(1).optional(),
   REDIS_PASSWORD: z.string().trim().min(1).optional(),
-  REDIS_MAX_RETRIES_PER_REQUEST: z.coerce.number().default(3),
+  REDIS_COMMAND_TIMEOUT_SECONDS: z.coerce.number().default(1),
 
   // mocks settings
   ENABLED_MOCKS: z.string().transform(emptyToUndefined).transform(csvToArray).refine(areValidMockNames).default(''),

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -44,7 +44,7 @@ export async function loader({ context: { appContainer }, request }: LoaderFunct
       REDIS_SENTINEL_NAME: serverConfig.REDIS_SENTINEL_NAME ?? '',
       REDIS_SENTINEL_HOST: serverConfig.REDIS_SENTINEL_HOST ?? '',
       REDIS_SENTINEL_PORT: (serverConfig.REDIS_SENTINEL_PORT ?? '').toString(),
-      REDIS_MAX_RETRIES_PER_REQUEST: serverConfig.REDIS_MAX_RETRIES_PER_REQUEST.toString(),
+      REDIS_COMMAND_TIMEOUT_SECONDS: serverConfig.REDIS_COMMAND_TIMEOUT_SECONDS.toString(),
     },
   };
 


### PR DESCRIPTION
### Description

This PR:

1. allows the application to start when Redis is unavailable
2. shows a friendly error page when Redis is unavailable

### Checklist

- [x] I have tested the changes locally
