### PR TITLE
move demographic survey questions to adult-child flow

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -138,6 +138,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     dentalBenefits,
     confirmDentalBenefits,
     dentalInsurance,
+    demographicSurvey,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -215,6 +216,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     partnerInformation,
     children,
     hasAddressChanged,
+    demographicSurvey,
   };
 }
 

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -117,8 +117,8 @@ export const pageIds = {
         federalProvincialTerritorialBenefits: 'CDCP-RENW-ITA-0007',
         reviewInformation: 'CDCP-RENW-ITA-0008',
         confirmation: 'CDCP-RENW-ITA-0009',
-        exitApplication: 'CDCP-RENw-ITA-0010',
-        demographicSurvey: 'CDCP-RENw-ITA-0011',
+        exitApplication: 'CDCP-RENW-ITA-0010',
+        demographicSurvey: 'CDCP-RENW-ITA-0011',
       },
       adultChild: {
         confirmMaritalStatus: 'CDCP-RENW-ADCH-001',
@@ -136,6 +136,7 @@ export const pageIds = {
         exitApplication: 'CDCP-RENW-ADCH-0013',
         confirmation: 'CDCP-RENW-ADCH-0014',
         reviewAdultInformation: 'CDCP-APPL-ADCH-0015',
+        demographicSurvey: 'CDCP-RENw-ITA-0016',
       },
       child: {
         childInformation: 'CDCP-RENW-CHLD-0001',

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -108,7 +108,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
+  return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
 }
 
 export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
+import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -36,9 +36,9 @@ enum FormAction {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'gcweb'),
-  pageTitleI18nKey: 'renew-ita:demographic-survey.page-title',
-  pageIdentifier: pageIds.public.renew.ita.demographicSurvey,
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'gcweb'),
+  pageTitleI18nKey: 'renew-adult-child:demographic-survey.page-title',
+  pageIdentifier: pageIds.public.renew.adultChild.demographicSurvey,
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -46,13 +46,13 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
-  const state = loadRenewItaState({ params, request, session });
+  const state = loadRenewAdultChildState({ params, request, session });
 
   const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:demographic-survey.page-title', { memberName }) }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:demographic-survey.page-title', { memberName }) }) };
 
   const demographicSurveyService = appContainer.get(TYPES.domain.services.DemographicSurveyService);
   const indigenousStatuses = demographicSurveyService.listLocalizedIndigenousStatuses(locale);
@@ -97,11 +97,11 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .superRefine((val, ctx) => {
       if (val.indigenousStatus === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString() && !val.firstNations.length) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:demographic-survey.error-message.first-nations-required'), path: ['firstNations'] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:demographic-survey.error-message.first-nations-required'), path: ['firstNations'] });
       }
 
       if (val.ethnicGroups.includes(ANOTHER_ETHNIC_GROUP_OPTION.toString()) && !val.anotherEthnicGroup) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:demographic-survey.error-message.another-ethnic-group-required'), path: ['anotherEthnicGroup'] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:demographic-survey.error-message.another-ethnic-group-required'), path: ['anotherEthnicGroup'] });
       }
     });
 
@@ -124,14 +124,13 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       demographicSurvey: parsedDataResult.data,
-      editMode: true, // last step in the flow
     },
   });
 
-  return redirect(getPathById('public/renew/$id/ita/review-information', params));
+  return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewItaDemographicSurveyQuestions() {
+export default function RenewAdultChildDemographicSurveyQuestions() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
@@ -171,7 +170,7 @@ export default function RenewItaDemographicSurveyQuestions() {
     value: status.id,
     onChange: handleOnIsIndigenousStatusChanged,
     append: status.id === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString() && isIndigenousStatusValue && (
-      <InputCheckboxes id="first-nations" name="firstNations" legend={t('renew-ita:demographic-survey.indigenous-status')} options={firstNationsOptions} errorMessage={errors?.firstNations} required />
+      <InputCheckboxes id="first-nations" name="firstNations" legend={t('renew-adult-child:demographic-survey.indigenous-status')} options={firstNationsOptions} errorMessage={errors?.firstNations} required />
     ),
   }));
 
@@ -185,7 +184,7 @@ export default function RenewItaDemographicSurveyQuestions() {
     value: status.id,
     onChange: status.id === ANOTHER_ETHNIC_GROUP_OPTION.toString() ? handleOnIsAnotherEthnicGroupChanged : undefined,
     append: status.id === ANOTHER_ETHNIC_GROUP_OPTION.toString() && isAnotherEthnicGroupValue && (
-      <InputSanitizeField id="another-ethnic-group" name="anotherEthnicGroup" label={t('renew-ita:demographic-survey.ethnic-groups')} defaultValue={defaultState?.anotherEthnicGroup ?? ''} errorMessage={errors?.anotherEthnicGroup} required />
+      <InputSanitizeField id="another-ethnic-group" name="anotherEthnicGroup" label={t('renew-adult-child:demographic-survey.ethnic-groups')} defaultValue={defaultState?.anotherEthnicGroup ?? ''} errorMessage={errors?.anotherEthnicGroup} required />
     ),
   }));
 
@@ -200,47 +199,47 @@ export default function RenewItaDemographicSurveyQuestions() {
   return (
     <>
       <div className="max-w-prose">
-        <p className="mb-4 italic">{t('renew-ita:demographic-survey.optional')}</p>
+        <p className="mb-4 italic">{t('renew-adult-child:demographic-survey.optional')}</p>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
           <div className="mb-8 space-y-6">
-            <InputRadios id="indigenous-status" name="indigenousStatus" legend={t('renew-ita:demographic-survey.indigenous-status')} options={indigenousStatusOptions} errorMessage={errors?.indigenousStatus} required />
-            <InputRadios id="disability-status" name="disabilityStatus" legend={t('renew-ita:demographic-survey.disability-status')} options={disabilityStatusOptions} errorMessage={errors?.disabilityStatus} required />
-            <InputCheckboxes id="ethnic-groups" name="ethnicGroups" legend={t('renew-ita:demographic-survey.ethnic-groups')} options={ethnicGroupOptions} errorMessage={errors?.ethnicGroups} required />
-            <InputRadios id="location-born-status" name="locationBornStatus" legend={t('renew-ita:demographic-survey.location-born-status')} options={locationBornStatusOptions} errorMessage={errors?.locationBornStatus} required />
-            <InputRadios id="gender-status" name="genderStatus" legend={t('renew-ita:demographic-survey.gender-status')} options={genderStatusOptions} errorMessage={errors?.genderStatus} required />
+            <InputRadios id="indigenous-status" name="indigenousStatus" legend={t('renew-adult-child:demographic-survey.indigenous-status')} options={indigenousStatusOptions} errorMessage={errors?.indigenousStatus} required />
+            <InputRadios id="disability-status" name="disabilityStatus" legend={t('renew-adult-child:demographic-survey.disability-status')} options={disabilityStatusOptions} errorMessage={errors?.disabilityStatus} required />
+            <InputCheckboxes id="ethnic-groups" name="ethnicGroups" legend={t('renew-adult-child:demographic-survey.ethnic-groups')} options={ethnicGroupOptions} errorMessage={errors?.ethnicGroups} required />
+            <InputRadios id="location-born-status" name="locationBornStatus" legend={t('renew-adult-child:demographic-survey.location-born-status')} options={locationBornStatusOptions} errorMessage={errors?.locationBornStatus} required />
+            <InputRadios id="gender-status" name="genderStatus" legend={t('renew-adult-child:demographic-survey.gender-status')} options={genderStatusOptions} errorMessage={errors?.genderStatus} required />
           </div>
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Button name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental insurance click">
-                {t('renew-ita:demographic-survey.save-btn')}
+                {t('renew-adult-child:demographic-survey.save-btn')}
               </Button>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/ita/review-information"
+                routeId="public/renew/$id/adult-child/review-adult-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental insurance click"
               >
-                {t('renew-ita:demographic-survey.cancel-btn')}
+                {t('renew-adult-child:demographic-survey.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton id="save-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Demographic Survey:Save - Questions click">
-                {t('renew-ita:demographic-survey.continue-btn')}
+                {t('renew-adult-child:demographic-survey.continue-btn')}
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/ita/federal-provincial-territorial-benefits"
+                routeId="public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits"
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Demographic Survey:Cancel - Questions click"
               >
-                {t('renew-ita:demographic-survey.back-btn')}
+                {t('renew-adult-child:demographic-survey.back-btn')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -128,6 +128,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     },
   };
 
+  const demographicSurvey = state.demographicSurvey;
+
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:review-adult-information.page-title') }) };
 
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
@@ -143,6 +145,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     mailingAddressInfo,
     dentalInsurance,
     dentalBenefit,
+    demographicSurvey,
     meta,
     payload,
     hasChildren: state.children.length > 0,
@@ -183,7 +186,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function RenewAdultChildReviewAdultInformation() {
   const params = useParams();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, hasChildren, payload } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, demographicSurvey, hasChildren, payload } = useLoaderData<typeof loader>();
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();
@@ -372,6 +375,19 @@ export default function RenewAdultChildReviewAdultInformation() {
                 <div className="mt-4">
                   <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits" params={params}>
                     {t('renew-adult-child:review-adult-information.dental-benefit-change')}
+                  </InlineLink>
+                </div>
+              </DescriptionListItem>
+            </dl>
+          </section>
+          <section className="space-y-6">
+            <h2 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-adult-information.demographic-survey-title')}</h2>
+            <dl className="divide-y border-y">
+              <DescriptionListItem term={t('renew-adult-child:review-adult-information.demographic-survey-title')}>
+                <p>{demographicSurvey ? t('renew-adult-child:review-adult-information.demographic-survey-responded') : t('renew-adult-child:review-adult-information.no')}</p>
+                <div className="mt-4">
+                  <InlineLink id="change-demographic-survey" routeId="public/renew/$id/adult-child/demographic-survey" params={params}>
+                    {t('renew-adult-child:review-adult-information.demographic-survey-change')}
                   </InlineLink>
                 </div>
               </DescriptionListItem>

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -170,7 +170,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
+  return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
 }
 
 export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -518,6 +518,11 @@ export const routes = [
             paths: { en: '/:lang/renew/:id/adult-child/update-federal-provincial-territorial-benefits', fr: '/:lang/renew/:id/adulte-enfant/mise-a-jour-prestations-dentaires-federales-provinciales-territoriales' },
           },
           {
+            id: 'public/renew/$id/adult-child/demographic-survey',
+            file: 'routes/public/renew/$id/adult-child/demographic-survey.tsx',
+            paths: { en: '/:lang/renew/:id/adult-child/demographic-survey', fr: '/:lang/renew/:id/adult-child/demographic-survey' },
+          },
+          {
             id: 'public/renew/$id/adult-child/children/index',
             file: 'routes/public/renew/$id/adult-child/children/index.tsx',
             paths: { en: '/:lang/renew/:id/adult-child/children', fr: '/:lang/renew/:id/adulte-enfant/enfant' },

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -576,6 +576,10 @@
     "dental-benefit-title": "Access to government dental benefits",
     "dental-benefit-change": "Change answer to government dental benefits",
     "dental-benefit-has-access": "Has access to the following benefits:",
+    "demographic-survey-title": "Demographics questions",
+    "demographic-survey-heading": "Voluntary demographic questions",
+    "demographic-survey-responded": "Responded",
+    "demographic-survey-change": "Change answers to demographic questions",
     "no-change": "No update",
     "submit-button": "Submit Application",
     "exit-button": "Exit application",
@@ -588,5 +592,22 @@
     "submit-p-false-info": "If you provide false information on your renewal, you and others you applied for may be removed from the plan.",
     "submit-p-repayment": "If you or your family members were not eligible to renew, you or your family member may have to repay the full cost of care received through the Canadian Dental Care Plan.",
     "no-update": "No update"
+  },
+  "demographic-survey": {
+    "page-title": "Voluntary demographic questions for {{memberName}}",
+    "optional": "All questions are optional.",
+    "indigenous-status": "Is this person First Nations, Métis or Inuk (Inuit)?",
+    "disability-status": "Does this person have a disability?",
+    "ethnic-groups": "To which ethnic group(s) does this person belong? Please select all that apply.",
+    "location-born-status": "Where was this person born?",
+    "gender-status": "What is this person's gender?",
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "save-btn": "Save",
+    "cancel-btn": "Cancel",
+    "error-message": {
+      "first-nations-required": "Please select if this person is First Nations, Métis or Inuk (Inuit)",
+      "another-ethnic-group-required": "Please specify the ethnic group"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -577,6 +577,10 @@
     "dental-benefit-title": "Accès à des prestations dentaires gouvernementales",
     "dental-benefit-change": "Modifier la réponse à «\u00a0soins dentaires gouvernementaux\u00a0»",
     "dental-benefit-has-access": "Accès à des prestations dentaires gouvernementales\u00a0:",
+    "demographic-survey-title": "Demographics questions",
+    "demographic-survey-heading": "Voluntary demographic questions",
+    "demographic-survey-responded": "Responded",
+    "demographic-survey-change": "Change answers to demographic questions",
     "no-change": "Aucun changement",
     "submit-button": "Soumettre la demande",
     "exit-button": "Quitter la demande",
@@ -589,5 +593,22 @@
     "submit-p-false-info": "Si vous fournissez de faux renseignements dans votre demande de renouvellement, vous et les autres personnes pour lesquelles vous avez présenté une demande pourriez être exclus du régime.",
     "submit-p-repayment": "Si vous ou les membres de votre famille n'étiez pas admissibles au renouvellement, vous pourriez avoir à rembourser la totalité des frais pour les soins reçus par l'intermédiaire du Régime canadien de soins dentaires.",
     "no-update": "Pas de mise à jour"
+  },
+  "demographic-survey": {
+    "page-title": "Voluntary demographic questions for {{memberName}}",
+    "optional": "All questions are optional.",
+    "indigenous-status": "Is this person First Nations, Métis or Inuk (Inuit)?",
+    "disability-status": "Does this person have a disability?",
+    "ethnic-groups": "To which ethnic group(s) does this person belong? Please select all that apply.",
+    "location-born-status": "Where was this person born?",
+    "gender-status": "What is this person's gender?",
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "save-btn": "Save",
+    "cancel-btn": "Cancel",
+    "error-message": {
+      "first-nations-required": "Please select if this person is First Nations, Métis or Inuk (Inuit)",
+      "another-ethnic-group-required": "Please specify the ethnic group"
+    }
   }
 }


### PR DESCRIPTION
### Description
In an effort to reduce the size of this PR, adds the demographic survey questions to the ADULT ONLY portions of the adult-child flow in the renewal application.  I will add the demographic survey questions to the child portion in a separate PR.

### Related Azure Boards Work Items
[AB#4928](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4928)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`