### PR TITLE
add confirmation route to protected renew application

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -256,12 +256,6 @@ export async function startProtectedRenewState({ id, session, appContainer }: St
         id: randomUUID(),
         information: child.information,
         dentalInsurance: immutableChild?.dentalInsurance,
-        dentalBenefits: {
-          hasFederalBenefits: Boolean(immutableChild?.dentalBenefits[0]),
-          federalSocialProgram: immutableChild?.dentalBenefits[0],
-          hasProvincialTerritorialBenefits: Boolean(immutableChild?.dentalBenefits[1]),
-          provincialTerritorialSocialProgram: immutableChild?.dentalBenefits[1],
-        },
       };
       return childStateObj;
     }),

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -24,6 +24,7 @@ export const pageIds = {
       reviewAdultInformation: 'CDCP-PROT-RENW-0017',
       reviewChildInformation: 'CDCP-RENW-ADCH-0018',
       reviewSubmit: 'CDCP-PROT-RENW-0019',
+      confirmation: 'CDCP-PROT-RENW-0020',
     },
     dataUnavailable: 'CDCP-PROT-0099',
   },

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -1,0 +1,213 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData } from '@remix-run/react';
+
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { TYPES } from '~/.server/constants';
+import { clearProtectedRenewState, loadProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { getChildrenState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { DescriptionListItem } from '~/components/description-list-item';
+import { InlineLink } from '~/components/inline-link';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Submit = 'submit',
+  Close = 'close',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.confirmation,
+  pageTitleI18nKey: 'protected-renew:confirm.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const state = loadProtectedRenewState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  if (state.submissionInfo === undefined) {
+    throw new Error(`Incomplete application "${state.id}" state!`);
+  }
+
+  const selectedFederalBenefit = state.dentalBenefits?.federalSocialProgram
+    ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
+    : undefined;
+  const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
+    ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
+    : undefined;
+
+  const userInfo = {
+    firstName: state.clientApplication.applicantInformation.firstName,
+    lastName: state.clientApplication.applicantInformation.lastName,
+  };
+
+  const dentalInsurance = {
+    acessToDentalInsurance: state.dentalInsurance,
+    selectedFederalBenefit: selectedFederalBenefit?.name,
+    selectedProvincialBenefits: selectedProvincialBenefits?.name,
+  };
+
+  const children = getChildrenState(state).map((child) => {
+    if (child.dentalInsurance === undefined || child.information === undefined) {
+      throw new Error(`Incomplete application "${state.id}" child "${child.id}" state!`);
+    }
+
+    const federalBenefit = child.dentalBenefits?.federalSocialProgram
+      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+      : undefined;
+    const provincialTerritorialSocialProgram = child.dentalBenefits?.provincialTerritorialSocialProgram
+      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+      : undefined;
+
+    return {
+      id: child.id,
+      firstName: child.information.firstName,
+      lastName: child.information.lastName,
+      isParent: child.information.isParent,
+      dentalInsurance: {
+        acessToDentalInsurance: child.dentalInsurance,
+        federalBenefit: {
+          access: child.dentalBenefits?.hasFederalBenefits,
+          benefit: federalBenefit?.name,
+        },
+        provTerrBenefit: {
+          access: child.dentalBenefits?.hasProvincialTerritorialBenefits,
+          province: child.dentalBenefits?.province,
+          benefit: provincialTerritorialSocialProgram?.name,
+        },
+      },
+    };
+  });
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm.page-title') }) };
+
+  return {
+    userInfo,
+    dentalInsurance,
+    children,
+    meta,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const { SCCH_BASE_URI } = appContainer.get(TYPES.configs.ClientConfig);
+
+  clearProtectedRenewState({ params, session });
+
+  return redirect(t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI }));
+}
+
+export default function ProtectedRenewConfirm() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const { children, userInfo, dentalInsurance } = useLoaderData<typeof loader>();
+
+  const cdcpLink = <InlineLink to={t('protected-renew:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
+
+  return (
+    <div className="max-w-prose space-y-10">
+      <section>
+        <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
+        <p className="mt-4">{t('confirm.begin-process')}</p>
+        <p className="mt-4">
+          <Trans ns={handle.i18nNamespaces} i18nKey="confirm.cdcp-checker" components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+        </p>
+      </section>
+
+      <section className="space-y-8">
+        <h2 className="font-lato text-3xl font-bold">{t('confirm.applicant-summary')}</h2>
+        <section className="space-y-6">
+          <span className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</span>
+          <h3 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h3>
+          <dl className="divide-y border-y">
+            <DescriptionListItem term={t('confirm.full-name')}>{`${userInfo.firstName} ${userInfo.lastName}`}</DescriptionListItem>
+          </dl>
+        </section>
+
+        <section className="space-y-6">
+          <h3 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h3>
+          <dl className="divide-y border-y">
+            <DescriptionListItem term={t('confirm.dental-private')}> {dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
+            <DescriptionListItem term={t('confirm.dental-public')}>
+              {dentalInsurance.selectedFederalBenefit || dentalInsurance.selectedProvincialBenefits ? (
+                <>
+                  <p>{t('protected-renew:confirm.yes')}</p>
+                  <p>{t('protected-renew:confirm.dental-benefit-has-access')}</p>
+                  <ul className="ml-6 list-disc">
+                    {dentalInsurance.selectedFederalBenefit && <li>{dentalInsurance.selectedFederalBenefit}</li>}
+                    {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                  </ul>
+                </>
+              ) : (
+                <p>{t('confirm.no')}</p>
+              )}
+            </DescriptionListItem>
+          </dl>
+        </section>
+
+        {/* CHILDREN DETAILS */}
+        {children.map((child) => (
+          <section className="space-y-6" key={child.id}>
+            <h3 className="font-lato text-2xl font-bold">{child.firstName}</h3>
+            <section>
+              <h4 className="font-lato text-xl font-bold">{t('confirm.child-title', { childName: child.firstName })}</h4>
+              <dl className="mt-6 divide-y border-y">
+                <DescriptionListItem term={t('confirm.full-name')}>{`${child.firstName} ${child.lastName}`}</DescriptionListItem>
+                <DescriptionListItem term={t('confirm.dental-private')}>{child.dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
+                <DescriptionListItem term={t('confirm.dental-public')}>
+                  {child.dentalInsurance.federalBenefit.benefit || child.dentalInsurance.provTerrBenefit.benefit ? (
+                    <>
+                      <p>{t('protected-renew:confirm.yes')}</p>
+                      <p>{t('protected-renew:confirm.dental-benefit-has-access')}</p>
+                      <ul className="ml-6 list-disc">
+                        {child.dentalInsurance.federalBenefit.benefit && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                        {child.dentalInsurance.provTerrBenefit.benefit && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                      </ul>
+                    </>
+                  ) : (
+                    <p>{t('confirm.no')}</p>
+                  )}
+                </DescriptionListItem>
+                <DescriptionListItem term={t('confirm.is-parent')}>{child.isParent ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
+              </dl>
+            </section>
+          </section>
+        ))}
+      </section>
+
+      <div className="my-6 flex flex-wrap items-center gap-3">
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <LoadingButton name="_action" value={FormAction.Close} variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Confirmation - close application click">
+            {t('protected-renew:confirm.back-btn')}
+          </LoadingButton>
+        </fetcher.Form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -143,6 +143,11 @@ export const routes = [
             paths: { en: '/:lang/protected/renew/:id/review-child-information', fr: '/:lang/protected/renew/:id/review-child-information' },
           },
           {
+            id: 'protected/renew/$id/confirmation',
+            file: 'routes/protected/renew/$id/confirmation.tsx',
+            paths: { en: '/:lang/protected/renew/:id/confirmation', fr: '/:lang/protected/renew/:id/confirmation' },
+          },
+          {
             id: 'protected/renew/$id/review-and-submit',
             file: 'routes/protected/renew/$id/review-and-submit.tsx',
             paths: { en: '/:lang/protected/renew/:id/review-and-submit', fr: '/:lang/protected/renew/:id/review-and-submit' },

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -560,5 +560,25 @@
     "submit-button": "Submit renewal application",
     "yes": "Yes",
     "no": "No"
+  },
+  "confirm": {
+    "page-title": "Your renewal for the Canadian Dental Care Plan is complete!",
+    "whats-next": "What happens next",
+    "begin-process": "We will begin processing your renewal application immediately. You can continue to use your Canadian Dental Care Plan benefits.",
+    "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your renewal application or to receive more information. You will receive a letter within two weeks of submitting your renewal application to let you know if you're eligible for the upcoming benefit year.",
+    "status-checker-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html",
+    "applicant-summary": "Summary of updates",
+    "applicant-title": "Applicant",
+    "member-info": "Member information",
+    "dental-insurance": "Access to dental insurance",
+    "dental-benefit-has-access": "Has access to the following benefits:",
+    "full-name": "Full name",
+    "dental-private": "Access to dental insurance or coverage",
+    "dental-public": "Access to government dental benefits",
+    "child-title": "{{childName}} information",
+    "is-parent": "Parent or legal guardian of child",
+    "yes": "Yes",
+    "no": "No",
+    "back-btn": "Return to my dashboard"
   }
 }

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -560,5 +560,25 @@
     "submit-button": "Présenter la demande de renouvellement",
     "yes": "Oui",
     "no": "Non"
+  },
+  "confirm": {
+    "page-title": "Votre demande de renouvellement au Régime canadien de soins dentaires est terminée!",
+    "whats-next": "Prochaines étapes",
+    "begin-process": "Nous commencerons à traiter votre demande de renouvellement immédiatement. Vous pouvez continuer d'utiliser vos prestations du Régime canadien de soins dentaires.",
+    "cdcp-checker": "Vous pouvez utiliser le <cdcpLink>vérificateur de l'état de votre demande du Régime canadien de soins dentaires</cdcpLink> ou composer le numéro <noWarp>1-833-537-4342</noWrap> pour suivre l'évolution de votre demande de renouvellement ou pour recevoir plus de renseignements. Vous recevrez une lettre dans les deux semaines suivant la présentation de votre demande de renouvellement pour vous informer si vous êtes admissible à la prochaine année de prestations.",
+    "applicant-summary": "Résumé de la mise à jour",
+    "applicant-title": "Demandeur",
+    "member-info": "Renseignements sur le demandeur",
+    "dental-insurance": "Accès à une assurance dentaire",
+    "dental-benefit-has-access": "A accès aux prestations suivantes\u00a0:",
+    "full-name": "Nom complet",
+    "dental-private": "Accès à d'autres assurances ou couvertures de soins dentaires\u00a0:",
+    "dental-public": "Accès à des prestations dentaires gouvernementales\u00a0:",
+    "child-title": "Renseignements sur {{childName}}",
+    "is-parent": "Parent ou tuteur légal de l'enfant\u00a0:",
+    "yes": "Oui",
+    "no": "Non",
+    "back-btn": "Return to my dashboard",
+    "status-checker-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
   }
 }


### PR DESCRIPTION
### Description
- adds the confirmation screen to the protected renew app

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`