### PR TITLE
fix address state changes in protected renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -373,7 +373,7 @@ interface ValidateProtectedRenewStateForReviewArgs {
 }
 
 export function validateProtectedRenewStateForReview({ params, state }: ValidateProtectedRenewStateForReviewArgs) {
-  const { maritalStatus, partnerInformation, addressInformation, clientApplication, contactInformation, communicationPreferences, editMode, id, dentalBenefits, dentalInsurance, demographicSurvey } = state;
+  const { maritalStatus, partnerInformation, mailingAddress, homeAddress, addressInformation, clientApplication, contactInformation, communicationPreferences, editMode, id, dentalBenefits, dentalInsurance, demographicSurvey } = state;
 
   if (dentalInsurance === undefined) {
     throw redirect(getPathById('protected/renew/$id/dental-insurance', params));
@@ -388,6 +388,8 @@ export function validateProtectedRenewStateForReview({ params, state }: Validate
   return {
     maritalStatus,
     partnerInformation,
+    mailingAddress,
+    homeAddress,
     addressInformation,
     clientApplication,
     contactInformation,

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -54,7 +54,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,
@@ -108,9 +107,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = mailingAddressSchema.safeParse({
     address: String(formData.get('mailingAddress')),
     country: String(formData.get('mailingCountry')),
-    province: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : '',
+    province: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
     city: String(formData.get('mailingCity')),
-    postalCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : '',
+    postalCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
     copyMailingAddress: formData.get('copyMailingAddress') === 'copy',
   });
 

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -65,21 +65,21 @@ export async function loader({ context: { appContainer, session }, params, reque
   const preferredLanguage = state.communicationPreferences?.preferredLanguage
     ? appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name
     : appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
-  const mailingProvinceTerritoryStateAbbr = state.addressInformation?.mailingProvince
-    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.mailingProvince).abbr
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province
+    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr
     : state.clientApplication.contactInformation.mailingProvince
       ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.mailingProvince).abbr
       : undefined;
-  const homeProvinceTerritoryStateAbbr = state.addressInformation?.homeProvince
-    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.addressInformation.homeProvince).abbr
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province
+    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr
     : state.clientApplication.contactInformation.homeProvince
       ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince).abbr
       : undefined;
-  const mailingCountryAbbr = state.addressInformation?.mailingCountry
-    ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.mailingCountry, locale).name
+  const mailingCountryAbbr = state.mailingAddress?.country
+    ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale).name
     : appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.mailingCountry, locale).name;
-  const homeCountryAbbr = state.addressInformation?.homeCountry
-    ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.addressInformation.homeCountry, locale).name
+  const homeCountryAbbr = state.homeAddress?.country
+    ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name
     : appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.homeCountry, locale).name;
 
   const userInfo = {
@@ -104,21 +104,21 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 
   const mailingAddressInfo = {
-    address: state.addressInformation?.mailingAddress ?? state.clientApplication.contactInformation.mailingAddress,
-    city: state.addressInformation?.mailingCity ?? state.clientApplication.contactInformation.mailingCity,
+    address: state.mailingAddress?.address ?? state.clientApplication.contactInformation.mailingAddress,
+    city: state.mailingAddress?.city ?? state.clientApplication.contactInformation.mailingCity,
     province: mailingProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation?.mailingPostalCode ?? state.clientApplication.contactInformation.mailingPostalCode,
+    postalCode: state.mailingAddress?.postalCode ?? state.clientApplication.contactInformation.mailingPostalCode,
     country: mailingCountryAbbr,
-    apartment: state.addressInformation?.mailingApartment ?? state.clientApplication.contactInformation.mailingApartment,
+    apartment: state.mailingAddress?.apartment ?? state.clientApplication.contactInformation.mailingApartment,
   };
 
   const homeAddressInfo = {
-    address: state.addressInformation?.homeAddress ?? state.clientApplication.contactInformation.homeAddress,
-    city: state.addressInformation?.homeCity ?? state.clientApplication.contactInformation.homeCity,
+    address: state.homeAddress?.address ?? state.clientApplication.contactInformation.homeAddress,
+    city: state.homeAddress?.city ?? state.clientApplication.contactInformation.homeCity,
     province: homeProvinceTerritoryStateAbbr,
-    postalCode: state.addressInformation?.homePostalCode ?? state.clientApplication.contactInformation.homePostalCode,
+    postalCode: state.homeAddress?.postalCode ?? state.clientApplication.contactInformation.homePostalCode,
     country: homeCountryAbbr,
-    apartment: state.addressInformation?.homeApartment ?? state.clientApplication.contactInformation.homeApartment,
+    apartment: state.homeAddress?.apartment ?? state.clientApplication.contactInformation.homeApartment,
   };
 
   const dentalInsurance = state.dentalInsurance;


### PR DESCRIPTION
### Description
- before this PR no changes to the `homeAddress` and `mailingAddress` were being made in the edit screen.  
- we could at some point remove `addressInformation` from the `ProtectedRenewState` in a future PR?
- should the edit screens fallback to the `clientApplication` data for addresses?  

### Related Azure Boards Work Items
AB#4822
### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`