### PR TITLE
AB#4627 / AB#4626 -- Added marital status pages for the renew child flow

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -151,6 +151,8 @@ export const pageIds = {
         updateFederalProvincialTerritorialBenefits: 'CDCP-RENW-CHLD-0006',
         confirmPhone: 'CDCP-RENW-CHLD-0007',
         confirmEmail: 'CDCP-RENW-CHLD-0008',
+        confirmMaritalStatus: 'CDCP-RENW-CHLD-0009',
+        maritalStatus: 'CDCP-RENW-CHLD-00010',
       },
     },
     demographicSurvey: {

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -1,0 +1,162 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum MaritalStatusRadioOptions {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.confirmMaritalStatus,
+  pageTitleI18nKey: 'renew-child:confirm-marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-marital-status.page-title') }) };
+
+  return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const confirmMaritalStatusSchema = z.object({
+    hasMaritalStatusChanged: z.boolean({
+      errorMap: () => ({ message: t('renew-child:confirm-marital-status.error-message.has-marital-status-changed-required') }),
+    }),
+  });
+
+  const parsedDataResult = confirmMaritalStatusSchema.safeParse({
+    hasMaritalStatusChanged: formData.get('hasMaritalStatusChanged') ? formData.get('hasMaritalStatusChanged') === 'yes' : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      hasMaritalStatusChanged: parsedDataResult.data.hasMaritalStatusChanged,
+      maritalStatus: undefined,
+    },
+  });
+
+  if (state.editMode) {
+    if (parsedDataResult.data.hasMaritalStatusChanged) {
+      return redirect(getPathById('public/renew/$id/child/marital-status', params));
+    }
+    return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+  }
+
+  if (parsedDataResult.data.hasMaritalStatusChanged) {
+    return redirect(getPathById('public/renew/$id/child/marital-status', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/child/confirm-phone', params));
+}
+
+export default function RenewChildConfirmMaritalStatus() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasMaritalStatusChanged: 'input-radio-has-marital-status-changed-option-0',
+  });
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={22} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-6">
+            <InputRadios
+              id="has-marital-status-changed"
+              name="hasMaritalStatusChanged"
+              legend={t('renew-child:confirm-marital-status.has-marital-status-changed')}
+              options={[
+                { value: MaritalStatusRadioOptions.Yes, children: t('renew-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
+                { value: MaritalStatusRadioOptions.No, children: t('renew-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
+              ]}
+              helpMessagePrimary={t('renew-child:confirm-marital-status.help-message')}
+              errorMessage={errors?.hasMaritalStatusChanged}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button name="_action" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Confirm marital status click">
+                {t('renew-child:marital-status.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/renew/$id/child/review-parent-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Confirm marital status click">
+                {t('marital-status.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Confirm marital status click">
+                {t('renew-child:confirm-marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/type-renewal"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Confirm marital status click"
+              >
+                {t('renew-child:confirm-marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -1,0 +1,231 @@
+import type { ChangeEventHandler } from 'react';
+import { useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import type { PartnerInformationState } from '~/.server/routes/helpers/renew-route-helpers';
+import { renewStateHasPartner, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.maritalStatus,
+  pageTitleI18nKey: 'renew-child:marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewChildState({ params, request, session });
+  if (!state.hasMaritalStatusChanged) {
+    return redirect(getPathById('public/renew/$id/child/confirm-marital-status', params));
+  }
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:marital-status.page-title') }) };
+
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // state validation schema
+  const maritalStatusSchema = z.object({
+    maritalStatus: z
+      .string({ errorMap: () => ({ message: t('renew-child:marital-status.error-message.marital-status-required') }) })
+      .trim()
+      .min(1, t('renew-child:marital-status.error-message.marital-status-required')),
+  });
+
+  const currentYear = new Date().getFullYear().toString();
+  const partnerInformationSchema = z.object({
+    confirm: z.boolean().refine((val) => val === true, t('renew-child:marital-status.error-message.confirm-required')),
+    yearOfBirth: z
+      .string()
+      .trim()
+      .min(1, t('renew-child:marital-status.error-message.date-of-birth-year-required'))
+      .refine((year) => year < currentYear, t('renew-child:marital-status.error-message.yob-is-future')),
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('renew-child:marital-status.error-message.sin-required'))
+      .refine(isValidSin, t('renew-child:marital-status.error-message.sin-valid'))
+      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-child:marital-status.error-message.sin-unique')),
+  }) satisfies z.ZodType<PartnerInformationState>;
+
+  const maritalStatusData = {
+    maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,
+  };
+  const partnerInformationData = {
+    confirm: formData.get('confirm') === 'yes',
+    yearOfBirth: String(formData.get('yearOfBirth') ?? ''),
+    socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),
+  };
+
+  const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
+  const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
+
+  if (!parsedMaritalStatus.success || (renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
+    return {
+      errors: {
+        ...(parsedMaritalStatus.error ? transformFlattenedError(parsedMaritalStatus.error.flatten()) : {}),
+        ...(parsedMaritalStatus.success && renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(parsedPartnerInformation.error.flatten()) : {}),
+      },
+    };
+  }
+
+  saveRenewState({ params, session, state: { maritalStatus: parsedMaritalStatus.data.maritalStatus, partnerInformation: parsedPartnerInformation.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/child/confirm-phone', params));
+}
+
+export default function RenewChildMaritalStatus() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const [marriedOrCommonlaw, setMarriedOrCommonlaw] = useState(defaultState.maritalStatus);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    maritalStatus: 'input-radio-marital-status-option-0',
+    yearOfBirth: 'year-of-birth',
+    socialInsuranceNumber: 'social-insurance-number',
+    confirm: 'input-checkbox-confirm',
+  });
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setMarriedOrCommonlaw(e.target.value);
+  };
+
+  const maritalStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState.maritalStatus, children: status.name, value: status.id, onChange: handleChange }));
+  }, [defaultState, maritalStatuses]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={44} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-8 space-y-6">
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('renew-child:marital-status.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+
+            {(marriedOrCommonlaw === MARITAL_STATUS_CODE_COMMONLAW.toString() || marriedOrCommonlaw === MARITAL_STATUS_CODE_MARRIED.toString()) && (
+              <>
+                <h2 className="mb-6 font-lato text-2xl font-bold">{t('renew-child:marital-status.spouse-or-commonlaw')}</h2>
+                <p className="mb-4">{t('renew-child:marital-status.provide-sin')}</p>
+                <p className="mb-6">{t('renew-child:marital-status.required-information')}</p>
+                <InputPatternField
+                  id="social-insurance-number"
+                  name="socialInsuranceNumber"
+                  format={sinInputPatternFormat}
+                  label={t('marital-status.sin')}
+                  inputMode="numeric"
+                  helpMessagePrimary={t('renew-child:marital-status.help-message.sin')}
+                  helpMessagePrimaryClassName="text-black"
+                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                  errorMessage={errors?.socialInsuranceNumber}
+                  required
+                />
+                <InputPatternField id="year-of-birth" name="yearOfBirth" inputMode="numeric" format="####" defaultValue={defaultState.yearOfBirth ?? ''} label={t('renew-child:marital-status.year-of-birth')} errorMessage={errors?.yearOfBirth} required />
+                <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.confirm === true} required>
+                  {t('renew-child:marital-status.confirm-checkbox')}
+                </InputCheckbox>
+              </>
+            )}
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Marital status click">
+                {t('renew-child:marital-status.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Marital status click">
+                {t('renew-child:marital-status.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Marital status click"
+              >
+                {t('renew-child:marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/child/confirm-marital-status"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Marital status click"
+              >
+                {t('renew-child:marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
+++ b/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
@@ -99,11 +99,11 @@ export default function RenewChildParentIntro() {
             variant="primary"
             loading={isSubmitting && submitAction === FormAction.Continue}
             endIcon={faChevronRight}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Child Application Form:Continue - Parent intro click"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Parent intro click"
           >
             {t('renew-child:parent-intro.continue-btn')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Child Application Form:Back - Parent intro click">
+          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Parent intro click">
             {t('renew-child:parent-intro.back-btn')}
           </Button>
         </div>

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -613,6 +613,16 @@ export const routes = [
             paths: { en: '/:lang/renew/:id/child/parent-intro', fr: '/:lang/renew/:id/enfant/parent-intro' },
           },
           {
+            id: 'public/renew/$id/child/confirm-marital-status',
+            file: 'routes/public/renew/$id/child/confirm-marital-status.tsx',
+            paths: { en: '/:lang/renew/:id/child/confirm-marital-status', fr: '/:lang/renew/:id/enfant/confirmer-etat-civil' },
+          },
+          {
+            id: 'public/renew/$id/child/marital-status',
+            file: 'routes/public/renew/$id/child/marital-status.tsx',
+            paths: { en: '/:lang/renew/:id/child/marital-status', fr: '/:lang/renew/:id/enfant/etat-civil' },
+          },
+          {
             id: 'public/renew/$id/child/children/$childId/dental-insurance',
             file: 'routes/public/renew/$id/child/children/$childId/dental-insurance.tsx',
             paths: { en: '/:lang/renew/:id/child/children/:childId/dental-insurance', fr: '/:lang/renew/:id/enfant/enfants/:childId/assurance-dentaire' },

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -237,5 +237,47 @@
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"
     }
+  },
+  "confirm-marital-status": {
+    "page-title": "Marital status",
+    "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
+    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "error-message": {
+      "has-marital-status-changed-required": "Please indicate if your marital status has changed"
+    }
+  },
+  "marital-status": {
+    "page-title": "Marital status",
+    "marital-status": "What is your current marital status?",
+    "spouse-or-commonlaw": "Spouse or common-law partner information",
+    "provide-sin": "Provide the Social Insurance Number (SIN) of your current spouse or common-law partner. The information is required to calculate your adjusted family net income.",
+    "required-information": "Your spouse or common-law partner must submit their own application or renewal for the Canadian Dental Care Plan.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Social Insurance Number (SIN)",
+    "year-of-birth": "Year of birth",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "help-message": {
+      "sin": "Enter the 9-digit SIN"
+    },
+    "error-message": {
+      "marital-status-required": "Select marital status",
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-year-required": "Year of birth is required",
+      "yob-is-future": "Year of birth must be in the past",
+      "sin-required": "Enter 9-digit SIN, for example 123 456 789",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -240,5 +240,47 @@
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"
     }
+  },
+  "confirm-marital-status": {
+    "page-title": "État civil",
+    "has-marital-status-changed": "Votre état civil ou votre conjoint a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
+    "help-message": "L'état civil que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Sauvegarder",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "error-message": {
+      "has-marital-status-changed-required": "Please indicate if your marital status has changed"
+    }
+  },
+  "marital-status": {
+    "page-title": "État civil",
+    "marital-status": "Quel est votre état civil actuel?",
+    "spouse-or-commonlaw": "Renseignements sur l'époux/épouse ou le conjoint/la conjointe de fait",
+    "provide-sin": "Fournissez le numéro d'assurance sociale de votre époux/épouse ou conjoint/conjointe de fait actuel(le). Ces renseignements sont nécessaires pour calculer votre revenu familial net rajusté.",
+    "required-information": "Votre époux/épouse ou conjoint/conjointe de fait doit présenter sa propre demande initiale ou demande de renouvellement au Régime canadien de soins dentaires.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "year-of-birth": "Année de naissance",
+    "confirm-checkbox": "Je confirme que mon époux/épouse ou conjoint/conjointe de fait est au courant de la communication de ses renseignements personnels et y a consenti.",
+    "help-message": {
+      "sin": "Entrez le NAS à 9 chiffres"
+    },
+    "error-message": {
+      "marital-status-required": "Sélectionnez l'état civil",
+      "confirm-required": "La case à cocher doit être sélectionnée",
+      "date-of-birth-year-required": "L'année de naissance doit être fournie",
+      "yob-is-future": "L'année de naissance doit être dans le passé",
+      "sin-required": "Entrez un NAS de 9 chiffres",
+      "sin-valid": "Doit être un NAS valide",
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+    }
   }
 }


### PR DESCRIPTION
### Description
Added the confirm-marital-status and marital-status pages for the renew child flow.

### Related Azure Boards Work Items
[AB#4627](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4627)
[AB#4626](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4626)

### Screenshots (if applicable)
![cms](https://github.com/user-attachments/assets/b8fa5fc4-1913-4073-b430-c7303a5c4fe5)
![mst](https://github.com/user-attachments/assets/92f639c1-5302-4bca-a868-5728d3081d59)
