### PR TITLE
add select member error to member-selection screen in protected-renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -368,6 +368,10 @@ export function isPrimaryApplicantStateComplete(state: ProtectedRenewState) {
   return state.dentalInsurance !== undefined && state.demographicSurvey !== undefined;
 }
 
+export function isChildrenStateComplete(state: ProtectedRenewState) {
+  return state.children.every((child) => child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && child.demographicSurvey !== undefined);
+}
+
 interface ValidateProtectedRenewStateForReviewArgs {
   params: Params;
   state: ProtectedRenewState;

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -110,7 +110,11 @@
     "back-btn": "Back",
     "continue-btn": "Continue",
     "cancel-btn": "Cancel",
-    "save-btn": "Save"
+    "save-btn": "Save",
+    "select-member": {
+      "heading": "Select a member",
+      "to-continue": "You must select a member to continue."
+    }
   },
   "dental-insurance": {
     "page-title": "{{memberName}}: Access to other dental insurance",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -110,7 +110,11 @@
     "back-btn": "Back",
     "continue-btn": "Continue",
     "cancel-btn": "Cancel",
-    "save-btn": "Save"
+    "save-btn": "Save",
+    "select-member": {
+      "heading": "Select a member",
+      "to-continue": "You must select a member to continue."
+    }
   },
   "dental-insurance": {
     "page-title": "{{memberName}}\u00a0: Access to other dental insurance",


### PR DESCRIPTION
### Description
adds "Select member" contextual alert to the member-selection screen if the primary applicant state and all the children state isn't complete when the user attempts to click continue.

Note:
translations will be up in a separate PR when the entire screen is translated.  This PR just puts in the implementation 

### Related Azure Boards Work Items
[AB#4977](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4977)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/7ee58529-4641-4b8f-b05e-fadab3c326f9)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`