### PR TITLE
Changing partner information's date of birth to year of birth for client application and benefit renewal entities/DTOs

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -135,7 +135,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
             RelatedPerson: [
               {
                 PersonBirthDate: {
-                  date: '2000-01-01',
+                  YearDate: '2000',
                 },
                 PersonName: [
                   {
@@ -219,7 +219,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
         livingIndependently: true,
         partnerInformation: {
           confirm: false,
-          dateOfBirth: '2000-01-01',
+          yearOfBirth: '2000',
           firstName: 'Jane',
           lastName: 'Doe',
           socialInsuranceNumber: '80000002',

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -96,7 +96,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
     isInvitationToApplyClient: false,
     partnerInformation: {
       confirm: true,
-      dateOfBirth: '1970-01-01',
+      yearOfBirth: '1970',
       firstName: 'Jane',
       lastName: 'Doe',
       socialInsuranceNumber: '800011819',

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest';
 
-import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, ContactInformationDto, PartnerInformationDto } from '~/.server/domain/dtos/benefit-application.dto';
+import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, ContactInformationDto } from '~/.server/domain/dtos/benefit-application.dto';
 
 export type ClientApplicationDto = ReadonlyDeep<{
   applicantInformation: ClientApplicantInformationDto;
@@ -14,7 +14,7 @@ export type ClientApplicationDto = ReadonlyDeep<{
   hasFiledTaxes: boolean;
   isInvitationToApplyClient: boolean;
   livingIndependently?: boolean;
-  partnerInformation?: PartnerInformationDto;
+  partnerInformation?: ClientPartnerInformationDto;
 }>;
 
 export type ClientApplicantInformationDto = ApplicantInformationDto & { clientNumber?: string };
@@ -29,6 +29,14 @@ export type ClientChildDto = Omit<ChildDto, 'information'> & {
     socialInsuranceNumber: string;
   };
 };
+
+export type ClientPartnerInformationDto = ReadonlyDeep<{
+  confirm: boolean;
+  yearOfBirth: string;
+  firstName: string;
+  lastName: string;
+  socialInsuranceNumber: string;
+}>;
 
 export type ClientApplicationBasicInfoRequestDto = Readonly<{
   clientNumber: string;

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -103,7 +103,8 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
           IdentificationCategoryText: string;
         }[];
         PersonBirthDate: {
-          date: string;
+          date?: string;
+          YearDate?: string;
         };
         PersonName?: {
           PersonGivenName: string[];

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -80,7 +80,8 @@ export type ClientApplicationEntity = ReadonlyDeep<{
       }>;
       RelatedPerson: Array<{
         PersonBirthDate: {
-          date: string;
+          date?: string;
+          YearDate?: string;
         };
         PersonName: Array<{
           PersonGivenName: Array<string>;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -366,7 +366,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
   private toRelatedPersonSpouse({ confirm, socialInsuranceNumber, yearOfBirth }: RenewalPartnerInformationDto) {
     return {
       PersonBirthDate: {
-        date: yearOfBirth, // TODO verify with Interop/PP that the PersonBirthDate field can be populated with just a year
+        YearDate: yearOfBirth,
       },
       PersonRelationshipCode: {
         ReferenceDataName: 'Spouse' as const,
@@ -400,7 +400,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
         PrivateDentalInsuranceIndicator: child.dentalInsurance,
         InsurancePlan: this.toInsurancePlan(child.dentalBenefits),
       },
-      BenefitApplicationDetail: [], // TODO map this
+      BenefitApplicationDetail: this.toBenefitApplicationDetail(child.demographicSurvey),
       ClientIdentification: [
         {
           IdentificationID: child.clientNumber,

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -62,7 +62,11 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
       information: {
         firstName: child.PersonName[0].PersonGivenName[0],
         lastName: child.PersonName[0].PersonSurName,
-        dateOfBirth: child.PersonBirthDate.date,
+        dateOfBirth:
+          child.PersonBirthDate.date ??
+          (() => {
+            throw new Error('Expected child.PersonBirthDate.date to be defined');
+          })(),
         isParent:
           child.ApplicantDetail.AttestParentOrGuardianIndicator ??
           (() => {
@@ -112,7 +116,11 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
             (() => {
               throw new Error('Expected partner.ApplicantDetail.ConsentToSharePersonalInformationIndicator to be defined');
             })(),
-          dateOfBirth: partner.PersonBirthDate.date,
+          yearOfBirth:
+            partner.PersonBirthDate.YearDate ??
+            (() => {
+              throw new Error('Expected partner.PersonBirthDate.YearDate to be defined');
+            })(),
           firstName: partner.PersonName[0].PersonGivenName[0],
           lastName: partner.PersonName[0].PersonSurName,
           socialInsuranceNumber: partner.PersonSINIdentification.IdentificationID,

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -200,7 +200,7 @@
         },
         {
           "PersonBirthDate": {
-            "date": "1970-01-01"
+            "YearDate": "1970"
           },
           "PersonName": [
             {

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -11,10 +11,10 @@ import type {
   ClientApplicantInformationDto,
   ClientApplicationDto,
   ClientChildDto,
+  ClientPartnerInformationDto,
   CommunicationPreferencesDto,
   ContactInformationDto,
   ItaBenefitRenewalDto,
-  PartnerInformationDto,
   ProtectedBenefitRenewalDto,
   RenewalApplicantInformationDto,
 } from '~/.server/domain/dtos';
@@ -135,7 +135,7 @@ interface ToDentalBenefitsArgs {
 }
 
 interface ToPartnerInformationArgs {
-  existingPartnerInformation?: ReadonlyObjectDeep<PartnerInformationDto>;
+  existingPartnerInformation?: ReadonlyObjectDeep<ClientPartnerInformationDto>;
   hasMaritalStatusChanged: boolean;
   renewedPartnerInformation?: PartnerInformationState;
 }
@@ -506,13 +506,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
   }
 
   private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs) {
-    if (hasMaritalStatusChanged) return renewedPartnerInformation;
-    if (!existingPartnerInformation) return undefined;
-
-    return {
-      confirm: existingPartnerInformation.confirm,
-      socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber,
-      yearOfBirth: new Date(existingPartnerInformation.dateOfBirth).getFullYear().toString(),
-    };
+    return hasMaritalStatusChanged ? renewedPartnerInformation : existingPartnerInformation;
   }
 }

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
   const partnerInformation = hasPartner
     ? (state.clientApplication.partnerInformation ?? state.partnerInformation) && {
-        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.dateOfBirth,
+        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.yearOfBirth,
         socialInsuranceNumber: state.partnerInformation?.socialInsuranceNumber ?? state.clientApplication.partnerInformation?.socialInsuranceNumber,
         confirm: state.partnerInformation?.confirm ?? state.clientApplication.partnerInformation?.confirm,
       }

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -100,7 +100,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
   const spouseInfo = hasPartner
     ? (state.clientApplication.partnerInformation ?? state.partnerInformation) && {
-        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.dateOfBirth,
+        yearOfBirth: state.partnerInformation?.yearOfBirth ?? state.clientApplication.partnerInformation?.yearOfBirth,
         sin: state.partnerInformation?.socialInsuranceNumber ?? state.clientApplication.partnerInformation?.socialInsuranceNumber,
         consent: state.partnerInformation?.confirm ?? state.clientApplication.partnerInformation?.confirm,
       }


### PR DESCRIPTION
### Description
Intrerop will return a year instead of a date for the partner (when retrieving a client application) to be consistent with accepting a year for submitting a benefit renewal.

Before this change, the protected Review page would be displaying the full date of birth for the partner.

Children and applicant will still be using date of birth.

### Related Azure Boards Work Items
[AB#4985](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4985)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/31c36ebe-a7c5-491e-8493-57f15cf5a6a7)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go to `/en/protected/renew` and reach the Review page. The partner's year of birth should display (assuming you have the Power Platform mock enabled).

### Additional Notes
Also sneaked in a `TODO` fix to map demographics for children when submitting a renewal application.