### PR TITLE
add demographic-survey route to renew-child flow

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -157,6 +157,7 @@ export const pageIds = {
         updateAddress: 'CDCP-RENW-CHLD-0012',
         reviewChildInformation: 'CDCP-RENW-CHLD-0013',
         exitApplication: 'CDCP-RENW-CHLD-0015',
+        demographicSurvey: 'CDCP-RENW-CHLD-0016',
       },
     },
     unableToProcessRequest: 'CDCP-UNAB-0001',

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
+import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import type { InputCheckboxesProps } from '~/components/input-checkboxes';
+import { InputCheckboxes } from '~/components/input-checkboxes';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { InputSanitizeField } from '~/components/input-sanitize-field';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Save = 'save',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.child.demographicSurvey,
+  pageTitleI18nKey: 'renew-child:demographic-survey.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const state = loadRenewSingleChildState({ params, request, session });
+
+  const childNumber = t('renew-child:children.child-number', { childNumber: state.childNumber });
+  const memberName = state.information?.firstName ?? childNumber;
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:demographic-survey.page-title', { memberName }) }) };
+
+  const demographicSurveyService = appContainer.get(TYPES.domain.services.DemographicSurveyService);
+  const indigenousStatuses = demographicSurveyService.listLocalizedIndigenousStatuses(locale);
+  const firstNations = demographicSurveyService.listLocalizedFirstNations(locale);
+  const disabilityStatuses = demographicSurveyService.listLocalizedDisabilityStatuses(locale);
+  const ethnicGroups = demographicSurveyService.listLocalizedEthnicGroups(locale);
+  const locationBornStatuses = demographicSurveyService.listLocalizedLocationBornStatuses(locale);
+  const genderStatuses = demographicSurveyService.listLocalizedGenderStatuses(locale);
+
+  return {
+    meta,
+    indigenousStatuses,
+    firstNations,
+    disabilityStatuses,
+    ethnicGroups,
+    locationBornStatuses,
+    genderStatuses,
+    defaultState: state.demographicSurvey,
+    editMode: state.editMode,
+    i18nOptions: { memberName },
+    memberName,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewSingleChildState({ params, request, session });
+  const renewState = loadRenewState({ params, session });
+
+  const {
+    IS_APPLICANT_FIRST_NATIONS_YES_OPTION,
+    ANOTHER_ETHNIC_GROUP_OPTION,
+    INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER,
+    DISABILITY_STATUS_PREFER_NOT_TO_ANSWER,
+    ETHNIC_GROUP_PREFER_NOT_TO_ANSWER,
+    LOCATION_BORN_STATUS_PREFER_NOT_TO_ANSWER,
+    GENDER_STATUS_PREFER_NOT_TO_ANSWER,
+  } = appContainer.get(TYPES.configs.ClientConfig);
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const demographicSurveySchema = z
+    .object({
+      indigenousStatus: z.string().trim().optional(),
+      firstNations: z.string().trim().optional(),
+      disabilityStatus: z.string().trim().optional(),
+      ethnicGroups: z.array(z.string().trim()),
+      anotherEthnicGroup: z.string().trim().optional(),
+      locationBornStatus: z.string().trim().optional(),
+      genderStatus: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.indigenousStatus === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString() && !val.firstNations) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:demographic-survey.error-message.first-nations-required'), path: ['firstNations'] });
+      }
+
+      if (val.ethnicGroups.includes(ANOTHER_ETHNIC_GROUP_OPTION.toString()) && !val.anotherEthnicGroup) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:demographic-survey.error-message.another-ethnic-group-required'), path: ['anotherEthnicGroup'] });
+      }
+    });
+
+  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+
+  const parsedDataResult = demographicSurveySchema.safeParse({
+    indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
+    firstNations: String(formData.get('firstNations') ?? ''),
+    disabilityStatus: preferNotToAnswer ? DISABILITY_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('disabilityStatus') ?? ''),
+    ethnicGroups: preferNotToAnswer || formData.getAll('ethnicGroups').includes(ETHNIC_GROUP_PREFER_NOT_TO_ANSWER.toString()) ? [ETHNIC_GROUP_PREFER_NOT_TO_ANSWER.toString()] : formData.getAll('ethnicGroups'),
+    anotherEthnicGroup: String(formData.get('anotherEthnicGroup') ?? ''),
+    locationBornStatus: preferNotToAnswer ? LOCATION_BORN_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('locationBornStatus') ?? ''),
+    genderStatus: preferNotToAnswer ? GENDER_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('genderStatus') ?? ''),
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      children: renewState.children.map((child) => {
+        if (child.id !== state.id) return child;
+        return { ...child, isSurveyCompleted: true, demographicSurvey: parsedDataResult.data, previouslyReviewed: true };
+      }),
+    },
+  });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/child/review-child-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/child/children/index', params));
+}
+
+export default function RenewChildrenDemographicSurveyQuestions() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = useLoaderData<typeof loader>();
+  const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const params = useParams();
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    indigenousStatus: 'input-radio-indigenous-status-option-0-label',
+    firstNations: 'input-radio-first-nations-option-0-label',
+    disabilityStatus: 'input-radio-disability-status-option-0-label',
+    ethnicGroups: 'input-checkboxes-ethnic-groups',
+    anotherEthnicGroup: 'another-ethnic-group',
+    locationBornStatus: 'input-radio-location-born-status-option-0-label',
+    genderStatus: 'input-radio-gender-status-option-0-label',
+  });
+
+  const [isIndigenousStatusValue, setIsIndigenousStatusValue] = useState(defaultState?.indigenousStatus === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString());
+  const [isAnotherEthnicGroupValue, setIsAnotherEthnicGroupValue] = useState(defaultState?.ethnicGroups?.includes(ANOTHER_ETHNIC_GROUP_OPTION.toString()));
+
+  function handleOnIsIndigenousStatusChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setIsIndigenousStatusValue(e.target.value === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString());
+  }
+
+  function handleOnIsAnotherEthnicGroupChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setIsAnotherEthnicGroupValue(e.target.value === ANOTHER_ETHNIC_GROUP_OPTION.toString());
+  }
+
+  const firstNationsOptions = useMemo<InputCheckboxesProps['options']>(() => {
+    return firstNations.map((status) => ({ defaultChecked: defaultState?.firstNations?.includes(status.id), children: status.name, value: status.id }));
+  }, [defaultState?.firstNations, firstNations]);
+
+  const indigenousStatusOptions = indigenousStatuses.map((status) => ({
+    defaultChecked: status.id === defaultState?.indigenousStatus,
+    children: status.name,
+    value: status.id,
+    onChange: handleOnIsIndigenousStatusChanged,
+    append: status.id === IS_APPLICANT_FIRST_NATIONS_YES_OPTION.toString() && isIndigenousStatusValue && (
+      <InputRadios id="first-nations" name="firstNations" legend={t('renew-child:demographic-survey.indigenous-status')} options={firstNationsOptions} errorMessage={errors?.firstNations} required />
+    ),
+  }));
+
+  const disabilityStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return disabilityStatuses.map((status) => ({ defaultChecked: status.id === defaultState?.disabilityStatus, children: status.name, value: status.id }));
+  }, [defaultState?.disabilityStatus, disabilityStatuses]);
+
+  const ethnicGroupOptions = ethnicGroups.map((status) => ({
+    defaultChecked: defaultState?.ethnicGroups?.includes(status.id),
+    children: status.name,
+    value: status.id,
+    onChange: status.id === ANOTHER_ETHNIC_GROUP_OPTION.toString() ? handleOnIsAnotherEthnicGroupChanged : undefined,
+    append: status.id === ANOTHER_ETHNIC_GROUP_OPTION.toString() && isAnotherEthnicGroupValue && (
+      <InputSanitizeField
+        id="another-ethnic-group"
+        name="anotherEthnicGroup"
+        label={t('renew-child:demographic-survey.ethnic-groups', { memberName })}
+        defaultValue={defaultState?.anotherEthnicGroup ?? ''}
+        errorMessage={errors?.anotherEthnicGroup}
+        required
+      />
+    ),
+  }));
+
+  const locationBornStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return locationBornStatuses.map((status) => ({ defaultChecked: status.id === defaultState?.locationBornStatus, children: status.name, value: status.id }));
+  }, [defaultState?.locationBornStatus, locationBornStatuses]);
+
+  const genderStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return genderStatuses.map((status) => ({ defaultChecked: status.id === defaultState?.genderStatus, children: status.name, value: status.id }));
+  }, [defaultState?.genderStatus, genderStatuses]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={88} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-8 space-y-6">
+            <p>{t('renew-child:demographic-survey.improve-cdcp')}</p>
+            <p>{t('renew-child:demographic-survey.confidential')}</p>
+            <p>{t('renew-child:demographic-survey.impact-enrollment')}</p>
+            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application:Prefer not to answer - Demographic survey click">
+              {t('renew-child:demographic-survey.prefer-not-to-answer-btn')}
+            </Button>
+            <p className="mb-4 italic">{t('renew-child:demographic-survey.optional')}</p>
+            <InputRadios id="indigenous-status" name="indigenousStatus" legend={t('renew-child:demographic-survey.indigenous-status', { memberName })} options={indigenousStatusOptions} errorMessage={errors?.indigenousStatus} required />
+            <InputRadios id="disability-status" name="disabilityStatus" legend={t('renew-child:demographic-survey.disability-status', { memberName })} options={disabilityStatusOptions} errorMessage={errors?.disabilityStatus} required />
+            <InputCheckboxes id="ethnic-groups" name="ethnicGroups" legend={t('renew-child:demographic-survey.ethnic-groups', { memberName })} options={ethnicGroupOptions} errorMessage={errors?.ethnicGroups} required />
+            <InputRadios id="location-born-status" name="locationBornStatus" legend={t('renew-child:demographic-survey.location-born-status', { memberName })} options={locationBornStatusOptions} errorMessage={errors?.locationBornStatus} required />
+            <InputRadios id="gender-status" name="genderStatus" legend={t('renew-child:demographic-survey.gender-status', { memberName })} options={genderStatusOptions} errorMessage={errors?.genderStatus} required />
+          </div>
+
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <LoadingButton id="save-button" variant="primary" name="_action" value={FormAction.Continue} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other dental insurance click">
+                {t('renew-child:demographic-survey.save-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/child/review-child-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other dental insurance click"
+              >
+                {t('renew-child:demographic-survey.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="continue-button" variant="primary" name="_action" value={FormAction.Continue} loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Demographic Survey:Save - Questions click">
+                {t('renew-child:demographic-survey.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/child/children/$childId/dental-insurance"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Demographic Survey:Cancel - Questions click"
+              >
+                {t('renew-child:demographic-survey.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -396,5 +396,26 @@
     "back-btn": "Back",
     "exit-btn": "Exit",
     "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "demographic-survey": {
+    "page-title": "Voluntary demographic questions for {{memberName}}",
+    "improve-cdcp": "Answering these questions is optional. Your answers will help Health Canada improve the Canadian Dental Care Plan and make sure our services are accessible to everyone.",
+    "confidential": "The information collected will only be used for statistical purposes and will be kept confidential.",
+    "impact-enrollment": "Your completion of the demographic questions will not impact your enrolment in the Canadian Dental Care Plan.",
+    "prefer-not-to-answer-btn": "Prefer not to answer",
+    "optional": "All questions are optional.",
+    "indigenous-status": "Is {{memberName}} First Nations, Métis or Inuk (Inuit)?",
+    "disability-status": "Does {{memberName}} have a disability?",
+    "ethnic-groups": "In our society, people are often described by their race or racial background. These are not based in science, but our race may influence the way we are treated by individuals and institutions, and this may affect our health. Which category(ies) best describes {{memberName}}? Check all that apply:",
+    "location-born-status": "Where was {{memberName}} born?",
+    "gender-status": "What is {{memberName}}'s gender?",
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "save-btn": "Save",
+    "cancel-btn": "Cancel",
+    "error-message": {
+      "first-nations-required": "Please select if this person is First Nations, Métis or Inuk (Inuit)",
+      "another-ethnic-group-required": "Please specify the ethnic group"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -399,5 +399,26 @@
     "back-btn": "Retour",
     "exit-btn": "Quitter",
     "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
+  "demographic-survey": {
+    "page-title": "Voluntary demographic questions for {{memberName}}",
+    "improve-cdcp": "Answering these questions is optional. Your answers will help Health Canada improve the Canadian Dental Care Plan and make sure our services are accessible to everyone.",
+    "confidential": "The information collected will only be used for statistical purposes and will be kept confidential.",
+    "impact-enrollment": "Your completion of the demographic questions will not impact your enrolment in the Canadian Dental Care Plan.",
+    "prefer-not-to-answer-btn": "Prefer not to answer",
+    "optional": "All questions are optional.",
+    "indigenous-status": "Is {{memberName}} First Nations, Métis or Inuk (Inuit)?",
+    "disability-status": "Does {{memberName}} have a disability?",
+    "ethnic-groups": "In our society, people are often described by their race or racial background. These are not based in science, but our race may influence the way we are treated by individuals and institutions, and this may affect our health. Which category(ies) best describes {{memberName}}? Check all that apply:",
+    "location-born-status": "Where was {{memberName}} born?",
+    "gender-status": "What is {{memberName}}'s gender?",
+    "continue-btn": "Continue",
+    "back-btn": "Back",
+    "save-btn": "Save",
+    "cancel-btn": "Cancel",
+    "error-message": {
+      "first-nations-required": "Please select if this person is First Nations, Métis or Inuk (Inuit)",
+      "another-ethnic-group-required": "Please specify the ethnic group"
+    }
   }
 }


### PR DESCRIPTION
### Description
adds `public/renew/$id/child/children/$childId/demographic-survey`

Note:
- translations need to be added/updated (I plan to do this in one fell swoop across all flows)
- PP json needs to be 'reloaded' (we control this data though since PP never actually sent this file; I will address in a separate PR)
- there is no adult only demographic-survey route in the renew-child flow 

### Related Azure Boards Work Items
[AB#4587](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4587)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
