### PR TITLE
Fixing client application entity structure

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -120,7 +120,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
                   ],
                 },
               ],
-              ItaIndicator: false,
+              InvitationToApplyIndicator: false,
               LivingIndependentlyIndicator: true,
               PreviousApplicationIndicator: false,
               PreviousTaxesFiledIndicator: true,
@@ -246,7 +246,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
 
       const mockClientApplicationBasicInfoRequestEntity: ClientApplicationBasicInfoRequestEntity = {
         Applicant: {
-          PersonName: [{ PersonGivenName: ['John'], PersonSurName: 'Doe' }],
+          PersonName: { PersonGivenName: ['John'], PersonSurName: 'Doe' },
           PersonBirthDate: { date: '2000-01-01' },
           ClientIdentification: [{ IdentificationID: 'ABC123' }],
         },

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -96,7 +96,7 @@ describe('DefaultClientApplicationService', () => {
               ],
             },
           ],
-          ItaIndicator: true,
+          InvitationToApplyIndicator: true,
           LivingIndependentlyIndicator: true,
           PreviousApplicationIndicator: false,
           PreviousTaxesFiledIndicator: true,
@@ -240,7 +240,7 @@ describe('DefaultClientApplicationService', () => {
       const mockClientApplicationBasicInfoRequestDto: ClientApplicationBasicInfoRequestDto = { firstName: 'John', lastName: 'Doe', dateOfBirth: '2000-01-01', clientNumber: 'ABC123' };
       const mockClientApplicationBasicInfoRequestEntity: ClientApplicationBasicInfoRequestEntity = {
         Applicant: {
-          PersonName: [{ PersonGivenName: [mockClientApplicationBasicInfoRequestDto.firstName], PersonSurName: mockClientApplicationBasicInfoRequestDto.lastName }],
+          PersonName: { PersonGivenName: [mockClientApplicationBasicInfoRequestDto.firstName], PersonSurName: mockClientApplicationBasicInfoRequestDto.lastName },
           PersonBirthDate: { date: mockClientApplicationBasicInfoRequestDto.dateOfBirth },
           ClientIdentification: [{ IdentificationID: mockClientApplicationBasicInfoRequestDto.clientNumber }],
         },
@@ -270,7 +270,7 @@ describe('DefaultClientApplicationService', () => {
       const mockClientApplicationBasicInfoRequestDto: ClientApplicationBasicInfoRequestDto = { firstName: 'John', lastName: 'Doe', dateOfBirth: '2000-01-01', clientNumber: 'ABC123' };
       const mockClientApplicationBasicInfoRequestEntity: ClientApplicationBasicInfoRequestEntity = {
         Applicant: {
-          PersonName: [{ PersonGivenName: [mockClientApplicationBasicInfoRequestDto.firstName], PersonSurName: mockClientApplicationBasicInfoRequestDto.lastName }],
+          PersonName: { PersonGivenName: [mockClientApplicationBasicInfoRequestDto.firstName], PersonSurName: mockClientApplicationBasicInfoRequestDto.lastName },
           PersonBirthDate: { date: mockClientApplicationBasicInfoRequestDto.dateOfBirth },
           ClientIdentification: [{ IdentificationID: mockClientApplicationBasicInfoRequestDto.clientNumber }],
         },

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -68,7 +68,7 @@ export type ClientApplicationEntity = ReadonlyDeep<{
             IdentificationCategoryText?: string;
           }>;
         }>;
-        ItaIndicator: boolean; // TODO to be renamed not yet exposed by Interop
+        InvitationToApplyIndicator: boolean;
         LivingIndependentlyIndicator: boolean;
         PreviousApplicationIndicator: boolean;
         PreviousTaxesFiledIndicator: boolean;
@@ -125,10 +125,10 @@ export type ClientApplicationEntity = ReadonlyDeep<{
 
 export type ClientApplicationBasicInfoRequestEntity = ReadonlyDeep<{
   Applicant: {
-    PersonName: Array<{
+    PersonName: {
       PersonGivenName: Array<string>;
       PersonSurName: string;
-    }>;
+    };
     PersonBirthDate: {
       date: string;
     };

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -15,12 +15,10 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
   mapClientApplicationBasicInfoRequestDtoToClientApplicationBasicInfoRequestEntity(clientApplicationBasicInfoRequestDto: ClientApplicationBasicInfoRequestDto) {
     return {
       Applicant: {
-        PersonName: [
-          {
-            PersonGivenName: [clientApplicationBasicInfoRequestDto.firstName],
-            PersonSurName: clientApplicationBasicInfoRequestDto.lastName,
-          },
-        ],
+        PersonName: {
+          PersonGivenName: [clientApplicationBasicInfoRequestDto.firstName],
+          PersonSurName: clientApplicationBasicInfoRequestDto.lastName,
+        },
         PersonBirthDate: {
           date: clientApplicationBasicInfoRequestDto.dateOfBirth,
         },
@@ -131,7 +129,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
       dentalInsurance: applicant.ApplicantDetail.PrivateDentalInsuranceIndicator,
       disabilityTaxCredit: applicant.ApplicantDetail.DisabilityTaxCreditIndicator,
       hasFiledTaxes: applicant.ApplicantDetail.PreviousTaxesFiledIndicator,
-      isInvitationToApplyClient: applicant.ApplicantDetail.ItaIndicator,
+      isInvitationToApplyClient: applicant.ApplicantDetail.InvitationToApplyIndicator,
       livingIndependently: applicant.ApplicantDetail.LivingIndependentlyIndicator,
       partnerInformation,
     };

--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -113,19 +113,19 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
 
 @injectable()
 export class MockClientApplicationRepository implements ClientApplicationRepository {
-  private readonly mockApplicantFlags: ReadonlyMap<string, Readonly<{ ItaIndicator: boolean; PreviousTaxesFiledIndicator: boolean }>> = new Map([
+  private readonly mockApplicantFlags: ReadonlyMap<string, Readonly<{ InvitationToApplyIndicator: boolean; PreviousTaxesFiledIndicator: boolean }>> = new Map([
     // by basic info
     [
       '10000000001',
       {
-        ItaIndicator: true,
+        InvitationToApplyIndicator: true,
         PreviousTaxesFiledIndicator: false,
       },
     ],
     [
       '10000000002',
       {
-        ItaIndicator: false,
+        InvitationToApplyIndicator: false,
         PreviousTaxesFiledIndicator: true,
       },
     ],
@@ -133,14 +133,14 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
     [
       '800000002',
       {
-        ItaIndicator: false,
+        InvitationToApplyIndicator: false,
         PreviousTaxesFiledIndicator: true,
       },
     ],
     [
       '700000003',
       {
-        ItaIndicator: false,
+        InvitationToApplyIndicator: false,
         PreviousTaxesFiledIndicator: true,
       },
     ],
@@ -156,8 +156,8 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
     this.log.debug('Fetching client application for basic info [%j]', clientApplicationBasicInfoRequestEntity);
 
     const identificationId = clientApplicationBasicInfoRequestEntity.Applicant.ClientIdentification[0].IdentificationID;
-    const personGivenName = clientApplicationBasicInfoRequestEntity.Applicant.PersonName[0].PersonGivenName[0];
-    const personSurName = clientApplicationBasicInfoRequestEntity.Applicant.PersonName[0].PersonSurName;
+    const personGivenName = clientApplicationBasicInfoRequestEntity.Applicant.PersonName.PersonGivenName[0];
+    const personSurName = clientApplicationBasicInfoRequestEntity.Applicant.PersonName.PersonSurName;
     const personBirthDate = clientApplicationBasicInfoRequestEntity.Applicant.PersonBirthDate.date;
 
     // If the ID is '10000000000', return a 404 error
@@ -168,7 +168,7 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
 
     // Otherwise, return specific flags or the default
     const clientApplicationFlags = this.mockApplicantFlags.get(identificationId) ?? {
-      ItaIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.ItaIndicator,
+      InvitationToApplyIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.InvitationToApplyIndicator,
       PreviousTaxesFiledIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.PreviousTaxesFiledIndicator,
     };
 
@@ -212,7 +212,7 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
 
     // Otherwise, return specific flags or the default
     const clientApplicationFlags = this.mockApplicantFlags.get(personSINIdentification) ?? {
-      ItaIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.ItaIndicator,
+      InvitationToApplyIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.InvitationToApplyIndicator,
       PreviousTaxesFiledIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.PreviousTaxesFiledIndicator,
     };
 

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -114,7 +114,7 @@
             ]
           }
         ],
-        "ItaIndicator": false,
+        "InvitationToApplyIndicator": false,
         "LivingIndependentlyIndicator": true,
         "PreviousApplicationIndicator": false,
         "PreviousTaxesFiledIndicator": false,


### PR DESCRIPTION
### Description
Updates made based on Interop's v1.0.11 specs for retrieving application:
- `ItaIndicator` has been renamed is now returned as `InvitationToApplyIndicator`
- `PersonName` is not an array in the request to retrieve client application, but rather an object

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Connect to Interop's INT instance and start a renewal application (disable the power-platform mock). You should be able to proceed after submitting the /applicant-information page. Or enable the power-platform mock since it has been fixed too.