### PR TITLE
add validation and redirection for adult only renewal behind msca

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -344,7 +344,6 @@ export function loadProtectedRenewSingleChildState({ params, session }: LoadProt
 
 interface LoadProtectedRenewStateForReviewArgs {
   params: Params;
-  request: Request;
   session: Session;
 }
 
@@ -367,6 +366,10 @@ export function loadProtectedRenewStateForReview({ params, session }: LoadProtec
   }
 }
 
+export function isPrimaryApplicantStateComplete(state: ProtectedRenewState) {
+  return state.dentalInsurance !== undefined && state.demographicSurvey !== undefined;
+}
+
 interface ValidateProtectedRenewStateForReviewArgs {
   params: Params;
   state: ProtectedRenewState;
@@ -375,15 +378,14 @@ interface ValidateProtectedRenewStateForReviewArgs {
 export function validateProtectedRenewStateForReview({ params, state }: ValidateProtectedRenewStateForReviewArgs) {
   const { maritalStatus, partnerInformation, mailingAddress, homeAddress, addressInformation, clientApplication, contactInformation, communicationPreferences, editMode, id, dentalBenefits, dentalInsurance, demographicSurvey } = state;
 
-  if (dentalInsurance === undefined) {
-    throw redirect(getPathById('protected/renew/$id/dental-insurance', params));
-  }
-
-  if (demographicSurvey === undefined) {
-    throw redirect(getPathById('protected/renew/$id/demographic-survey', params));
-  }
-
   const children = validateProtectedChildrenStateForReview(state.children);
+
+  if (!isPrimaryApplicantStateComplete(state)) {
+    if (children.length === 0) {
+      throw redirect(getPathById('protected/renew/$id/member-selection', params));
+    }
+    throw redirect(getPathById('protected/renew/$id/review-child-information', params));
+  }
 
   return {
     maritalStatus,

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -72,7 +72,7 @@ export interface ProtectedRenewState {
   contactInformation?: ProtectedContactInformationState;
   demographicSurvey?: ProtectedDemographicSurveyState;
   dentalBenefits?: ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
-  dentalInsurance: boolean;
+  dentalInsurance?: boolean;
   maritalStatus?: string;
   partnerInformation?: ProtectedPartnerInformationState;
 }

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -49,7 +49,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const state = loadProtectedRenewStateForReview({ params, request, session });
+  const state = loadProtectedRenewStateForReview({ params, session });
 
   // renew state is valid then edit mode can be set to true
   saveProtectedRenewState({ params, session, state: { editMode: true } });
@@ -200,7 +200,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
   invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
-  const state = loadProtectedRenewStateForReview({ params, request, session });
+  const state = loadProtectedRenewStateForReview({ params, session });
 
   if (validateProtectedChildrenStateForReview(state.children).length === 0) {
     const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapProtectedRenewStateToProtectedBenefitRenewalDto(state, userInfoToken.sub);


### PR DESCRIPTION
### Description
Similar to #2744, this PR handles the case where the primary applicant only applies for themself when they have children on file, but choose not to renew for them.

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`