### PR TITLE
use fallback state for marital status and partner information

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -56,10 +56,19 @@ export async function loader({ context: { appContainer, session }, params, reque
   const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:marital-status.page-title') }) };
 
+  const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
+  const partnerInformation = hasPartner
+    ? (state.clientApplication.partnerInformation ?? state.partnerInformation) && {
+        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.dateOfBirth,
+        socialInsuranceNumber: state.partnerInformation?.socialInsuranceNumber ?? state.clientApplication.partnerInformation?.socialInsuranceNumber,
+        confirm: state.partnerInformation?.confirm ?? state.clientApplication.partnerInformation?.confirm,
+      }
+    : undefined;
+
   return {
     defaultState: {
-      maritalStatus: state.maritalStatus,
-      ...state.partnerInformation,
+      maritalStatus: state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus,
+      partnerInformation,
     },
     maritalStatuses,
     meta,
@@ -174,12 +183,21 @@ export default function ProtectedRenewMaritalStatus() {
                 inputMode="numeric"
                 helpMessagePrimary={t('protected-renew:marital-status.help-message.sin')}
                 helpMessagePrimaryClassName="text-black"
-                defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                defaultValue={defaultState.partnerInformation?.socialInsuranceNumber ?? ''}
                 errorMessage={errors?.socialInsuranceNumber}
                 required
               />
-              <InputPatternField id="year-of-birth" name="yearOfBirth" inputMode="numeric" format="####" defaultValue={defaultState.yearOfBirth ?? ''} label={t('protected-renew:marital-status.year-of-birth')} errorMessage={errors?.yearOfBirth} required />
-              <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.confirm === true} required>
+              <InputPatternField
+                id="year-of-birth"
+                name="yearOfBirth"
+                inputMode="numeric"
+                format="####"
+                defaultValue={defaultState.partnerInformation?.yearOfBirth ?? ''}
+                label={t('protected-renew:marital-status.year-of-birth')}
+                errorMessage={errors?.yearOfBirth}
+                required
+              />
+              <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.partnerInformation?.confirm === true} required>
                 {t('protected-renew:marital-status.confirm-checkbox')}
               </InputCheckbox>
             </>

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -13,7 +13,7 @@ import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
-import { clearProtectedRenewState, getProtectedChildrenState, loadProtectedRenewStateForReview, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { clearProtectedRenewState, getProtectedChildrenState, loadProtectedRenewStateForReview, renewStateHasPartner, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { UserinfoToken } from '~/.server/utils/raoidc.utils';
@@ -97,11 +97,14 @@ export async function loader({ context: { appContainer, session }, params, reque
     communicationPreferenceEmail: state.clientApplication.communicationPreferences.email,
   };
 
-  const spouseInfo = (state.clientApplication.partnerInformation ?? state.partnerInformation) && {
-    yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.dateOfBirth,
-    sin: state.partnerInformation?.socialInsuranceNumber ?? state.clientApplication.partnerInformation?.socialInsuranceNumber,
-    consent: state.partnerInformation?.confirm ?? state.clientApplication.partnerInformation?.confirm,
-  };
+  const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
+  const spouseInfo = hasPartner
+    ? (state.clientApplication.partnerInformation ?? state.partnerInformation) && {
+        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.dateOfBirth,
+        sin: state.partnerInformation?.socialInsuranceNumber ?? state.clientApplication.partnerInformation?.socialInsuranceNumber,
+        consent: state.partnerInformation?.confirm ?? state.clientApplication.partnerInformation?.confirm,
+      }
+    : undefined;
 
   const mailingAddressInfo = {
     address: state.mailingAddress?.address ?? state.clientApplication.contactInformation.mailingAddress,


### PR DESCRIPTION
### Description
- `maritalStatus` and `partnerInformatiom` default to `clientApplication` data if it doesn't exist in state
- if `partnerInformation` isn't defined, it isn't displayed in the review information screen
- on the edit screen, if a user declares they are no longer "married" or "common law", the `partnerInformation` is wiped from state once they save the page.  If they decide to re-edit and select "married" or "common law" again, they'll have to re-enter their partner's SIN, year of birth, and consent.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`