### PR TITLE
4822 add update fpt benefits for child in protected renew flow

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -62,6 +62,13 @@ export interface ProtectedRenewState {
       readonly locationBornStatus?: string;
       readonly genderStatus?: string;
     };
+    readonly dentalBenefits?: {
+      hasFederalBenefits?: boolean;
+      federalSocialProgram?: string;
+      hasProvincialTerritorialBenefits?: boolean;
+      provincialTerritorialSocialProgram?: string;
+      province?: string;
+    };
   }[];
   readonly contactInformation?: {
     isNewOrUpdatedPhoneNumber?: boolean;
@@ -235,7 +242,7 @@ export async function startProtectedRenewState({ id, session, appContainer }: St
     id: parsedId,
     editMode: false,
     clientApplication,
-    children: clientApplication.children.map((child) => ({ id: randomUUID(), ...child, ...child.information })),
+    children: clientApplication.children.map((child) => ({ id: randomUUID(), ...child.information })),
   };
 
   session.set(sessionName, initialState);

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,0 +1,348 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { Trans, useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadProtectedRenewSingleChildState, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum HasFederalBenefitsOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+enum HasProvincialTerritorialBenefitsOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.confirmFederalProvincialTerritorialBenefits,
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
+
+  const state = loadProtectedRenewSingleChildState({ params, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const childNumber = t('protected-renew:children.child-number', { childNumber: state.childNumber });
+  const childName = state.isNew ? childNumber : (state.firstName ?? childNumber);
+
+  const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
+  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:children.update-dental-benefits.title', { childName }) }) };
+
+  return {
+    defaultState: state.dentalBenefits,
+    childName,
+    federalSocialPrograms,
+    id: state.id,
+    meta,
+    provincialTerritorialSocialPrograms,
+    provinceTerritoryStates,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadProtectedRenewSingleChildState({ params, session });
+  const renewState = loadProtectedRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // NOTE: state validation schemas are independent otherwise user have to anwser
+  // both question first before the superRefine can be executed
+  const federalBenefitsSchema = z
+    .object({
+      hasFederalBenefits: z.boolean({ errorMap: () => ({ message: t('protected-renew:children.update-dental-benefits.error-message.federal-benefit-required') }) }),
+      federalSocialProgram: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasFederalBenefits) {
+        if (!val.federalSocialProgram || validator.isEmpty(val.federalSocialProgram)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:children.update-dental-benefits.error-message.federal-benefit-program-required'), path: ['federalSocialProgram'] });
+        }
+      }
+    })
+    .transform((val) => {
+      return {
+        ...val,
+        federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
+      };
+    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+
+  const provincialTerritorialBenefitsSchema = z
+    .object({
+      hasProvincialTerritorialBenefits: z.boolean({ errorMap: () => ({ message: t('protected-renew:children.update-dental-benefits.error-message.provincial-benefit-required') }) }),
+      provincialTerritorialSocialProgram: z.string().trim().optional(),
+      province: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.hasProvincialTerritorialBenefits) {
+        if (!val.province || validator.isEmpty(val.province)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:children.update-dental-benefits.error-message.provincial-territorial-required'), path: ['province'] });
+        } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:children.update-dental-benefits.error-message.provincial-benefit-program-required'), path: ['provincialTerritorialSocialProgram'] });
+        }
+      }
+    })
+    .transform((val) => {
+      return {
+        ...val,
+        province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
+        provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
+      };
+    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+
+  const dentalFederalBenefits = {
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
+  };
+
+  const dentalProvincialTerritorialBenefits = {
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
+    province: formData.get('province') ? String(formData.get('province')) : undefined,
+  };
+
+  const parsedFederalBenefitsResult = federalBenefitsSchema.safeParse(dentalFederalBenefits);
+  const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalProvincialTerritorialBenefits);
+
+  if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
+    return {
+      errors: {
+        ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
+        ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+      },
+    };
+  }
+
+  saveProtectedRenewState({
+    params,
+    session,
+    state: {
+      children: renewState.children.map((child) => {
+        if (child.id !== state.id) return child;
+        return {
+          ...child,
+          dentalBenefits: {
+            ...parsedFederalBenefitsResult.data,
+            ...parsedProvincialTerritorialBenefitsResult.data,
+          },
+        };
+      }),
+    },
+  });
+
+  return redirect(getPathById('protected/renew/$id/review-child-information', params));
+}
+
+export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefits() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);
+  const [hasProvincialTerritorialBenefitValue, setHasProvincialTerritorialBenefitValue] = useState(defaultState?.hasProvincialTerritorialBenefits);
+  const [provincialTerritorialSocialProgramValue, setProvincialTerritorialSocialProgramValue] = useState(defaultState?.provincialTerritorialSocialProgram);
+  const [provinceValue, setProvinceValue] = useState(defaultState?.province);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasFederalBenefits: 'input-radio-has-federal-benefits-option-0',
+    federalSocialProgram: 'input-radio-federal-social-programs-option-0',
+    hasProvincialTerritorialBenefits: 'input-radio-has-provincial-territorial-benefits-option-0',
+    province: 'province',
+    provincialTerritorialSocialProgram: 'input-radio-provincial-territorial-social-programs-option-0',
+  });
+
+  function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+  }
+
+  function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
+    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+      setProvinceValue(undefined);
+      setProvincialTerritorialSocialProgramValue(undefined);
+    }
+  }
+
+  function handleOnProvincialTerritorialSocialProgramChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setProvincialTerritorialSocialProgramValue(e.target.value);
+  }
+
+  function handleOnRegionChanged(e: React.ChangeEvent<HTMLSelectElement>) {
+    setProvinceValue(e.target.value);
+    setProvincialTerritorialSocialProgramValue(undefined);
+  }
+
+  return (
+    <>
+      <div className="max-w-prose">
+        <p className="mb-4">{t('protected-renew:children.update-dental-benefits.access-to-dental')}</p>
+        <p className="mb-4">{t('protected-renew:children.update-dental-benefits.eligibility-criteria')}</p>
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+
+          <fieldset className="mb-6">
+            <legend className="mb-4 font-lato text-2xl font-bold">{t('protected-renew:children.update-dental-benefits.federal-benefits.title')}</legend>
+            <InputRadios
+              id="has-federal-benefits"
+              name="hasFederalBenefits"
+              legend={t('protected-renew:children.update-dental-benefits.federal-benefits.legend', { childName })}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.federal-benefits.option-yes" />,
+                  value: HasFederalBenefitsOption.Yes,
+                  defaultChecked: hasFederalBenefitValue === true,
+                  onChange: handleOnHasFederalBenefitChanged,
+                  append: hasFederalBenefitValue === true && (
+                    <InputRadios
+                      id="federal-social-programs"
+                      name="federalSocialProgram"
+                      legend={t('protected-renew:children.update-dental-benefits.federal-benefits.social-programs.legend')}
+                      legendClassName="font-normal"
+                      options={federalSocialPrograms.map((option) => ({
+                        children: option.name,
+                        defaultChecked: defaultState?.federalSocialProgram === option.id,
+                        value: option.id,
+                      }))}
+                      errorMessage={errors?.federalSocialProgram}
+                      required
+                    />
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.federal-benefits.option-no" />,
+                  value: HasFederalBenefitsOption.No,
+                  defaultChecked: hasFederalBenefitValue === false,
+                  onChange: handleOnHasFederalBenefitChanged,
+                },
+              ]}
+              errorMessage={errors?.hasFederalBenefits}
+              required
+            />
+          </fieldset>
+          <fieldset className="mb-8">
+            <legend className="mb-4 font-lato text-2xl font-bold">{t('protected-renew:children.update-dental-benefits.provincial-territorial-benefits.title')}</legend>
+            <InputRadios
+              id="has-provincial-territorial-benefits"
+              name="hasProvincialTerritorialBenefits"
+              legend={t('protected-renew:children.update-dental-benefits.provincial-territorial-benefits.legend', { childName })}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.provincial-territorial-benefits.option-yes" />,
+                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  defaultChecked: hasProvincialTerritorialBenefitValue === true,
+                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  append: hasProvincialTerritorialBenefitValue && (
+                    <div className="space-y-6">
+                      <InputSelect
+                        id="province"
+                        name="province"
+                        className="w-full sm:w-1/2"
+                        label={t('protected-renew:children.update-dental-benefits.provincial-territorial-benefits.social-programs.input-legend')}
+                        onChange={handleOnRegionChanged}
+                        options={[
+                          {
+                            children: t('protected-renew:children.update-dental-benefits.select-one'),
+                            value: '',
+                            hidden: true,
+                          },
+                          ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                        ]}
+                        defaultValue={provinceValue}
+                        errorMessage={errors?.province}
+                        required
+                      />
+                      {provinceValue && (
+                        <InputRadios
+                          id="provincial-territorial-social-programs"
+                          name="provincialTerritorialSocialProgram"
+                          legend={t('protected-renew:children.update-dental-benefits.provincial-territorial-benefits.social-programs.radio-legend')}
+                          legendClassName="font-normal"
+                          errorMessage={errors?.provincialTerritorialSocialProgram}
+                          options={provincialTerritorialSocialPrograms
+                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                            .map((option) => ({
+                              children: option.name,
+                              value: option.id,
+                              checked: provincialTerritorialSocialProgramValue === option.id,
+                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                            }))}
+                          required
+                        />
+                      )}
+                    </div>
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.provincial-territorial-benefits.option-no" />,
+                  value: HasProvincialTerritorialBenefitsOption.No,
+                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                },
+              ]}
+              errorMessage={errors?.hasProvincialTerritorialBenefits}
+              required
+            />
+          </fieldset>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental benefits click">
+              {t('protected-renew:children.update-dental-benefits.button.save-btn')}
+            </Button>
+            <ButtonLink
+              id="back-button"
+              routeId="protected/renew/$id/review-child-information"
+              params={params}
+              disabled={isSubmitting}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental benefits click"
+            >
+              {t('protected-renew:children.update-dental-benefits.button.cancel-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -95,6 +95,11 @@ export const routes = [
                 file: 'routes/protected/renew/$id/$childId/demographic-survey.tsx',
                 paths: { en: '/:lang/protected/renew/:id/:childId/demographic-survey', fr: '/:lang/protected/renew/:id/:childId/demographic-survey' },
               },
+              {
+                id: 'protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits',
+                file: 'routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx',
+                paths: { en: '/:lang/protected/renew/:id/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/protected/renew/:id/:childId/confirm-federal-provincial-territorial-benefits' },
+              },
             ],
           },
           {

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -263,6 +263,44 @@
       "error-message": {
         "dental-insurance-required": "Select whether the child has access to dental insurance"
       }
+    },
+    "update-dental-benefits": {
+      "title": "{{childName}}: access to other federal, provincial or territorial dental benefits",
+      "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
+      "select-one": "Select one",
+      "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
+      "federal-benefits": {
+        "title": "Federal benefits",
+        "legend": "Does {{childName}} have dental benefits through a federal social program?",
+        "option-yes": "<strong>Yes</strong>, this child has <strong>federal</strong> benefits",
+        "option-no": "<strong>No</strong>, this child does not have <strong>federal</strong> benefits",
+        "social-programs": {
+          "legend": "Please select which social program this child is covered under. If this child has more than one, please select the one they use the most."
+        }
+      },
+      "provincial-territorial-benefits": {
+        "title": "Provincial or territorial benefits",
+        "legend": "Does {{childName}} have dental benefits through a provincial or territorial social program?",
+        "option-yes": "<strong>Yes</strong>, this child has <strong>provincial or territorial</strong> benefits",
+        "option-no": "<strong>No</strong>, this child does not have <strong>provincial or territorial</strong> benefits",
+        "social-programs": {
+          "input-legend": "Through which province or territory?",
+          "radio-legend": "Please select which social program this child is covered under. If this child has more than one, please select the one they use the most."
+        }
+      },
+      "button": {
+        "back": "Back",
+        "continue": "Continue",
+        "cancel-btn": "Cancel",
+        "save-btn": "Save"
+      },
+      "error-message": {
+        "federal-benefit-program-required": "Select which federal program you are covered under",
+        "federal-benefit-required": "Select whether you have federal dental benefits",
+        "provincial-benefit-program-required": "Select which provincial or territorial program you are covered under",
+        "provincial-benefit-required": "Select whether you have provincial or territorial dental benefits",
+        "provincial-territorial-required": "Select a province or territory"
+      }
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -263,6 +263,44 @@
       "error-message": {
         "dental-insurance-required": "Select whether the child has access to dental insurance"
       }
+    },
+    "update-dental-benefits": {
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
+      "select-one": "Sélectionnez une option",
+      "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
+      "federal-benefits": {
+        "title": "Prestations fédérales",
+        "legend": "L'accès de {{childName}} aux prestations fédérales a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
+        "option-yes": "<strong>Oui</strong>, les prestations fédérales de cet enfant ont changé",
+        "option-no": "<strong>Non</strong>, les prestations fédérales de cet enfant n'ont pas changé",
+        "social-programs": {
+          "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
+        }
+      },
+      "provincial-territorial-benefits": {
+        "title": "Prestations provinciales ou territoriales",
+        "legend": "L'accès de {{childName}} aux prestations provinciales ou territoriales a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
+        "option-yes": "<strong>Oui</strong, les prestations provinciales ou territoriales de cet enfant ont changé",
+        "option-no": "<strong>Non</strong, les prestations provinciales ou territoriales de cet enfant n'ont pas changé",
+        "social-programs": {
+          "input-legend": "Par l'entremise de quelle province ou de quel territoire?",
+          "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
+        }
+      },
+      "button": {
+        "back": "Retour",
+        "continue": "Continuer",
+        "cancel-btn": "Annuler",
+        "save-btn": "Sauvegarder"
+      },
+      "error-message": {
+        "federal-benefit-program-required": "Sélectionnez le programme fédéral dont relève votre enfant",
+        "federal-benefit-required": "Sélectionnez si votre enfant bénéficie de prestations dentaires fédérales",
+        "provincial-benefit-program-required": "Sélectionnez le programme provincial ou territorial dont relève votre enfant",
+        "provincial-benefit-required": "Sélectionnez si votre enfant bénéficie d'une assurance dentaire provinciale ou territoriale",
+        "provincial-territorial-required": "Sélectionnez une province ou un territoire"
+      }
     }
   },
   "confirm-phone": {


### PR DESCRIPTION
### Description
adds `protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits` so that a user can update FPT benefits for a child if they click on the "change answer to dental benefits" link on the review child screen in the protected renew flow.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`