### PR TITLE
Removing renewal Terms and Conditions checkboxes

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -25,11 +25,6 @@ export interface ProtectedRenewState {
   readonly externallyReviewed?: boolean;
   readonly previouslyReviewed?: boolean;
   readonly taxFiling?: boolean;
-  readonly termsAndConditions?: {
-    readonly acknowledgeTerms: boolean;
-    readonly acknowledgePrivacy: boolean;
-    readonly shareData: boolean;
-  };
   readonly dentalInsurance?: boolean;
   readonly dentalBenefits?: {
     hasFederalBenefits: boolean;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -120,11 +120,6 @@ export interface RenewState {
     submittedOn: string;
   };
   readonly taxFiling?: boolean;
-  readonly termsAndConditions?: {
-    acknowledgeTerms: boolean;
-    acknowledgePrivacy: boolean;
-    shareData: boolean;
-  };
   readonly demographicSurvey?: {
     readonly indigenousStatus?: string;
     readonly firstNations?: string;

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -1,21 +1,17 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { data, redirect } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { redirect } from '@remix-run/node';
+import { useFetcher } from '@remix-run/react';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
-import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
-import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { useErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
-import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
@@ -24,10 +20,6 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-
-enum CheckboxValue {
-  Yes = 'yes',
-}
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
@@ -43,12 +35,12 @@ export async function loader({ context: { appContainer, session }, request, para
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  const state = loadProtectedRenewState({ params, session });
+  loadProtectedRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:terms-and-conditions.page-title') }) };
 
-  return { meta, defaultState: state.termsAndConditions };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, request, params }: ActionFunctionArgs) {
@@ -58,54 +50,16 @@ export async function action({ context: { appContainer, session }, request, para
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
-  const t = await getFixedT(request, handle.i18nNamespaces);
-
-  const consentSchema = z
-    .object({
-      acknowledgeTerms: z.nativeEnum(CheckboxValue, {
-        errorMap: () => ({ message: t('protected-renew:terms-and-conditions.checkboxes.error-message.acknowledge-terms-required') }),
-      }),
-      acknowledgePrivacy: z.nativeEnum(CheckboxValue, {
-        errorMap: () => ({ message: t('protected-renew:terms-and-conditions.checkboxes.error-message.acknowledge-privacy-required') }),
-      }),
-      shareData: z.nativeEnum(CheckboxValue, {
-        errorMap: () => ({ message: t('protected-renew:terms-and-conditions.checkboxes.error-message.share-data-required') }),
-      }),
-    })
-    .transform((val) => ({
-      acknowledgeTerms: val.acknowledgeTerms.valueOf() === CheckboxValue.Yes,
-      acknowledgePrivacy: val.acknowledgePrivacy.valueOf() === CheckboxValue.Yes,
-      shareData: val.shareData.valueOf() === CheckboxValue.Yes,
-    }));
-
-  const parsedDataResult = consentSchema.safeParse({
-    acknowledgeTerms: formData.get('acknowledgeTerms'),
-    acknowledgePrivacy: formData.get('acknowledgePrivacy'),
-    shareData: formData.get('shareData'),
-  });
-
-  if (!parsedDataResult.success) {
-    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
-  }
-
-  saveProtectedRenewState({ params, session, state: { termsAndConditions: parsedDataResult.data } });
+  saveProtectedRenewState({ params, session, state: {} });
 
   return redirect(getPathById('protected/renew/$id/tax-filing', params));
 }
 
 export default function RenewTermsAndConditions() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
   const { SCCH_BASE_URI } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-
-  const errors = fetcher.data?.errors;
-  const errorSummary = useErrorSummary(errors, {
-    acknowledgeTerms: 'input-checkbox-acknowledge-terms',
-    acknowledgePrivacy: 'input-checkbox-acknowledge-privacy',
-    shareData: 'input-checkbox-share-data',
-  });
 
   const canadaTermsConditions = <InlineLink to={t('protected-renew:terms-and-conditions.links.canada-ca-terms-and-conditions')} className="external-link" newTabIndicator target="_blank" />;
   const fileacomplaint = <InlineLink to={t('protected-renew:terms-and-conditions.links.file-complaint')} className="external-link" newTabIndicator target="_blank" />;
@@ -118,7 +72,6 @@ export default function RenewTermsAndConditions() {
     <div className="max-w-prose">
       <div className="space-y-6">
         <p>{t('protected-renew:terms-and-conditions.intro-text')}</p>
-        <errorSummary.ErrorSummary />
         <Collapsible summary={t('protected-renew:terms-and-conditions.terms-and-conditions-of-use.summary')}>
           <div className="space-y-6">
             <div className="space-y-4">
@@ -205,15 +158,6 @@ export default function RenewTermsAndConditions() {
         {t('protected-renew:terms-and-conditions.apply.application-consent')}
       </p>
       <fetcher.Form method="post" noValidate>
-        <InputCheckbox id="acknowledge-terms" name="acknowledgeTerms" value={CheckboxValue.Yes} defaultChecked={defaultState?.acknowledgeTerms} errorMessage={errors?.acknowledgeTerms} required>
-          {t('protected-renew:terms-and-conditions.checkboxes.acknowledge-terms')}
-        </InputCheckbox>
-        <InputCheckbox id="acknowledge-privacy" name="acknowledgePrivacy" value={CheckboxValue.Yes} defaultChecked={defaultState?.acknowledgePrivacy} errorMessage={errors?.acknowledgePrivacy} required>
-          {t('protected-renew:terms-and-conditions.checkboxes.acknowledge-privacy')}
-        </InputCheckbox>
-        <InputCheckbox id="share-data" name="shareData" value={CheckboxValue.Yes} defaultChecked={defaultState?.shareData} errorMessage={errors?.shareData} required>
-          {t('protected-renew:terms-and-conditions.checkboxes.share-data')}
-        </InputCheckbox>
         <CsrfTokenInput />
         <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <LoadingButton

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -22,7 +22,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
   pageIdentifier: pageIds.public.apply.index,
-  pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-heading',
+  pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -75,16 +75,6 @@
       "info-source": "https://www.canada.ca/en/employment-social-development/corporate/transparency/access-information/reports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/en-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/en/"
-    },
-    "checkboxes": {
-      "acknowledge-terms": "I acknowledge that I've read the Terms and Conditions",
-      "acknowledge-privacy": "I acknowledge that I have read the Privacy Notice Statement",
-      "share-data": "I consent to the sharing of data",
-      "error-message": {
-        "acknowledge-terms-required": "Terms and Conditions checkbox must be selected",
-        "acknowledge-privacy-required": "Privacy Notice Statement checkbox must be selected",
-        "share-data-required": "Sharing of data checkbox must be selected"
-      }
     }
   },
   "tax-filing": {

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -79,16 +79,6 @@
       "info-source": "https://www.canada.ca/en/employment-social-development/corporate/transparency/access-information/reports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/en-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/en/"
-    },
-    "checkboxes": {
-      "acknowledge-terms": "I acknowledge that I've read the Terms and Conditions",
-      "acknowledge-privacy": "I acknowledge that I have read the Privacy Notice Statement",
-      "share-data": "I consent to the sharing of data",
-      "error-message": {
-        "acknowledge-terms-required": "Terms and Conditions checkbox must be selected",
-        "acknowledge-privacy-required": "Privacy Notice Statement checkbox must be selected",
-        "share-data-required": "Sharing of data checkbox must be selected"
-      }
     }
   },
   "applicant-information": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -75,16 +75,6 @@
       "info-source": "https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/fr-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/fr/"
-    },
-    "checkboxes": {
-      "acknowledge-terms": "Je reconnais avoir lu les modalités",
-      "acknowledge-privacy": "Je reconnais avoir lu l'avis de confidentialité",
-      "share-data": "Je consens à l'échange des données",
-      "error-message": {
-        "acknowledge-terms-required": "La case à cocher des modalités doit être sélectionnée",
-        "acknowledge-privacy-required": "La case à cocher de l'avis de confidentialité doit être sélectionnée",
-        "share-data-required": "La case à cocher de l'échange des données doit être sélectionnée"
-      }
     }
   },
   "tax-filing": {

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -79,16 +79,6 @@
       "info-source": "https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html",
       "microsoft-data-privacy-policy": "https://www.microsoft.com/fr-ca/trust-center/privacy",
       "sun-life": "https://www.sunlife.ca/fr/"
-    },
-    "checkboxes": {
-      "acknowledge-terms": "Je reconnais avoir lu les modalités",
-      "acknowledge-privacy": "Je reconnais avoir lu l'avis de confidentialité",
-      "share-data": "Je consens à l'échange des données",
-      "error-message": {
-        "acknowledge-terms-required": "La case à cocher des modalités doit être sélectionnée",
-        "acknowledge-privacy-required": "La case à cocher de l'avis de confidentialité doit être sélectionnée",
-        "share-data-required": "La case à cocher de l'échange des données doit être sélectionnée"
-      }
     }
   },
   "applicant-information": {


### PR DESCRIPTION
### Description
Latest designs removes the Terms and Conditions checkboxes for renewal.

This PR also removes unused i18n keys, state object and fixes the `h1` on the `protected/renew/index`

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/fe936ce2-50e7-47f6-861d-521fbe9f2435)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/en/renew` and verify no checkboxes appear on Terms and Conditions page.
