### PR TITLE
Spliting addressInfo state into two.

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
@@ -78,7 +78,8 @@ interface ValidateRenewItaStateForReviewArgs {
 }
 
 export function validateRenewItaStateForReview({ params, state }: ValidateRenewItaStateForReviewArgs) {
-  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, addressInformation, applicantInformation, clientApplication, dentalBenefits, dentalInsurance, hasAddressChanged, demographicSurvey } = state;
+  const { maritalStatus, partnerInformation, contactInformation, editMode, id, submissionInfo, typeOfRenewal, mailingAddress, homeAddress, applicantInformation, clientApplication, dentalBenefits, dentalInsurance, hasAddressChanged, demographicSurvey } =
+    state;
 
   if (typeOfRenewal === undefined) {
     throw redirect(getPathById('public/renew/$id/type-renewal', params));
@@ -112,7 +113,7 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     throw redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
   }
 
-  if (hasAddressChanged && addressInformation === undefined) {
+  if (hasAddressChanged && mailingAddress === undefined) {
     throw redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
   }
 
@@ -135,7 +136,8 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     applicantInformation,
     dentalBenefits,
     dentalInsurance,
-    addressInformation,
+    mailingAddress,
+    homeAddress,
     partnerInformation,
     hasAddressChanged,
     demographicSurvey,

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -75,6 +75,22 @@ export interface RenewState {
     mailingPostalCode?: string;
     mailingProvince?: string;
   };
+  readonly mailingAddress?: {
+    address: string;
+    apartment?: string;
+    city: string;
+    country: string;
+    postalCode?: string;
+    province?: string;
+  };
+  readonly homeAddress?: {
+    address: string;
+    apartment?: string;
+    city: string;
+    country: string;
+    postalCode?: string;
+    province?: string;
+  };
   readonly dentalInsurance?: boolean;
   readonly dentalBenefits?: {
     hasFederalBenefits: boolean;
@@ -118,6 +134,8 @@ export type ApplicantInformationState = NonNullable<RenewState['applicantInforma
 export type TypeOfRenewalState = NonNullable<RenewState['typeOfRenewal']>;
 export type PartnerInformationState = NonNullable<RenewState['partnerInformation']>;
 export type AddressInformationState = NonNullable<RenewState['addressInformation']>;
+export type MailingAddressState = NonNullable<RenewState['mailingAddress']>;
+export type HomeAddressState = NonNullable<RenewState['homeAddress']>;
 export type DentalFederalBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
 export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
 export type ConfirmDentalBenefitsState = NonNullable<RenewState['confirmDentalBenefits']>;

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     state.contactInformation === undefined ||
     state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
-    (state.hasAddressChanged && state.addressInformation===undefined) ||
+    (state.hasAddressChanged && state.mailingAddress===undefined) ||
     state.submissionInfo === undefined ||
     state.maritalStatus === undefined ||
     state.typeOfRenewal === undefined) {
@@ -70,10 +70,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const mailingProvinceTerritoryStateAbbr = state.addressInformation?.mailingProvince ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.addressInformation?.homeProvince ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
-  const countryMailing = state.addressInformation?.mailingCountry ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.mailingCountry, locale) : undefined;
-  const countryHome = state.addressInformation?.homeCountry ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.homeCountry, locale) : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
 
   const userInfo = {
@@ -95,25 +95,25 @@ export async function loader({ context: { appContainer, session }, params, reque
       }
     : null;
 
-  const mailingAddressInfo = state.addressInformation
+  const mailingAddressInfo = state.mailingAddress
     ? {
-        address: state.addressInformation.mailingAddress,
-        city: state.addressInformation.mailingCity,
+        address: state.mailingAddress.address,
+        city: state.mailingAddress.city,
         province: mailingProvinceTerritoryStateAbbr,
-        postalCode: state.addressInformation.mailingPostalCode,
+        postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
-        apartment: state.addressInformation.mailingApartment,
+        apartment: state.mailingAddress.apartment,
       }
     : null;
 
-  const homeAddressInfo = state.addressInformation
+  const homeAddressInfo = state.homeAddress
     ? {
-        address: state.addressInformation.homeAddress,
-        city: state.addressInformation.homeCity,
+        address: state.homeAddress.address,
+        city: state.homeAddress.city,
         province: homeProvinceTerritoryStateAbbr,
-        postalCode: state.addressInformation.homePostalCode,
+        postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
-        apartment: state.addressInformation.homeApartment,
+        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -269,8 +269,8 @@ export default function RenewFlowConfirm() {
               {mailingAddressInfo ? (
                 <Address
                   address={{
-                    address: mailingAddressInfo.address ?? '',
-                    city: mailingAddressInfo.city ?? '',
+                    address: mailingAddressInfo.address,
+                    city: mailingAddressInfo.city,
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,
@@ -285,8 +285,8 @@ export default function RenewFlowConfirm() {
               {homeAddressInfo ? (
                 <Address
                   address={{
-                    address: homeAddressInfo.address ?? '',
-                    city: homeAddressInfo.city ?? '',
+                    address: homeAddressInfo.address,
+                    city: homeAddressInfo.city,
                     provinceState: homeAddressInfo.province,
                     postalZipCode: homeAddressInfo.postalCode,
                     country: homeAddressInfo.country,

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -62,10 +62,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.addressInformation?.mailingProvince ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.addressInformation?.homeProvince ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr : undefined;
-  const countryMailing = state.addressInformation?.mailingCountry ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.mailingCountry, locale) : undefined;
-  const countryHome = state.addressInformation?.homeCountry ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.homeCountry, locale) : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
 
   const userInfo = {
@@ -85,25 +85,25 @@ export async function loader({ context: { appContainer, session }, params, reque
     consent: state.partnerInformation.confirm,
   };
 
-  const mailingAddressInfo = state.addressInformation
+  const mailingAddressInfo = state.mailingAddress
     ? {
-        address: state.addressInformation.mailingAddress,
-        city: state.addressInformation.mailingCity,
+        address: state.mailingAddress.address,
+        city: state.mailingAddress.city,
         province: mailingProvinceTerritoryStateAbbr,
-        postalCode: state.addressInformation.mailingPostalCode,
+        postalCode: state.mailingAddress.postalCode,
         country: countryMailing,
-        apartment: state.addressInformation.mailingApartment,
+        apartment: state.mailingAddress.apartment,
       }
     : null;
 
-  const homeAddressInfo = state.addressInformation
+  const homeAddressInfo = state.homeAddress
     ? {
-        address: state.addressInformation.homeAddress,
-        city: state.addressInformation.homeCity,
+        address: state.homeAddress.address,
+        city: state.homeAddress.city,
         province: homeProvinceTerritoryStateAbbr,
-        postalCode: state.addressInformation.homePostalCode,
+        postalCode: state.homeAddress.postalCode,
         country: countryHome,
-        apartment: state.addressInformation.homeApartment,
+        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -298,8 +298,8 @@ export default function RenewItaReviewInformation() {
                 {mailingAddressInfo ? (
                   <Address
                     address={{
-                      address: mailingAddressInfo.address ?? '',
-                      city: mailingAddressInfo.city ?? '',
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
                       provinceState: mailingAddressInfo.province,
                       postalZipCode: mailingAddressInfo.postalCode,
                       country: mailingAddressInfo.country?.name ?? '',
@@ -319,8 +319,8 @@ export default function RenewItaReviewInformation() {
                 {homeAddressInfo ? (
                   <Address
                     address={{
-                      address: homeAddressInfo.address ?? '',
-                      city: homeAddressInfo.city ?? '',
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
                       provinceState: homeAddressInfo.province,
                       postalZipCode: homeAddressInfo.postalCode,
                       country: homeAddressInfo.country?.name ?? '',


### PR DESCRIPTION
### Description
I'm only adding what will replace `addressInformation` state. 

Only affecting `ita` route.

### Related Azure Boards Work Items
[AB#4925](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4925)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`