### PR TITLE
add prefer not to answer button to protected renew demographic survey

### DIFF
--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -156,7 +156,7 @@ export default function ProtectedChildrenDemographicSurveyQuestions() {
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
     indigenousStatus: 'input-radio-indigenous-status-option-0-label',
-    firstNations: 'input-checkbox-first-nations-option-0-label',
+    firstNations: 'input-radio-first-nations-option-0-label',
     disabilityStatus: 'input-radio-disability-status-option-0-label',
     ethnicGroups: 'input-checkboxes-ethnic-groups',
     anotherEthnicGroup: 'another-ethnic-group',
@@ -214,11 +214,17 @@ export default function ProtectedChildrenDemographicSurveyQuestions() {
   return (
     <>
       <div className="max-w-prose">
-        <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
           <div className="mb-8 space-y-6">
+            <p>{t('protected-renew:demographic-survey.improve-cdcp')}</p>
+            <p>{t('protected-renew:demographic-survey.confidential')}</p>
+            <p>{t('protected-renew:demographic-survey.impact-enrollment')}</p>
+            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application:Prefer not to answer - Demographic survey click">
+              {t('protected-renew:demographic-survey.prefer-not-to-answer-btn')}
+            </Button>
+            <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
             <InputRadios id="indigenous-status" name="indigenousStatus" legend={t('protected-renew:demographic-survey.indigenous-status')} options={indigenousStatusOptions} errorMessage={errors?.indigenousStatus} required />
             <InputRadios id="disability-status" name="disabilityStatus" legend={t('protected-renew:demographic-survey.disability-status')} options={disabilityStatusOptions} errorMessage={errors?.disabilityStatus} required />
             <InputCheckboxes id="ethnic-groups" name="ethnicGroups" legend={t('protected-renew:demographic-survey.ethnic-groups')} options={ethnicGroupOptions} errorMessage={errors?.ethnicGroups} required />

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -152,7 +152,7 @@ export default function ProtectedDemographicSurveyQuestions() {
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
     indigenousStatus: 'input-radio-indigenous-status-option-0-label',
-    firstNations: 'input-checkbox-first-nations-option-0-label',
+    firstNations: 'input-radio-first-nations-option-0-label',
     disabilityStatus: 'input-radio-disability-status-option-0-label',
     ethnicGroups: 'input-checkboxes-ethnic-groups',
     anotherEthnicGroup: 'another-ethnic-group',
@@ -210,23 +210,28 @@ export default function ProtectedDemographicSurveyQuestions() {
   return (
     <>
       <div className="max-w-prose">
-        <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
           <div className="mb-8 space-y-6">
+            <p>{t('protected-renew:demographic-survey.improve-cdcp')}</p>
+            <p>{t('protected-renew:demographic-survey.confidential')}</p>
+            <p>{t('protected-renew:demographic-survey.impact-enrollment')}</p>
+            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application:Prefer not to answer - Demographic survey click">
+              {t('protected-renew:demographic-survey.prefer-not-to-answer-btn')}
+            </Button>
+            <p className="mb-4 italic">{t('protected-renew:demographic-survey.optional')}</p>
             <InputRadios id="indigenous-status" name="indigenousStatus" legend={t('protected-renew:demographic-survey.indigenous-status')} options={indigenousStatusOptions} errorMessage={errors?.indigenousStatus} required />
             <InputRadios id="disability-status" name="disabilityStatus" legend={t('protected-renew:demographic-survey.disability-status')} options={disabilityStatusOptions} errorMessage={errors?.disabilityStatus} required />
             <InputCheckboxes id="ethnic-groups" name="ethnicGroups" legend={t('protected-renew:demographic-survey.ethnic-groups')} options={ethnicGroupOptions} errorMessage={errors?.ethnicGroups} required />
             <InputRadios id="location-born-status" name="locationBornStatus" legend={t('protected-renew:demographic-survey.location-born-status')} options={locationBornStatusOptions} errorMessage={errors?.locationBornStatus} required />
             <InputRadios id="gender-status" name="genderStatus" legend={t('protected-renew:demographic-survey.gender-status')} options={genderStatusOptions} errorMessage={errors?.genderStatus} required />
           </div>
-
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental insurance click">
-                {t('protected-renew:demographic-survey.save-btn')}
-              </Button>
+              <LoadingButton id="prefer-not-to-answer-button" variant="alternative" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Demographic Survey:Save - Questions click">
+                {t('protected-renew:demographic-survey.continue-btn')}
+              </LoadingButton>
               <ButtonLink
                 id="back-button"
                 routeId="protected/renew/$id/review-adult-information"

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -162,6 +162,10 @@
   },
   "demographic-survey": {
     "page-title": "Voluntary demographic questions for {{memberName}}",
+    "improve-cdcp": "Answering these questions is optional. Your answers will help Health Canada improve the Canadian Dental Care Plan and make sure our services are accessible to everyone.",
+    "confidential": "The information collected will only be used for statistical purposes and will be kept confidential.",
+    "impact-enrollment": "Your completion of the demographic questions will not impact your enrolment in the Canadian Dental Care Plan.",
+    "prefer-not-to-answer-btn": "Prefer not to answer",
     "optional": "All questions are optional.",
     "indigenous-status": "Is this person First Nations, Métis or Inuk (Inuit)?",
     "disability-status": "Does this person have a disability?",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -162,6 +162,10 @@
   },
   "demographic-survey": {
     "page-title": "Voluntary demographic questions for {{memberName}}",
+    "improve-cdcp": "La réponse à ces questions est facultative. Vos réponses aideront Santé Canada à améliorer le Régime canadien de soins dentaires et à s'assurer que nos services sont accessibles à tous.",
+    "confidential": "Les renseignements recueillis ne serviront qu'à des fins statistiques et resteront confidentiels.",
+    "impact-enrollment": "Le fait de répondre aux questions d'ordre démographique n'aura pas d'incidence sur votre adhésion au Régime canadien de soins dentaires.",
+    "prefer-not-to-answer-btn": "Sauter les questions d'ordre démographique",
     "optional": "All questions are optional.",
     "indigenous-status": "Is this person First Nations, Métis or Inuk (Inuit)?",
     "disability-status": "Does this person have a disability?",


### PR DESCRIPTION
### Description
adds the "prefer not to answer" button to the demographic survey in the protected renew app.

I will add this to the public facing app in a future PR.  

### Related Azure Boards Work Items
[AB#4822](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4822)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`