### PR TITLE
Adding `findRenewalApplicationYear` service method with corresponding DTO and mapper

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { ApplicationYearRequestDto, ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
+import type { ApplicationYearDtoMapper } from '~/.server/domain/mappers';
+import type { ApplicationYearRepository } from '~/.server/domain/repositories';
+import { DefaultApplicationYearService } from '~/.server/domain/services';
+import type { AuditService } from '~/.server/domain/services';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+describe('DefaultApplicationYearService', () => {
+  const mockLogFactory = mock<LogFactory>();
+  mockLogFactory.createLogger.mockReturnValue(mock<Logger>());
+
+  const mockApplicationYearResultDtos: ApplicationYearResultDto[] = [
+    {
+      // all fields set
+      id: '1',
+      applicationYear: '2024',
+      taxYear: '2024',
+      coverageStartDate: '2024-01-01',
+      coverageEndDate: '2024-12-31',
+      intakeStartDate: '2024-01-01',
+      intakeEndDate: '2024-12-31',
+      renewalStartDate: '2024-01-01',
+      renewalEndDate: '2024-12-31',
+    },
+    {
+      // optional dates not set
+      id: '2',
+      applicationYear: '2025',
+      taxYear: '2025',
+      coverageStartDate: '2025-01-01',
+      coverageEndDate: '2025-12-31',
+      intakeStartDate: '2025-01-01',
+    },
+    {
+      // optional end dates not set
+      id: '3',
+      applicationYear: '2026',
+      taxYear: '2026',
+      coverageStartDate: '2026-01-01',
+      coverageEndDate: '2026-12-31',
+      intakeStartDate: '2026-01-01',
+      renewalStartDate: '2026-01-01',
+    },
+  ];
+
+  const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = {
+    id: '1',
+    taxYear: '2024',
+    coverageStartDate: '2024-01-01',
+    coverageEndDate: '2024-12-31',
+  };
+  const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
+  mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
+  mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
+
+  const mockApplicationYearResultEntity: ApplicationYearResultEntity = {
+    BenefitApplicationYear: [
+      {
+        BenefitApplicationYearIdentification: [{ IdentificationID: '1' }],
+        BenefitApplicationYearEffectivePeriod: {
+          StartDate: { YearDate: '2024' },
+        },
+        BenefitApplicationYearTaxYear: { YearDate: '2024' },
+        BenefitApplicationYearIntakePeriod: {
+          StartDate: { date: '2024-01-01' },
+          EndDate: { date: '2024-12-31' },
+        },
+        BenefitApplicationYearRenewalPeriod: {
+          StartDate: { date: '2024-01-01' },
+          EndDate: { date: '2024-12-31' },
+        },
+        BenefitApplicationYearNext: {
+          BenefitApplicationYearIdentification: { IdentificationID: '1' },
+        },
+        BenefitApplicationYearCoveragePeriod: {
+          StartDate: { date: '2024-01-01' },
+          EndDate: { date: '2024-12-31' },
+        },
+      },
+    ],
+  };
+  const mockApplicationYearRepository = mock<ApplicationYearRepository>();
+  mockApplicationYearRepository.listApplicationYears.mockResolvedValue(mockApplicationYearResultEntity);
+
+  describe('findRenewalApplicationYear', () => {
+    it('should return the correct renewal application year if given date is within a renewal period', async () => {
+      const mockAuditService = mock<AuditService>();
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
+        date: '2024-01-01',
+        userId: 'userId',
+      };
+
+      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      expect(result).toEqual(mockRenewalApplicationYearResultDto);
+    });
+
+    it('should return the correct renewal application year when the given date is on or after the renewal start date and no renewal end date is provided', async () => {
+      const mockAuditService = mock<AuditService>();
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
+        date: '2026-01-01',
+        userId: 'userId',
+      };
+
+      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      expect(result).toEqual(mockRenewalApplicationYearResultDto);
+    });
+
+    it('should return null if given date is not within any renewal period', async () => {
+      const mockAuditService = mock<AuditService>();
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
+        date: '2025-01-01',
+        userId: 'userId',
+      };
+
+      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -2,7 +2,7 @@
  * Represents a Data Transfer Object (DTO) for an application year request.
  */
 export type ApplicationYearRequestDto = Readonly<{
-  /** The date sent to get the application year(s). */
+  /** The date sent to get the application year(s) in ISO 8601 format (e.g., "2024-12-25"). */
   date: string;
 
   /** A unique identifier for the user making the request - used for auditing */
@@ -23,3 +23,13 @@ export type ApplicationYearResultDto = Readonly<{
   coverageStartDate: string;
   coverageEndDate: string;
 }>;
+
+/**
+ * Represents a Data Transfer Object (DTO) for a renewal application year result.
+ */
+export type RenewalApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate'>;
+
+/**
+ * Represents a Data Transfer Object (DTO) for an intake application year result.
+ */
+export type IntakeApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate' | 'coverageStartDate' | 'coverageEndDate'>;

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -1,15 +1,26 @@
 import { injectable } from 'inversify';
 
-import type { ApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 
 export interface ApplicationYearDtoMapper {
-  mapApplicationYearResultEntityToApplicationYearResultDto(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto>;
+  mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto>;
+
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): RenewalApplicationYearResultDto;
 }
 
 @injectable()
 export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper {
-  mapApplicationYearResultEntityToApplicationYearResultDto(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto> {
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): RenewalApplicationYearResultDto {
+    return {
+      id: applicationYearResultDto.id,
+      taxYear: applicationYearResultDto.taxYear,
+      coverageStartDate: applicationYearResultDto.coverageStartDate,
+      coverageEndDate: applicationYearResultDto.coverageEndDate,
+    };
+  }
+
+  mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto> {
     const applicationYearData = applicationYearResultEntity['BenefitApplicationYear'];
 
     const applicationYears = applicationYearData.map((applicationYear) => ({

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -1,13 +1,22 @@
 import { inject, injectable } from 'inversify';
 
 import { TYPES } from '~/.server/constants';
-import type { ApplicationYearRequestDto, ApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearRequestDto, ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearDtoMapper } from '~/.server/domain/mappers';
 import type { ApplicationYearRepository } from '~/.server/domain/repositories';
 import type { AuditService } from '~/.server/domain/services';
 import type { LogFactory, Logger } from '~/.server/factories';
 
 export interface ApplicationYearService {
+  /**
+   * Fetches the renewal application year DTO using the data passed in the `ApplicationYearRequest` object.
+   *
+   * @param applicationYearRequestDto The request DTO object containing the current date and user id
+   * @returns A promise that resolves to a `RenewalApplicationYearResultDto` object containing the renewal application year result DTO
+   *   or `null` if no matching renewal application year is found.
+   */
+  findRenewalApplicationYear(applicationYearRequestDto: ApplicationYearRequestDto): Promise<RenewalApplicationYearResultDto | null>;
+
   /**
    * fetches possible application year(s) using the data passed in the `ApplicationYearRequest` object.
    *
@@ -30,13 +39,44 @@ export class DefaultApplicationYearService implements ApplicationYearService {
     this.log = logFactory.createLogger('DefaultApplicationYearService');
   }
 
+  async findRenewalApplicationYear(applicationYearRequestDto: ApplicationYearRequestDto): Promise<RenewalApplicationYearResultDto | null> {
+    this.log.trace('Finding renewal application year results with applicationYearRequest: [%j]', applicationYearRequestDto);
+
+    this.auditService.createAudit('application-year.find-renewal-application-year', { userId: applicationYearRequestDto.userId });
+
+    const applicationYearResultDtos = await this.listApplicationYears(applicationYearRequestDto);
+
+    const matchingRenewalApplicationYear = applicationYearResultDtos.find((applicationYear) => {
+      const { renewalStartDate, renewalEndDate } = applicationYear;
+      const requestDate = new Date(applicationYearRequestDto.date);
+
+      const startDate = renewalStartDate ? new Date(renewalStartDate) : null;
+      const endDate = renewalEndDate ? new Date(renewalEndDate) : null;
+
+      // Determine if the request date falls within the renewal period;
+      // Treat end date as open-ended (they represent an indefinite period)
+      if (!startDate) return false;
+      return requestDate >= startDate && (!endDate || requestDate <= endDate);
+    });
+
+    if (!matchingRenewalApplicationYear) {
+      this.log.info('No matching renewal application year found for date: [%s]', applicationYearRequestDto.date);
+      return null;
+    }
+
+    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto(matchingRenewalApplicationYear);
+
+    this.log.trace('Returning renewal application year result: [%j]', renewalApplicationYearResultDto);
+    return renewalApplicationYearResultDto;
+  }
+
   async listApplicationYears(applicationYearRequestDto: ApplicationYearRequestDto): Promise<ReadonlyArray<ApplicationYearResultDto>> {
     this.log.trace('Getting possible application years results with applicationYearRequest: [%j]', applicationYearRequestDto);
 
     this.auditService.createAudit('application-year.get-application-year-result', { userId: applicationYearRequestDto.userId });
 
     const applicationYearResultEntity = await this.applicationYearRepository.listApplicationYears(applicationYearRequestDto.date);
-    const applicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDto(applicationYearResultEntity);
+    const applicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity);
 
     this.log.trace('Returning possible application years result: [%j]', applicationYearResultDto);
     return applicationYearResultDto;


### PR DESCRIPTION
### Description
Introduce `findRenewalApplicationYear` service method that will be used at the beginning of the renewal flow and saved in state. The service returns a `RenewalApplicationYearResultDto`, which consists of:
-  `id`: passed in the request to Interop to submit a renewal
- `taxYear`: displayed on the renewal Tax Filing routes
- `coverageStartDate`: used to determine whether a child is eligible for renewal

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
Future PR will be created to call this service from the appropriate renew routes as well as introduce a service method for the online intake application application year details.