### PR TITLE
Updating benefit renewal dto, entity and mappers to based on updated specs

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -175,6 +175,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           lastName: 'Doe',
           maritalStatus: 'Single',
           socialInsuranceNumber: '800000002',
+          clientNumber: '00000000000',
         },
         contactInformation: {
           copyMailingAddress: false,
@@ -204,6 +205,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         },
         children: [
           {
+            clientNumber: '11111111111',
             dentalBenefits: ['New federal program', 'New provincial program'],
             dentalInsurance: true,
             information: {

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -1,6 +1,6 @@
-import type { BenefitApplicationDto } from '~/.server/domain/dtos/benefit-application.dto';
+import type { ApplicantInformationDto, BenefitApplicationDto, ChildDto } from '~/.server/domain/dtos/benefit-application.dto';
 
-export type AdultChildBenefitRenewalDto = BenefitApplicationDto &
+export type AdultChildBenefitRenewalDto = BenefitRenewalDto &
   Readonly<{
     changeIndicators: AdultChildChangeIndicators;
   }>;
@@ -14,7 +14,7 @@ export type AdultChildChangeIndicators = Readonly<{
   hasProvincialTerritorialBenefitsChanged: boolean;
 }>;
 
-export type ItaBenefitRenewalDto = BenefitApplicationDto &
+export type ItaBenefitRenewalDto = BenefitRenewalDto &
   Readonly<{
     changeIndicators: ItaChangeIndicators;
   }>;
@@ -23,4 +23,20 @@ export type ItaChangeIndicators = Readonly<{
   hasAddressChanged: boolean;
 }>;
 
-export type ProtectedBenefitRenewalDto = BenefitApplicationDto;
+export type ProtectedBenefitRenewalDto = BenefitRenewalDto;
+
+export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformation' | 'children'> &
+  Readonly<{
+    children: RenewalChildDto[];
+    applicantInformation: RenewalApplicantInformationDto;
+  }>;
+
+export type RenewalApplicantInformationDto = ApplicantInformationDto &
+  Readonly<{
+    clientNumber: string;
+  }>;
+
+export type RenewalChildDto = ChildDto &
+  Readonly<{
+    clientNumber: string;
+  }>;

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -3,7 +3,7 @@ import type { ReadonlyDeep } from 'type-fest';
 import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, ContactInformationDto, PartnerInformationDto } from '~/.server/domain/dtos/benefit-application.dto';
 
 export type ClientApplicationDto = ReadonlyDeep<{
-  applicantInformation: ApplicantInformationDto & { clientNumber?: string };
+  applicantInformation: ClientApplicantInformationDto;
   children: ClientChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;
@@ -16,6 +16,8 @@ export type ClientApplicationDto = ReadonlyDeep<{
   livingIndependently?: boolean;
   partnerInformation?: PartnerInformationDto;
 }>;
+
+export type ClientApplicantInformationDto = ApplicantInformationDto & { clientNumber?: string };
 
 export type ClientChildDto = Omit<ChildDto, 'information'> & {
   information: {

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -7,13 +7,27 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
         PrivateDentalInsuranceIndicator?: boolean;
         DisabilityTaxCreditIndicator?: boolean;
         LivingIndependentlyIndicator?: boolean;
+        MaritalStatusChangedIndicator?: boolean;
+        AddressChangedIndicator?: boolean;
+        PhoneChangedIndicator?: boolean;
+        EmailChangedIndicator?: boolean;
+        PublicInsuranceChangedIndicator?: boolean;
         InsurancePlan?: {
           InsurancePlanIdentification?: {
             IdentificationID?: string;
           }[];
         }[];
       };
-      ChangedInformation: string[]; // TODO subject to change - specifications not yet provided
+      BenefitApplicationDetail: {
+        BenefitApplicationDetailID: string;
+        BenefitApplicationDetailValue?: string;
+        BenefitApplicationDetailValues?: string[];
+        BenefitApplicationDetailIndicator?: boolean;
+      }[];
+      ClientIdentification: {
+        IdentificationID: string;
+        IdentificationCategoryText: string;
+      }[];
       PersonBirthDate: {
         date: string;
       };
@@ -78,6 +92,16 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
           ConsentToSharePersonalInformationIndicator?: boolean;
           AttestParentOrGuardianIndicator?: boolean;
         };
+        BenefitApplicationDetail?: {
+          BenefitApplicationDetailID: string;
+          BenefitApplicationDetailValue?: string;
+          BenefitApplicationDetailValues?: string[];
+          BenefitApplicationDetailIndicator?: boolean;
+        }[];
+        ClientIdentification?: {
+          IdentificationID: string;
+          IdentificationCategoryText: string;
+        }[];
         PersonBirthDate: {
           date: string;
         };
@@ -99,9 +123,15 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
     };
     BenefitApplicationCategoryCode: {
       ReferenceDataID: string;
+      ReferenceDataName: string;
     };
     BenefitApplicationChannelCode: {
       ReferenceDataID: string;
+    };
+    BenefitApplicationYear: {
+      BenefitApplicationYearIdentification: {
+        IdentificationID: string;
+      }[];
     };
   };
 }>;


### PR DESCRIPTION
### Description
- Added and mapped client number field to `ClientIdentification` in benefit renewal request - introduced new types to include client number field
- Added and mapped various changed indicators (eg. `MaritalStatusChangedIndicator`, `AddressChangedIndicator`, etc.)
- Added `TODO` for fields that are not yet mapped: `BenefitApplicationDetail` and `BenefitApplicationYear`

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run frontend locally and go through `/renew` flow until you reach the review information screen. Verify that the request payload has client number and changed indicators.