### PR TITLE
AB#4890 Adult flow type of renewal screen

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -111,7 +111,7 @@ export interface RenewState {
     provincialTerritorialSocialProgram?: string;
     province?: string;
   };
-  readonly typeOfRenewal?: 'adult-child' | 'child' | 'delegate';
+  readonly typeOfRenewal?: 'adult' | 'adult-child' | 'child' | 'delegate';
   readonly submissionInfo?: {
     /**
      * The UTC date and time when the application was submitted.

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -24,6 +24,7 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 enum RenewalType {
+  Adult = 'adult',
   AdultChild = 'adult-child',
   Child = 'child',
   Delegate = 'delegate',
@@ -82,6 +83,13 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
+  if (parsedDataResult.data.typeOfRenewal === RenewalType.Adult) {
+    if (state.clientApplication?.isInvitationToApplyClient) {
+      return redirect(getPathById('public/renew/$id/ita/marital-status', params));
+    }
+    return redirect(getPathById('public/renew/$id/adult/confirm-marital-status', params));
+  }
+
   if (parsedDataResult.data.typeOfRenewal === RenewalType.AdultChild) {
     if (state.clientApplication?.isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
@@ -121,6 +129,11 @@ export default function RenewTypeOfRenewal() {
             name="typeOfRenewal"
             legend={t('renew:type-of-renewal.form-instructions')}
             options={[
+              {
+                value: RenewalType.Adult,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.personal" />,
+                defaultChecked: defaultState === RenewalType.Adult,
+              },
               {
                 value: RenewalType.AdultChild,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.personal-and-child" />,

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -129,6 +129,7 @@
     "page-title": "Type of renewal",
     "form-instructions": "Who are you renewing for?",
     "radio-options": {
+      "personal": "I am renewing for <strong>myself</strong>",
       "personal-and-child": "I am renewing for <strong>myself</strong> or <strong>myself and my child(ren)</strong>",
       "child": "I am renewing for <strong>my child(ren)</strong>",
       "delegate": "I am renewing on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>"

--- a/frontend/public/locales/en/renew.json
+++ b/frontend/public/locales/en/renew.json
@@ -130,7 +130,7 @@
     "form-instructions": "Who are you renewing for?",
     "radio-options": {
       "personal": "I am renewing for <strong>myself</strong>",
-      "personal-and-child": "I am renewing for <strong>myself</strong> or <strong>myself and my child(ren)</strong>",
+      "personal-and-child": "I am renewing for <strong>myself and my child(ren)</strong>",
       "child": "I am renewing for <strong>my child(ren)</strong>",
       "delegate": "I am renewing on behalf of someone else as a <strong>legal delegate or Power of Attorney</strong>"
     },

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -130,7 +130,7 @@
     "form-instructions": "Pour qui renouvelez-vous l'adhésion?",
     "radio-options": {
       "personal": "Je renouvelle pour <strong>moi-même</strong>",
-      "personal-and-child": "Je présente une demande de renouvellement pour <strong>moi-même</strong> ou pour <strong>moi-même et mon ou mes enfants</strong>",
+      "personal-and-child": "Je renouvelle pour <strong>moi-même et mon ou mes enfants</strong>",
       "child": "Je présente une demande de renouvellement pour <strong>mon ou mes enfants</strong>",
       "delegate": "Je présente une demande de renouvellement <strong>au nom d'une autre personne à titre de représentant légal ou mandataire</strong>"
     },

--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -129,6 +129,7 @@
     "page-title": "Type de renouvellement",
     "form-instructions": "Pour qui renouvelez-vous l'adhésion?",
     "radio-options": {
+      "personal": "Je renouvelle pour <strong>moi-même</strong>",
       "personal-and-child": "Je présente une demande de renouvellement pour <strong>moi-même</strong> ou pour <strong>moi-même et mon ou mes enfants</strong>",
       "child": "Je présente une demande de renouvellement pour <strong>mon ou mes enfants</strong>",
       "delegate": "Je présente une demande de renouvellement <strong>au nom d'une autre personne à titre de représentant légal ou mandataire</strong>"


### PR DESCRIPTION
### Description
add adult option to type renewal

### Related Azure Boards Work Items
[AB#4890](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4890)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->