### PR TITLE
[gitops] Updating `AUTH_RAOIDC_BASE_URL` in dev

### DIFF
--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -37,7 +37,7 @@ AUTH_RASCL_LOGOUT_URL=https://cdcp-dev.dev-dp.dts-stn.com/
 # RAOIDC mock confuguration
 # replace with actual URL once RAOIDC integration is complete
 #
-AUTH_RAOIDC_BASE_URL=https://cdcp-dev.dev-dp.dts-stn.com/auth
+AUTH_RAOIDC_BASE_URL=https://cdcp-dev.dev-dp.dts-stn.com/oidc
 MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-dev.dev-dp.dts-stn.com/auth/callback/raoidc
 
 #


### PR DESCRIPTION
### Description
As per title.

`AUTH_RAOIDC_BASE_URL`  changed in #2687