### PR TITLE
update confirm-email route in protected renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -84,12 +84,10 @@ export interface ProtectedRenewState {
     };
   }[];
   readonly contactInformation?: {
-    isNewOrUpdatedPhoneNumber?: boolean;
-    isNewOrUpdatedEmail?: boolean;
-    phoneNumber?: string;
-    phoneNumberAlt?: string;
-    email?: string;
-    shouldReceiveEmailCommunication?: boolean;
+    readonly phoneNumber?: string;
+    readonly phoneNumberAlt?: string;
+    readonly email?: string;
+    readonly shouldReceiveEmailCommunication?: boolean;
   };
   readonly preferredLanguage?: string;
   readonly hasAddressChanged?: boolean;

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -1,11 +1,8 @@
-import { useState } from 'react';
-
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { data, redirect } from '@remix-run/node';
-import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+import { useFetcher, useLoaderData } from '@remix-run/react';
 
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
 
@@ -13,13 +10,10 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
-import { Button, ButtonLink } from '~/components/buttons';
+import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { InputRadios } from '~/components/input-radios';
-import { LoadingButton } from '~/components/loading-button';
-import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -28,19 +22,8 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 enum FormAction {
-  Continue = 'continue',
   Cancel = 'cancel',
   Save = 'save',
-}
-
-enum AddOrUpdateEmailOption {
-  Yes = 'yes',
-  No = 'no',
-}
-
-enum ShouldReceiveEmailCommunicationOption {
-  Yes = 'yes',
-  No = 'no',
 }
 
 export const handle = {
@@ -64,14 +47,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     id: state.id,
-
     meta,
     defaultState: {
-      isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,
-      email: state.contactInformation?.email,
-      shouldReceiveEmailCommunication: state.contactInformation?.shouldReceiveEmailCommunication,
+      email: state.contactInformation?.email ?? state.clientApplication.contactInformation.email,
     },
-    editMode: state.editMode,
   };
 }
 
@@ -87,20 +66,10 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const emailSchema = z
     .object({
-      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
-        errorMap: () => ({ message: t('protected-renew:confirm-email.error-message.add-or-update-required') }),
-      }),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
-      shouldReceiveEmailCommunication: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
-        if (!val.email) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-required'), path: ['email'] });
-        }
-      }
-
       if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-required'), path: ['email'] });
@@ -116,24 +85,11 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
-
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
-        if (val.shouldReceiveEmailCommunication === undefined) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
-        }
-      }
-    })
-    .transform((val) => ({
-      ...val,
-      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
-      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes : undefined,
-    }));
+    });
 
   const parsedDataResult = emailSchema.safeParse({
-    isNewOrUpdatedEmail: formData.get('isNewOrUpdatedEmail'),
     email: formData.get('email') ? String(formData.get('email')) : undefined,
     confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail')) : undefined,
-    shouldReceiveEmailCommunication: formData.get('shouldReceiveEmailCommunication') ? String(formData.get('shouldReceiveEmailCommunication')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -142,158 +98,67 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveProtectedRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
 
-  if (state.editMode) {
-    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
-  }
-
-  return redirect(getPathById('protected/renew/$id/confirm-address', params));
+  return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 
 export default function ProtectedRenewConfirmEmail() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    isNewOrUpdatedEmail: 'input-radio-is-new-or-updated-email-option-0',
     email: 'email',
     confirmEmail: 'confirm-email',
-    shouldReceiveEmailCommunication: 'input-radio-should-receive-email-communication-option-0',
   });
-
-  const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
-
-  function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
-  }
 
   return (
     <>
-      <div className="my-6 sm:my-8">
-        <Progress value={45} size="lg" label={t('renew:progress.label')} />
-      </div>
       <div className="max-w-prose">
-        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <p className="mb-4 italic">{t('renew:all-optional-label')}</p>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
           <div className="mb-6">
-            <p id="adding-email" className="mb-4">
-              {t('protected-renew:confirm-email.add-email')}
-            </p>
-            <InputRadios
-              id="is-new-or-updated-email"
-              name="isNewOrUpdatedEmail"
-              legend={t('protected-renew:confirm-email.add-or-update.legend')}
-              helpMessagePrimary={t('protected-renew:confirm-email.add-or-update.help-message')}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-yes" />,
-                  value: AddOrUpdateEmailOption.Yes,
-                  defaultChecked: isNewOrUpdatedEmail === true,
-                  onChange: handleNewOrUpdateEmailChanged,
-                  append: isNewOrUpdatedEmail === true && (
-                    <div className="grid gap-6 md:grid-cols-2">
-                      <InputField
-                        id="email"
-                        name="email"
-                        type="email"
-                        inputMode="email"
-                        className="w-full"
-                        autoComplete="email"
-                        defaultValue={defaultState.email}
-                        errorMessage={errors?.email}
-                        label={t('protected-renew:confirm-email.email')}
-                        maxLength={64}
-                        aria-describedby="adding-email"
-                      />
-                      <InputField
-                        id="confirm-email"
-                        name="confirmEmail"
-                        type="email"
-                        inputMode="email"
-                        className="w-full"
-                        autoComplete="email"
-                        defaultValue={defaultState.email}
-                        errorMessage={errors?.confirmEmail}
-                        label={t('protected-renew:confirm-email.confirm-email')}
-                        maxLength={64}
-                        aria-describedby="adding-email"
-                      />
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-no" />,
-                  value: AddOrUpdateEmailOption.No,
-                  defaultChecked: isNewOrUpdatedEmail === false,
-                  onChange: handleNewOrUpdateEmailChanged,
-                },
-              ]}
-              errorMessage={errors?.isNewOrUpdatedEmail}
-              required
-            />
-          </div>
-          {isNewOrUpdatedEmail && (
-            <div className="mb-6">
-              <InputRadios
-                id="should-receive-email-communication"
-                name="shouldReceiveEmailCommunication"
-                legend={t('protected-renew:confirm-email.receive-comms.legend')}
-                options={[
-                  {
-                    children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-yes" />,
-                    value: ShouldReceiveEmailCommunicationOption.Yes,
-                    defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
-                  },
-                  {
-                    children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-no" />,
-                    value: ShouldReceiveEmailCommunicationOption.No,
-                    defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
-                  },
-                ]}
-                errorMessage={errors?.shouldReceiveEmailCommunication}
-                required
+            <div className="grid gap-6 md:grid-cols-2">
+              <InputField
+                id="email"
+                name="email"
+                type="email"
+                inputMode="email"
+                className="w-full"
+                autoComplete="email"
+                defaultValue={defaultState.email}
+                errorMessage={errors?.email}
+                label={t('protected-renew:confirm-email.email')}
+                maxLength={64}
+                aria-describedby="adding-email"
+              />
+              <InputField
+                id="confirm-email"
+                name="confirmEmail"
+                type="email"
+                inputMode="email"
+                className="w-full"
+                autoComplete="email"
+                defaultValue={defaultState.email}
+                errorMessage={errors?.confirmEmail}
+                label={t('protected-renew:confirm-email.confirm-email')}
+                maxLength={64}
+                aria-describedby="adding-email"
               />
             </div>
-          )}
-          {editMode ? (
-            <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
-                {t('protected-renew:confirm-email.save-btn')}
-              </Button>
-              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
-                {t('protected-renew:confirm-email.cancel-btn')}
-              </Button>
-            </div>
-          ) : (
-            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton
-                id="continue-button"
-                name="_action"
-                value={FormAction.Continue}
-                variant="primary"
-                loading={isSubmitting}
-                endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Contact information click"
-              >
-                {t('protected-renew:confirm-email.continue-btn')}
-              </LoadingButton>
-              <ButtonLink
-                id="back-button"
-                routeId="protected/renew/$id/confirm-phone"
-                params={params}
-                disabled={isSubmitting}
-                startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Contact information click"
-              >
-                {t('protected-renew:confirm-email.back-btn')}
-              </ButtonLink>
-            </div>
-          )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
+              {t('protected-renew:confirm-email.save-btn')}
+            </Button>
+            <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
+              {t('protected-renew:confirm-email.cancel-btn')}
+            </Button>
+          </div>
         </fetcher.Form>
       </div>
     </>

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -316,30 +316,16 @@
   },
   "confirm-email": {
     "page-title": "Email",
-    "add-email": "Having an up-to-date email on file helps the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan membership.",
-    "add-or-update": {
-      "legend": "Would you like to update or add your email address?",
-      "help-message": "The email address we have on file can also be found on the renewal letter you received from Service Canada."
-    },
-    "receive-comms": {
-      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?"
-    },
     "email": "Email address",
     "confirm-email": "Confirm email address",
-    "back-btn": "Back",
-    "continue-btn": "Continue",
     "cancel-btn": "Cancel",
     "save-btn": "Save",
-    "option-yes": "Yes",
-    "option-no": "No",
     "error-message": {
-      "add-or-update-required": "Select whether you would like to add or update your email",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
       "email-required": "Enter email address",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
-      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
-      "receive-comms-required": "Select whether you would like to receive email communication"
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
     }
   },
   "confirm-address": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -316,30 +316,16 @@
   },
   "confirm-email": {
     "page-title": "Adresse courriel",
-    "add-email": "Adresse courriel",
-    "add-or-update": {
-      "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
-      "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
-    },
-    "receive-comms": {
-      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?"
-    },
     "email": "Adresse courriel",
     "confirm-email": "Confirmer l'adresse courriel",
-    "back-btn": "Retour",
-    "continue-btn": "Continuer",
     "cancel-btn": "Annuler",
     "save-btn": "Sauvegarder",
-    "option-yes": "Oui",
-    "option-no": "Non",
     "error-message": {
-      "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
       "email-required": "Entrez l'adresse courriel",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
-      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
-      "receive-comms-required": "Select whether you would like to receive email communication"
+      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com"
     }
   },
   "confirm-address": {


### PR DESCRIPTION
### Description
updates the confirm-email route in the protected renew app to align with figma.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
