### PR TITLE
Refactoring application year repository to accept date instead of object

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/application-year.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/application-year.repository.test.ts
@@ -73,7 +73,7 @@ describe('DefaultApplicationYearRepository', () => {
 
       const repository = new DefaultApplicationYearRepository(mockLogFactory, mockServerConfig, mockHttpClient);
 
-      const result = await repository.listApplicationYears({ currentDate: '2024-11-13' });
+      const result = await repository.listApplicationYears('2024-11-13');
       expect(result).toEqual(mockResponseData);
     });
 
@@ -88,7 +88,7 @@ describe('DefaultApplicationYearRepository', () => {
       mockHttpClient.instrumentedFetch.mockResolvedValue(Response.json(null, { status: 500 }));
 
       const repository = new DefaultApplicationYearRepository(mockLogFactory, mockServerConfig, mockHttpClient);
-      await expect(() => repository.listApplicationYears({ currentDate: '2024-11-13' })).rejects.toThrowError();
+      await expect(() => repository.listApplicationYears('2024-11-13')).rejects.toThrowError();
     });
   });
 });

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -2,8 +2,8 @@
  * Represents a Data Transfer Object (DTO) for an application year request.
  */
 export type ApplicationYearRequestDto = Readonly<{
-  /** The current date sent to get the application year(s). */
-  currentDate: string;
+  /** The date sent to get the application year(s). */
+  date: string;
 
   /** A unique identifier for the user making the request - used for auditing */
   userId: string;

--- a/frontend/app/.server/domain/entities/application-year.entity.ts
+++ b/frontend/app/.server/domain/entities/application-year.entity.ts
@@ -1,9 +1,5 @@
 import type { ReadonlyDeep } from 'type-fest';
 
-export type ApplicationYearRequestEntity = Readonly<{
-  currentDate: string;
-}>;
-
 export type ApplicationYearResultEntity = ReadonlyDeep<{
   BenefitApplicationYear: {
     BenefitApplicationYearIdentification: {

--- a/frontend/app/.server/domain/repositories/application-year.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-year.repository.ts
@@ -2,18 +2,18 @@ import { inject, injectable } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { ApplicationYearRequestEntity, ApplicationYearResultEntity } from '~/.server/domain/entities';
+import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 import type { LogFactory, Logger } from '~/.server/factories';
 import type { HttpClient } from '~/.server/http';
 
 export interface ApplicationYearRepository {
   /**
-   * Returns possible application years given the current date in 'applicationYearRequestEntity'.
+   * Returns all application year entities given a date
    *
    * @param applicationYearRequestEntity The request entity object containing the current date.
-   * @returns A promise that resolves to a `ApplicationYearResultEntity` object containing the possible application years.
+   * @returns A promise that resolves to a `ApplicationYearResultEntity` object containing all application years.
    */
-  listApplicationYears(applicationYearRequestEntity: ApplicationYearRequestEntity): Promise<ApplicationYearResultEntity>;
+  listApplicationYears(date: string): Promise<ApplicationYearResultEntity>;
 }
 
 @injectable()
@@ -28,11 +28,11 @@ export class DefaultApplicationYearRepository implements ApplicationYearReposito
     this.log = logFactory.createLogger('DefaultApplicationYearRepository');
   }
 
-  async listApplicationYears(applicationYearRequestEntity: ApplicationYearRequestEntity): Promise<ApplicationYearResultEntity> {
-    this.log.trace('Getting possible application year dates given applicationYearRequest: [%j]', applicationYearRequestEntity);
+  async listApplicationYears(date: string): Promise<ApplicationYearResultEntity> {
+    this.log.trace('Fetching all application year entities for date: [%s]', date);
 
     const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/retrieve-benefit-application-config-dates`);
-    url.searchParams.set('date', applicationYearRequestEntity.currentDate);
+    url.searchParams.set('date', date);
 
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.retrieve-benefit-application-config-dates.gets', url, {
       proxyUrl: this.serverConfig.HTTP_PROXY_URL,
@@ -70,8 +70,8 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
     this.log = logFactory.createLogger('MockApplicationYearRepository');
   }
 
-  listApplicationYears(applicationYearRequestEntity: ApplicationYearRequestEntity): Promise<ApplicationYearResultEntity> {
-    this.log.debug('Fetching all application years for request [%j]', applicationYearRequestEntity);
+  listApplicationYears(date: string): Promise<ApplicationYearResultEntity> {
+    this.log.debug('Fetching all application year entities for date: [%s]', date);
 
     const applicationYearResponseEntity: ApplicationYearResultEntity = {
       BenefitApplicationYear: [

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -35,7 +35,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
 
     this.auditService.createAudit('application-year.get-application-year-result', { userId: applicationYearRequestDto.userId });
 
-    const applicationYearResultEntity = await this.applicationYearRepository.listApplicationYears(applicationYearRequestDto);
+    const applicationYearResultEntity = await this.applicationYearRepository.listApplicationYears(applicationYearRequestDto.date);
     const applicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDto(applicationYearResultEntity);
 
     this.log.trace('Returning possible application years result: [%j]', applicationYearResultDto);

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -33,7 +33,7 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const id = randomUUID().toString();
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
-  const applicationYears = await applicationYearService.listApplicationYears({ currentDate, userId: 'anonymous' });
+  const applicationYears = await applicationYearService.listApplicationYears({ date: currentDate, userId: 'anonymous' });
   const state = startApplyState({ id, session, applicationYears });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:index.page-title') }) };


### PR DESCRIPTION
### Description
As per title (to keep future PRs for displaying year in frontend small)

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`