### PR TITLE
use clientApplication fallback state for address information in protected renew app

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -50,12 +50,29 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
+  const homeAddressInfo = state.homeAddress
+    ? {
+        address: state.homeAddress.address,
+        city: state.homeAddress.city,
+        province: state.homeAddress.province,
+        postalCode: state.homeAddress.postalCode,
+        country: state.homeAddress.country,
+        apartment: state.homeAddress.apartment,
+      }
+    : {
+        address: state.clientApplication.contactInformation.homeAddress,
+        city: state.clientApplication.contactInformation.homeCity,
+        province: state.clientApplication.contactInformation.homeProvince,
+        postalCode: state.clientApplication.contactInformation.homePostalCode,
+        country: state.clientApplication.contactInformation.homeCountry,
+        apartment: state.clientApplication.contactInformation.homeApartment,
+      };
+
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.home-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
-    defaultState: state,
+    defaultState: { ...homeAddressInfo },
     countryList,
     regionList,
   };
@@ -139,7 +156,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.country);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
 
   const errors = fetcher.data?.errors;
@@ -188,7 +205,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
             helpMessagePrimaryClassName="text-black"
             maxLength={30}
             autoComplete="address-line1"
-            defaultValue={defaultState.homeAddress?.address}
+            defaultValue={defaultState.address}
             errorMessage={errors?.address}
             required
           />
@@ -200,7 +217,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
               label={t('protected-renew:update-address.address-field.city')}
               maxLength={100}
               autoComplete="address-level2"
-              defaultValue={defaultState.homeAddress?.city}
+              defaultValue={defaultState.city}
               errorMessage={errors?.city}
               required
             />
@@ -211,7 +228,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
               label={homePostalCodeRequired ? t('protected-renew:update-address.address-field.postal-code') : t('protected-renew:update-address.address-field.postal-code-optional')}
               maxLength={100}
               autoComplete="postal-code"
-              defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+              defaultValue={defaultState.postalCode ?? ''}
               errorMessage={errors?.postalCode}
               required={homePostalCodeRequired}
             />
@@ -222,7 +239,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
               name="homeProvince"
               className="w-full sm:w-1/2"
               label={t('protected-renew:update-address.address-field.province')}
-              defaultValue={defaultState.homeAddress?.province}
+              defaultValue={defaultState.province}
               errorMessage={errors?.province}
               options={[dummyOption, ...homeRegions]}
               required
@@ -234,7 +251,7 @@ export default function ProtectedRenewConfirmHomeAddress() {
             className="w-full sm:w-1/2"
             label={t('protected-renew:update-address.address-field.country')}
             autoComplete="country"
-            defaultValue={defaultState.homeAddress?.country ?? ''}
+            defaultValue={defaultState.country}
             errorMessage={errors?.country}
             options={countries}
             onChange={homeCountryChangeHandler}

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -51,11 +51,32 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
+  const mailingAddressInfo = state.mailingAddress
+    ? {
+        address: state.mailingAddress.address,
+        city: state.mailingAddress.city,
+        province: state.mailingAddress.province,
+        postalCode: state.mailingAddress.postalCode,
+        country: state.mailingAddress.country,
+        apartment: state.mailingAddress.apartment,
+      }
+    : {
+        address: state.clientApplication.contactInformation.mailingAddress,
+        city: state.clientApplication.contactInformation.mailingCity,
+        province: state.clientApplication.contactInformation.mailingProvince,
+        postalCode: state.clientApplication.contactInformation.mailingPostalCode,
+        country: state.clientApplication.contactInformation.mailingCountry,
+        apartment: state.clientApplication.contactInformation.mailingApartment,
+      };
+
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };
 
   return {
     meta,
-    defaultState: state,
+    defaultState: {
+      ...mailingAddressInfo,
+      isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
+    },
     countryList,
     regionList,
   };
@@ -155,7 +176,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.mailingAddress?.country ?? CANADA_COUNTRY_ID);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.country);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState.isHomeAddressSameAsMailingAddress === true);
 
@@ -208,7 +229,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
             helpMessagePrimary={t('protected-renew:update-address.address-field.address-note')}
             helpMessagePrimaryClassName="text-black"
             autoComplete="address-line1"
-            defaultValue={defaultState.mailingAddress?.address}
+            defaultValue={defaultState.address}
             errorMessage={errors?.address}
             required
           />
@@ -220,7 +241,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
               label={t('protected-renew:update-address.address-field.city')}
               maxLength={100}
               autoComplete="address-level2"
-              defaultValue={defaultState.mailingAddress?.city}
+              defaultValue={defaultState.city}
               errorMessage={errors?.city}
               required
             />
@@ -231,7 +252,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
               label={mailingPostalCodeRequired ? t('protected-renew:update-address.address-field.postal-code') : t('protected-renew:update-address.address-field.postal-code-optional')}
               maxLength={100}
               autoComplete="postal-code"
-              defaultValue={defaultState.mailingAddress?.postalCode}
+              defaultValue={defaultState.postalCode}
               errorMessage={errors?.postalCode}
               required={mailingPostalCodeRequired}
             />
@@ -242,7 +263,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
               name="mailingProvince"
               className="w-full sm:w-1/2"
               label={t('protected-renew:update-address.address-field.province')}
-              defaultValue={defaultState.mailingAddress?.province}
+              defaultValue={defaultState.province}
               errorMessage={errors?.province}
               options={[dummyOption, ...mailingRegions]}
               required
@@ -254,7 +275,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
             className="w-full sm:w-1/2"
             label={t('protected-renew:update-address.address-field.country')}
             autoComplete="country"
-            defaultValue={defaultState.mailingAddress?.country}
+            defaultValue={defaultState.country}
             errorMessage={errors?.country}
             options={countries}
             onChange={mailingCountryChangeHandler}


### PR DESCRIPTION
### Description
per title

Will address other fallbacks in future PRs

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`