### PR TITLE
Added renew child address confirm/mailing/home pages

### DIFF
--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -72,6 +72,7 @@ import type { HttpClient } from '~/.server/http';
 import type { InstrumentationService } from '~/.server/observability';
 import type { BenefitApplicationStateMapper, BenefitRenewalStateMapper } from '~/.server/routes/mappers';
 import type { MailingAddressValidatorFactory } from '~/.server/routes/public/address-validation';
+import type { MailingAddressValidatorFactoryChild } from '~/.server/routes/public/renew/child';
 import type { MailingAddressValidatorFactoryIta } from '~/.server/routes/public/renew/ita';
 import type { SecurityHandler } from '~/.server/routes/security';
 import type { AddressValidatorFactory } from '~/.server/routes/validators';
@@ -232,6 +233,9 @@ export const TYPES = assignServiceIdentifiers({
       renew: {
         ita: {
           MailingAddressValidatorFactoryIta: serviceId<MailingAddressValidatorFactoryIta>(),
+        },
+        child: {
+          MailingAddressValidatorFactoryChild: serviceId<MailingAddressValidatorFactoryChild>(),
         },
       },
     },

--- a/frontend/app/.server/container-modules/factories.container-module.ts
+++ b/frontend/app/.server/container-modules/factories.container-module.ts
@@ -3,6 +3,7 @@ import { ContainerModule } from 'inversify';
 import { TYPES } from '~/.server/constants';
 import { DefaultConfigFactory, DefaultLogFactory } from '~/.server/factories';
 import { DefaultMailingAddressValidatorFactory } from '~/.server/routes/public/address-validation/mailing-address.validator.factory';
+import { DefaultMailingAddressValidatorFactoryChild } from '~/.server/routes/public/renew/child/mailing-address.validator.factory';
 import { DefaultMailingAddressValidatorFactoryIta } from '~/.server/routes/public/renew/ita/mailing-address.validator.factory';
 import { DefaultAddressValidatorFactory } from '~/.server/routes/validators';
 
@@ -13,6 +14,7 @@ export const factoriesContainerModule = new ContainerModule((bind) => {
   bind(TYPES.domain.services.ConfigFactory).to(DefaultConfigFactory);
   bind(TYPES.factories.LogFactory).to(DefaultLogFactory);
   bind(TYPES.routes.public.addressValidation.MailingAddressValidatorFactory).to(DefaultMailingAddressValidatorFactory);
+  bind(TYPES.routes.public.renew.child.MailingAddressValidatorFactoryChild).to(DefaultMailingAddressValidatorFactoryChild);
   bind(TYPES.routes.public.renew.ita.MailingAddressValidatorFactoryIta).to(DefaultMailingAddressValidatorFactoryIta);
   bind(TYPES.routes.validators.AddressValidatorFactory).to(DefaultAddressValidatorFactory);
 });

--- a/frontend/app/.server/routes/public/renew/child/index.ts
+++ b/frontend/app/.server/routes/public/renew/child/index.ts
@@ -1,0 +1,2 @@
+export * from './mailing-address.validator';
+export * from './mailing-address.validator.factory';

--- a/frontend/app/.server/routes/public/renew/child/mailing-address.validator.factory.ts
+++ b/frontend/app/.server/routes/public/renew/child/mailing-address.validator.factory.ts
@@ -1,0 +1,52 @@
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import { TYPES } from '~/.server/constants';
+import type { LogFactory, Logger } from '~/.server/factories';
+import { DefaultMailingAddressValidatorChild } from '~/.server/routes/public/renew/child/mailing-address.validator';
+import type { MailingAddressValidatorChild } from '~/.server/routes/public/renew/child/mailing-address.validator';
+import type { AddressValidatorFactory } from '~/.server/routes/validators/';
+
+/**
+ * Factory interface for creating mailing address validators.
+ */
+export interface MailingAddressValidatorFactoryChild {
+  /**
+   * Creates a new mailing address validator for the given locale.
+   * @param locale The locale to use for validation.
+   * @returns A new mailing address validator.
+   */
+  createMailingAddressValidator(locale: AppLocale): MailingAddressValidatorChild;
+}
+
+@injectable()
+export class DefaultMailingAddressValidatorFactoryChild implements MailingAddressValidatorFactoryChild {
+  private readonly log: Logger;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.routes.validators.AddressValidatorFactory) private readonly addressValidatorFactory: AddressValidatorFactory,
+  ) {
+    this.log = logFactory.createLogger(this.constructor.name);
+    this.init();
+  }
+
+  private init() {
+    this.createMailingAddressValidator = moize(this.createMailingAddressValidator, {
+      maxSize: Infinity,
+      onCacheAdd: (cache) => {
+        this.log.info('Creating new createMailingAddressValidator memo; cache.key: %s', [...cache.keys].shift());
+      },
+    });
+
+    this.log.debug('%s initiated.', this.constructor.name);
+  }
+
+  /**
+   * Memoizes the creation of mailing address validators to reduce the number of times i18next files are read.
+   * Each locale will have its own memoized validator.
+   */
+  createMailingAddressValidator(locale: AppLocale): MailingAddressValidatorChild {
+    return new DefaultMailingAddressValidatorChild(locale, this.addressValidatorFactory);
+  }
+}

--- a/frontend/app/.server/routes/public/renew/child/mailing-address.validator.ts
+++ b/frontend/app/.server/routes/public/renew/child/mailing-address.validator.ts
@@ -1,0 +1,56 @@
+import type { Address, AddressValidatorErrorMessages, AddressValidatorFactory } from '~/.server/routes/validators/';
+import type { InvalidResult, ValidResult } from '~/.server/routes/validators/types.validator';
+import { getFixedT } from '~/.server/utils/locale.utils';
+
+/**
+ * Interface for a mailing address validator.
+ */
+export interface MailingAddressValidatorChild {
+  /**
+   * Validates a mailing address.
+   * @param data The address data to validate.
+   * @returns A promise that resolves to either a valid or invalid result.
+   */
+  validateMailingAddress(data: Partial<Address>): Promise<InvalidResult<Address> | ValidResult<Address>>;
+}
+
+export class DefaultMailingAddressValidatorChild implements MailingAddressValidatorChild {
+  constructor(
+    private readonly locale: AppLocale,
+    private readonly addressValidatorFactory: AddressValidatorFactory,
+  ) {}
+
+  async validateMailingAddress(data: Partial<Address>): Promise<InvalidResult<Address> | ValidResult<Address>> {
+    const errorMessages = await this.buildMailingAddressSchemaErrorMessages();
+    const addressValidator = this.addressValidatorFactory.createAddressValidator(errorMessages);
+    return addressValidator.validateAddress(data);
+  }
+
+  private async buildMailingAddressSchemaErrorMessages(): Promise<AddressValidatorErrorMessages> {
+    const t = await getFixedT(this.locale, ['renew-child']);
+    return {
+      address: {
+        invalidCharacters: t('renew-child:update-address.error-message.characters-valid'),
+        required: t('renew-child:update-address.error-message.mailing-address.address-required'),
+      },
+      city: {
+        required: t('renew-child:update-address.error-message.mailing-address.city-required'),
+        invalidCharacters: t('renew-child:update-address.error-message.characters-valid'),
+      },
+      country: {
+        required: t('renew-child:update-address.error-message.mailing-address.country-required'),
+      },
+      provinceState: {
+        required: t('renew-child:update-address.error-message.mailing-address.province-required'),
+      },
+      postalZipCode: {
+        invalidCharacters: t('renew-child:update-address.error-message.characters-valid'),
+        invalidPostalCode: t('renew-child:update-address.error-message.mailing-address.postal-code-valid'),
+        invalidPostalCodeForProvince: t('renew-child:update-address.error-message.mailing-address.invalid-postal-code-for-province'),
+        invalidPostalZipCodeForCountry: t('renew-child:update-address.error-message.mailing-address.invalid-postal-code-for-country'),
+        invalidZipCode: t('renew-child:update-address.error-message.mailing-address.zip-code-valid'),
+        required: t('renew-child:update-address.error-message.mailing-address.postal-code-required'),
+      },
+    };
+  }
+}

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -153,6 +153,8 @@ export const pageIds = {
         confirmEmail: 'CDCP-RENW-CHLD-0008',
         confirmMaritalStatus: 'CDCP-RENW-CHLD-0009',
         maritalStatus: 'CDCP-RENW-CHLD-00010',
+        confirmAddress: 'CDCP-RENW-CHLD-0011',
+        updateAddress: 'CDCP-RENW-ITA-00012',
       },
     },
     demographicSurvey: {

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -1,0 +1,166 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+enum AddressRadioOptions {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.confirmAddress,
+  pageTitleI18nKey: 'renew-child:confirm-address.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-address.page-title') }) };
+
+  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const confirmAddressSchema = z.object({
+    hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+      errorMap: () => ({ message: t('renew-child:confirm-address.error-message.has-address-changed-required') }),
+    }),
+  });
+
+  const parsedDataResult = confirmAddressSchema.safeParse({
+    hasAddressChanged: formData.get('hasAddressChanged'),
+    isHomeAddressSameAsMailingAddress: formData.get('isHomeAddressSameAsMailingAddress') ?? '',
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
+      addressInformation: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.addressInformation,
+    },
+  });
+
+  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes) {
+    return redirect(getPathById('public/renew/$id/child/update-mailing-address', params));
+  }
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+  }
+  return redirect(getPathById('public/renew/$id/child/review-child-information', params));
+}
+
+export default function RenewChildConfirmAddress() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasAddressChanged: 'input-radio-has-address-changed-option-0',
+  });
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={22} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="space-y-6">
+            <InputRadios
+              id="has-address-changed"
+              name="hasAddressChanged"
+              legend={t('renew-child:confirm-address.have-you-moved')}
+              options={[
+                { value: AddressRadioOptions.Yes, children: t('renew-child:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
+                { value: AddressRadioOptions.No, children: t('renew-child:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
+              ]}
+              helpMessagePrimary={t('renew-child:confirm-address.help-message')}
+              errorMessage={errors?.hasAddressChanged}
+              required
+            />
+          </div>
+
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Confirm address click">
+                {t('renew-child:confirm-address.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Confirm address click">
+                {t('renew-child:confirm-address.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Confirm address click">
+                {t('renew-child:confirm-address.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/child/confirm-email"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Confirm address click"
+              >
+                {t('renew-child:confirm-address.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -1,0 +1,550 @@
+import type { SyntheticEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faCheck, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import validator from 'validator';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import type { HomeAddressState } from '~/.server/routes/helpers/renew-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/.server/utils/postal-zip-code.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Address } from '~/components/address';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { useErrorSummary } from '~/components/error-summary';
+import type { InputOptionProps } from '~/components/input-option';
+import { InputRadios } from '~/components/input-radios';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+import { InputSelect } from '~/components/input-select';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { useEnhancedFetcher } from '~/hooks';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
+
+enum FormAction {
+  Submit = 'submit',
+  UseInvalidAddress = 'use-invalid-address',
+  UseSelectedAddress = 'use-selected-address',
+}
+
+interface CanadianAddress {
+  address: string;
+  city: string;
+  country: string;
+  countryId: string;
+  postalZipCode: string;
+  provinceState: string;
+  provinceStateId: string;
+}
+
+interface AddressSuggestionResponse {
+  enteredAddress: CanadianAddress;
+  status: 'address-suggestion';
+  suggestedAddress: CanadianAddress;
+}
+
+interface AddressInvalidResponse {
+  invalidAddress: CanadianAddress;
+  status: 'address-invalid';
+}
+
+type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.updateAddress,
+  pageTitleI18nKey: 'renew-child:update-address.home-address.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.home-address.page-title') }) };
+
+  return {
+    id: state.id,
+    meta,
+    defaultState: state,
+    countryList,
+    regionList,
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const locale = getLocale(request);
+
+  const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
+  const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
+  const countryService = appContainer.get(TYPES.domain.services.CountryService);
+  const provinceTerritoryStateService = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService);
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
+
+  const homeAddressSchema = z
+    .object({
+      address: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-child:update-address.error-message.characters-valid')),
+      country: z.string().trim(),
+      province: z.string().trim().optional(),
+      city: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-child:update-address.error-message.characters-valid')),
+      postalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-child:update-address.error-message.characters-valid')).optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (!val.address || validator.isEmpty(val.address)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.address-required'), path: ['address'] });
+      }
+
+      if (!val.country || validator.isEmpty(val.country)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.country-required'), path: ['country'] });
+      }
+
+      if (!val.city || validator.isEmpty(val.city)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.city-required'), path: ['city'] });
+      }
+
+      if (val.country === CANADA_COUNTRY_ID || val.country === USA_COUNTRY_ID) {
+        if (!val.province || validator.isEmpty(val.province)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.province-required'), path: ['province'] });
+        }
+        if (!val.postalCode || validator.isEmpty(val.postalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.postal-code-required'), path: ['postalCode'] });
+        } else if (!isValidPostalCode(val.country, val.postalCode)) {
+          const message = val.country === CANADA_COUNTRY_ID ? t('renew-child:update-address.error-message.home-address.postal-code-valid') : t('renew-child:update-address.error-message.home-address.zip-code-valid');
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['postalCode'] });
+        } else if (val.country === CANADA_COUNTRY_ID && val.province && !isValidCanadianPostalCode(val.province, val.postalCode)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.invalid-postal-code-for-province'), path: ['postalCode'] });
+        }
+      }
+
+      if (val.country && val.country !== CANADA_COUNTRY_ID && val.postalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.postalCode)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:update-address.error-message.home-address.invalid-postal-code-for-country'), path: ['country'] });
+      }
+    })
+    .transform((val) => ({
+      ...val,
+      postalCode: val.country && val.postalCode ? formatPostalCode(val.country, val.postalCode) : val.postalCode,
+    })) satisfies z.ZodType<HomeAddressState>;
+
+  const parsedDataResult = homeAddressSchema.safeParse({
+    address: String(formData.get('homeAddress')),
+    country: String(formData.get('homeCountry')),
+    province: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
+    city: String(formData.get('homeCity')),
+    postalCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+  const isNotCanada = parsedDataResult.data.country !== clientConfig.CANADA_COUNTRY_ID;
+  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
+  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const canProceedToReviewChild = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
+  if (canProceedToReviewChild) {
+    saveRenewState({ params, session, state: { homeAddress: parsedDataResult.data } });
+
+    if (state.editMode) {
+      return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+    }
+    return redirect(getPathById('public/renew/$id/child/review-child-information', params));
+  }
+
+  invariant(parsedDataResult.data.postalCode, 'Postal zip code is required for Canadian addresses');
+  invariant(parsedDataResult.data.province, 'Province state is required for Canadian addresses');
+
+  // Build the address object using validated data, transforming unique identifiers
+  const formattedHomeAddress: CanadianAddress = {
+    address: parsedDataResult.data.address,
+    city: parsedDataResult.data.city,
+    countryId: parsedDataResult.data.country,
+    country: countryService.getLocalizedCountryById(parsedDataResult.data.country, locale).name,
+    postalZipCode: parsedDataResult.data.postalCode,
+    provinceStateId: parsedDataResult.data.province,
+    provinceState: parsedDataResult.data.province && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.province, locale).abbr,
+  };
+
+  const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
+    address: formattedHomeAddress.address,
+    city: formattedHomeAddress.city,
+    postalCode: formattedHomeAddress.postalZipCode,
+    provinceCode: formattedHomeAddress.provinceState,
+    userId: 'anonymous',
+  });
+
+  if (addressCorrectionResult.status === 'not-correct') {
+    return {
+      invalidAddress: formattedHomeAddress,
+      status: 'address-invalid',
+    } as const satisfies AddressInvalidResponse;
+  }
+
+  if (addressCorrectionResult.status === 'corrected') {
+    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    return {
+      enteredAddress: formattedHomeAddress,
+      status: 'address-suggestion',
+      suggestedAddress: {
+        address: addressCorrectionResult.address,
+        city: addressCorrectionResult.city,
+        country: formattedHomeAddress.country,
+        countryId: formattedHomeAddress.countryId,
+        postalZipCode: addressCorrectionResult.postalCode,
+        provinceState: provinceTerritoryState.abbr,
+        provinceStateId: provinceTerritoryState.id,
+      },
+    } as const satisfies AddressSuggestionResponse;
+  }
+  saveRenewState({ params, session, state: { homeAddress: parsedDataResult.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+  }
+  return redirect(getPathById('public/renew/$id/child/review-child-information', params));
+}
+
+function isAddressResponse(data: unknown): data is AddressResponse {
+  return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
+}
+
+export default function RenewChildUpdateAddress() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);
+  const [homeCountryRegions, setHomeCountryRegions] = useState<typeof regionList>([]);
+  const [addressDialogContent, setAddressDialogContent] = useState<AddressResponse | null>(null);
+
+  const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+  const errorSummary = useErrorSummary(errors, {
+    address: 'home-address',
+    province: 'home-province',
+    country: 'home-country',
+    city: 'home-city',
+    postalCode: 'home-postal-code',
+  });
+
+  useEffect(() => {
+    const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedHomeCountry);
+    setHomeCountryRegions(filteredProvinceTerritoryStates);
+  }, [selectedHomeCountry, regionList]);
+
+  useEffect(() => {
+    setAddressDialogContent(isAddressResponse(fetcher.data) ? fetcher.data : null);
+  }, [fetcher, fetcher.data]);
+
+  function onDialogOpenChangeHandler(open: boolean) {
+    if (!open) {
+      setAddressDialogContent(null);
+    }
+  }
+  const homeCountryChangeHandler = (event: React.SyntheticEvent<HTMLSelectElement>) => {
+    setSelectedHomeCountry(event.currentTarget.value);
+  };
+
+  const countries = useMemo<InputOptionProps[]>(() => {
+    return countryList.map(({ id, name }) => ({ children: name, value: id }));
+  }, [countryList]);
+
+  const homeRegions = useMemo<InputOptionProps[]>(() => homeCountryRegions.map(({ id, name }) => ({ children: name, value: id })), [homeCountryRegions]);
+
+  const dummyOption: InputOptionProps = { children: t('renew-child:update-address.address-field.select-one'), value: '' };
+
+  const isPostalCodeRequired = [CANADA_COUNTRY_ID, USA_COUNTRY_ID].includes(selectedHomeCountry);
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={55} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <fieldset className="mb-8">
+            <div className="space-y-6">
+              <>
+                <InputSanitizeField
+                  id="home-address"
+                  name="homeAddress"
+                  className="w-full"
+                  label={t('renew-child:update-address.address-field.address')}
+                  helpMessagePrimary={t('renew-child:update-address.address-field.address-note')}
+                  helpMessagePrimaryClassName="text-black"
+                  maxLength={30}
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.homeAddress?.address}
+                  errorMessage={errors?.address}
+                  required
+                />
+                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+                  <InputSanitizeField
+                    id="home-city"
+                    name="homeCity"
+                    className="w-full"
+                    label={t('renew-child:update-address.address-field.city')}
+                    maxLength={100}
+                    autoComplete="address-level2"
+                    defaultValue={defaultState.homeAddress?.city}
+                    errorMessage={errors?.city}
+                    required
+                  />
+                  <InputSanitizeField
+                    id="home-postal-code"
+                    name="homePostalCode"
+                    className="w-full"
+                    label={isPostalCodeRequired ? t('renew-child:update-address.address-field.postal-code') : t('renew-child:update-address.address-field.postal-code-optional')}
+                    maxLength={100}
+                    autoComplete="postal-code"
+                    defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+                    errorMessage={errors?.postalCode}
+                    required={isPostalCodeRequired}
+                  />
+                </div>
+                {homeRegions.length > 0 && (
+                  <InputSelect
+                    id="home-province"
+                    name="homeProvince"
+                    className="w-full sm:w-1/2"
+                    label={t('renew-child:update-address.address-field.province')}
+                    defaultValue={defaultState.homeAddress?.province}
+                    errorMessage={errors?.province}
+                    options={[dummyOption, ...homeRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="home-country"
+                  name="homeCountry"
+                  className="w-full sm:w-1/2"
+                  label={t('renew-child:update-address.address-field.country')}
+                  autoComplete="country"
+                  defaultValue={defaultState.homeAddress?.country ?? ''}
+                  errorMessage={errors?.country}
+                  options={countries}
+                  onChange={homeCountryChangeHandler}
+                  required
+                />
+              </>
+            </div>
+          </fieldset>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Update address click">
+                {t('renew-child:update-address.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/renew/$id/child/review-parent-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Update address click">
+                {t('renew-child:update-address.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FormAction.Submit}
+                    loading={isSubmitting}
+                    endIcon={faChevronRight}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Update home address click"
+                  >
+                    {t('renew-child:update-address.continue')}
+                  </LoadingButton>
+                </DialogTrigger>
+                {addressDialogContent && addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
+                {addressDialogContent && addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+              </Dialog>
+              <ButtonLink
+                id="back-button"
+                routeId={defaultState.hasAddressChanged ? `public/renew/$id/child/update-mailing-address` : `public/renew/$id/child/confirm-address`}
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Update home address click"
+              >
+                {t('renew-child:update-address.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}
+
+interface AddressSuggestionDialogContentProps {
+  enteredAddress: CanadianAddress;
+  suggestedAddress: CanadianAddress;
+}
+
+function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+  const enteredAddressOptionValue = 'entered-address';
+  const suggestedAddressOptionValue = 'suggested-address';
+  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
+  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
+    formData.set('homeAddress', selectedAddressSuggestion.address);
+    formData.set('homeCity', selectedAddressSuggestion.city);
+    formData.set('homeCountry', selectedAddressSuggestion.countryId);
+    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
+    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-child:update-address.dialog.address-suggestion.header')}</DialogTitle>
+        <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
+      </DialogHeader>
+      <InputRadios
+        id="addressSelection"
+        name="addressSelection"
+        legend={t('renew-child:update-address.dialog.address-suggestion.address-selection-legend')}
+        options={[
+          {
+            value: enteredAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <Address address={enteredAddress} />
+              </>
+            ),
+          },
+          {
+            value: suggestedAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <Address address={suggestedAddress} />
+              </>
+            ),
+          },
+        ].map((option) => ({
+          ...option,
+          onChange: (e) => {
+            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
+          },
+          checked: option.value === selectedAddressSuggestionOption,
+        }))}
+      />
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
+            {t('renew-child:update-address.dialog.address-suggestion.cancel-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-child:update-address.dialog.address-suggestion.use-selected-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+interface AddressInvalidDialogContentProps {
+  invalidAddress: CanadianAddress;
+}
+
+function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    formData.set('homeAddress', invalidAddress.address);
+    formData.set('homeCity', invalidAddress.city);
+    formData.set('homeCountry', invalidAddress.countryId);
+    formData.set('homePostalCode', invalidAddress.postalZipCode);
+    formData.set('homeProvince', invalidAddress.provinceStateId);
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-child:update-address.dialog.address-invalid.header')}</DialogTitle>
+        <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <p className="font-semibold">{t('renew-child:update-address.dialog.address-invalid.entered-address')}</p>
+        <Address address={invalidAddress} />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
+            {t('renew-child:update-address.dialog.address-invalid.close-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-child:update-address.dialog.address-invalid.use-entered-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -1,0 +1,549 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { SyntheticEvent } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faCheck, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { Address } from '~/components/address';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputCheckbox } from '~/components/input-checkbox';
+import type { InputOptionProps } from '~/components/input-option';
+import { InputRadios } from '~/components/input-radios';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+import { InputSelect } from '~/components/input-select';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { useEnhancedFetcher } from '~/hooks';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Submit = 'submit',
+  UseInvalidAddress = 'use-invalid-address',
+  UseSelectedAddress = 'use-selected-address',
+}
+
+interface CanadianAddress {
+  address: string;
+  city: string;
+  country: string;
+  countryId: string;
+  postalZipCode: string;
+  provinceState: string;
+  provinceStateId: string;
+}
+
+interface AddressSuggestionResponse {
+  enteredAddress: CanadianAddress;
+  status: 'address-suggestion';
+  suggestedAddress: CanadianAddress;
+}
+
+interface AddressInvalidResponse {
+  invalidAddress: CanadianAddress;
+  status: 'address-invalid';
+}
+
+type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.updateAddress,
+  pageTitleI18nKey: 'renew-child:update-address.mailing-address.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.mailing-address.page-title') }) };
+
+  return {
+    id: state.id,
+    meta,
+    defaultState: state,
+    countryList,
+    regionList,
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const locale = getLocale(request);
+
+  const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
+  const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
+  const countryService = appContainer.get(TYPES.domain.services.CountryService);
+  const provinceTerritoryStateService = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService);
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewChildState({ params, request, session });
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+
+  const mailingAddressValidator = appContainer.get(TYPES.routes.public.renew.child.MailingAddressValidatorFactoryChild).createMailingAddressValidator(locale);
+  const validatedResult = await mailingAddressValidator.validateMailingAddress({
+    address: String(formData.get('mailingAddress')),
+    countryId: String(formData.get('mailingCountry')),
+    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : '',
+    city: String(formData.get('mailingCity')),
+    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : '',
+  });
+
+  if (!validatedResult.success) {
+    return data({ errors: validatedResult.errors }, { status: 400 });
+  }
+
+  const mailingAddress = {
+    address: validatedResult.data.address,
+    city: validatedResult.data.city,
+    country: validatedResult.data.countryId,
+    postalCode: validatedResult.data.postalZipCode,
+    province: validatedResult.data.provinceStateId,
+  };
+
+  const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
+
+  const isNotCanada = validatedResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
+  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
+  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const canProceedToReviewChild = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
+
+  if (canProceedToReviewChild) {
+    saveRenewState({
+      params,
+      session,
+      state: {
+        mailingAddress,
+        isHomeAddressSameAsMailingAddress: isCopyMailingToHome,
+        ...(homeAddress && { homeAddress }),
+      },
+    });
+
+    if (state.editMode) {
+      return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+    }
+    return redirect(isCopyMailingToHome ? getPathById('public/renew/$id/child/review-child-information', params) : getPathById('public/renew/$id/child/update-home-address', params));
+  }
+
+  // Validate Canadian adddress
+  invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
+  invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
+
+  // Build the address object using validated data, transforming unique identifiers
+  const formattedMailingAddress: CanadianAddress = {
+    address: validatedResult.data.address,
+    city: validatedResult.data.city,
+    countryId: validatedResult.data.countryId,
+    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    postalZipCode: validatedResult.data.postalZipCode,
+    provinceStateId: validatedResult.data.provinceStateId,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+  };
+
+  const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
+    address: formattedMailingAddress.address,
+    city: formattedMailingAddress.city,
+    postalCode: formattedMailingAddress.postalZipCode,
+    provinceCode: formattedMailingAddress.provinceState,
+    userId: 'anonymous',
+  });
+
+  if (addressCorrectionResult.status === 'not-correct') {
+    return {
+      invalidAddress: formattedMailingAddress,
+      status: 'address-invalid',
+    } as const satisfies AddressInvalidResponse;
+  }
+
+  if (addressCorrectionResult.status === 'corrected') {
+    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    return {
+      enteredAddress: formattedMailingAddress,
+      status: 'address-suggestion',
+      suggestedAddress: {
+        address: addressCorrectionResult.address,
+        city: addressCorrectionResult.city,
+        country: formattedMailingAddress.country,
+        countryId: formattedMailingAddress.countryId,
+        postalZipCode: addressCorrectionResult.postalCode,
+        provinceState: provinceTerritoryState.abbr,
+        provinceStateId: provinceTerritoryState.id,
+      },
+    } as const satisfies AddressSuggestionResponse;
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      mailingAddress,
+      isHomeAddressSameAsMailingAddress: isCopyMailingToHome,
+      ...(homeAddress && { homeAddress }),
+    },
+  });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/child/review-parent-information', params));
+  }
+  return redirect(isCopyMailingToHome ? getPathById('public/renew/$id/child/review-child-information', params) : getPathById('public/renew/$id/child/update-home-address', params));
+}
+
+function isAddressResponse(data: unknown): data is AddressResponse {
+  return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
+}
+
+export default function RenewChildUpdateAddress() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.mailingAddress?.country ?? CANADA_COUNTRY_ID);
+  const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
+  const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState.isHomeAddressSameAsMailingAddress === true);
+  const [addressDialogContent, setAddressDialogContent] = useState<AddressResponse | null>(null);
+
+  const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+  const errorSummary = useErrorSummary(errors, {
+    address: 'mailing-address',
+    provinceStateId: 'mailing-province',
+    countryId: 'mailing-country',
+    city: 'mailing-city',
+    postalZipCode: 'mailing-postal-code',
+    copyMailingAddress: 'copy-mailing-address',
+  });
+  const checkHandler = () => {
+    setCopyAddressChecked((curState) => !curState);
+  };
+  useEffect(() => {
+    const filteredProvinceTerritoryStates = regionList.filter(({ countryId }) => countryId === selectedMailingCountry);
+    setMailingCountryRegions(filteredProvinceTerritoryStates);
+  }, [selectedMailingCountry, regionList]);
+
+  useEffect(() => {
+    setAddressDialogContent(isAddressResponse(fetcher.data) ? fetcher.data : null);
+  }, [fetcher, fetcher.data]);
+
+  function onDialogOpenChangeHandler(open: boolean) {
+    if (!open) {
+      setAddressDialogContent(null);
+    }
+  }
+
+  const mailingCountryChangeHandler = (event: React.SyntheticEvent<HTMLSelectElement>) => {
+    setSelectedMailingCountry(event.currentTarget.value);
+  };
+
+  const countries = useMemo<InputOptionProps[]>(() => {
+    return countryList.map(({ id, name }) => ({ children: name, value: id }));
+  }, [countryList]);
+
+  const mailingRegions = useMemo<InputOptionProps[]>(() => mailingCountryRegions.map(({ id, name }) => ({ children: name, value: id })), [mailingCountryRegions]);
+
+  const dummyOption: InputOptionProps = { children: t('renew-child:update-address.address-field.select-one'), value: '' };
+
+  const isPostalCodeRequired = [CANADA_COUNTRY_ID, USA_COUNTRY_ID].includes(selectedMailingCountry);
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={55} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <fieldset className="mb-6">
+            <div className="space-y-6">
+              <InputSanitizeField
+                id="mailing-address"
+                name="mailingAddress"
+                className="w-full"
+                label={t('renew-child:update-address.address-field.address')}
+                maxLength={30}
+                helpMessagePrimary={t('renew-child:update-address.address-field.address-note')}
+                helpMessagePrimaryClassName="text-black"
+                autoComplete="address-line1"
+                defaultValue={defaultState.mailingAddress?.address}
+                errorMessage={errors?.address}
+                required
+              />
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputSanitizeField
+                  id="mailing-city"
+                  name="mailingCity"
+                  className="w-full"
+                  label={t('renew-child:update-address.address-field.city')}
+                  maxLength={100}
+                  autoComplete="address-level2"
+                  defaultValue={defaultState.mailingAddress?.city}
+                  errorMessage={errors?.city}
+                  required
+                />
+                <InputSanitizeField
+                  id="mailing-postal-code"
+                  name="mailingPostalCode"
+                  className="w-full"
+                  label={isPostalCodeRequired ? t('renew-child:update-address.address-field.postal-code') : t('renew-child:update-address.address-field.postal-code-optional')}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.mailingAddress?.postalCode}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                />
+              </div>
+              {mailingRegions.length > 0 && (
+                <InputSelect
+                  id="mailing-province"
+                  name="mailingProvince"
+                  className="w-full sm:w-1/2"
+                  label={t('renew-child:update-address.address-field.province')}
+                  defaultValue={defaultState.mailingAddress?.province}
+                  errorMessage={errors?.provinceStateId}
+                  options={[dummyOption, ...mailingRegions]}
+                  required
+                />
+              )}
+              <InputSelect
+                id="mailing-country"
+                name="mailingCountry"
+                className="w-full sm:w-1/2"
+                label={t('renew-child:update-address.address-field.country')}
+                autoComplete="country"
+                defaultValue={defaultState.mailingAddress?.country}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={mailingCountryChangeHandler}
+                required
+              />
+              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+                {t('renew-child:update-address.home-address.use-mailing-address')}
+              </InputCheckbox>
+            </div>
+          </fieldset>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Update address click">
+                {t('renew-child:update-address.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/renew/$id/child/review-parent-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Update address click">
+                {t('renew-child:update-address.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FormAction.Submit}
+                    loading={isSubmitting}
+                    endIcon={faChevronRight}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Update address click"
+                  >
+                    {t('renew-child:update-address.continue')}
+                  </LoadingButton>
+                </DialogTrigger>
+                {addressDialogContent && addressDialogContent.status === 'address-suggestion' && (
+                  <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                )}
+                {addressDialogContent && addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+              </Dialog>
+
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/child/confirm-address"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Update mailing address click"
+              >
+                {t('renew-child:update-address.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}
+
+interface AddressSuggestionDialogContentProps {
+  enteredAddress: CanadianAddress;
+  suggestedAddress: CanadianAddress;
+  copyAddressToHome: boolean;
+}
+
+function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+  const enteredAddressOptionValue = 'entered-address';
+  const suggestedAddressOptionValue = 'suggested-address';
+  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
+  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
+    formData.set('mailingAddress', selectedAddressSuggestion.address);
+    formData.set('mailingCity', selectedAddressSuggestion.city);
+    formData.set('mailingCountry', selectedAddressSuggestion.countryId);
+    formData.set('mailingPostalCode', selectedAddressSuggestion.postalZipCode);
+    formData.set('mailingProvince', selectedAddressSuggestion.provinceStateId);
+    if (copyAddressToHome) {
+      formData.set('copyMailingAddress', 'copy');
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-child:update-address.dialog.address-suggestion.header')}</DialogTitle>
+        <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
+      </DialogHeader>
+      <InputRadios
+        id="addressSelection"
+        name="addressSelection"
+        legend={t('renew-child:update-address.dialog.address-suggestion.address-selection-legend')}
+        options={[
+          {
+            value: enteredAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <Address address={enteredAddress} />
+              </>
+            ),
+          },
+          {
+            value: suggestedAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <Address address={suggestedAddress} />
+              </>
+            ),
+          },
+        ].map((option) => ({
+          ...option,
+          onChange: (e) => {
+            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
+          },
+          checked: option.value === selectedAddressSuggestionOption,
+        }))}
+      />
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
+            {t('renew-child:update-address.dialog.address-suggestion.cancel-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-child:update-address.dialog.address-suggestion.use-selected-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+interface AddressInvalidDialogContentProps {
+  invalidAddress: CanadianAddress;
+  copyAddressToHome: boolean;
+}
+
+function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const fetcher = useEnhancedFetcher();
+
+  function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    formData.set('mailingAddress', invalidAddress.address);
+    formData.set('mailingCity', invalidAddress.city);
+    formData.set('mailingCountry', invalidAddress.countryId);
+    formData.set('mailingPostalCode', invalidAddress.postalZipCode);
+    formData.set('mailingProvince', invalidAddress.provinceStateId);
+    if (copyAddressToHome) {
+      formData.set('copyMailingAddress', 'copy');
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('renew-child:update-address.dialog.address-invalid.header')}</DialogTitle>
+        <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <p className="font-semibold">{t('renew-child:update-address.dialog.address-invalid.entered-address')}</p>
+        <Address address={invalidAddress} />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
+            {t('renew-child:update-address.dialog.address-invalid.close-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('renew-child:update-address.dialog.address-invalid.use-entered-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -623,6 +623,21 @@ export const routes = [
             paths: { en: '/:lang/renew/:id/child/marital-status', fr: '/:lang/renew/:id/enfant/etat-civil' },
           },
           {
+            id: 'public/renew/$id/child/confirm-address',
+            file: 'routes/public/renew/$id/child/confirm-address.tsx',
+            paths: { en: '/:lang/renew/:id/child/confirm-address', fr: '/:lang/renew/:id/enfant/confirmer-adresse' },
+          },
+          {
+            id: 'public/renew/$id/child/update-mailing-address',
+            file: 'routes/public/renew/$id/child/update-mailing-address.tsx',
+            paths: { en: '/:lang/renew/:id/child/update-mailing-address', fr: '/:lang/renew/:id/child/mise-a-jour-adresse-postale' },
+          },
+          {
+            id: 'public/renew/$id/child/update-home-address',
+            file: 'routes/public/renew/$id/child/update-home-address.tsx',
+            paths: { en: '/:lang/renew/:id/child/update-home-address', fr: '/:lang/renew/:id/child/mise-a-jour-adresse-domicile' },
+          },
+          {
             id: 'public/renew/$id/child/children/$childId/dental-insurance',
             file: 'routes/public/renew/$id/child/children/$childId/dental-insurance.tsx',
             paths: { en: '/:lang/renew/:id/child/children/:childId/dental-insurance', fr: '/:lang/renew/:id/enfant/enfants/:childId/assurance-dentaire' },

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -279,5 +279,89 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique"
     }
+  },
+  "confirm-address": {
+    "page-title": "Address",
+    "have-you-moved": "Would you like to update your home or mailing address?",
+    "is-home-address-same-as-mailing-address": "Is your home address the same as your mailing address?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
+    "error-message": {
+      "has-address-changed-required": "Select whether you have moved or changed your mailing address",
+      "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save"
+  },
+  "update-address": {
+    "mailing-address": {
+      "page-title": "Mailing address"
+    },
+    "home-address": {
+      "page-title": "Home address",
+      "use-mailing-address": "My mailing address is the same as my home address"
+    },
+    "address-field": {
+      "address": "Address",
+      "address-note": "Include apartment number (if applicable), street number, street name. For example: 123 Main Street Suite 4B",
+      "country": "Country",
+      "province": "Province, territory, state, or region",
+      "city": "City or town",
+      "postal-code": "Postal code or ZIP code",
+      "postal-code-optional": "Postal code or ZIP code (optional)",
+      "select-one": "Select one"
+    },
+    "dialog": {
+      "address-suggestion": {
+        "address-selection-legend": "Please select an address option below:",
+        "cancel-button": "Cancel",
+        "description": "There's a problem with the address you provided.  Please select the address you want to use. If you live in an apartment or suite, make sure to include that information.",
+        "entered-address-option": "Entered address:",
+        "header": "Verify your address",
+        "suggested-address-option": "Suggested address:",
+        "use-selected-address-button": "Use selected address"
+      },
+      "address-invalid": {
+        "close-button": "Close",
+        "description": "The mailing address you entered appears to be invalid. Please review the details below.",
+        "entered-address": "Entered address:",
+        "header": "Invalid address",
+        "use-entered-address-button": "Use entered address"
+      }
+    },
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "mailing-address": {
+        "address-required": "Address must be provided",
+        "city-required": "City must be provided",
+        "country-required": "Country must be selected",
+        "postal-code-required": "Postal code or Zip code must be provided",
+        "postal-code-valid": "Invalid postal code (A1A 1A1)",
+        "province-required": "Province must be selected",
+        "zip-code-valid": "Invalid zip code (12345)",
+        "invalid-postal-code-for-country": "A Canadian postal code in the mailing address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
+      },
+      "home-address": {
+        "address-required": "Address must be provided",
+        "city-required": "City must be provided",
+        "country-required": "Country must be selected",
+        "postal-code-required": "Postal code or Zip code must be provided",
+        "postal-code-valid": "Invalid postal code (A1A 1A1)",
+        "province-required": "Province must be selected",
+        "zip-code-valid": "Invalid zip code (12345)",
+        "invalid-postal-code-for-country": "A Canadian postal code in the home address was entered but Canada was not selected as the country. Please select Canada, and the proper province, or change the postal code",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
+      },
+      "characters-valid": "Only letters, numbers and the following characters are accepted: apostrophe ('), comma (,), period (.), hyphen (-) and bracket ()"
+    }
   }
 }

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -319,7 +319,7 @@
     "dialog": {
       "address-suggestion": {
         "address-selection-legend": "Please select an address option below:",
-        "cancel-button": "Cancel",
+        "cancel-button": "Back",
         "description": "There's a problem with the address you provided.  Please select the address you want to use. If you live in an apartment or suite, make sure to include that information.",
         "entered-address-option": "Entered address:",
         "header": "Verify your address",
@@ -327,10 +327,10 @@
         "use-selected-address-button": "Use selected address"
       },
       "address-invalid": {
-        "close-button": "Close",
-        "description": "The mailing address you entered appears to be invalid. Please review the details below.",
+        "close-button": "Back",
+        "description": "We could not verify your address. You can either update it or continue with the address you entered. If you live in an apartment or suite, make sure to include that information.",
         "entered-address": "Entered address:",
-        "header": "Invalid address",
+        "header": "Verify your address",
         "use-entered-address-button": "Use entered address"
       }
     },

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -282,5 +282,89 @@
       "sin-valid": "Doit être un NAS valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
     }
+  },
+  "confirm-address": {
+    "page-title": "Adresse",
+    "have-you-moved": "Souhaitez-vous mettre à jour l'adresse de votre domicile ou votre adresse postale?",
+    "is-home-address-same-as-mailing-address": "L'adresse de votre domicile est-elle la même que votre adresse postale?",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "help-message": "L'adresse que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
+    "error-message": {
+      "has-address-changed-required": "Sélectionnez si vous avez déménagé ou changé d'adresse postale",
+      "is-home-address-same-as-mailing-address-required": "Sélectionnez si votre adresse postale et votre adresse domicile sont identiques ou non"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer"
+  },
+  "update-address": {
+    "mailing-address": {
+      "page-title": "Adresse postale"
+    },
+    "home-address": {
+      "page-title": "Adresse à domicile",
+      "use-mailing-address": "Mon adresse postale est la même que celle de mon adresse à domicile"
+    },
+    "address-field": {
+      "address": "Adresse",
+      "address-note": "Inclure le numéro d'appartement (s'il y a lieu), le numéro municipal et le nom de la rue. Par exemple\u00a0: 4B - 123 Rue Main",
+      "country": "Pays",
+      "province": "Province, territoire, État ou région",
+      "city": "Ville ou municipalité",
+      "postal-code": "Code postal",
+      "postal-code-optional": "Code postal (facultatif)",
+      "select-one": "Sélectionnez une option"
+    },
+    "dialog": {
+      "address-suggestion": {
+        "address-selection-legend": "Veuillez sélectionner une option d'adresse ci\u2011dessous\u00a0:",
+        "cancel-button": "Annuler",
+        "description": "Il y a un problème avec l'adresse que vous avez fournie. Veuillez sélectionner l'adresse que vous souhaitez utiliser. Si vous vivez dans un appartement ou une chambre, n'oubliez pas de le préciser.",
+        "entered-address-option": "Adresse saisie\u00a0:",
+        "header": "Vérifiez votre adresse",
+        "suggested-address-option": "Adresse suggérée\u00a0:",
+        "use-selected-address-button": "Utiliser l'adresse sélectionnée"
+      },
+      "address-invalid": {
+        "close-button": "Fermer",
+        "description": "L'adresse postale que vous avez saisie semble invalide. Veuillez vérifier les détails ci\u2011dessous.",
+        "entered-address": "Adresse saisie\u00a0:",
+        "header": "Adresse invalide",
+        "use-entered-address-button": "Utiliser l'adresse saisie"
+      }
+    },
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "sauvegarder",
+    "error-message": {
+      "mailing-address": {
+        "address-required": "Une adresse doit être fournie",
+        "city-required": "Une ville doit être fournie",
+        "country-required": "Un pays doit être sélectionné",
+        "postal-code-required": "Le code postal ou le code zip doit être fourni",
+        "postal-code-valid": "Code postal invalide (A1A 1A1)",
+        "province-required": "Une province doit être sélectionnée",
+        "zip-code-valid": "Code zip invalide (12345)",
+        "invalid-postal-code-for-country": "Un code postal canadien a été saisi dans l'adresse postale, mais le Canada n'a pas été sélectionné comme pays. Veuillez sélectionner le Canada et la province appropriée, ou modifier le code postal",
+        "invalid-postal-code-for-province": "The postal code does not match the province or territory you selected"
+      },
+      "home-address": {
+        "address-required": "Une adresse doit être fournie",
+        "city-required": "Une ville doit être fournie",
+        "country-required": "Un pays doit être sélectionné",
+        "postal-code-required": "Le code postal ou le code zip doit être fourni",
+        "postal-code-valid": "Code postal invalide (A1A 1A1)",
+        "province-required": "Une province doit être sélectionnée",
+        "zip-code-valid": "Code zip invalide (12345)",
+        "invalid-postal-code-for-country": "Un code postal canadien a été saisi dans l'adresse du domicile, mais le Canada n'a pas été sélectionné comme pays. Veuillez sélectionner le Canada et la province appropriée, ou modifier le code postal",
+        "invalid-postal-code-for-province": "Le code postal ne correspond pas à la province ou au territoire que vous avez sélectionné"
+      },
+      "characters-valid": "Seuls les lettres, les chiffres et les caractères suivants sont acceptés : apostrophe ('), virgule (,), point (.), trait d'union (-) et crochet ()"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -322,7 +322,7 @@
     "dialog": {
       "address-suggestion": {
         "address-selection-legend": "Veuillez sélectionner une option d'adresse ci\u2011dessous\u00a0:",
-        "cancel-button": "Annuler",
+        "cancel-button": "Retour",
         "description": "Il y a un problème avec l'adresse que vous avez fournie. Veuillez sélectionner l'adresse que vous souhaitez utiliser. Si vous vivez dans un appartement ou une chambre, n'oubliez pas de le préciser.",
         "entered-address-option": "Adresse saisie\u00a0:",
         "header": "Vérifiez votre adresse",
@@ -330,10 +330,10 @@
         "use-selected-address-button": "Utiliser l'adresse sélectionnée"
       },
       "address-invalid": {
-        "close-button": "Fermer",
-        "description": "L'adresse postale que vous avez saisie semble invalide. Veuillez vérifier les détails ci\u2011dessous.",
+        "close-button": "Retour",
+        "description": "Nous n'avons pas pu vérifier votre adresse. Vous pouvez soit la mettre à jour, soit continuer avec l'adresse que vous avez saisie. Si vous vivez dans un appartement ou une chambre, n'oubliez pas d'indiquer cette information.",
         "entered-address": "Adresse saisie\u00a0:",
-        "header": "Adresse invalide",
+        "header": "Vérifiez votre adresse",
         "use-entered-address-button": "Utiliser l'adresse saisie"
       }
     },


### PR DESCRIPTION
### Description
Added the renew child address pages for confirm-address, mailing-address, home-address 

### Related Azure Boards Work Items
[AB#4630](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4630)
[AB#4631](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4631)
[AB#4912](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4912)
[AB#4913](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4913)

### Screenshots (if applicable)
![cadr1](https://github.com/user-attachments/assets/4b9ff163-87bd-4a96-a7a2-a68e8e6554ed)
![cadr2](https://github.com/user-attachments/assets/2b09b9b2-f6a7-4266-a299-f68cfcb4ebe9)
![cadr3](https://github.com/user-attachments/assets/a36eae66-6903-4532-912e-944b40cb141f)
