### PR TITLE
Updating Tax filing and File your taxes content and making tax year dynamic

### DIFF
--- a/frontend/app/routes/protected/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/$id/tax-filing.tsx
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:tax-filing.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.taxFiling };
+  return { id: state.id, meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -83,7 +83,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedRenewFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
+  const { defaultState, taxYear } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -91,39 +91,37 @@ export default function ProtectedRenewFlowTaxFiling() {
   const errorSummary = useErrorSummary(errors, { taxFiling: 'input-radio-tax-filing-option-0' });
 
   return (
-    <>
-      <div className="max-w-prose">
-        <errorSummary.ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="tax-filing"
-            name="taxFiling"
-            legend={t('protected-renew:tax-filing.form-instructions')}
-            options={[
-              { value: TaxFilingOption.Yes, children: t('protected-renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: TaxFilingOption.No, children: t('protected-renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
-            ]}
-            errorMessage={errors?.taxFiling}
-            required
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Continue - Tax filing click">
-              {t('protected-renew:tax-filing.continue-btn')}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              routeId="protected/renew/$id/terms-and-conditions"
-              params={params}
-              disabled={isSubmitting}
-              startIcon={faChevronLeft}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Back - Tax filing click"
-            >
-              {t('protected-renew:tax-filing.back-btn')}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </>
+    <div className="max-w-prose">
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <InputRadios
+          id="tax-filing"
+          name="taxFiling"
+          legend={t('protected-renew:tax-filing.form-instructions', { taxYear })}
+          options={[
+            { value: TaxFilingOption.Yes, children: t('protected-renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+            { value: TaxFilingOption.No, children: t('protected-renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+          ]}
+          errorMessage={errors?.taxFiling}
+          required
+        />
+        <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Continue - Tax filing click">
+            {t('protected-renew:tax-filing.continue-btn')}
+          </LoadingButton>
+          <ButtonLink
+            id="back-button"
+            routeId="protected/renew/$id/terms-and-conditions"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-protected-Renew:Back - Tax filing click"
+          >
+            {t('protected-renew:tax-filing.back-btn')}
+          </ButtonLink>
+        </div>
+      </fetcher.Form>
+    </div>
   );
 }

--- a/frontend/app/routes/public/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/renew/$id/file-taxes.tsx
@@ -2,7 +2,7 @@ import type { FormEvent } from 'react';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
-import { useFetcher, useParams } from '@remix-run/react';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -31,12 +31,12 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
-  const { id } = loadRenewState({ params, session });
+  const { id, applicationYear } = loadRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:file-your-taxes.page-title') }) };
 
-  return { id, meta };
+  return { id, meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -53,6 +53,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewFileYourTaxes() {
   const { t } = useTranslation(handle.i18nNamespaces);
+  const { taxYear } = useLoaderData<typeof loader>();
 
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
@@ -70,7 +71,7 @@ export default function RenewFileYourTaxes() {
     <div className="max-w-prose">
       <div className="mb-8 space-y-4">
         <p>{t('renew:file-your-taxes.ineligible-to-renew')}</p>
-        <p>{t('renew:file-your-taxes.tax-not-filed')}</p>
+        <p>{t('renew:file-your-taxes.tax-not-filed', { taxYear })}</p>
         <p>{t('renew:file-your-taxes.unable-to-assess')}</p>
         <p>
           <Trans ns={handle.i18nNamespaces} i18nKey="renew:file-your-taxes.tax-info" components={{ taxInfo }} />

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -44,7 +44,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:tax-filing.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.taxFiling };
+  return { id: state.id, meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -78,7 +78,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewFlowTaxFiling() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
+  const { defaultState, taxYear } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -98,7 +98,7 @@ export default function RenewFlowTaxFiling() {
           <InputRadios
             id="tax-filing"
             name="taxFiling"
-            legend={t('renew:tax-filing.form-instructions')}
+            legend={t('renew:tax-filing.form-instructions', { taxYear })}
             options={[
               { value: TaxFilingOption.Yes, children: t('renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
               { value: TaxFilingOption.No, children: t('renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -89,7 +89,7 @@
   },
   "tax-filing": {
     "page-title": "Tax filing",
-    "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2024 and received your Notice of Assessment?",
+    "form-instructions": "Have you, and if applicable, your spouse or common-law partner, filed your tax return for {{taxYear}} in Canada and received your Notice of Assessment?",
     "radio-options": {
       "yes": "Yes",
       "no": "No"
@@ -102,15 +102,14 @@
   },
   "file-your-taxes": {
     "page-title": "File your taxes",
-    "ineligible-to-renew": "You are not eligible to renew for the Canadian Dental Care Plan at this time.",
-    "tax-not-filed": "You, your spouse or common-law partner have not filed a tax return for 2024 with the Canada Revenue Agency.",
-    "unable-to-assess": "We use the information from your tax file to verify that the income and residency eligibility requirements are met for the plan.",
+    "ineligible-to-renew": "You are not eligible to renew your coverage for the Canadian Dental Care Plan at this time.",
+    "tax-not-filed": "You, your spouse or common-law partner have not received your Notice of Assessment for {{taxYear}} from the Canada Revenue Agency.",
+    "unable-to-assess": "We use the information from your tax file to verify that the income and residency eligibility requirements for the Canadian Dental Care Plan are met.",
     "tax-info": "For more information on how to file your taxes, visit <taxInfo>Get ready to do your taxes</taxInfo>.",
-    "renew-after": "You can renew for the plan after you or your spouse or common-law partner have filed your taxes and received your Notice of Assessment.",
+    "renew-after": "You can renew your coverage only after you or your spouse or common-law partner have filed your taxes and received your Notice of Assessment.",
     "tax-info-href": "https://www.canada.ca/en/services/taxes/income-tax/personal-income-tax/get-ready-taxes.html",
     "back-btn": "Back",
-    "return-btn": "Return to dashboard",
-    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    "return-btn": "Return to dashboard"
   },
   "member-selection": {
     "page-title": "Renew your Canadian Dental Care Plan benefits",

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -161,7 +161,7 @@
   },
   "tax-filing": {
     "page-title": "Tax filing",
-    "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2024 and received your Notice of Assessment?",
+    "form-instructions": "Have you, and if applicable, your spouse or common-law partner, filed your tax return for {{taxYear}} in Canada and received your Notice of Assessment?",
     "radio-options": {
       "yes": "Yes",
       "no": "No"
@@ -174,11 +174,11 @@
   },
   "file-your-taxes": {
     "page-title": "File your taxes",
-    "ineligible-to-renew": "You are not eligible to renew for the Canadian Dental Care Plan at this time.",
-    "tax-not-filed": "You, your spouse or common-law partner have not filed a tax return for 2024 with the Canada Revenue Agency.",
-    "unable-to-assess": "We use the information from your tax file to verify that the income and residency eligibility requirements are met for the plan.",
+    "ineligible-to-renew": "You are not eligible to renew your coverage for the Canadian Dental Care Plan at this time.",
+    "tax-not-filed": "You, your spouse or common-law partner have not received your Notice of Assessment for {{taxYear}} from the Canada Revenue Agency.",
+    "unable-to-assess": "We use the information from your tax file to verify that the income and residency eligibility requirements for the Canadian Dental Care Plan are met.",
     "tax-info": "For more information on how to file your taxes, visit <taxInfo>Get ready to do your taxes</taxInfo>.",
-    "renew-after": "You can renew for the plan after you or your spouse or common-law partner have filed your taxes and received your Notice of Assessment.",
+    "renew-after": "You can renew your coverage only after you or your spouse or common-law partner have filed your taxes and received your Notice of Assessment.",
     "tax-info-href": "https://www.canada.ca/en/services/taxes/income-tax/personal-income-tax/get-ready-taxes.html",
     "back-btn": "Back",
     "return-btn": "Return to main page",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -88,29 +88,28 @@
     }
   },
   "tax-filing": {
-    "page-title": "Tax filing",
-    "form-instructions": "Have you and your spouse or common-law partner (if applicable) filed your tax return for 2024 and received your Notice of Assessment?",
+    "page-title": "Déclaration de revenus",
+    "form-instructions": "Avez-vous, ainsi que votre époux ou conjoint de fait, le cas échéant, produit votre déclaration de revenus pour {{taxYear}} au Canada et reçu votre avis de cotisation?",
     "radio-options": {
-      "yes": "Yes",
-      "no": "No"
+      "yes": "Oui",
+      "no": "Non"
     },
     "error-message": {
-      "tax-filing-required": "Select whether or not you have filed your taxes"
+      "tax-filing-required": "Sélectionnez si vous avez fait votre déclaration de revenus ou non"
     },
-    "back-btn": "Back",
-    "continue-btn": "Continue"
+    "back-btn": "Retour",
+    "continue-btn": "Continuer"
   },
   "file-your-taxes": {
-    "page-title": "File your taxes",
-    "ineligible-to-renew": "You are not eligible to renew for the Canadian Dental Care Plan at this time.",
-    "tax-not-filed": "You, your spouse or common-law partner have not filed a tax return for 2024 with the Canada Revenue Agency.",
-    "unable-to-assess": "We use the information from your tax file to verify that the income and residency eligibility requirements are met for the plan.",
-    "tax-info": "For more information on how to file your taxes, visit <taxInfo>Get ready to do your taxes</taxInfo>.",
-    "renew-after": "You can renew for the plan after you or your spouse or common-law partner have filed your taxes and received your Notice of Assessment.",
-    "tax-info-href": "https://www.canada.ca/en/services/taxes/income-tax/personal-income-tax/get-ready-taxes.html",
-    "back-btn": "Back",
-    "return-btn": "Return to dashboard",
-    "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    "page-title": "Produire votre déclaration de revenus",
+    "ineligible-to-renew": "Vous n'êtes pas admissible au renouvellement de votre adhésion au Régime canadien de soins dentaires pour le moment.",
+    "tax-not-filed": "Vous, votre époux/épouse ou conjoint/conjointe de fait n'avez pas reçu votre avis de cotisation pour {{taxYear}} auprès de l'Agence du revenu du Canada.",
+    "unable-to-assess": "Nous utilisons les renseignements de votre déclaration de revenus pour nous assurer que les critères d'admissibilité relatifs au revenu et à la résidence sont remplis.",
+    "tax-info": "Pour en savoir plus sur la façon de produire votre déclaration de revenus, consultez la page <taxInfo>Préparez-vous à faire vos impôts</taxInfo>.",
+    "renew-after": "Vous pourrez présenter une demande de renouvellement au régime après que vous ou votre époux/épouse ou conjoint/conjointe de fait aurez produit vos déclarations de revenus et reçu votre avis de cotisation.",
+    "tax-info-href": "https://www.canada.ca/fr/services/impots/impot-sur-le-revenu/impot-sur-le-revenu-des-particuliers/preparez-vous-impots.html",
+    "back-btn": "Retour",
+    "return-btn": "Revenir à la page principale"
   },
   "member-selection": {
     "page-title": "Renew your Canadian Dental Care Plan benefits",

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -161,7 +161,7 @@
   },
   "tax-filing": {
     "page-title": "Déclaration de revenus",
-    "form-instructions": "Est-ce que vous et votre époux/épouse ou conjoint/conjointe de fait (s'il y a lieu) avez produit votre déclaration de revenus pour 2024 et avez reçu votre avis de cotisation?",
+    "form-instructions": "Avez-vous, ainsi que votre époux ou conjoint de fait, le cas échéant, produit votre déclaration de revenus pour {{taxYear}} au Canada et reçu votre avis de cotisation?",
     "radio-options": {
       "yes": "Oui",
       "no": "Non"
@@ -173,9 +173,9 @@
     "continue-btn": "Continuer"
   },
   "file-your-taxes": {
-    "page-title": "File your taxes",
+    "page-title": "Produire votre déclaration de revenus",
     "ineligible-to-renew": "Vous n'êtes pas admissible au renouvellement de votre adhésion au Régime canadien de soins dentaires pour le moment.",
-    "tax-not-filed": "Vous, votre époux/épouse ou conjoint/conjointe de fait n'avez pas produit de déclaration de revenus pour l'année 2024 auprès de l'Agence du revenu du Canada.",
+    "tax-not-filed": "Vous, votre époux/épouse ou conjoint/conjointe de fait n'avez pas reçu votre avis de cotisation pour {{taxYear}} auprès de l'Agence du revenu du Canada.",
     "unable-to-assess": "Nous utilisons les renseignements de votre déclaration de revenus pour nous assurer que les critères d'admissibilité relatifs au revenu et à la résidence sont remplis.",
     "tax-info": "Pour en savoir plus sur la façon de produire votre déclaration de revenus, consultez la page <taxInfo>Préparez-vous à faire vos impôts</taxInfo>.",
     "renew-after": "Vous pourrez présenter une demande de renouvellement au régime après que vous ou votre époux/épouse ou conjoint/conjointe de fait aurez produit vos déclarations de revenus et reçu votre avis de cotisation.",


### PR DESCRIPTION
### 
Updated "Tax filing" and "File your taxes" page content for public and protected areas based on latest Figma.
The tax year for both these pages are now dynamic and based off the result of `findRenewalApplicationYear(..)` service call, which is stored in the state object.

Also in this PR:
- Updated "Return to dashboard" text and redirect in `/protected/renew/file-taxes`
- Removed unnecessary empty fragment in `/protected/renew/tax-filing`

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d9f1c429-2c70-4de6-b58c-1998099b087e)
![image](https://github.com/user-attachments/assets/52de6fd5-29cc-4010-8d53-3a50ecb496c1)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/en/renew` or `/en/protected/renew` and reach the `/tax-filing` route. Verify that the tax year displays. Answer "No" to be redirected to `/file-taxes` route. Verify that the tax year displays.