### PR TITLE
Adding date of birth validation based on coverage start date on child information pages

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
-import { getFixedT } from '~/.server/utils/locale.utils';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
@@ -27,7 +27,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
-import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
+import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -77,6 +77,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const renewState = loadRenewAdultChildState({ params, request, session });
+
+  const locale = getLocale(request);
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // Form action Continue & Save
@@ -122,6 +124,8 @@ export async function action({ context: { appContainer, session }, params, reque
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
 
+      const coverageStartDate = renewState.applicationYear.coverageStartDate;
+
       if (!isValidDateString(dateOfBirth)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -138,6 +142,12 @@ export async function action({ context: { appContainer, session }, params, reque
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t('renew-adult-child:children.information.error-message.date-of-birth-is-past-valid'),
+          path: ['dateOfBirth'],
+        });
+      } else if (getAgeFromDateString(dateOfBirth, coverageStartDate) >= 18) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('renew-adult-child:children.information.error-message.date-of-birth-ineligible', { coverageStartDate: toLocaleDateString(parseDateString(coverageStartDate), locale) }),
           path: ['dateOfBirth'],
         });
       }

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -310,6 +310,7 @@
         "date-of-birth-day-required": "Date of birth must include a day",
         "date-of-birth-is-past": "Date of birth must be in the past",
         "date-of-birth-is-past-valid": "Date of birth too far in the past",
+        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageStartDate}}. They must submit an application as an adult to maintain their dental coverage.",
         "date-of-birth-month-required": "Date of birth must include a month",
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -58,6 +58,7 @@
         "date-of-birth-day-required": "Date of birth must include a day",
         "date-of-birth-is-past": "Date of birth must be in the past",
         "date-of-birth-is-past-valid": "Date of birth too far in the past",
+        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageStartDate}}. They must submit an application as an adult to maintain their dental coverage.",
         "date-of-birth-month-required": "Date of birth must include a month",
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -311,6 +311,7 @@
         "date-of-birth-day-required": "La date de naissance doit inclure un jour",
         "date-of-birth-is-past": "La date de naissance doit être dans le passé",
         "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
+        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageStartDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
         "date-of-birth-month-required": "La date de naissance doit inclure un mois",
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -59,6 +59,7 @@
         "date-of-birth-day-required": "La date de naissance doit inclure un jour",
         "date-of-birth-is-past": "La date de naissance doit être dans le passé",
         "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
+        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageStartDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
         "date-of-birth-month-required": "La date de naissance doit inclure un mois",
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisi",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",


### PR DESCRIPTION
### Description
If the child is 18 or over when the coverage period starts, an error message appears on the child information page's date of birth field.

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Screenshots (if applicable)
English:
![image](https://github.com/user-attachments/assets/f610bdcd-1dad-496b-a3e5-45c770ea600e)

French:
![image](https://github.com/user-attachments/assets/cbb0d79c-7938-43b3-9f32-beb9b3003722)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go to `/en/renew` navigate to either the Adult/Child or Child flow. Fill out the form to renew a new child, but enter a date of birth that is April 1, 2007 or before (the mocks currently have a coverage start date of April 1, 2025). You should see an error message display.

### Additional Notes
Will be done in a future PR:

- For the protected renewal flow, any children over 18 when coverage starts will not be available on the member selection screen. 
- ~~The state mapper will need to filter out these ineligible children when mapping to the benefit renewal DTO.~~
No need to do this as the mapper only maps children who have been added to state and can only be eligible.