### PR TITLE
Fixing structure of client application entity

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -155,12 +155,10 @@ describe('DefaultClientApplicationDtoMapper', () => {
                   ConsentToSharePersonalInformationIndicator: false,
                   AttestParentOrGuardianIndicator: false,
                 },
-                ClientIdentification: [
-                  {
-                    IdentificationID: '10000000003',
-                    IdentificationCategoryText: 'Client Number',
-                  },
-                ],
+                ClientIdentification: {
+                  IdentificationID: '10000000003',
+                  IdentificationCategoryText: 'Client Number',
+                },
               },
             ],
           },

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -135,12 +135,10 @@ describe('DefaultClientApplicationService', () => {
               ConsentToSharePersonalInformationIndicator: false,
               AttestParentOrGuardianIndicator: false,
             },
-            ClientIdentification: [
-              {
-                IdentificationID: '10000000003',
-                IdentificationCategoryText: 'Client Number',
-              },
-            ],
+            ClientIdentification: {
+              IdentificationID: '10000000003',
+              IdentificationCategoryText: 'Client Number',
+            },
           },
         ],
       },

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -103,10 +103,10 @@ export type ClientApplicationEntity = ReadonlyDeep<{
           ConsentToSharePersonalInformationIndicator?: boolean;
           AttestParentOrGuardianIndicator?: boolean;
         };
-        ClientIdentification: Array<{
+        ClientIdentification: {
           IdentificationID: string;
           IdentificationCategoryText?: string;
-        }>;
+        };
       }>;
     };
     BenefitApplicationChannelCode: {

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -70,7 +70,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
           (() => {
             throw new Error('Expected child.ApplicantDetail.AttestParentOrGuardianIndicator to be defined');
           })(),
-        clientNumber: child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
+        clientNumber: child.ClientIdentification.IdentificationCategoryText === 'Client Number' ? child.ClientIdentification.IdentificationID : undefined,
         socialInsuranceNumber: child.PersonSINIdentification.IdentificationID,
       },
     }));

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -168,12 +168,10 @@
             ],
             "AttestParentOrGuardianIndicator": true
           },
-          "ClientIdentification": [
-            {
-              "IdentificationID": "10000000003",
-              "IdentificationCategoryText": "Client Number"
-            }
-          ]
+          "ClientIdentification": {
+            "IdentificationID": "10000000003",
+            "IdentificationCategoryText": "Client Number"
+          }
         },
         {
           "PersonBirthDate": {
@@ -194,12 +192,10 @@
           "ApplicantDetail": {
             "ConsentToSharePersonalInformationIndicator": true
           },
-          "ClientIdentification": [
-            {
-              "IdentificationID": "10000000004",
-              "IdentificationCategoryText": "Client Number"
-            }
-          ]
+          "ClientIdentification": {
+            "IdentificationID": "10000000004",
+            "IdentificationCategoryText": "Client Number"
+          }
         }
       ]
     },


### PR DESCRIPTION
### Description
`RelatedPerson` > `ClientIdentification` is an object, not an array. All depending files with this change have been corrected. Tested with Interop's mock endpoint for retrieving client application.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Connect to Interop's INT instance and start a renewal application (disable the `power-platform` mock). You should be able to proceed after submitting the `/applicant-information` page. Or enable the `power-platform` mock since it has been fixed too.