### PR TITLE
Replacing content on renew index page with placeholder content

### DIFF
--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -1,19 +1,12 @@
 import { useEffect } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { redirect } from '@remix-run/node';
-import { useFetcher } from '@remix-run/react';
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { useLoaderData, useNavigate, useParams } from '@remix-run/react';
 
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { randomUUID } from 'crypto';
-import { useTranslation } from 'react-i18next';
 
-import { TYPES } from '~/.server/constants';
 import { startRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { ButtonLink } from '~/components/buttons';
-import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -24,7 +17,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew', 'gcweb'),
   pageIdentifier: pageIds.public.renew.index,
-  pageTitleI18nKey: 'renew:index.page-title',
+  pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
@@ -35,63 +28,42 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('renew:index.page-title') }) };
-
-  return { locale, meta };
-}
-
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
-  const formData = await request.formData();
-
-  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
-  securityHandler.validateCsrfToken({ formData, session });
-
   const id = randomUUID().toString();
-  startRenewState({ id, session });
+  const state = startRenewState({ id, session });
 
-  return redirect(getPathById('public/renew/$id/terms-and-conditions', { ...params, id }));
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew:terms-and-conditions.page-title') }) };
+
+  return { id: state.id, locale, meta };
 }
 
 export default function RenewIndex() {
-  const { t } = useTranslation(handle.i18nNamespaces);
+  const { id } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const navigate = useNavigate();
 
-  const fetcher = useFetcher<typeof action>();
-  const isSubmitting = fetcher.state !== 'idle';
+  const path = getPathById('public/renew/$id/terms-and-conditions', { ...params, id });
 
   useEffect(() => {
     sessionStorage.setItem('renew.state', 'active');
-  }, []);
+    navigate(path, { replace: true });
+  }, [navigate, path]);
 
   return (
-    <>
+    <div className="max-w-prose animate-pulse">
       <div className="space-y-6">
-        <section className="space-y-4">
-          <p>{t('renew:index.eligibility')}</p>
-          <ul className="list-disc space-y-1 pl-7">
-            <li>{t('renew:index.full-name')}</li>
-            <li>{t('renew:index.client-number')}</li>
-            <li>{t('renew:index.dob')}</li>
-            <li>{t('renew:index.sin')}</li>
-            <li>{t('renew:index.address')}</li>
-            <li>{t('renew:index.dental-coverage')}</li>
-          </ul>
-        </section>
-        <section className="space-y-4">
-          <h2 className="font-lato text-lg font-bold">{t('renew:index.renew-now')}</h2>
-          <p>{t('renew:index.to-apply')}</p>
-        </section>
-      </div>
-      <fetcher.Form method="post" noValidate>
-        <CsrfTokenInput />
-        <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <LoadingButton aria-describedby="application-consent" variant="green" id="continue-button" loading={isSubmitting} endIcon={faChevronRight}>
-            {t('renew:index.start-button')}
-          </LoadingButton>
-          <ButtonLink id="back-button" to={t('renew:index.apply-link')} disabled={isSubmitting} startIcon={faChevronLeft}>
-            {t('renew:index.back-button')}
-          </ButtonLink>
+        <div className="space-y-2">
+          <div className="h-5 w-full rounded bg-gray-200"></div>
+          <div className="h-5 w-full rounded bg-gray-200"></div>
+          <div className="h-5 w-2/3 rounded bg-gray-200"></div>
         </div>
-      </fetcher.Form>
-    </>
+        <div className="h-5 w-1/2 rounded bg-gray-200"></div>
+        <div className="h-5 w-1/2 rounded bg-gray-200"></div>
+      </div>
+      <div className="my-8 space-y-2">
+        <div className="h-5 w-full rounded bg-gray-200"></div>
+        <div className="h-5 w-2/3 rounded bg-gray-200"></div>
+      </div>
+      <div className="h-10 w-2/5 rounded bg-gray-200"></div>
+    </div>
   );
 }

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -5,21 +5,6 @@
   "required-label": "Complete all fields.",
   "optional-label": "Complete all fields unless marked as optional.",
   "all-optional-label": "All fields are optional.",
-  "index": {
-    "page-title": "Renew your Canadian Dental Care Plan membership",
-    "eligibility": "To renew your Canadian Dental Care Plan, you'll need to provide the following information for each applicant:",
-    "full-name": "Full name",
-    "client-number": "Client number",
-    "dob": "Date of birth",
-    "sin": "Spouse or common-law partner's Social Insurance Number (SIN) (if applicable)",
-    "address": "Home and mailing address",
-    "dental-coverage": "List of the dental coverage you currently have through government social programs (if applicable)",
-    "renew-now": "Renew now",
-    "to-apply": "To apply for the Canadian Dental Care Plan, click the button below.",
-    "start-button": "Renew now",
-    "back-button": "Back",
-    "apply-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html"
-  },
   "terms-and-conditions": {
     "page-title": "Terms and conditions",
     "page-heading": "Terms and conditions of use and privacy notice statement",

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -5,21 +5,6 @@
   "required-label": "Remplir tous les champs.",
   "optional-label": "Remplir tous les champs sauf s'ils sont indiqués facultatifs.",
   "all-optional-label": "Toutes les champs sont faculatives.",
-  "index": {
-    "page-title": "Renouvelez votre adhésion au Régime canadien de soins dentaires",
-    "eligibility": "Pour renouveler votre adhésion au Régime canadien de soins dentaires, vous devez fournir les renseignements suivants pour chaque demandeur\u00a0:",
-    "full-name": "Nom complet",
-    "client-number": "Numéro de client",
-    "dob": "Date de naissance",
-    "sin": "Numéro d'assurance sociale (NAS) de l'époux ou du conjoint de fait (le cas échéant)",
-    "address": "Adresse personnelle et adresse postale",
-    "dental-coverage": "Liste des assurances pour soins dentaires dont vous bénéficiez actuellement dans le cadre de programmes sociaux gouvernementaux (le cas échéant)",
-    "renew-now": "Renouvelez maintenant",
-    "to-apply": "Pour renouveler votre adhésion au Régime canadien de soins dentaires, cliquez sur le bouton ci-dessous.",
-    "start-button": "Renouvelez maintenant",
-    "back-button": "Retour",
-    "apply-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html"
-  },
   "terms-and-conditions": {
     "page-title": "Présentation d'une demande d'adhésion au Régime canadien de soins dentaires",
     "page-heading": "Conditions générales d'utilisation et énoncé de confidentialité",


### PR DESCRIPTION
### Description
The current `/renew` content will be displayed on Canada.ca.
This PR replaces this content with placeholder text for the Terms and Conditions page, exactly like the [`/apply` route](https://github.com/DTS-STN/canadian-dental-care-plan/blob/main/frontend/app/routes/public/apply/index.tsx).

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/2922c061-21f9-4868-afd7-8ac533bfb07a)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/renew`. You should briefly see a page that resembles the screenshot above.