### PR TITLE
Adding optional `referenceDate` parameter for `getAge` functions

### DIFF
--- a/frontend/__tests__/utils/date-utils.test.ts
+++ b/frontend/__tests__/utils/date-utils.test.ts
@@ -101,6 +101,11 @@ describe('useMonths', () => {
     it('should throw an error for an invalid date string', () => {
       expect(() => getAgeFromDateString('abcd-ef-gh')).toThrowError();
     });
+
+    it('should return age when reference date is passed', () => {
+      expect(getAgeFromDateString('2000-01-01', '2024-12-31')).toEqual(24);
+      expect(getAgeFromDateString('2000-01-01', '2025-01-01')).toEqual(25);
+    });
   });
 
   describe('getAgeFromDateTimeString', () => {
@@ -115,19 +120,32 @@ describe('useMonths', () => {
     it('should throw an error for an invalid datetime string', () => {
       expect(() => getAgeFromDateTimeString('abcd-ef-gh')).toThrowError();
     });
+
+    it('should return age when reference date is passed', () => {
+      expect(getAgeFromDateTimeString('2000-01-02T00:00:00.000Z', '2025-01-01T23:59:59.999Z')).toEqual(24);
+      expect(getAgeFromDateTimeString('2000-01-02T00:00:00.000Z', '2025-01-02T00:00:00.000Z')).toEqual(25);
+    });
   });
 
   describe('getAgeFromDate', () => {
-    it('should return the age from a given UTC date object', () => {
+    it('should return the age from a given UTC date object with default date', () => {
       expect(getAgeFromDate(new UTCDate(2000, 0, 1))).toEqual(24);
     });
 
-    it('should return the age rounded down to closest full year from a given UTC date object', () => {
+    it('should return the age rounded down to closest full year from a given UTC date object with default date', () => {
       expect(getAgeFromDate(new UTCDate(2000, 0, 2))).toEqual(23);
     });
 
     it('should throw an error if the UTC date is in the future', () => {
       expect(() => getAgeFromDate(new UTCDate(3000, 0, 1))).toThrowError();
+    });
+
+    it('should calculate age as of a specific reference date in the future', () => {
+      expect(getAgeFromDate(new UTCDate(2000, 0, 1), new UTCDate(2030, 0, 1))).toEqual(30);
+    });
+
+    it('should throw an error if referenceDate is before the UTC date', () => {
+      expect(() => getAgeFromDate(new UTCDate(2000, 1, 1, 24, 0, 0, 0), new UTCDate(2000, 1, 1, 23, 59, 59, 999))).toThrowError();
     });
   });
 

--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -39,33 +39,56 @@ export function extractDateParts(date: string) {
 }
 
 /**
+ * Calculates the age in full years based on a given date string.
+ * The age is determined by comparing the provided date to the current date or to an optional reference date.
  *
  * @param date string representing the date (ex. '2024-01-01')
- * @returns difference in full years from the current date and the input.  This operation rounds the year down for fractional time differences.
+ * @param referenceDate optional string representing the reference date (ex. '2025-01-01'). If not provided, the current date is used.
+ * @returns difference in full years from the current date and the input. This operation rounds the year down for fractional time differences.
+ * @throws Error if the provided `date` or `referenceDate` is invalid.
  */
-export function getAgeFromDateString(date: string) {
+export function getAgeFromDateString(date: string, referenceDate?: string) {
   invariant(isValidDateString(date), `date is invalid [${date}]`);
-  return getAgeFromDate(parseDateString(date));
+  if (!referenceDate) {
+    return getAgeFromDate(parseDateString(date));
+  }
+
+  invariant(isValidDateString(referenceDate), `referenceDate is invalid [${referenceDate}]`);
+  return getAgeFromDate(parseDateString(date), parseDateString(referenceDate));
 }
 
 /**
+ * Calculates the age in full years based on a given date-time string.
+ * The age is determined by comparing the provided date-time to the current date-time or to an optional reference date-time.
  *
  * @param dateTime string representing the datetime (ex. '2024-01-01T00:00:00Z')
- * @returns difference in full years from the current date and the input.  This operation rounds the year down for fractional time differences.
+ * @param referenceDateTime (optional) string representing the reference datetime (ex. '2025-01-01T00:00:00Z'). If not provided, the current date-time is used.
+ * @returns difference in full years from the current date and the input. This operation rounds the year down for fractional time differences.
+ * @throws Error if the provided `dateTime` or `referenceDateTime` is invalid.
  */
-export function getAgeFromDateTimeString(dateTime: string) {
+export function getAgeFromDateTimeString(dateTime: string, referenceDateTime?: string) {
   invariant(isValidDateTimeString(dateTime), `dateTime is invalid [${dateTime}]`);
-  return getAgeFromDate(parseDateTimeString(dateTime));
+  if (!referenceDateTime) {
+    return getAgeFromDate(parseDateTimeString(dateTime));
+  }
+
+  invariant(isValidDateTimeString(referenceDateTime), `referenceDateTime is invalid [${referenceDateTime}]`);
+  return getAgeFromDate(parseDateTimeString(dateTime), parseDateTimeString(referenceDateTime));
 }
 
 /**
+ * Calculates the difference in full years between two dates.
+ * If no specific date is provided, it defaults to today's date.
  *
- * @param utcDate UTC date object (ex. new UTCDate(2024,1,1))
- * @returns difference in full years from the current date and the input.  This operation rounds the year down for fractional time differences.
+ * @param utcDate UTC date object (ex. new UTCDate(2024, 1, 1))
+ * @param referenceDate Optional UTC date object to calculate the age as of that date. Defaults to today's date.
+ * @returns Difference in full years between `referenceDate` (or today) and `utcDate`. This operation rounds the year down for fractional time differences.
+ * @throws Error if `utcDate` is in the past or if `referenceDate` is earlier than `utcDate`.
  */
-export function getAgeFromDate(utcDate: UTCDate) {
+export function getAgeFromDate(utcDate: UTCDate, referenceDate: UTCDate = new UTCDate()) {
   invariant(isPastDate(utcDate), `utcDate must be in past [${utcDate}]`);
-  return differenceInYears(new UTCDate(), utcDate);
+  invariant(referenceDate >= utcDate, `referenceDate [${referenceDate}] must not be earlier than utcDate [${utcDate}]`);
+  return differenceInYears(referenceDate, utcDate);
 }
 
 export function isPastDateString(date: string) {


### PR DESCRIPTION
### Description
As per title.

This optional parameter will eventually be used for calculating children's age based off the coverage start date introduced in: #2761. 

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`