### PR TITLE
[gitops] Disable maintenance page

### DIFF
--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -22,9 +22,9 @@ resources:
   #      - for full application maintenance, uncomment ./ingresses-maintenance.yaml
   #      - for online application maintenance, uncomment ./ingresses-apply-maintenance.yaml
   #
-  # - ./ingresses.yaml
+  - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
-  - ./ingresses-apply-maintenance.yaml
+  # - ./ingresses-apply-maintenance.yaml
 patches:
   - path: ./patches/deployments-frontend.yaml
   - path: ./patches/deployments-maintenance.yaml


### PR DESCRIPTION
### Description

Disables the maintenance page that was added and enabled in #2632.
Comparison with #2632: https://github.com/DTS-STN/canadian-dental-care-plan/compare/nick/gitops-apply-maintenance...GjB/disable-maintenance

Marking as draft until sometime around **Sunday December 08 10:45 am ET**, when we are scheduled to come back online.