### PR TITLE
AB#4628 Renew child confirm email

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -150,6 +150,7 @@ export const pageIds = {
         confirmFederalProvincialTerritorialBenefits: 'CDCP-RENW-CHLD-0005',
         updateFederalProvincialTerritorialBenefits: 'CDCP-RENW-CHLD-0006',
         confirmPhone: 'CDCP-RENW-CHLD-0007',
+        confirmEmail: 'CDCP-RENW-CHLD-0008',
       },
     },
     demographicSurvey: {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -167,7 +167,6 @@ export default function RenewAdultChildConfirmPhone() {
               id="is-new-or-updated-phone-number"
               name="isNewOrUpdatedPhoneNumber"
               legend={t('renew-adult-child:confirm-phone.add-or-update.legend')}
-              helpMessagePrimary={t('renew-adult-child:confirm-phone.add-or-update.help-message')}
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-phone.option-yes" />,

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -10,7 +10,7 @@ import validator from 'validator';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -45,9 +45,9 @@ enum ShouldReceiveEmailCommunicationOption {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
-  pageIdentifier: pageIds.public.renew.adultChild.confirmEmail,
-  pageTitleI18nKey: 'renew-adult-child:confirm-email.page-title',
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.confirmEmail,
+  pageTitleI18nKey: 'renew-child:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -55,10 +55,10 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const state = loadRenewAdultChildState({ params, request, session });
+  const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-email.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-email.page-title') }) };
 
   return {
     id: state.id,
@@ -79,13 +79,13 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  const state = loadRenewAdultChildState({ params, request, session });
+  const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const emailSchema = z
     .object({
       isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
-        errorMap: () => ({ message: t('renew-adult-child:confirm-email.error-message.add-or-update-required') }),
+        errorMap: () => ({ message: t('renew-child:confirm-email.error-message.add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
@@ -94,29 +94,29 @@ export async function action({ context: { appContainer, session }, params, reque
     .superRefine((val, ctx) => {
       if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
         if (!val.email) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.email-required'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.email-required'), path: ['email'] });
         }
       }
 
       if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.email-required'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.email-valid'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.email-valid'), path: ['email'] });
         }
 
         if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.confirm-email-required'), path: ['confirmEmail'] });
         } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.confirm-email-valid'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.confirm-email-valid'), path: ['confirmEmail'] });
         } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
 
       if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
         if (val.shouldReceiveEmailCommunication === undefined) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
         }
       }
     })
@@ -140,10 +140,10 @@ export async function action({ context: { appContainer, session }, params, reque
   saveRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
 
   if (state.editMode) {
-    return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
+    return redirect(getPathById('public/renew/$id/child/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
+  return redirect(getPathById('public/renew/$id/child/confirm-address', params));
 }
 
 export default function RenewAdultChildConfirmEmail() {
@@ -179,15 +179,15 @@ export default function RenewAdultChildConfirmEmail() {
           <CsrfTokenInput />
           <div className="mb-6">
             <p id="adding-email" className="mb-4">
-              {t('renew-adult-child:confirm-email.add-email')}
+              {t('renew-child:confirm-email.add-email')}
             </p>
             <InputRadios
               id="is-new-or-updated-email"
               name="isNewOrUpdatedEmail"
-              legend={t('renew-adult-child:confirm-email.add-or-update.legend')}
+              legend={t('renew-child:confirm-email.add-or-update.legend')}
               options={[
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-yes" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-yes" />,
                   value: AddOrUpdateEmailOption.Yes,
                   defaultChecked: isNewOrUpdatedEmail === true,
                   onChange: handleNewOrUpdateEmailChanged,
@@ -202,7 +202,7 @@ export default function RenewAdultChildConfirmEmail() {
                         autoComplete="email"
                         defaultValue={defaultState.email}
                         errorMessage={errors?.email}
-                        label={t('renew-adult-child:confirm-email.email')}
+                        label={t('renew-child:confirm-email.email')}
                         maxLength={64}
                         aria-describedby="adding-email"
                       />
@@ -215,7 +215,7 @@ export default function RenewAdultChildConfirmEmail() {
                         autoComplete="email"
                         defaultValue={defaultState.email}
                         errorMessage={errors?.confirmEmail}
-                        label={t('renew-adult-child:confirm-email.confirm-email')}
+                        label={t('renew-child:confirm-email.confirm-email')}
                         maxLength={64}
                         aria-describedby="adding-email"
                       />
@@ -223,7 +223,7 @@ export default function RenewAdultChildConfirmEmail() {
                   ),
                 },
                 {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-no" />,
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-no" />,
                   value: AddOrUpdateEmailOption.No,
                   defaultChecked: isNewOrUpdatedEmail === false,
                   onChange: handleNewOrUpdateEmailChanged,
@@ -238,15 +238,15 @@ export default function RenewAdultChildConfirmEmail() {
               <InputRadios
                 id="should-receive-email-communication"
                 name="shouldReceiveEmailCommunication"
-                legend={t('renew-adult-child:confirm-email.receive-comms.legend')}
+                legend={t('renew-child:confirm-email.receive-comms.legend')}
                 options={[
                   {
-                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-yes" />,
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-yes" />,
                     value: ShouldReceiveEmailCommunicationOption.Yes,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
                   },
                   {
-                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-no" />,
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-no" />,
                     value: ShouldReceiveEmailCommunicationOption.No,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
                   },
@@ -259,10 +259,10 @@ export default function RenewAdultChildConfirmEmail() {
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
-                {t('renew-adult-child:confirm-email.save-btn')}
+                {t('renew-child:confirm-email.save-btn')}
               </Button>
               <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
-                {t('renew-adult-child:confirm-email.cancel-btn')}
+                {t('renew-child:confirm-email.cancel-btn')}
               </Button>
             </div>
           ) : (
@@ -276,17 +276,17 @@ export default function RenewAdultChildConfirmEmail() {
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Contact information click"
               >
-                {t('renew-adult-child:confirm-email.continue-btn')}
+                {t('renew-child:confirm-email.continue-btn')}
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/adult-child/confirm-phone"
+                routeId="public/renew/$id/child/confirm-phone"
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Contact information click"
               >
-                {t('renew-adult-child:confirm-email.back-btn')}
+                {t('renew-child:confirm-email.back-btn')}
               </ButtonLink>
             </div>
           )}

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -166,7 +166,6 @@ export default function RenewChildConfirmPhone() {
               id="is-new-or-updated-phone-number"
               name="isNewOrUpdatedPhoneNumber"
               legend={t('renew-child:confirm-phone.add-or-update.legend')}
-              helpMessagePrimary={t('renew-child:confirm-phone.add-or-update.help-message')}
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-phone.option-yes" />,

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -632,6 +632,11 @@ export const routes = [
             file: 'routes/public/renew/$id/child/confirm-phone.tsx',
             paths: { en: '/:lang/renew/:id/child/confirm-phone', fr: '/:lang/renew/:id/enfant/confirmer-telephone' },
           },
+          {
+            id: 'public/renew/$id/child/confirm-email',
+            file: 'routes/public/renew/$id/child/confirm-email.tsx',
+            paths: { en: '/:lang/renew/:id/child/confirm-email', fr: '/:lang/renew/:id/enfant/confirmer-courriel' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -43,10 +43,9 @@
   },
   "confirm-phone": {
     "page-title": "Phone Number",
-    "add-phone": "Having an up-to-date phone number on file helps the Government of Canada contact you if there is an issue with your renewal. Otherwise, we'll contact you by mail.",
+    "add-phone": "An up-to-date phone number helps the Government of Canada contact you if there's an issue with your renewal. You can find the number we have on file in the letter from Service Canada. If you don't provide a phone number, we'll contact you by mail.",
     "add-or-update": {
-      "legend": "Would you like to update or add your phone number?",
-      "help-message": "The phone number we have on file can also be found on the renewal letter you received from Service Canada."
+      "legend": "Would you like to update or add your phone number?"
     },
     "phone-number": "Phone number",
     "phone-number-alt": "Alternate phone number (optional)",
@@ -65,10 +64,9 @@
   },
   "confirm-email": {
     "page-title": "Email",
-    "add-email": "Having an up-to-date email on file helps the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan membership.",
+    "add-email": "An up-to-date email helps the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan coverage. You can find the email we have on file in the letter from Service Canada.",
     "add-or-update": {
-      "legend": "Would you like to update or add your email address?",
-      "help-message": "The email address we have on file can also be found on the renewal letter you received from Service Canada."
+      "legend": "Would you like to update or add your email address?"
     },
     "receive-comms": {
       "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?"

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -192,10 +192,9 @@
   },
   "confirm-phone": {
     "page-title": "Phone Number",
-    "add-phone": "Having an up-to-date phone number on file helps the Government of Canada contact you if there is an issue with your renewal. Otherwise, we'll contact you by mail.",
+    "add-phone": "An up-to-date phone number helps the Government of Canada contact you if there's an issue with your renewal. You can find the number we have on file in the letter from Service Canada. If you don't provide a phone number, we'll contact you by mail.",
     "add-or-update": {
-      "legend": "Would you like to update or add your phone number?",
-      "help-message": "The phone number we have on file can also be found on the renewal letter you received from Service Canada."
+      "legend": "Would you like to update or add your phone number?"
     },
     "phone-number": "Phone number",
     "phone-number-alt": "Alternate phone number (optional)",
@@ -210,6 +209,33 @@
       "phone-number-valid": "Invalid phone number",
       "phone-number-alt-valid": "Invalid phone number",
       "phone-required": "Enter a phone number"
+    }
+  },
+  "confirm-email": {
+    "page-title": "Email",
+    "add-email": "An up-to-date email helps the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan coverage. You can find the email we have on file in the letter from Service Canada.",
+    "add-or-update": {
+      "legend": "Would you like to update or add your email address?"
+    },
+    "receive-comms": {
+      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?"
+    },
+    "email": "Email address",
+    "confirm-email": "Confirm email address",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "option-yes": "Yes",
+    "option-no": "No",
+    "error-message": {
+      "add-or-update-required": "Select whether you would like to add or update your email",
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com",
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
     }
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -43,10 +43,9 @@
   },
   "confirm-phone": {
     "page-title": "Numéro de téléphone",
-    "add-phone": "L'ajout d'un numéro de téléphone à jour au dossier aidera le gouvernement du Canada à communiquer avec vous en cas de problème lié à votre demande de renouvellement. Sinon, nous communiquerons avec vous par la poste.",
+    "add-phone": "Un numéro de téléphone à jour permet au gouvernement du Canada de communiquer avec vous en cas de problème avec votre renouvellement. Vous trouverez le numéro que nous avons en dossier dans la lettre de Service Canada. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
     "add-or-update": {
-      "legend": "Souhaitez-vous mettre à jour ou ajouter votre numéro de téléphone?",
-      "help-message": "Le numéro de téléphone que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre numéro de téléphone?"
     },
     "phone-number": "Numéro de téléphone",
     "phone-number-alt": "Autre numéro de téléphone (facultatif)",
@@ -65,7 +64,7 @@
   },
   "confirm-email": {
     "page-title": "Adresse courriel",
-    "add-email": "Adresse courriel",
+    "add-email": "Une adresse courriel à jour permet au gouvernement du Canada et à la Sun Life de communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires. Vous trouverez l'adresse courriel que nous avons dans nos dossiers dans la lettre de Service Canada.",
     "add-or-update": {
       "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
       "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -194,10 +194,9 @@
   },
   "confirm-phone": {
     "page-title": "Numéro de téléphone",
-    "add-phone": "L'ajout d'un numéro de téléphone à jour au dossier aidera le gouvernement du Canada à communiquer avec vous en cas de problème lié à votre demande de renouvellement. Sinon, nous communiquerons avec vous par la poste.",
+    "add-phone": "Un numéro de téléphone à jour permet au gouvernement du Canada de communiquer avec vous en cas de problème avec votre renouvellement. Vous trouverez le numéro que nous avons en dossier dans la lettre de Service Canada. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
     "add-or-update": {
-      "legend": "Souhaitez-vous mettre à jour ou ajouter votre numéro de téléphone?",
-      "help-message": "Le numéro de téléphone que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre numéro de téléphone?"
     },
     "phone-number": "Numéro de téléphone",
     "phone-number-alt": "Autre numéro de téléphone (facultatif)",
@@ -212,6 +211,34 @@
       "phone-number-valid": "Numéro de téléphone invalide",
       "phone-number-alt-valid": "Numéro de téléphone invalide",
       "phone-required": "Entrer un numéro de téléphone"
+    }
+  },
+  "confirm-email": {
+    "page-title": "Adresse courriel",
+    "add-email": "Une adresse courriel à jour permet au gouvernement du Canada et à la Sun Life de communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires. Vous trouverez l'adresse courriel que nous avons dans nos dossiers dans la lettre de Service Canada.",
+    "add-or-update": {
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
+      "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
+    },
+    "receive-comms": {
+      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?"
+    },
+    "email": "Adresse courriel",
+    "confirm-email": "Confirmer l'adresse courriel",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Sauvegarder",
+    "option-yes": "Oui",
+    "option-no": "Non",
+    "error-message": {
+      "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
+      "email-match": "Les adresses courriel entrées ne concordent pas",
+      "confirm-email-required": "Confirmez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
+      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
     }
   }
 }


### PR DESCRIPTION
### Description
Add `confirm-phone` screen for renew child route.
This pr also updates the `confirm-phone` and `confirm-email` in adult-child and child flow to match latest Figma design.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->