### PR TITLE
Updating benefit renewal DTO and mappers to map partner information

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -251,6 +251,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         },
         dentalBenefits: ['New federal program', 'Original provincial benefit'],
         dentalInsurance: true,
+        partnerInformation: undefined,
         typeOfApplication: 'adult-child',
         userId: 'anonymous',
       };

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -25,11 +25,12 @@ export type ItaChangeIndicators = Readonly<{
 
 export type ProtectedBenefitRenewalDto = BenefitRenewalDto;
 
-export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformation' | 'children'> &
+export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformation' | 'children' | 'partnerInformation'> &
   Readonly<{
-    children: RenewalChildDto[];
     applicantInformation: RenewalApplicantInformationDto;
+    children: RenewalChildDto[];
     demographicSurvey?: DemographicSurveyDto;
+    partnerInformation?: RenewalPartnerInformationDto;
   }>;
 
 export type RenewalApplicantInformationDto = ApplicantInformationDto &
@@ -42,6 +43,12 @@ export type RenewalChildDto = ChildDto &
     clientNumber: string;
     demographicSurvey?: DemographicSurveyDto;
   }>;
+
+export type RenewalPartnerInformationDto = Readonly<{
+  confirm: boolean;
+  yearOfBirth: string;
+  socialInsuranceNumber: string;
+}>;
 
 export type DemographicSurveyDto = Readonly<{
   indigenousStatus?: string;

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -105,7 +105,7 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
         PersonBirthDate: {
           date: string;
         };
-        PersonName: {
+        PersonName?: {
           PersonGivenName: string[];
           PersonSurName: string;
         }[];

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -12,10 +12,10 @@ import type {
   DemographicSurveyDto,
   ItaBenefitRenewalDto,
   ItaChangeIndicators,
-  PartnerInformationDto,
   ProtectedBenefitRenewalDto,
   RenewalApplicantInformationDto,
   RenewalChildDto,
+  RenewalPartnerInformationDto,
   TypeOfApplicationDto,
 } from '~/.server/domain/dtos';
 import type { BenefitRenewalRequestEntity } from '~/.server/domain/entities';
@@ -39,7 +39,7 @@ interface ToBenefitRenewalRequestEntityArgs {
   dentalInsurance?: boolean;
   disabilityTaxCredit?: boolean;
   livingIndependently?: boolean;
-  partnerInformation?: PartnerInformationDto;
+  partnerInformation?: RenewalPartnerInformationDto;
   typeOfApplication: TypeOfApplicationDto;
 }
 
@@ -338,7 +338,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     return telephoneNumber;
   }
 
-  private toRelatedPersons(partnerInformation: PartnerInformationDto | undefined, children: ReadonlyArray<RenewalChildDto>) {
+  private toRelatedPersons(partnerInformation: RenewalPartnerInformationDto | undefined, children: ReadonlyArray<RenewalChildDto>) {
     const relatedPersons = [];
 
     if (partnerInformation) {
@@ -351,15 +351,11 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     return relatedPersons;
   }
 
-  private toRelatedPersonSpouse({ confirm, dateOfBirth, firstName, lastName, socialInsuranceNumber }: PartnerInformationDto) {
+  private toRelatedPersonSpouse({ confirm, socialInsuranceNumber, yearOfBirth }: RenewalPartnerInformationDto) {
     return {
-      PersonBirthDate: this.toDate(dateOfBirth),
-      PersonName: [
-        {
-          PersonGivenName: [firstName],
-          PersonSurName: lastName,
-        },
-      ],
+      PersonBirthDate: {
+        date: yearOfBirth, // TODO verify with Interop/PP that the PersonBirthDate field can be populated with just a year
+      },
       PersonRelationshipCode: {
         ReferenceDataName: 'Spouse' as const,
       },

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -454,9 +454,13 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
   }
 
   private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs) {
-    if (!hasMaritalStatusChanged) return existingPartnerInformation;
+    if (hasMaritalStatusChanged) return renewedPartnerInformation;
+    if (!existingPartnerInformation) return undefined;
 
-    // TODO figure out how to map this since renewal doesn't have first name, last name and date of birth fields
-    return existingPartnerInformation;
+    return {
+      confirm: existingPartnerInformation.confirm,
+      socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber,
+      yearOfBirth: new Date(existingPartnerInformation.dateOfBirth).getFullYear().toString(),
+    };
   }
 }


### PR DESCRIPTION
### Description
As per title. Based off Interop's v1.0.11 specs.

Left TODO where more discussion is required with Interop involving how we send year of birth for partner.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`