### PR TITLE
fix back navigation in protected-renew application

### DIFF
--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -135,7 +135,7 @@ export async function action({ context: { appContainer, session }, params, reque
     if (!isPrimaryApplicantStateComplete(state)) {
       return redirect(getPathById('protected/renew/$id/member-selection', params));
     }
-    return redirect(getPathById('protected/renew/$id/review-child-information', params));
+    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');


### PR DESCRIPTION
### Description
Users should navigate back to the review-adult-information screen if the primary applicant state has been completed.  This fixes a typo in the redirect.

### Related Azure Boards Work Items
[AB#4977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4977)