### PR TITLE
add exit-application route to renew-child flow

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -156,6 +156,7 @@ export const pageIds = {
         confirmAddress: 'CDCP-RENW-CHLD-0011',
         updateAddress: 'CDCP-RENW-CHLD-0012',
         reviewChildInformation: 'CDCP-RENW-CHLD-0013',
+        exitApplication: 'CDCP-RENW-CHLD-0015',
       },
     },
     unableToProcessRequest: 'CDCP-UNAB-0001',

--- a/frontend/app/routes/public/renew/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/child/exit-application.tsx
@@ -1,0 +1,83 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useParams } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.exitApplication,
+  pageTitleI18nKey: 'renew-child:exit-application.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const { id } = loadRenewChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:exit-application.page-title') }) };
+
+  return { id, meta };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  clearRenewState({ params, session });
+  return redirect(t('renew-child:exit-application.exit-link'));
+}
+
+export default function RenewChildExitApplication() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <div className="max-w-prose">
+      <div className="mb-8 space-y-4">
+        <p>{t('renew-child:exit-application.are-you-sure')}</p>
+        <p>{t('renew-child:exit-application.click-back')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <CsrfTokenInput />
+        <ButtonLink
+          id="back-button"
+          routeId="public/renew/$id/child/review-adult-information"
+          params={params}
+          disabled={isSubmitting}
+          startIcon={faChevronLeft}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Exiting the application click"
+        >
+          {t('renew-child:exit-application.back-btn')}
+        </ButtonLink>
+        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Exit - Exiting the application click">
+          {t('renew-child:exit-application.exit-btn')}
+        </LoadingButton>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -388,5 +388,13 @@
     "yes": "Yes",
     "no": "No",
     "no-update": "No update"
+  },
+  "exit-application": {
+    "page-title": "Exiting the application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and the information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -391,5 +391,13 @@
     "yes": "Oui",
     "no": "Non",
     "no-update": "Aucun changement"
+  },
+  "exit-application": {
+    "page-title": "Quitter la demande",
+    "are-you-sure": "Êtes-vous certain de vouloir quitter cette demande? Si vous cliquez sur «\u00a0Quitter\u00a0», le formulaire sera réinitialisé et vos renseignements seront perdus.",
+    "click-back": "Cliquez sur «\u00a0Retour\u00a0» pour retourner au formulaire.",
+    "back-btn": "Retour",
+    "exit-btn": "Quitter",
+    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   }
 }


### PR DESCRIPTION
### Description
adds `/renew/child/exit-application`

### Related Azure Boards Work Items
[AB#4587](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4587)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`