### PR TITLE
fix back navigation in renew-adult-child flow

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -87,10 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.hasFederalProvincialTerritorialBenefitsChanged) {
-      return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
-    }
-    return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
+    return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
   }
 
   if (formAction === FormAction.Add) {


### PR DESCRIPTION
### Description
expected behaviour:
- user clicks 'back' on children hub => taken back to demographic-survey
- user clicks 'back' on demographic-survey => taken back to update-fpt-benefit screen if and only if they have indicated their benefits have changed, otherwise taken back to confirm-fpt-benefit screen

### Related Azure Boards Work Items
AB#5001

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`