### PR TITLE
AB#4892 Renew adult marital status and spouse info

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -113,6 +113,7 @@ export const pageIds = {
       renewalDelegate: 'CDCP-RENW-0007',
       adult: {
         confirmMaritalStatus: 'CDCP-RENW-AD-0001',
+        maritalStatus: 'CDCP-RENW-AD-0002',
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -1,0 +1,231 @@
+import type { ChangeEventHandler } from 'react';
+import { useMemo, useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
+import type { PartnerInformationState } from '~/.server/routes/helpers/renew-route-helpers';
+import { renewStateHasPartner, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adult.maritalStatus,
+  pageTitleI18nKey: 'renew-adult:marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultState({ params, request, session });
+  if (!state.hasMaritalStatusChanged) {
+    return redirect(getPathById('public/renew/$id/adult/confirm-marital-status', params));
+  }
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:marital-status.page-title') }) };
+
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  // state validation schema
+  const maritalStatusSchema = z.object({
+    maritalStatus: z
+      .string({ errorMap: () => ({ message: t('renew-adult:marital-status.error-message.marital-status-required') }) })
+      .trim()
+      .min(1, t('renew-adult:marital-status.error-message.marital-status-required')),
+  });
+
+  const currentYear = new Date().getFullYear().toString();
+  const partnerInformationSchema = z.object({
+    confirm: z.boolean().refine((val) => val === true, t('renew-adult:marital-status.error-message.confirm-required')),
+    yearOfBirth: z
+      .string()
+      .trim()
+      .min(1, t('renew-adult:marital-status.error-message.date-of-birth-year-required'))
+      .refine((year) => year < currentYear, t('renew-adult:marital-status.error-message.yob-is-future')),
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('renew-adult:marital-status.error-message.sin-required'))
+      .refine(isValidSin, t('renew-adult:marital-status.error-message.sin-valid'))
+      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-adult:marital-status.error-message.sin-unique')),
+  }) satisfies z.ZodType<PartnerInformationState>;
+
+  const maritalStatusData = {
+    maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,
+  };
+  const partnerInformationData = {
+    confirm: formData.get('confirm') === 'yes',
+    yearOfBirth: String(formData.get('yearOfBirth') ?? ''),
+    socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),
+  };
+
+  const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
+  const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
+
+  if (!parsedMaritalStatus.success || (renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
+    return {
+      errors: {
+        ...(parsedMaritalStatus.error ? transformFlattenedError(parsedMaritalStatus.error.flatten()) : {}),
+        ...(parsedMaritalStatus.success && renewStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(parsedPartnerInformation.error.flatten()) : {}),
+      },
+    };
+  }
+
+  saveRenewState({ params, session, state: { maritalStatus: parsedMaritalStatus.data.maritalStatus, partnerInformation: parsedPartnerInformation.data } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/confirm-phone', params));
+}
+
+export default function RenewAdultMaritalStatus() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const [marriedOrCommonlaw, setMarriedOrCommonlaw] = useState(defaultState.maritalStatus);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    maritalStatus: 'input-radio-marital-status-option-0',
+    yearOfBirth: 'year-of-birth',
+    socialInsuranceNumber: 'social-insurance-number',
+    confirm: 'input-checkbox-confirm',
+  });
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setMarriedOrCommonlaw(e.target.value);
+  };
+
+  const maritalStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState.maritalStatus, children: status.name, value: status.id, onChange: handleChange }));
+  }, [defaultState, maritalStatuses]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={44} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-8 space-y-6">
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('renew-adult:marital-status.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+
+            {(marriedOrCommonlaw === MARITAL_STATUS_CODE_COMMONLAW.toString() || marriedOrCommonlaw === MARITAL_STATUS_CODE_MARRIED.toString()) && (
+              <>
+                <h2 className="mb-6 font-lato text-2xl font-bold">{t('renew-adult:marital-status.spouse-or-commonlaw')}</h2>
+                <p className="mb-4">{t('renew-adult:marital-status.provide-sin')}</p>
+                <p className="mb-6">{t('renew-adult:marital-status.required-information')}</p>
+                <InputPatternField
+                  id="social-insurance-number"
+                  name="socialInsuranceNumber"
+                  format={sinInputPatternFormat}
+                  label={t('marital-status.sin')}
+                  inputMode="numeric"
+                  helpMessagePrimary={t('renew-adult:marital-status.help-message.sin')}
+                  helpMessagePrimaryClassName="text-black"
+                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                  errorMessage={errors?.socialInsuranceNumber}
+                  required
+                />
+                <InputPatternField id="year-of-birth" name="yearOfBirth" inputMode="numeric" format="####" defaultValue={defaultState.yearOfBirth ?? ''} label={t('renew-adult:marital-status.year-of-birth')} errorMessage={errors?.yearOfBirth} required />
+                <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.confirm === true} required>
+                  {t('renew-adult:marital-status.confirm-checkbox')}
+                </InputCheckbox>
+              </>
+            )}
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Marital status click">
+                {t('renew-adult:marital-status.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Marital status click">
+                {t('renew-adult:marital-status.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Marital status click"
+              >
+                {t('renew-adult:marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult/confirm-marital-status"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Marital status click"
+              >
+                {t('renew-adult:marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -693,6 +693,11 @@ export const routes = [
             file: 'routes/public/renew/$id/adult/confirm-marital-status.tsx',
             paths: { en: '/:lang/renew/:id/adult/confirm-marital-status', fr: '/:lang/renouveller/:id/adulte/confirmer-etat-civil' },
           },
+          {
+            id: 'public/renew/$id/adult/marital-status',
+            file: 'routes/public/renew/$id/adult/marital-status.tsx',
+            paths: { en: '/:lang/renew/:id/adult/marital-status', fr: '/:lang/renouveller/:id/adulte/etat-civil' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -14,5 +14,31 @@
     "error-message": {
       "has-marital-status-changed-required": "Please indicate if your marital status has changed"
     }
+  },
+  "marital-status": {
+    "page-title": "Marital status",
+    "marital-status": "What is your current marital status?",
+    "spouse-or-commonlaw": "Spouse or common-law partner information",
+    "provide-sin": "Provide the Social Insurance Number (SIN) of your current spouse or common-law partner. The information is required to calculate your adjusted family net income.",
+    "required-information": "Your spouse or common-law partner must submit their own application or renewal for the Canadian Dental Care Plan.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Social Insurance Number (SIN)",
+    "year-of-birth": "Year of birth",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "help-message": {
+      "sin": "Enter the 9-digit SIN"
+    },
+    "error-message": {
+      "marital-status-required": "Select marital status",
+      "confirm-required": "Checkbox must be selected",
+      "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-future": "Year of birth must be in the past",
+      "sin-required": "Enter 9-digit SIN, for example 123 456 789",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -14,5 +14,31 @@
     "error-message": {
       "has-marital-status-changed-required": "Please indicate if your marital status has changed"
     }
+  },
+  "marital-status": {
+    "page-title": "État civil",
+    "marital-status": "Quel est votre état civil actuel?",
+    "spouse-or-commonlaw": "Renseignements sur l'époux/épouse ou le conjoint/la conjointe de fait",
+    "provide-sin": "Fournissez le numéro d'assurance sociale de votre époux/épouse ou conjoint/conjointe de fait actuel(le). Ces renseignements sont nécessaires pour calculer votre revenu familial net rajusté.",
+    "required-information": "Votre époux/épouse ou conjoint/conjointe de fait doit présenter sa propre demande initiale ou demande de renouvellement au Régime canadien de soins dentaires.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "year-of-birth": "Année de naissance",
+    "confirm-checkbox": "Je confirme que mon époux/épouse ou conjoint/conjointe de fait est au courant de la communication de ses renseignements personnels et y a consenti.",
+    "help-message": {
+      "sin": "Entrez le NAS à 9 chiffres"
+    },
+    "error-message": {
+      "marital-status-required": "Sélectionnez l'état civil",
+      "confirm-required": "La case à cocher doit être sélectionnée",
+      "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-future": "L'année de naissance doit être dans le passé",
+      "sin-required": "Entrez un NAS de 9 chiffres",
+      "sin-valid": "Doit être un NAS valide",
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+    }
   }
 }


### PR DESCRIPTION
### Description
Add marital-status page for renew adult flow

### Related Azure Boards Work Items
[AB#4892](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4892)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->