### PR TITLE
Calling service to submit renewal application in MSCA

### DIFF
--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -155,9 +155,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:review-adult-information.page-title') }) };
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
-  //prettier - ignore;
+  // prettier-ignore
   const payload =
     viewPayloadEnabled &&
     appContainer
@@ -198,8 +197,6 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
-
   const state = loadProtectedRenewStateForReview({ params, session });
 
   if (validateProtectedChildrenStateForReview(state.children).length === 0) {

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -67,9 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
-  //prettier - ignore;
+  // prettier-ignore
   const payload =
     viewPayloadEnabled &&
     appContainer
@@ -140,7 +139,6 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');
-  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
   const benefitRenewalDto = appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapProtectedRenewStateToProtectedBenefitRenewalDto(state, userInfoToken.sub);
   await appContainer.get(TYPES.domain.services.BenefitRenewalService).createProtectedBenefitRenewal(benefitRenewalDto);


### PR DESCRIPTION
### Description
As per title to remove a `TODO`.

Also sneaked in a fix to correct `prettier-ignore` comment and removed unneeded `userInfoToken.sin` invariant since `sin` is not being used in the function.

### Related Azure Boards Work Items
[AB#4983](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4983)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/13f549b9-6f8c-4da0-bce0-239ab1c2bb36)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Enable `trace` logging. Complete the `/en/protected/renew` flow. You should see a protected benefit renewal being submitted in the logs.