### PR TITLE
Adding renewal application year details into state object

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -14,6 +14,11 @@ import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
 export interface RenewState {
   readonly id: string;
   readonly editMode: boolean;
+  readonly applicationYear: {
+    id: string;
+    taxYear: string;
+    coverageStartDate: string;
+  };
   readonly applicantInformation?: {
     firstName: string;
     lastName: string;
@@ -140,6 +145,7 @@ export interface RenewState {
   // TODO Add remaining states
 }
 
+export type ApplicationYearState = RenewState['applicationYear'];
 export type ChildState = RenewState['children'][number];
 export type ApplicantInformationState = NonNullable<RenewState['applicantInformation']>;
 export type TypeOfRenewalState = NonNullable<RenewState['typeOfRenewal']>;
@@ -249,6 +255,7 @@ export function clearRenewState({ params, session }: ClearStateArgs) {
 }
 
 interface StartArgs {
+  applicationYear: ApplicationYearState;
   id: string;
   session: Session;
 }
@@ -258,13 +265,14 @@ interface StartArgs {
  * @param args - The arguments.
  * @returns The initial Renew state.
  */
-export function startRenewState({ id, session }: StartArgs) {
+export function startRenewState({ applicationYear, id, session }: StartArgs) {
   const log = getLogger('renew-route-helpers.server/startRenewState');
   const parsedId = idSchema.parse(id);
 
   const initialState: RenewState = {
     id: parsedId,
     editMode: false,
+    applicationYear,
     children: [],
   };
 


### PR DESCRIPTION
### Description
Incremental PR that depends on #2758.

For public renewal, if renewal application year details cannot be found (ie. if current date is outside the renewal period), redirect to the online intake form.

For protected renewal, throw exception for that scenario until we introduce the protected apply flow.

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/cfbba8a3-82fb-4174-a65d-ea3fabd6baa6)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and navigate to `/en/renew`. `trace` logs should indicate that the application year service being called.