### PR TITLE
Filter children who are 18 or older at the start of the coverage period on protected renew member selection page

### DIFF
--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -175,6 +175,31 @@
         },
         {
           "PersonBirthDate": {
+            "date": "2000-01-01"
+          },
+          "PersonName": [
+            {
+              "PersonGivenName": ["Richard"],
+              "PersonSurName": "Doe"
+            }
+          ],
+          "PersonRelationshipCode": {
+            "ReferenceDataName": "Dependant"
+          },
+          "PersonSINIdentification": {
+            "IdentificationID": "100000010"
+          },
+          "ApplicantDetail": {
+            "PrivateDentalInsuranceIndicator": false,
+            "AttestParentOrGuardianIndicator": true
+          },
+          "ClientIdentification": {
+            "IdentificationID": "10000000004",
+            "IdentificationCategoryText": "Client Number"
+          }
+        },
+        {
+          "PersonBirthDate": {
             "date": "1970-01-01"
           },
           "PersonName": [


### PR DESCRIPTION
### Description
Also added a second child to the client application data mock for testing. This child is ineligible because they are over 18 at the (mock) coverage start date.

### Related Azure Boards Work Items
[AB#4860](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4860)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b12ba516-5317-460c-9237-5935abcdfbab)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go to `/en/protected/renew` and continue until you reach the member selection page. Assuming the power platform mocks are enabled, "Richard Doe" (another child on file in the client application response) should not appear on the member selection page.