### PR TITLE
Adding address correction to update-home-address

### DIFF
--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -1,11 +1,13 @@
+import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { data, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import validator from 'validator';
 import { z } from 'zod';
 
@@ -16,14 +18,18 @@ import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/.server/utils/postal-zip-code.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
+import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
+import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -32,6 +38,35 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { isAllValidInputCharacters } from '~/utils/string-utils';
+
+enum FormAction {
+  Submit = 'submit',
+  UseInvalidAddress = 'use-invalid-address',
+  UseSelectedAddress = 'use-selected-address',
+}
+
+interface CanadianAddress {
+  address: string;
+  city: string;
+  country: string;
+  countryId: string;
+  postalZipCode: string;
+  provinceState: string;
+  provinceStateId: string;
+}
+
+interface AddressSuggestionResponse {
+  enteredAddress: CanadianAddress;
+  status: 'address-suggestion';
+  suggestedAddress: CanadianAddress;
+}
+
+interface AddressInvalidResponse {
+  invalidAddress: CanadianAddress;
+  status: 'address-invalid';
+}
+
+type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -65,10 +100,16 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
   const formData = await request.formData();
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const locale = getLocale(request);
 
+  const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
+  const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
+  const countryService = appContainer.get(TYPES.domain.services.CountryService);
+  const provinceTerritoryStateService = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService);
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
-  securityHandler.validateCsrfToken({ formData, session });
 
+  securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
@@ -128,14 +169,74 @@ export async function action({ context: { appContainer, session }, params, reque
   if (!parsedDataResult.success) {
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
+  const isNotCanada = parsedDataResult.data.country !== clientConfig.CANADA_COUNTRY_ID;
+  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
+  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
+  if (canProceedToDental) {
+    saveRenewState({ params, session, state: { homeAddress: parsedDataResult.data } });
 
+    if (state.editMode) {
+      return redirect(getPathById('public/renew/$id/ita/review-information', params));
+    }
+    return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
+  }
+
+  invariant(parsedDataResult.data.postalCode, 'Postal zip code is required for Canadian addresses');
+  invariant(parsedDataResult.data.province, 'Province state is required for Canadian addresses');
+
+  // Build the address object using validated data, transforming unique identifiers
+  const formattedHomeAddress: CanadianAddress = {
+    address: parsedDataResult.data.address,
+    city: parsedDataResult.data.city,
+    countryId: parsedDataResult.data.country,
+    country: countryService.getLocalizedCountryById(parsedDataResult.data.country, locale).name,
+    postalZipCode: parsedDataResult.data.postalCode,
+    provinceStateId: parsedDataResult.data.province,
+    provinceState: parsedDataResult.data.province && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.province, locale).abbr,
+  };
+
+  const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
+    address: formattedHomeAddress.address,
+    city: formattedHomeAddress.city,
+    postalCode: formattedHomeAddress.postalZipCode,
+    provinceCode: formattedHomeAddress.provinceState,
+    userId: 'anonymous',
+  });
+
+  if (addressCorrectionResult.status === 'not-correct') {
+    return {
+      invalidAddress: formattedHomeAddress,
+      status: 'address-invalid',
+    } as const satisfies AddressInvalidResponse;
+  }
+
+  if (addressCorrectionResult.status === 'corrected') {
+    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    return {
+      enteredAddress: formattedHomeAddress,
+      status: 'address-suggestion',
+      suggestedAddress: {
+        address: addressCorrectionResult.address,
+        city: addressCorrectionResult.city,
+        country: formattedHomeAddress.country,
+        countryId: formattedHomeAddress.countryId,
+        postalZipCode: addressCorrectionResult.postalCode,
+        provinceState: provinceTerritoryState.abbr,
+        provinceStateId: provinceTerritoryState.id,
+      },
+    } as const satisfies AddressSuggestionResponse;
+  }
   saveRenewState({ params, session, state: { homeAddress: parsedDataResult.data } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/ita/review-information', params));
   }
-
   return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
+}
+
+function isAddressResponse(data: unknown): data is AddressResponse {
+  return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
 export default function RenewItaUpdateAddress() {
@@ -147,8 +248,9 @@ export default function RenewItaUpdateAddress() {
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);
   const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
+  const [addressDialogContent, setAddressDialogContent] = useState<AddressResponse | null>(null);
 
-  const errors = fetcher.data?.errors;
+  const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
   const errorSummary = useErrorSummary(errors, {
     address: 'home-address',
     province: 'home-province',
@@ -157,27 +259,33 @@ export default function RenewItaUpdateAddress() {
     postalCode: 'home-postal-code',
   });
 
-  const countries = useMemo<InputOptionProps[]>(() => {
-    return countryList.map(({ id, name }) => ({ children: name, value: id }));
-  }, [countryList]);
-
   useEffect(() => {
     const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedHomeCountry);
     setHomeCountryRegions(filteredProvinceTerritoryStates);
   }, [selectedHomeCountry, regionList]);
 
+  useEffect(() => {
+    setAddressDialogContent(isAddressResponse(fetcher.data) ? fetcher.data : null);
+  }, [fetcher, fetcher.data]);
+
+  function onDialogOpenChangeHandler(open: boolean) {
+    if (!open) {
+      setAddressDialogContent(null);
+    }
+  }
   const homeCountryChangeHandler = (event: React.SyntheticEvent<HTMLSelectElement>) => {
     setSelectedHomeCountry(event.currentTarget.value);
   };
 
-  // populate home region/province/state list with selected country or current address country
-  const homeRegions: InputOptionProps[] = homeCountryRegions.map(({ id, name }) => ({ children: name, value: id }));
+  const countries = useMemo<InputOptionProps[]>(() => {
+    return countryList.map(({ id, name }) => ({ children: name, value: id }));
+  }, [countryList]);
+
+  const homeRegions = useMemo<InputOptionProps[]>(() => homeCountryRegions.map(({ id, name }) => ({ children: name, value: id })), [homeCountryRegions]);
 
   const dummyOption: InputOptionProps = { children: t('renew-ita:update-address.address-field.select-one'), value: '' };
 
-  const postalCodeRequiredContries = [CANADA_COUNTRY_ID, USA_COUNTRY_ID];
-  const homePostalCodeRequired = postalCodeRequiredContries.includes(selectedHomeCountry);
-
+  const isPostalCodeRequired = [CANADA_COUNTRY_ID, USA_COUNTRY_ID].includes(selectedHomeCountry);
   return (
     <>
       <div className="my-6 sm:my-8">
@@ -221,12 +329,12 @@ export default function RenewItaUpdateAddress() {
                     id="home-postal-code"
                     name="homePostalCode"
                     className="w-full"
-                    label={homePostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
+                    label={isPostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
                     maxLength={100}
                     autoComplete="postal-code"
                     defaultValue={defaultState.homeAddress?.postalCode ?? ''}
                     errorMessage={errors?.postalCode}
-                    required={homePostalCodeRequired}
+                    required={isPostalCodeRequired}
                   />
                 </div>
                 {homeRegions.length > 0 && (
@@ -267,9 +375,24 @@ export default function RenewItaUpdateAddress() {
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Update address click">
-                {t('renew-ita:update-address.continue')}
-              </LoadingButton>
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FormAction.Submit}
+                    loading={isSubmitting}
+                    endIcon={faChevronRight}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Update home address click"
+                  >
+                    {t('renew-ita:update-address.continue')}
+                  </LoadingButton>
+                </DialogTrigger>
+                {addressDialogContent && addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
+                {addressDialogContent && addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+              </Dialog>
               <ButtonLink
                 id="back-button"
                 routeId={defaultState.hasAddressChanged ? `public/renew/$id/ita/update-mailing-address` : `public/renew/$id/ita/confirm-address`}
@@ -285,5 +408,144 @@ export default function RenewItaUpdateAddress() {
         </fetcher.Form>
       </div>
     </>
+  );
+}
+
+interface AddressSuggestionDialogContentProps {
+  enteredAddress: CanadianAddress;
+  suggestedAddress: CanadianAddress;
+}
+
+function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+  const enteredAddressOptionValue = 'entered-address';
+  const suggestedAddressOptionValue = 'suggested-address';
+  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
+  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
+    formData.set('homeAddress', selectedAddressSuggestion.address);
+    formData.set('homeCity', selectedAddressSuggestion.city);
+    formData.set('homeCountry', selectedAddressSuggestion.countryId);
+    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
+    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-ita:update-address.dialog.address-suggestion.header')}</DialogTitle>
+        <DialogDescription>{t('renew-ita:update-address.dialog.address-suggestion.description')}</DialogDescription>
+      </DialogHeader>
+      <InputRadios
+        id="addressSelection"
+        name="addressSelection"
+        legend={t('renew-ita:update-address.dialog.address-suggestion.address-selection-legend')}
+        options={[
+          {
+            value: enteredAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <Address address={enteredAddress} />
+              </>
+            ),
+          },
+          {
+            value: suggestedAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <Address address={suggestedAddress} />
+              </>
+            ),
+          },
+        ].map((option) => ({
+          ...option,
+          onChange: (e) => {
+            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
+          },
+          checked: option.value === selectedAddressSuggestionOption,
+        }))}
+      />
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
+            {t('renew-ita:update-address.dialog.address-suggestion.cancel-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-ita:update-address.dialog.address-suggestion.use-selected-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+interface AddressInvalidDialogContentProps {
+  invalidAddress: CanadianAddress;
+}
+
+function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    formData.set('homeAddress', invalidAddress.address);
+    formData.set('homeCity', invalidAddress.city);
+    formData.set('homeCountry', invalidAddress.countryId);
+    formData.set('homePostalCode', invalidAddress.postalZipCode);
+    formData.set('homeProvince', invalidAddress.provinceStateId);
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-ita:update-address.dialog.address-invalid.header')}</DialogTitle>
+        <DialogDescription>{t('renew-ita:update-address.dialog.address-invalid.description')}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <p className="font-semibold">{t('renew-ita:update-address.dialog.address-invalid.entered-address')}</p>
+        <Address address={invalidAddress} />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
+            {t('renew-ita:update-address.dialog.address-invalid.close-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-ita:update-address.dialog.address-invalid.use-entered-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
   );
 }


### PR DESCRIPTION
### Description
Validation is not replaced yet. This is just for the correction.


### Related Azure Boards Work Items
[AB#4921](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4921)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Go to `/renew`
- Go through the flow and manually switch the url to be in `/ita/` flow
- Select `no` to `Do you want to update your mailing address?` and `no` for `is your home address the same?`
