### PR TITLE
Replacing current form validation with addressValidator Service. Mailing-address in ITA

### DIFF
--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -72,6 +72,7 @@ import type { HttpClient } from '~/.server/http';
 import type { InstrumentationService } from '~/.server/observability';
 import type { BenefitApplicationStateMapper, BenefitRenewalStateMapper } from '~/.server/routes/mappers';
 import type { MailingAddressValidatorFactory } from '~/.server/routes/public/address-validation';
+import type { MailingAddressValidatorFactoryIta } from '~/.server/routes/public/renew/ita';
 import type { SecurityHandler } from '~/.server/routes/security';
 import type { AddressValidatorFactory } from '~/.server/routes/validators';
 import { assignServiceIdentifiers, serviceIdentifier as serviceId } from '~/.server/utils/service-identifier.utils';
@@ -228,6 +229,11 @@ export const TYPES = assignServiceIdentifiers({
       addressValidation: {
         MailingAddressValidatorFactory: serviceId<MailingAddressValidatorFactory>(),
       },
+      renew: {
+        ita: {
+          MailingAddressValidatorFactoryIta: serviceId<MailingAddressValidatorFactoryIta>(),
+        }
+      }
     },
     security: {
       SecurityHandler: serviceId<SecurityHandler>(),

--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -232,8 +232,8 @@ export const TYPES = assignServiceIdentifiers({
       renew: {
         ita: {
           MailingAddressValidatorFactoryIta: serviceId<MailingAddressValidatorFactoryIta>(),
-        }
-      }
+        },
+      },
     },
     security: {
       SecurityHandler: serviceId<SecurityHandler>(),

--- a/frontend/app/.server/container-modules/factories.container-module.ts
+++ b/frontend/app/.server/container-modules/factories.container-module.ts
@@ -3,6 +3,7 @@ import { ContainerModule } from 'inversify';
 import { TYPES } from '~/.server/constants';
 import { DefaultConfigFactory, DefaultLogFactory } from '~/.server/factories';
 import { DefaultMailingAddressValidatorFactory } from '~/.server/routes/public/address-validation/mailing-address.validator.factory';
+import { DefaultMailingAddressValidatorFactoryIta } from '~/.server/routes/public/renew/ita/mailing-address.validator.factory';
 import { DefaultAddressValidatorFactory } from '~/.server/routes/validators';
 
 /**
@@ -12,5 +13,6 @@ export const factoriesContainerModule = new ContainerModule((bind) => {
   bind(TYPES.domain.services.ConfigFactory).to(DefaultConfigFactory);
   bind(TYPES.factories.LogFactory).to(DefaultLogFactory);
   bind(TYPES.routes.public.addressValidation.MailingAddressValidatorFactory).to(DefaultMailingAddressValidatorFactory);
+  bind(TYPES.routes.public.renew.ita.MailingAddressValidatorFactoryIta).to(DefaultMailingAddressValidatorFactoryIta);
   bind(TYPES.routes.validators.AddressValidatorFactory).to(DefaultAddressValidatorFactory);
 });

--- a/frontend/app/.server/routes/public/renew/ita/index.ts
+++ b/frontend/app/.server/routes/public/renew/ita/index.ts
@@ -1,0 +1,2 @@
+export * from './mailing-address.validator';
+export * from './mailing-address.validator.factory';

--- a/frontend/app/.server/routes/public/renew/ita/mailing-address.validator.factory.ts
+++ b/frontend/app/.server/routes/public/renew/ita/mailing-address.validator.factory.ts
@@ -1,0 +1,34 @@
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import { TYPES } from '~/.server/constants';
+import { DefaultMailingAddressValidatorIta } from '~/.server/routes/public/renew/ita/mailing-address.validator';
+import type { MailingAddressValidatorIta } from '~/.server/routes/public/renew/ita/mailing-address.validator';
+import type { AddressValidatorFactory } from '~/.server/routes/validators/';
+
+/**
+ * Factory interface for creating mailing address validators.
+ */
+export interface MailingAddressValidatorFactoryIta {
+  /**
+   * Creates a new mailing address validator for the given locale.
+   * @param locale The locale to use for validation.
+   * @returns A new mailing address validator.
+   */
+  createMailingAddressValidator(locale: AppLocale): MailingAddressValidatorIta;
+}
+
+@injectable()
+export class DefaultMailingAddressValidatorFactoryIta implements MailingAddressValidatorFactoryIta {
+  constructor(@inject(TYPES.routes.validators.AddressValidatorFactory) private readonly addressValidatorFactory: AddressValidatorFactory) {}
+
+  /**
+   * Memoizes the creation of mailing address validators to reduce the number of times i18next files are read.
+   * Each locale will have its own memoized validator.
+   */
+  createMailingAddressValidator = moize(this._createMailingAddressValidator, { maxSize: Infinity });
+
+  private _createMailingAddressValidator(locale: AppLocale): MailingAddressValidatorIta {
+    return new DefaultMailingAddressValidatorIta(locale, this.addressValidatorFactory);
+  }
+}

--- a/frontend/app/.server/routes/public/renew/ita/mailing-address.validator.ts
+++ b/frontend/app/.server/routes/public/renew/ita/mailing-address.validator.ts
@@ -1,0 +1,56 @@
+import type { Address, AddressValidatorErrorMessages, AddressValidatorFactory } from '~/.server/routes/validators/';
+import type { InvalidResult, ValidResult } from '~/.server/routes/validators/types.validator';
+import { getFixedT } from '~/.server/utils/locale.utils';
+
+/**
+ * Interface for a mailing address validator.
+ */
+export interface MailingAddressValidatorIta {
+  /**
+   * Validates a mailing address.
+   * @param data The address data to validate.
+   * @returns A promise that resolves to either a valid or invalid result.
+   */
+  validateMailingAddress(data: Partial<Address>): Promise<InvalidResult<Address> | ValidResult<Address>>;
+}
+
+export class DefaultMailingAddressValidatorIta implements MailingAddressValidatorIta {
+  constructor(
+    private readonly locale: AppLocale,
+    private readonly addressValidatorFactory: AddressValidatorFactory,
+  ) {}
+
+  async validateMailingAddress(data: Partial<Address>): Promise<InvalidResult<Address> | ValidResult<Address>> {
+    const errorMessages = await this.buildMailingAddressSchemaErrorMessages();
+    const addressValidator = this.addressValidatorFactory.createAddressValidator(errorMessages);
+    return addressValidator.validateAddress(data);
+  }
+
+  private async buildMailingAddressSchemaErrorMessages(): Promise<AddressValidatorErrorMessages> {
+    const t = await getFixedT(this.locale, ['renew-ita']);
+    return {
+      address: {
+        invalidCharacters: t('renew-ita:update-address.error-message.characters-valid'),
+        required: t('renew-ita:update-address.error-message.mailing-address.address-required'),
+      },
+      city: {
+        required: t('renew-ita:update-address.error-message.mailing-address.city-required'),
+        invalidCharacters: t('renew-ita:update-address.error-message.characters-valid'),
+      },
+      country: {
+        required: t('renew-ita:update-address.error-message.mailing-address.country-required'),
+      },
+      provinceState: {
+        required: t('renew-ita:update-address.error-message.mailing-address.province-required'),
+      },
+      postalZipCode: {
+        invalidCharacters: t('renew-ita:update-address.error-message.characters-valid'),
+        invalidPostalCode: t('renew-ita:update-address.error-message.mailing-address.postal-code-valid'),
+        invalidPostalCodeForProvince: t('renew-ita:update-address.error-message.mailing-address.invalid-postal-code-for-province'),
+        invalidPostalZipCodeForCountry: t('renew-ita:update-address.error-message.mailing-address.invalid-postal-code-for-country'),
+        invalidZipCode: t('renew-ita:update-address.error-message.mailing-address.zip-code-valid'),
+        required: t('renew-ita:update-address.error-message.mailing-address.postal-code-required'),
+      },
+    };
+  }
+}


### PR DESCRIPTION
### Description
Only adding form validation. 

Address CORRECTION will be added in a separate PR.

### Related Azure Boards Work Items
[AB#4922](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4922)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
