### PR TITLE
Renew child flow navigation fix

### DIFF
--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -272,6 +272,7 @@ export default function RenewChildIndex() {
               <LoadingButton
                 id="continue-button"
                 name="_action"
+                disabled={!hasChildren || isSubmitting}
                 value={FormAction.Continue}
                 variant="primary"
                 loading={isSubmitting && submitAction === FormAction.Continue}

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -130,7 +130,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewChildConfirmPhone() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
   const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -238,7 +238,7 @@ export default function RenewChildConfirmPhone() {
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/child/children/index" //TODO: marital-status screen is still work in progress, change the link when marital-status is done
+                routeId={hasMaritalStatusChanged ? 'public/renew/$id/child/marital-status' : 'public/renew/$id/child/confirm-marital-status'}
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}


### PR DESCRIPTION
### Description
A small pr to update the navigation on child index page and confirm email page.

- On child index page, the continue button is disabled when no children found
- Complete TODO on confirm email page, back button should navigate back to `marital-status` or `confirm-marital-status`

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->