### PR TITLE
Refactor `remixRequestHandler` to prevent session initialization for stateless requests and make health checks dependency-injectable

### DIFF
--- a/frontend/__tests__/.server/providers/app-container.provider.test.ts
+++ b/frontend/__tests__/.server/providers/app-container.provider.test.ts
@@ -42,7 +42,6 @@ describe('DefaultAppContainerProvider', () => {
 
       expect(result).toBeUndefined();
       expect(mockLogger.trace).toHaveBeenCalledWith('Finding service for service identifier: %s', mockServiceIdentifier);
-      expect(mockLogger.trace).toHaveBeenCalledWith('Service not found for service identifier: %s; returning undefined. Error: %o', mockServiceIdentifier, expect.any(Error));
     });
   });
 
@@ -59,6 +58,44 @@ describe('DefaultAppContainerProvider', () => {
     it('should throw an error if service is not found', () => {
       expect(() => appContainerProvider.get(mockServiceIdentifier)).toThrowError();
       expect(mockLogger.trace).toHaveBeenCalledWith('Get service for service identifier: %s', mockServiceIdentifier);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all instances of the service if found', () => {
+      const mockServiceInstances = [{ name: 'MockService1' }, { name: 'MockService2' }];
+      container.bind(mockServiceIdentifier).toConstantValue(mockServiceInstances[0]);
+      container.bind(mockServiceIdentifier).toConstantValue(mockServiceInstances[1]);
+
+      const result = appContainerProvider.findAll(mockServiceIdentifier);
+
+      expect(result).toEqual(mockServiceInstances);
+      expect(mockLogger.trace).toHaveBeenCalledWith('Finding service for service identifier: %s', mockServiceIdentifier);
+    });
+
+    it('should return an empty array if no instances are found', () => {
+      const result = appContainerProvider.findAll(mockServiceIdentifier);
+
+      expect(result).toEqual([]);
+      expect(mockLogger.trace).toHaveBeenCalledWith('Finding service for service identifier: %s', mockServiceIdentifier);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all instances of the service if found', () => {
+      const mockServiceInstances = [{ name: 'MockService1' }, { name: 'MockService2' }];
+      container.bind(mockServiceIdentifier).toConstantValue(mockServiceInstances[0]);
+      container.bind(mockServiceIdentifier).toConstantValue(mockServiceInstances[1]);
+
+      const result = appContainerProvider.getAll(mockServiceIdentifier);
+
+      expect(result).toEqual(mockServiceInstances);
+      expect(mockLogger.trace).toHaveBeenCalledWith('Getting all services for service identifier: %s', mockServiceIdentifier);
+    });
+
+    it('should throw an error if no instances are found', () => {
+      expect(() => appContainerProvider.getAll(mockServiceIdentifier)).toThrowError();
+      expect(mockLogger.trace).toHaveBeenCalledWith('Getting all services for service identifier: %s', mockServiceIdentifier);
     });
   });
 });

--- a/frontend/app/.server/app-container.provider.ts
+++ b/frontend/app/.server/app-container.provider.ts
@@ -16,11 +16,25 @@ export interface AppContainerProvider {
   find<T>(serviceIdentifier: ServiceIdentifier<T>): T | undefined;
 
   /**
+   * Retrieves all instances of a service from the container without throwing an error if the service is not found.
+   * @param serviceIdentifier - The service identifier for the requested service.
+   * @returns An array of instances of the requested service.
+   */
+  findAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[];
+
+  /**
    * Retrieves a service from the container. Throws an error if the service is not found.
    * @param serviceIdentifier - The service identifier for the requested service.
    * @returns The instance of the requested service.
    */
   get<T>(serviceIdentifier: ServiceIdentifier<T>): T;
+
+  /**
+   * Retrieves all instances of a service from the container. Throws an error if the service is not found.
+   * @param serviceIdentifier - The service identifier for the requested service.
+   * @returns An array of instances of the requested service.
+   */
+  getAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[];
 }
 
 export class DefaultAppContainerProvider implements AppContainerProvider {
@@ -33,16 +47,21 @@ export class DefaultAppContainerProvider implements AppContainerProvider {
 
   find<T>(serviceIdentifier: ServiceIdentifier<T>): T | undefined {
     this.log.trace('Finding service for service identifier: %s', serviceIdentifier);
-    try {
-      return this.container.get(serviceIdentifier);
-    } catch (error) {
-      this.log.trace('Service not found for service identifier: %s; returning undefined. Error: %o', serviceIdentifier, error);
-      return undefined;
-    }
+    return this.container.tryGet(serviceIdentifier);
+  }
+
+  findAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[] {
+    this.log.trace('Finding service for service identifier: %s', serviceIdentifier);
+    return this.container.tryGetAll(serviceIdentifier, { enforceBindingConstraints: true });
   }
 
   get<T>(serviceIdentifier: ServiceIdentifier<T>): T {
     this.log.trace('Get service for service identifier: %s', serviceIdentifier);
     return this.container.get(serviceIdentifier);
+  }
+
+  getAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[] {
+    this.log.trace('Getting all services for service identifier: %s', serviceIdentifier);
+    return this.container.getAll(serviceIdentifier, { enforceBindingConstraints: true });
   }
 }

--- a/frontend/app/.server/app.container.ts
+++ b/frontend/app/.server/app.container.ts
@@ -5,7 +5,17 @@ import { makeLoggerMiddleware, textSerializer } from 'inversify-logger-middlewar
 import type { AppContainerProvider } from '~/.server/app-container.provider';
 import { DefaultAppContainerProvider } from '~/.server/app-container.provider';
 import { TYPES } from '~/.server/constants';
-import { authContainerModule, configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, routesContainerModule, servicesContainerModule, webContainerModule } from '~/.server/container-modules';
+import {
+  authContainerModule,
+  configsContainerModule,
+  factoriesContainerModule,
+  healthContainerModule,
+  mappersContainerModule,
+  repositoriesContainerModule,
+  routesContainerModule,
+  servicesContainerModule,
+  webContainerModule,
+} from '~/.server/container-modules';
 import { getLogger } from '~/.server/utils/logging.utils';
 
 /**
@@ -55,7 +65,7 @@ function createContainer(): interfaces.Container {
   log.info('Creating IoC container; id: [%s], options: [%j]', container.id, container.options);
 
   // load container modules
-  container.load(authContainerModule, configsContainerModule, factoriesContainerModule, mappersContainerModule, repositoriesContainerModule, routesContainerModule, servicesContainerModule, webContainerModule);
+  container.load(authContainerModule, configsContainerModule, factoriesContainerModule, healthContainerModule, mappersContainerModule, repositoriesContainerModule, routesContainerModule, servicesContainerModule, webContainerModule);
 
   // configure container logger middleware
   const serverConfig = container.get(TYPES.configs.ServerConfig);

--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -1,3 +1,4 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
 import type { interfaces } from 'inversify';
 
 import type { BearerTokenResolver, TokenRolesExtractor } from '~/.server/auth';
@@ -208,6 +209,9 @@ export const TYPES = assignServiceIdentifiers({
   },
   factories: {
     LogFactory: serviceId<LogFactory>(),
+  },
+  health: {
+    HealthCheck: serviceId<HealthCheck>(),
   },
   http: {
     HttpClient: serviceId<HttpClient>(),

--- a/frontend/app/.server/container-modules/health.container-module.ts
+++ b/frontend/app/.server/container-modules/health.container-module.ts
@@ -1,0 +1,20 @@
+import type { interfaces } from 'inversify';
+import { ContainerModule } from 'inversify';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import { RedisHealthCheck } from '~/.server/health';
+
+function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
+  return ({ parentContext }: interfaces.Request) => {
+    const serverConfig = parentContext.container.get(TYPES.configs.ServerConfig);
+    return serverConfig.SESSION_STORAGE_TYPE === sessionType;
+  };
+}
+
+/**
+ * Container module for health components.
+ */
+export const healthContainerModule = new ContainerModule((bind) => {
+  bind(TYPES.health.HealthCheck).to(RedisHealthCheck).when(sessionTypeIs('redis'));
+});

--- a/frontend/app/.server/container-modules/index.ts
+++ b/frontend/app/.server/container-modules/index.ts
@@ -1,6 +1,7 @@
 export * from './auth.container-module';
 export * from './configs.container-module';
 export * from './factories.container-module';
+export * from './health.container-module';
 export * from './mappers.container-module';
 export * from './repositories.container-module';
 export * from './routes.container-module';

--- a/frontend/app/.server/data/services/redis.service.ts
+++ b/frontend/app/.server/data/services/redis.service.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'inversify';
 import Redis from 'ioredis';
+import type { RedisOptions } from 'ioredis';
 import type { Logger } from 'winston';
 
 import type { ServerConfig } from '~/.server/configs';
@@ -68,7 +69,7 @@ export class DefaultRedisService implements RedisService {
     return await this.redisClient.ping();
   }
 
-  private getRedisConfig(serverConfig: ServerConfig) {
+  private getRedisConfig(serverConfig: ServerConfig): RedisOptions {
     const retryStrategy = (times: number): number => {
       // exponential backoff starting at 250ms to a maximum of 5s
       const retryIn = Math.min(250 * Math.pow(2, times - 1), 5000);

--- a/frontend/app/.server/health/index.ts
+++ b/frontend/app/.server/health/index.ts
@@ -1,0 +1,1 @@
+export * from './redis.health';

--- a/frontend/app/.server/health/redis.health.ts
+++ b/frontend/app/.server/health/redis.health.ts
@@ -1,0 +1,52 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { RedisService } from '~/.server/data/services';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+@injectable()
+export class RedisHealthCheck implements HealthCheck {
+  private readonly log: Logger;
+
+  readonly name: string;
+  readonly check: (signal?: AbortSignal) => Promise<void> | void;
+  readonly metadata?: Record<string, string>;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.configs.ServerConfig)
+    private readonly serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL' | 'REDIS_USERNAME' | 'REDIS_STANDALONE_HOST' | 'REDIS_STANDALONE_PORT' | 'REDIS_SENTINEL_NAME' | 'REDIS_SENTINEL_HOST' | 'REDIS_SENTINEL_PORT' | 'REDIS_COMMAND_TIMEOUT_SECONDS'>,
+    @inject(TYPES.data.services.RedisService) private readonly redisService: RedisService,
+  ) {
+    this.log = logFactory.createLogger('RedisHealthCheck');
+
+    this.name = 'redis';
+    this.check = this.redisCheckFn();
+    this.metadata = {
+      REDIS_USERNAME: this.serverConfig.REDIS_USERNAME ?? '',
+      REDIS_STANDALONE_HOST: this.serverConfig.REDIS_STANDALONE_HOST,
+      REDIS_STANDALONE_PORT: this.serverConfig.REDIS_STANDALONE_PORT.toString(),
+      REDIS_SENTINEL_NAME: this.serverConfig.REDIS_SENTINEL_NAME ?? '',
+      REDIS_SENTINEL_HOST: this.serverConfig.REDIS_SENTINEL_HOST ?? '',
+      REDIS_SENTINEL_PORT: (this.serverConfig.REDIS_SENTINEL_PORT ?? '').toString(),
+      REDIS_COMMAND_TIMEOUT_SECONDS: this.serverConfig.REDIS_COMMAND_TIMEOUT_SECONDS.toString(),
+    };
+  }
+
+  private redisCheckFn(): (signal?: AbortSignal) => Promise<void> {
+    return moize.promise(
+      async () => {
+        await this.redisService.ping();
+      },
+      {
+        // transformArgs is required to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
+        transformArgs: () => [],
+        onCacheAdd: () => this.log.info('Initializing new cached Redis health check function'),
+        maxAge: this.serverConfig.HEALTH_CACHE_TTL,
+      },
+    );
+  }
+}

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -1,61 +1,29 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 
-import type { HealthCheck, HealthCheckOptions } from '@dts-stn/health-checks';
+import type { HealthCheckOptions } from '@dts-stn/health-checks';
 import { HealthCheckConfig, execute, getHttpStatusCode } from '@dts-stn/health-checks';
 import { isEmpty } from 'moderndash';
-import moize from 'moize';
 
-import { getAppContainerProvider } from '~/.server/app.container';
 import { TYPES } from '~/.server/constants';
 
-const appContainerProvider = getAppContainerProvider();
-
-const bearerTokenResolver = appContainerProvider.get(TYPES.auth.BearerTokenResolver);
-const serverConfig = appContainerProvider.get(TYPES.configs.ServerConfig);
-const tokenRolesExtractor = appContainerProvider.get(TYPES.auth.HealthTokenRolesExtractor);
-const redisService = appContainerProvider.find(TYPES.data.services.RedisService);
-
-// memoize the result of redisCheckFn for a period of time
-// transformArgs is require to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
-// for memoization to work, the call to moize must be done in module scope, so it only ever happens once
-const redisCheck = moize.promise(async () => void (await redisService?.ping()), { maxAge: serverConfig.HEALTH_CACHE_TTL, transformArgs: () => [] });
-
-export async function loader({ context: { appContainer }, request }: LoaderFunctionArgs) {
+export async function loader({ context, request }: LoaderFunctionArgs) {
   const { include, exclude, timeout } = Object.fromEntries(new URL(request.url).searchParams);
 
-  const buildInfoService = appContainer.get(TYPES.core.BuildInfoService);
+  const allHealthChecks = context.appContainer.findAll(TYPES.health.HealthCheck);
+  const buildInfoService = context.appContainer.get(TYPES.core.BuildInfoService);
+
   const { buildRevision: buildId, buildVersion: version } = buildInfoService.getBuildInfo();
 
   const healthCheckOptions: HealthCheckOptions = {
     excludeComponents: toArray(exclude),
     includeComponents: toArray(include),
-    includeDetails: await isAuthorized(request),
+    includeDetails: await isAuthorized({ context, request }),
     metadata: { buildId, version },
     timeoutMs: toNumber(timeout),
   };
 
-  const redisHealthCheck: HealthCheck = {
-    name: 'redis',
-    check: redisCheck,
-    metadata: {
-      REDIS_USERNAME: serverConfig.REDIS_USERNAME ?? '',
-      REDIS_STANDALONE_HOST: serverConfig.REDIS_STANDALONE_HOST,
-      REDIS_STANDALONE_PORT: serverConfig.REDIS_STANDALONE_PORT.toString(),
-      REDIS_SENTINEL_NAME: serverConfig.REDIS_SENTINEL_NAME ?? '',
-      REDIS_SENTINEL_HOST: serverConfig.REDIS_SENTINEL_HOST ?? '',
-      REDIS_SENTINEL_PORT: (serverConfig.REDIS_SENTINEL_PORT ?? '').toString(),
-      REDIS_COMMAND_TIMEOUT_SECONDS: serverConfig.REDIS_COMMAND_TIMEOUT_SECONDS.toString(),
-    },
-  };
-
-  // exclude the redis health check if the application is not using it
-  if (serverConfig.SESSION_STORAGE_TYPE !== 'redis') {
-    healthCheckOptions.excludeComponents ??= [];
-    healthCheckOptions.excludeComponents.push(redisHealthCheck.name);
-  }
-
   // execute the health checks
-  const systemHealthSummary = await execute([redisHealthCheck], healthCheckOptions);
+  const systemHealthSummary = await execute(allHealthChecks, healthCheckOptions);
 
   return Response.json(systemHealthSummary, {
     headers: { 'Content-Type': HealthCheckConfig.responses.contentType },
@@ -66,9 +34,14 @@ export async function loader({ context: { appContainer }, request }: LoaderFunct
 /**
  * Returns true if the incoming request is authorized to view detailed responses.
  */
-async function isAuthorized(request: Request): Promise<boolean> {
+async function isAuthorized({ context, request }: Omit<LoaderFunctionArgs, 'params'>): Promise<boolean> {
+  const bearerTokenResolver = context.appContainer.get(TYPES.auth.BearerTokenResolver);
+  const serverConfig = context.appContainer.get(TYPES.configs.ServerConfig);
+  const tokenRolesExtractor = context.appContainer.get(TYPES.auth.HealthTokenRolesExtractor);
+
   const token = bearerTokenResolver.resolve(request);
   const roles = await tokenRolesExtractor.extract(token);
+
   return roles.includes(serverConfig.HEALTH_AUTH_ROLE);
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
         "i18next": "^24.0.5",
         "i18next-fs-backend": "^2.6.0",
         "i18next-http-backend": "^3.0.1",
-        "inversify": "^6.1.6",
+        "inversify": "^6.2.0-beta.1",
         "inversify-logger-middleware": "^3.1.0",
         "ioredis": "^5.4.1",
         "isbot": "^5.1.17",
@@ -8965,9 +8965,10 @@
       }
     },
     "node_modules/inversify": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.1.6.tgz",
-      "integrity": "sha512-qQLOINPTMoe0U4lGUuCkNr/MQ9+8xVlht1MBKm67wPzD5N9mwjgCgBXtJlSwibTnwc3OkTlLx/MpIR6pP6djUA==",
+      "version": "6.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.2.0-beta.1.tgz",
+      "integrity": "sha512-0Whl4e7aKCXW+SIc4AHDybyUTIBPBrmhoSNpNGer1tr36b0f6kI2HeLOLWDEb/Kb8rVm+rOvuBiXdu2g2P2/uA==",
+      "license": "MIT",
       "dependencies": {
         "@inversifyjs/common": "1.4.0",
         "@inversifyjs/core": "1.3.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "i18next": "^24.0.5",
     "i18next-fs-backend": "^2.6.0",
     "i18next-http-backend": "^3.0.1",
-    "inversify": "^6.1.6",
+    "inversify": "^6.2.0-beta.1",
     "inversify-logger-middleware": "^3.1.0",
     "ioredis": "^5.4.1",
     "isbot": "^5.1.17",


### PR DESCRIPTION
### Description
By creating an injectable class that implements the `HealthCheck` interface, the `loader(..)` of `/api/health` can find and execute all health checks.

Additionally, the `remixRequestHandler` has been updated to prevent session initialization for stateless requests (e.g. `/api/health`). This avoids unnecessary Redis session creation, which causes the application to throw errors if Redis is unavailable upon hitting stateless requests.

### Related Azure Boards Work Items
[AB#4551](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4551)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/44acae42-ae2c-4c18-987d-f7f96e43ab45)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Set `SESSION_STORAGE_TYPE` to `redis`.
- Run the application and hit `/api/health`. You should see an `UNHEALTHY` response.
- Launch a local Redis instance, ie.
```
podman run -d --name redis -p 6379:6379 docker.io/redis:latest
```
- Ensure enough time has passed (a time exceeding `HEALTH_CACHE_TTL`) and hit `/api/health` again. You should see a `HEALTHY` response.

### Additional Notes
Co-authored by @sebastien-comeau 