### PR TITLE
add validation and redirection in protected renew app

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -6,8 +6,7 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { TYPES } from '~/.server/constants';
-import { clearProtectedRenewState, loadProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
-import { getChildrenState } from '~/.server/routes/helpers/renew-route-helpers';
+import { clearProtectedRenewState, loadProtectedRenewState, validateProtectedChildrenStateForReview } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -64,8 +63,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     selectedProvincialBenefits: selectedProvincialBenefits?.name,
   };
 
-  const children = getChildrenState(state).map((child) => {
-    if (child.dentalInsurance === undefined || child.information === undefined) {
+  const children = validateProtectedChildrenStateForReview(state.children).map((child) => {
+    if (child.demographicSurvey === undefined || child.isParentOrLegalGuardian === undefined || child.dentalInsurance === undefined || child.information === undefined) {
       throw new Error(`Incomplete application "${state.id}" child "${child.id}" state!`);
     }
 


### PR DESCRIPTION
### Description
in the protected renew application, it's possible for clients to renew only for themselves and not their children.  This PR adds validation and redirection to handle the case where the primary applicant only renews for themself.

A future PR should handle the inverse case where a primary applicant renews for their children and not themselves.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`