### PR TITLE
AB#4623 confirm FPT screen for renew child flow

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -30,7 +30,6 @@ export interface RenewState {
       provincialTerritorialSocialProgram?: string;
       province?: string;
     };
-    // TODO: Confirm FPT page no longer ask federal and provincial question seperately. Removing this state will cause error in the mapper, keeping it for now.
     readonly confirmDentalBenefits?: {
       federalBenefitsChanged: boolean;
       provincialTerritorialBenefitsChanged: boolean;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -30,10 +30,12 @@ export interface RenewState {
       provincialTerritorialSocialProgram?: string;
       province?: string;
     };
+    // TODO: Confirm FPT page no longer ask federal and provincial question seperately. Removing this state will cause error in the mapper, keeping it for now.
     readonly confirmDentalBenefits?: {
       federalBenefitsChanged: boolean;
       provincialTerritorialBenefitsChanged: boolean;
     };
+    readonly federalProvincialTerritorialBenefitsChanged?: boolean;
     readonly dentalInsurance?: boolean;
     readonly information?: {
       firstName: string;

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -146,6 +146,7 @@ export const pageIds = {
         parentOrGuardian: 'CDCP-RENW-CHLD-0002',
         parentIntro: 'CDCP-RENW-CHLD-0003',
         dentalInsurance: 'CDCP-RENW-CHLD-0004',
+        confirmFederalProvincialTerritorialBenefits: 'CDCP-RENW-CHLD-0005',
       },
     },
     demographicSurvey: {

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState, loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { AppPageTitle } from '~/components/layouts/public-layout';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FederalBenefitsChangedOption {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.confirmFederalProvincialTerritorialBenefits,
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewSingleChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const childNumber = t('renew-child:children.child-number', { childNumber: state.childNumber });
+  const childName = state.isNew ? childNumber : (state.information?.firstName ?? childNumber);
+
+  const meta = {
+    title: t('gcweb:meta.title.template', { title: t('renew-child:children.confirm-dental-benefits.title', { childName }) }),
+    dcTermsTitle: t('gcweb:meta.title.template', { title: t('renew-child:children.information.page-title', { childName: childNumber }) }),
+  };
+
+  return {
+    defaultState: state.federalProvincialTerritorialBenefitsChanged,
+    childName,
+    editMode: state.editMode,
+    meta,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewSingleChildState({ params, request, session });
+  const renewState = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // NOTE: state validation schemas are independent otherwise user have to anwser
+  // both question first before the superRefine can be executed
+  const dentalBenefitsChangedSchema = z.object({
+    federalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
+  });
+
+  const dentalBenefits = {
+    federalProvincialTerritorialBenefitsChanged: formData.get('federalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+  };
+
+  const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
+
+  if (!parsedDentalBenefitsResult.success) {
+    return {
+      errors: {
+        ...transformFlattenedError(parsedDentalBenefitsResult.error.flatten()),
+      },
+    };
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      children: renewState.children.map((child) => {
+        if (child.id !== state.id) return child;
+        return {
+          ...child,
+          federalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.federalProvincialTerritorialBenefitsChanged,
+        };
+      }),
+    },
+  });
+
+  if (dentalBenefits.federalProvincialTerritorialBenefitsChanged) {
+    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits', params));
+  }
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/children/demographic-survey', params));
+}
+
+export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [federalProvincialTerritorialBenefitChangedValue, setFederalProvincialTerrirorialBenefitChangedValue] = useState(defaultState);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    federalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
+  });
+
+  function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FederalBenefitsChangedOption.Yes);
+  }
+
+  return (
+    <>
+      <AppPageTitle>{t('renew-child:children.confirm-dental-benefits.title', { childName })}</AppPageTitle>
+      <div className="my-6 sm:my-8">
+        <Progress value={88} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4">{t('renew-child:children.confirm-dental-benefits.access-to-dental')}</p>
+        <p className="mb-4">{t('renew-child:children.confirm-dental-benefits.eligibility-criteria')}</p>
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <fieldset className="mb-6">
+            <InputRadios
+              id="federal-provincial-territorial-benefits-changed"
+              name="federalProvincialTerritorialBenefitsChanged"
+              legend={t('renew-child:children.confirm-dental-benefits.has-benefits-changed', { childName })}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.confirm-dental-benefits.option-yes" />,
+                  value: FederalBenefitsChangedOption.Yes,
+                  defaultChecked: federalProvincialTerritorialBenefitChangedValue === true,
+                  onChange: handleOnFederalProvincialTerritorialBenefitChanged,
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.confirm-dental-benefits.option-no" />,
+                  value: FederalBenefitsChangedOption.No,
+                  defaultChecked: federalProvincialTerritorialBenefitChangedValue === false,
+                  onChange: handleOnFederalProvincialTerritorialBenefitChanged,
+                },
+              ]}
+              errorMessage={errors?.federalProvincialTerritorialBenefitsChanged}
+              required
+            />
+          </fieldset>
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental benefits click">
+                {t('renew-child:children.confirm-dental-benefits.button.save-btn')}
+              </Button>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/review-child-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental benefits click"
+              >
+                {t('renew-child:children.confirm-dental-benefits.button.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Access to other dental benefits click">
+                {t('renew-child:children.confirm-dental-benefits.button.continue')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult-child/children/$childId/dental-insurance"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to other dental benefits click"
+              >
+                {t('renew-child:children.confirm-dental-benefits.button.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -105,14 +105,14 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (dentalBenefits.federalProvincialTerritorialBenefitsChanged) {
-    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits', params));
+    return redirect(getPathById('public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits', params));
   }
 
   if (state.editMode) {
-    return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
+    return redirect(getPathById('public/renew/$id/child/review-child-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/children/demographic-survey', params));
+  return redirect(getPathById('public/renew/$id/child/children/demographic-survey', params));
 }
 
 export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {
@@ -190,7 +190,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/adult-child/children/$childId/dental-insurance"
+                routeId="public/renew/$id/child/children/$childId/dental-insurance"
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -70,8 +70,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const renewState = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  // NOTE: state validation schemas are independent otherwise user have to anwser
-  // both question first before the superRefine can be executed
   const dentalBenefitsChangedSchema = z.object({
     federalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -617,6 +617,11 @@ export const routes = [
             file: 'routes/public/renew/$id/child/children/$childId/dental-insurance.tsx',
             paths: { en: '/:lang/renew/:id/child/children/:childId/dental-insurance', fr: '/:lang/renew/:id/enfant/enfants/:childId/assurance-dentaire' },
           },
+          {
+            id: 'public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits',
+            file: 'routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx',
+            paths: { en: '/:lang/renew/:id/child/children/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/renew/:id/enfant/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -126,6 +126,24 @@
       "error-message": {
         "dental-insurance-required": "Select whether the child has access to dental insurance"
       }
+    },
+    "confirm-dental-benefits": {
+      "title": "{{childName}}: access to other federal, provincial or territorial dental benefits",
+      "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
+      "select-one": "Select one",
+      "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
+      "has-benefits-changed": "Does {{childName}} have dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+      "option-yes": "<strong>Yes</strong>, this child has federal, provincial or territorial dental benefits.",
+      "option-no": "<strong>No</strong>, this child does not have federal, provincial or territorial dental benefits.",
+      "button": {
+        "back": "Back",
+        "continue": "Continue",
+        "cancel-btn": "Cancel",
+        "save-btn": "Save"
+      },
+      "error-message": {
+        "federal-provincial-territorial-benefit-required": "Select whether you have federal provincial or territorial dental benefits"
+      }
     }
   },
   "parent-intro": {

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -128,6 +128,24 @@
       "error-message": {
         "dental-insurance-required": "Sélectionnez si cet enfant a accès à une assurance dentaire"
       }
+    },
+    "confirm-dental-benefits": {
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
+      "select-one": "Sélectionnez une option",
+      "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
+      "has-benefits-changed": "Est-ce que {{nom de l'enfant 2}} bénéficie de prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
+      "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales, provincial ou territorial",
+      "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales, provincial ou territorial",
+      "button": {
+        "back": "Retour",
+        "continue": "Continuer",
+        "cancel-btn": "Annuler",
+        "save-btn": "Sauvegarder"
+      },
+      "error-message": {
+        "federal-provincial-territorial-benefit-required": "Sélectionnez si votre enfant bénéficie de prestations dentaires fédérales provinciale ou territoriale"
+      }
     }
   },
   "parent-intro": {

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -134,7 +134,7 @@
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
-      "has-benefits-changed": "Est-ce que {{nom de l'enfant 2}} bénéficie de prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
+      "has-benefits-changed": "Est-ce que {{childName}} bénéficie de prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
       "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales, provincial ou territorial",
       "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales, provincial ou territorial",
       "button": {


### PR DESCRIPTION
### Description
Added `confirm-federal-provincial-territorial-benefits` screen for renew child flow

This page no longer asks the federal, provincial, and territorial benefits question separately, as per the Figma design. A new state, `federalProvincialTerritorialBenefitsChanged`, has been introduced to accommodate this change.

### Related Azure Boards Work Items
[AB#4623](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4623)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->