### PR TITLE
AB#4953 Remove confirmDentalBenefits state and reference

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -168,6 +168,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         dentalInsurance: true,
         hasAddressChanged: true,
         hasMaritalStatusChanged: true,
+        hasFederalProvincialTerritorialBenefitsChanged: true,
         maritalStatus: 'Single',
       };
 
@@ -240,7 +241,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           genderStatus: 'Male',
           locationBornStatus: 'Outside Canada',
         },
-        dentalBenefits: ['New federal program', 'Original provincial benefit'],
+        dentalBenefits: ['New federal program'],
         dentalInsurance: true,
         partnerInformation: undefined,
         typeOfApplication: 'adult-child',

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -205,7 +205,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           hasEmailChanged: true,
           hasMaritalStatusChanged: true,
           hasPhoneChanged: true,
-          hasFederalProvincialTerritorialBenefitsChanged: false,
+          hasFederalProvincialTerritorialBenefitsChanged: true,
         },
         children: [
           {

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -122,10 +122,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         children: [
           {
             id: '1',
-            confirmDentalBenefits: {
-              federalBenefitsChanged: true,
-              provincialTerritorialBenefitsChanged: true,
-            },
             demographicSurvey: {
               disabilityStatus: 'Disability status placeholder',
               ethnicGroups: ['Group 1', 'Group 2'],
@@ -150,10 +146,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           },
         ],
         clientApplication: mockClientApplication,
-        confirmDentalBenefits: {
-          federalBenefitsChanged: true,
-          provincialTerritorialBenefitsChanged: false,
-        },
         contactInformation: {
           email: 'new@example.com',
           phoneNumber: '555-555-1234',
@@ -213,8 +205,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           hasEmailChanged: true,
           hasMaritalStatusChanged: true,
           hasPhoneChanged: true,
-          hasFederalBenefitsChanged: true,
-          hasProvincialTerritorialBenefitsChanged: false,
+          hasFederalProvincialTerritorialBenefitsChanged: false,
         },
         children: [
           {

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -10,8 +10,7 @@ export type AdultChildChangeIndicators = Readonly<{
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
   hasPhoneChanged: boolean;
-  hasFederalBenefitsChanged: boolean;
-  hasProvincialTerritorialBenefitsChanged: boolean;
+  hasFederalProvincialTerritorialBenefitsChanged: boolean;
 }>;
 
 export type ItaBenefitRenewalDto = BenefitRenewalDto &

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -185,7 +185,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       EmailChangedIndicator: hasEmailChanged,
       MaritalStatusChangedIndicator: hasMaritalStatusChanged,
       PhoneChangedIndicator: hasPhoneChanged,
-      PublicInsuranceChangedIndicator: !!hasFederalProvincialTerritorialBenefitsChanged,
+      PublicInsuranceChangedIndicator: hasFederalProvincialTerritorialBenefitsChanged,
     };
   }
 

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -56,10 +56,9 @@ interface ToAddressArgs {
 interface ToChangeIndicatorsArgs {
   hasAddressChanged?: boolean;
   hasEmailChanged?: boolean;
-  hasFederalBenefitsChanged?: boolean;
   hasMaritalStatusChanged?: boolean;
   hasPhoneChanged?: boolean;
-  hasProvincialTerritorialBenefitsChanged?: boolean;
+  hasFederalProvincialTerritorialBenefitsChanged?: boolean;
 }
 
 interface ToEmailAddressArgs {
@@ -180,13 +179,13 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       return {};
     }
 
-    const { hasAddressChanged, hasEmailChanged, hasFederalBenefitsChanged, hasMaritalStatusChanged, hasPhoneChanged, hasProvincialTerritorialBenefitsChanged } = changeIndicators;
+    const { hasAddressChanged, hasEmailChanged, hasMaritalStatusChanged, hasPhoneChanged, hasFederalProvincialTerritorialBenefitsChanged } = changeIndicators;
     return {
       AddressChangedIndicator: hasAddressChanged,
       EmailChangedIndicator: hasEmailChanged,
       MaritalStatusChangedIndicator: hasMaritalStatusChanged,
       PhoneChangedIndicator: hasPhoneChanged,
-      PublicInsuranceChangedIndicator: !!hasFederalBenefitsChanged || !!hasProvincialTerritorialBenefitsChanged,
+      PublicInsuranceChangedIndicator: !!hasFederalProvincialTerritorialBenefitsChanged,
     };
   }
 

--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -138,7 +138,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     dentalBenefits,
     dentalInsurance,
     demographicSurvey,
-    federalProvincialTerritorialBenefitsChanged,
+    hasFederalProvincialTerritorialBenefitsChanged,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -189,11 +189,11 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/renew/$id/adult-child/dental-insurance', params));
   }
 
-  if (federalProvincialTerritorialBenefitsChanged === undefined) {
+  if (hasFederalProvincialTerritorialBenefitsChanged === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
   }
 
-  if (federalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
+  if (hasFederalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
   }
 
@@ -216,7 +216,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     children,
     hasAddressChanged,
     demographicSurvey,
-    federalProvincialTerritorialBenefitsChanged,
+    hasFederalProvincialTerritorialBenefitsChanged,
   };
 }
 
@@ -232,7 +232,7 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
     throw redirect(getPathById('public/renew/$id/adult-child/children/index', params));
   }
 
-  return children.map(({ id, dentalBenefits, dentalInsurance, information, demographicSurvey, federalProvincialTerritorialBenefitsChanged }) => {
+  return children.map(({ id, dentalBenefits, dentalInsurance, information, demographicSurvey, hasFederalProvincialTerritorialBenefitsChanged }) => {
     const childId = id;
 
     if (information === undefined) {
@@ -247,11 +247,11 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/dental-insurance', { ...params, childId }));
     }
 
-    if (federalProvincialTerritorialBenefitsChanged === undefined) {
+    if (hasFederalProvincialTerritorialBenefitsChanged === undefined) {
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
-    if (federalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
+    if (hasFederalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
@@ -261,7 +261,7 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
       dentalInsurance,
       information,
       demographicSurvey,
-      federalProvincialTerritorialBenefitsChanged,
+      hasFederalProvincialTerritorialBenefitsChanged,
     };
   });
 }

--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -136,9 +136,9 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     applicantInformation,
     clientApplication,
     dentalBenefits,
-    confirmDentalBenefits,
     dentalInsurance,
     demographicSurvey,
+    federalProvincialTerritorialBenefitsChanged,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -189,11 +189,11 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/renew/$id/adult-child/dental-insurance', params));
   }
 
-  if (confirmDentalBenefits === undefined) {
+  if (federalProvincialTerritorialBenefitsChanged === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
   }
 
-  if ((confirmDentalBenefits.federalBenefitsChanged || confirmDentalBenefits.provincialTerritorialBenefitsChanged) && dentalBenefits === undefined) {
+  if (federalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
     throw redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
   }
 
@@ -210,13 +210,13 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     contactInformation,
     applicantInformation,
     dentalBenefits,
-    confirmDentalBenefits,
     dentalInsurance,
     addressInformation,
     partnerInformation,
     children,
     hasAddressChanged,
     demographicSurvey,
+    federalProvincialTerritorialBenefitsChanged,
   };
 }
 
@@ -232,7 +232,7 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
     throw redirect(getPathById('public/renew/$id/adult-child/children/index', params));
   }
 
-  return children.map(({ id, confirmDentalBenefits, dentalBenefits, dentalInsurance, information, demographicSurvey }) => {
+  return children.map(({ id, dentalBenefits, dentalInsurance, information, demographicSurvey, federalProvincialTerritorialBenefitsChanged }) => {
     const childId = id;
 
     if (information === undefined) {
@@ -247,21 +247,21 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/dental-insurance', { ...params, childId }));
     }
 
-    if (confirmDentalBenefits === undefined) {
+    if (federalProvincialTerritorialBenefitsChanged === undefined) {
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
-    if ((confirmDentalBenefits.federalBenefitsChanged || confirmDentalBenefits.provincialTerritorialBenefitsChanged) && dentalBenefits === undefined) {
+    if (federalProvincialTerritorialBenefitsChanged && dentalBenefits === undefined) {
       throw redirect(getPathById('public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
     return {
       id,
-      confirmDentalBenefits,
       dentalBenefits,
       dentalInsurance,
       information,
       demographicSurvey,
+      federalProvincialTerritorialBenefitsChanged,
     };
   });
 }

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -30,7 +30,7 @@ export interface RenewState {
       provincialTerritorialSocialProgram?: string;
       province?: string;
     };
-    readonly federalProvincialTerritorialBenefitsChanged?: boolean;
+    readonly hasFederalProvincialTerritorialBenefitsChanged?: boolean;
     readonly dentalInsurance?: boolean;
     readonly information?: {
       firstName: string;
@@ -98,7 +98,7 @@ export interface RenewState {
     province?: string;
   };
   readonly dentalInsurance?: boolean;
-  readonly federalProvincialTerritorialBenefitsChanged?: boolean;
+  readonly hasFederalProvincialTerritorialBenefitsChanged?: boolean;
   readonly dentalBenefits?: {
     hasFederalBenefits: boolean;
     federalSocialProgram?: string;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -30,10 +30,6 @@ export interface RenewState {
       provincialTerritorialSocialProgram?: string;
       province?: string;
     };
-    readonly confirmDentalBenefits?: {
-      federalBenefitsChanged: boolean;
-      provincialTerritorialBenefitsChanged: boolean;
-    };
     readonly federalProvincialTerritorialBenefitsChanged?: boolean;
     readonly dentalInsurance?: boolean;
     readonly information?: {
@@ -110,10 +106,6 @@ export interface RenewState {
     provincialTerritorialSocialProgram?: string;
     province?: string;
   };
-  readonly confirmDentalBenefits?: {
-    federalBenefitsChanged: boolean;
-    provincialTerritorialBenefitsChanged: boolean;
-  };
   readonly typeOfRenewal?: 'adult-child' | 'child' | 'delegate';
   readonly submissionInfo?: {
     /**
@@ -149,7 +141,6 @@ export type MailingAddressState = NonNullable<RenewState['mailingAddress']>;
 export type HomeAddressState = NonNullable<RenewState['homeAddress']>;
 export type DentalFederalBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
 export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<RenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
-export type ConfirmDentalBenefitsState = NonNullable<RenewState['confirmDentalBenefits']>;
 export type ContactInformationState = NonNullable<RenewState['contactInformation']>;
 export type DemographicSurveyState = NonNullable<RenewState['demographicSurvey']>;
 

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -41,6 +41,7 @@ export interface RenewAdultChildState {
   hasMaritalStatusChanged: boolean;
   maritalStatus?: string;
   partnerInformation?: PartnerInformationState;
+  hasFederalProvincialTerritorialBenefitsChanged: boolean;
 }
 
 export interface RenewItaState {
@@ -132,6 +133,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     hasMaritalStatusChanged,
     maritalStatus,
     partnerInformation,
+    hasFederalProvincialTerritorialBenefitsChanged,
   }: RenewAdultChildState): AdultChildBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
@@ -159,7 +161,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         hasMaritalStatusChanged,
         hasPhoneChanged,
-        hasFederalProvincialTerritorialBenefitsChanged: !!dentalBenefits,
+        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
       },
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
@@ -178,7 +180,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: !!dentalBenefits,
+        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
         renewedDentalBenefits: dentalBenefits,
       }),
       dentalInsurance,
@@ -405,20 +407,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
 
     if (renewedDentalBenefits.hasFederalBenefits && renewedDentalBenefits.federalSocialProgram && !validator.isEmpty(renewedDentalBenefits.federalSocialProgram)) {
       dentalBenefits.push(renewedDentalBenefits.federalSocialProgram);
-    } else {
-      const federalGovernmentInsurancePlans = this.federalGovernmentInsurancePlanService.listFederalGovernmentInsurancePlans();
-      const existingFederalGovernmentInsurancePlan = federalGovernmentInsurancePlans.filter((plan) => existingDentalBenefits.includes(plan.id)).map((plan) => plan.id);
-
-      dentalBenefits.push(...existingFederalGovernmentInsurancePlan);
     }
 
     if (renewedDentalBenefits.hasProvincialTerritorialBenefits && renewedDentalBenefits.provincialTerritorialSocialProgram && !validator.isEmpty(renewedDentalBenefits.provincialTerritorialSocialProgram)) {
       dentalBenefits.push(renewedDentalBenefits.provincialTerritorialSocialProgram);
-    } else {
-      const provincialGovernmentInsurancePlans = this.provincialGovernmentInsurancePlanService.listProvincialGovernmentInsurancePlans();
-      const existingProvincialGovernmentInsurancePlan = provincialGovernmentInsurancePlans.filter((plan) => existingDentalBenefits.includes(plan.id)).map((plan) => plan.id);
-
-      dentalBenefits.push(...existingProvincialGovernmentInsurancePlan);
     }
 
     return dentalBenefits;

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 
   return {
-    defaultState: state.federalProvincialTerritorialBenefitsChanged,
+    defaultState: state.hasFederalProvincialTerritorialBenefitsChanged,
     childName,
     editMode: state.editMode,
     meta,
@@ -71,11 +71,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const dentalBenefitsChangedSchema = z.object({
-    federalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
+    hasFederalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });
 
   const dentalBenefits = {
-    federalProvincialTerritorialBenefitsChanged: formData.get('federalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -96,13 +96,13 @@ export async function action({ context: { appContainer, session }, params, reque
         if (child.id !== state.id) return child;
         return {
           ...child,
-          federalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.federalProvincialTerritorialBenefitsChanged,
+          hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
         };
       }),
     },
   });
 
-  if (dentalBenefits.federalProvincialTerritorialBenefitsChanged) {
+  if (dentalBenefits.hasFederalProvincialTerritorialBenefitsChanged) {
     return redirect(getPathById('public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits', params));
   }
 
@@ -123,7 +123,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    federalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
+    hasFederalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
@@ -162,7 +162,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
               ]}
-              errorMessage={errors?.federalProvincialTerritorialBenefitsChanged}
+              errorMessage={errors?.hasFederalProvincialTerritorialBenefitsChanged}
               required
             />
           </fieldset>

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -75,7 +75,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const dentalBenefits = {
-    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -146,7 +146,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           <fieldset className="mb-6">
             <InputRadios
               id="federal-provincial-territorial-benefits-changed"
-              name="federalProvincialTerritorialBenefitsChanged"
+              name="hasFederalProvincialTerritorialBenefitsChanged"
               legend={t('renew-adult-child:children.confirm-dental-benefits.has-benefits-changed', { childName })}
               options={[
                 {

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -87,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.federalProvincialTerritorialBenefitsChanged) {
+    if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -87,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.confirmDentalBenefits?.federalBenefitsChanged || state.confirmDentalBenefits?.provincialTerritorialBenefitsChanged) {
+    if (state.federalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -132,7 +132,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           <fieldset className="mb-6">
             <InputRadios
               id="federal-provincial-territorial-benefits-changed"
-              name="federalProvincialTerritorialBenefitsChanged"
+              name="hasFederalProvincialTerritorialBenefitsChanged"
               legend={t('renew-adult-child:confirm-dental-benefits.has-benefits')}
               options={[
                 {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-dental-benefits.title') }) };
 
   return {
-    defaultState: state.federalProvincialTerritorialBenefitsChanged,
+    defaultState: state.hasFederalProvincialTerritorialBenefitsChanged,
     editMode: state.editMode,
     meta,
   };
@@ -64,11 +64,11 @@ export async function action({ context: { appContainer, session }, params, reque
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const dentalBenefitsChangedSchema = z.object({
-    federalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
+    hasFederalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });
 
   const dentalBenefits = {
-    federalProvincialTerritorialBenefitsChanged: formData.get('federalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -85,11 +85,11 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      federalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.federalProvincialTerritorialBenefitsChanged,
+      hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
     },
   });
 
-  if (dentalBenefits.federalProvincialTerritorialBenefitsChanged) {
+  if (dentalBenefits.hasFederalProvincialTerritorialBenefitsChanged) {
     return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
   }
 
@@ -110,7 +110,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    federalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
+    hasFederalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
@@ -148,7 +148,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
               ]}
-              errorMessage={errors?.federalProvincialTerritorialBenefitsChanged}
+              errorMessage={errors?.hasFederalProvincialTerritorialBenefitsChanged}
               required
             />
           </fieldset>

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -116,7 +116,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
 
   const dentalBenefit = {
-    hasChanged: state.federalProvincialTerritorialBenefitsChanged,
+    hasChanged: state.hasFederalProvincialTerritorialBenefitsChanged,
     federalBenefit: {
       access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -116,7 +116,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
 
   const dentalBenefit = {
-    hasChanged: state.confirmDentalBenefits.federalBenefitsChanged || state.confirmDentalBenefits.provincialTerritorialBenefitsChanged,
+    hasChanged: state.federalProvincialTerritorialBenefitsChanged,
     federalBenefit: {
       access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -88,7 +88,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       isParent: child.information.isParent,
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
-        hasChanged: child.confirmDentalBenefits.federalBenefitsChanged || child.confirmDentalBenefits.provincialTerritorialBenefitsChanged,
+        hasChanged: child.federalProvincialTerritorialBenefitsChanged,
         federalBenefit: {
           access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectedFederalGovernmentInsurancePlan?.name,

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -88,7 +88,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       isParent: child.information.isParent,
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
-        hasChanged: child.federalProvincialTerritorialBenefitsChanged,
+        hasChanged: child.hasFederalProvincialTerritorialBenefitsChanged,
         federalBenefit: {
           access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectedFederalGovernmentInsurancePlan?.name,

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -71,11 +71,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const dentalBenefitsChangedSchema = z.object({
-    federalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
+    hasFederalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });
 
   const dentalBenefits = {
-    federalProvincialTerritorialBenefitsChanged: formData.get('federalProvincialTerritorialBenefitsChanged') ? formData.get('federalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -96,13 +96,13 @@ export async function action({ context: { appContainer, session }, params, reque
         if (child.id !== state.id) return child;
         return {
           ...child,
-          federalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.federalProvincialTerritorialBenefitsChanged,
+          hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
         };
       }),
     },
   });
 
-  if (dentalBenefits.federalProvincialTerritorialBenefitsChanged) {
+  if (dentalBenefits.hasFederalProvincialTerritorialBenefitsChanged) {
     return redirect(getPathById('public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits', params));
   }
 
@@ -123,7 +123,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
-    federalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
+    hasFederalProvincialTerritorialBenefitsChanged: 'input-radio-federal-provincial-territorial-benefits-changed-option-0',
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
@@ -146,7 +146,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           <fieldset className="mb-6">
             <InputRadios
               id="federal-provincial-territorial-benefits-changed"
-              name="federalProvincialTerritorialBenefitsChanged"
+              name="hasFederalProvincialTerritorialBenefitsChanged"
               legend={t('renew-child:children.confirm-dental-benefits.has-benefits-changed', { childName })}
               options={[
                 {
@@ -162,7 +162,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
               ]}
-              errorMessage={errors?.federalProvincialTerritorialBenefitsChanged}
+              errorMessage={errors?.hasFederalProvincialTerritorialBenefitsChanged}
               required
             />
           </fieldset>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 
   return {
-    defaultState: state.federalProvincialTerritorialBenefitsChanged,
+    defaultState: state.hasFederalProvincialTerritorialBenefitsChanged,
     childName,
     editMode: state.editMode,
     meta,

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -87,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.confirmDentalBenefits?.federalBenefitsChanged || state.confirmDentalBenefits?.provincialTerritorialBenefitsChanged) {
+    if (state.federalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/child/update-federal-provincial-territorial-benefits', params));
     }
     return redirect(getPathById('public/renew/$id/child/confirm-federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -87,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.federalProvincialTerritorialBenefitsChanged) {
+    if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/child/update-federal-provincial-territorial-benefits', params));
     }
     return redirect(getPathById('public/renew/$id/child/confirm-federal-provincial-territorial-benefits', params));


### PR DESCRIPTION
### Description
In the latest Figma design, the federal, provincial and territorial page have combined 2 questions into 1. In my previous pr #2738, I've updated the screens to reflect the latest design. This pr is to remove the `confirmDentalBenefits` state and reference, and refactore the dto mappers. The changes have been applied to both public and protected renew flow.

### Related Azure Boards Work Items
[AB#4953](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4953)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->