### PR TITLE
Updating benefit renewal DTO and mappers to include dempgraphics questions

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -126,6 +126,13 @@ describe('DefaultBenefitRenewalStateMapper', () => {
               federalBenefitsChanged: true,
               provincialTerritorialBenefitsChanged: true,
             },
+            demographicSurvey: {
+              disabilityStatus: 'Disability status placeholder',
+              ethnicGroups: ['Group 1', 'Group 2'],
+              indigenousStatus: 'No answer',
+              genderStatus: 'Male',
+              locationBornStatus: 'Canada',
+            },
             dentalBenefits: {
               hasFederalBenefits: true,
               hasProvincialTerritorialBenefits: true,
@@ -154,6 +161,12 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           isNewOrUpdatedEmail: true,
           isNewOrUpdatedPhoneNumber: true,
           shouldReceiveEmailCommunication: true,
+        },
+        demographicSurvey: {
+          ethnicGroups: ['Group 1'],
+          indigenousStatus: 'No answer',
+          genderStatus: 'Male',
+          locationBornStatus: 'Outside Canada',
         },
         dentalBenefits: {
           hasFederalBenefits: true,
@@ -208,6 +221,13 @@ describe('DefaultBenefitRenewalStateMapper', () => {
             clientNumber: '11111111111',
             dentalBenefits: ['New federal program', 'New provincial program'],
             dentalInsurance: true,
+            demographicSurvey: {
+              disabilityStatus: 'Disability status placeholder',
+              ethnicGroups: ['Group 1', 'Group 2'],
+              indigenousStatus: 'No answer',
+              genderStatus: 'Male',
+              locationBornStatus: 'Canada',
+            },
             information: {
               dateOfBirth: '2020-01-01',
               firstName: 'John Jr.',
@@ -223,6 +243,12 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           email: 'new@example.com',
         },
         dateOfBirth: '1970-01-01',
+        demographicSurvey: {
+          ethnicGroups: ['Group 1'],
+          indigenousStatus: 'No answer',
+          genderStatus: 'Male',
+          locationBornStatus: 'Outside Canada',
+        },
         dentalBenefits: ['New federal program', 'Original provincial benefit'],
         dentalInsurance: true,
         typeOfApplication: 'adult-child',

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -29,6 +29,7 @@ export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformatio
   Readonly<{
     children: RenewalChildDto[];
     applicantInformation: RenewalApplicantInformationDto;
+    demographicSurvey?: DemographicSurveyDto;
   }>;
 
 export type RenewalApplicantInformationDto = ApplicantInformationDto &
@@ -39,4 +40,15 @@ export type RenewalApplicantInformationDto = ApplicantInformationDto &
 export type RenewalChildDto = ChildDto &
   Readonly<{
     clientNumber: string;
+    demographicSurvey?: DemographicSurveyDto;
   }>;
+
+export type DemographicSurveyDto = Readonly<{
+  indigenousStatus?: string;
+  firstNations?: string[];
+  disabilityStatus?: string;
+  ethnicGroups?: string[];
+  anotherEthnicGroup?: string;
+  locationBornStatus?: string;
+  genderStatus?: string;
+}>;

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -144,6 +144,7 @@ export type ProtectedClientApplicationState = NonNullable<ProtectedRenewState['c
 export type ProtectedDentalFederalBenefitsState = Pick<NonNullable<ProtectedRenewState['dentalBenefits']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
 export type ProtectedDentalProvincialTerritorialBenefitsState = Pick<NonNullable<ProtectedRenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
 export type ProtectedContactInformationState = NonNullable<ProtectedRenewState['contactInformation']>;
+export type ProtectedDemographicSurveyState = NonNullable<ProtectedRenewState['demographicSurvey']>;
 
 /**
  * Schema for validating UUID.

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -149,6 +149,7 @@ export type DentalFederalBenefitsState = Pick<NonNullable<RenewState['dentalBene
 export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
 export type ConfirmDentalBenefitsState = NonNullable<RenewState['confirmDentalBenefits']>;
 export type ContactInformationState = NonNullable<RenewState['contactInformation']>;
+export type DemographicSurveyState = NonNullable<RenewState['demographicSurvey']>;
 
 /**
  * Schema for validating UUID.

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -22,11 +22,21 @@ import type {
   ProtectedAddressInformationState,
   ProtectedChildState,
   ProtectedContactInformationState,
+  ProtectedDemographicSurveyState,
   ProtectedDentalFederalBenefitsState,
   ProtectedDentalProvincialTerritorialBenefitsState,
   ProtectedPartnerInformationState,
 } from '~/.server/routes/helpers/protected-renew-route-helpers';
-import type { AddressInformationState, ChildState, ConfirmDentalBenefitsState, ContactInformationState, DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState, PartnerInformationState } from '~/.server/routes/helpers/renew-route-helpers';
+import type {
+  AddressInformationState,
+  ChildState,
+  ConfirmDentalBenefitsState,
+  ContactInformationState,
+  DemographicSurveyState,
+  DentalFederalBenefitsState,
+  DentalProvincialTerritorialBenefitsState,
+  PartnerInformationState,
+} from '~/.server/routes/helpers/renew-route-helpers';
 
 export interface RenewAdultChildState {
   addressInformation?: AddressInformationState;
@@ -34,6 +44,7 @@ export interface RenewAdultChildState {
   clientApplication: ClientApplicationDto;
   confirmDentalBenefits: ConfirmDentalBenefitsState;
   contactInformation: ContactInformationState;
+  demographicSurvey?: DemographicSurveyState;
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   hasAddressChanged: boolean;
@@ -46,6 +57,7 @@ export interface RenewItaState {
   addressInformation?: AddressInformationState;
   clientApplication: ClientApplicationDto;
   contactInformation: ContactInformationState;
+  demographicSurvey?: DemographicSurveyState;
   dentalBenefits: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   hasAddressChanged: boolean;
@@ -58,6 +70,7 @@ export interface ProtectedRenewState {
   clientApplication: ClientApplicationDto;
   children: ProtectedChildState[];
   contactInformation?: ProtectedContactInformationState;
+  demographicSurvey?: ProtectedDemographicSurveyState;
   dentalBenefits?: ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   maritalStatus?: string;
@@ -124,6 +137,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     clientApplication,
     confirmDentalBenefits,
     contactInformation,
+    demographicSurvey,
     dentalBenefits,
     dentalInsurance,
     hasAddressChanged,
@@ -177,6 +191,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         hasPhoneChanged,
       }),
+      demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
         hasFederalBenefitsChanged,
@@ -194,7 +209,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  mapRenewItaStateToItaBenefitRenewalDto({ addressInformation, clientApplication, contactInformation, dentalBenefits, dentalInsurance, hasAddressChanged, maritalStatus, partnerInformation }: RenewItaState): ItaBenefitRenewalDto {
+  mapRenewItaStateToItaBenefitRenewalDto({ addressInformation, clientApplication, contactInformation, demographicSurvey, dentalBenefits, dentalInsurance, hasAddressChanged, maritalStatus, partnerInformation }: RenewItaState): ItaBenefitRenewalDto {
     return {
       ...clientApplication,
       applicantInformation: this.toApplicantInformation({
@@ -220,6 +235,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedEmail: contactInformation.email,
         renewedReceiveEmailCommunication: contactInformation.shouldReceiveEmailCommunication,
       }),
+      demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
         hasFederalBenefitsChanged: true,
@@ -238,7 +254,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
   }
 
   mapProtectedRenewStateToProtectedBenefitRenewalDto(
-    { addressInformation, children, contactInformation, dentalBenefits, dentalInsurance, maritalStatus, partnerInformation, clientApplication }: ProtectedRenewState,
+    { addressInformation, children, contactInformation, demographicSurvey, dentalBenefits, dentalInsurance, maritalStatus, partnerInformation, clientApplication }: ProtectedRenewState,
     userId: string,
   ): ProtectedBenefitRenewalDto {
     return {
@@ -248,6 +264,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         renewedMaritalStatus: maritalStatus,
       }),
+      demographicSurvey,
       children: this.toChildren({
         existingChildren: clientApplication.children,
         renewedChildren: children,
@@ -327,6 +344,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
           hasProvincialTerritorialBenefitsChanged,
           renewedDentalBenefits: renewedChild.dentalBenefits,
         }),
+        demographicSurvey: renewedChild.demographicSurvey,
         dentalInsurance: renewedChild.dentalInsurance,
         information: {
           firstName: renewedChild.information.firstName,


### PR DESCRIPTION
### Description
As per title. Based off Interop's v1.0.11 specs.

Left some `TODO`s where more discussion is required with Interop.

### Related Azure Boards Work Items
[AB#4932](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4932)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/eca833be-d83a-43f4-9bef-1b3e1f9c7b89)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and go to `/en/renew`. Complete the renewal application including demographics questions. Verify that the request payload includes the expected `BenefitApplicationDetail` field.