### PR TITLE
AB#4893 Renew adult confirm phone

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -114,6 +114,7 @@ export const pageIds = {
       adult: {
         confirmMaritalStatus: 'CDCP-RENW-AD-0001',
         maritalStatus: 'CDCP-RENW-AD-0002',
+        confirmPhone: 'CDCP-RENW-AD-0003',
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { isValidPhoneNumber, parsePhoneNumberWithError } from 'libphonenumber-js';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputPhoneField } from '~/components/input-phone-field';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+enum AddOrUpdatePhoneOption {
+  Yes = 'yes',
+  No = 'no',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adult.confirmPhone,
+  pageTitleI18nKey: 'renew-adult:confirm-phone.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-phone.page-title') }) };
+
+  return {
+    id: state.id,
+
+    meta,
+    defaultState: {
+      isNewOrUpdatedPhoneNumber: state.contactInformation?.isNewOrUpdatedPhoneNumber,
+      phoneNumber: state.contactInformation?.phoneNumber,
+      phoneNumberAlt: state.contactInformation?.phoneNumberAlt,
+    },
+    hasMaritalStatusChanged: state.hasMaritalStatusChanged,
+    maritalStatus: state.maritalStatus,
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const phoneNumberSchema = z
+    .object({
+      isNewOrUpdatedPhoneNumber: z.nativeEnum(AddOrUpdatePhoneOption, {
+        errorMap: () => ({ message: t('renew-adult:confirm-phone.error-message.add-or-update-required') }),
+      }),
+      phoneNumber: z
+        .string()
+        .trim()
+        .max(100)
+        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('renew-adult:confirm-phone.error-message.phone-number-valid'))
+        .optional(),
+      phoneNumberAlt: z
+        .string()
+        .trim()
+        .max(100)
+        .refine((val) => !val || isValidPhoneNumber(val, 'CA'), t('renew-adult:confirm-phone.error-message.phone-number-alt-valid'))
+        .optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes) {
+        if (!val.phoneNumber) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-phone.error-message.phone-required'), path: ['phoneNumber'] });
+        }
+      }
+    })
+    .transform((val) => ({
+      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes,
+      phoneNumber: val.phoneNumber ? parsePhoneNumberWithError(val.phoneNumber, 'CA').formatInternational() : val.phoneNumber,
+      phoneNumberAlt: val.phoneNumberAlt ? parsePhoneNumberWithError(val.phoneNumberAlt, 'CA').formatInternational() : val.phoneNumberAlt,
+    }));
+
+  const parsedDataResult = phoneNumberSchema.safeParse({
+    isNewOrUpdatedPhoneNumber: formData.get('isNewOrUpdatedPhoneNumber'),
+    phoneNumber: formData.get('phoneNumber') ? String(formData.get('phoneNumber')) : undefined,
+    phoneNumberAlt: formData.get('phoneNumberAlt') ? String(formData.get('phoneNumberAlt')) : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/confirm-email', params));
+}
+
+export default function RenewAdultConfirmPhone() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    isNewOrUpdatedPhoneNumber: 'input-radio-is-new-or-updated-phone-number-option-0',
+    phoneNumber: 'phone-number',
+    phoneNumberAlt: 'phone-number-alt',
+  });
+
+  const [isNewOrUpdatedPhoneNumber, setIsNewOrUpdatedPhoneNumber] = useState(defaultState.isNewOrUpdatedPhoneNumber);
+
+  function handleNewOrUpdatePhoneNumberChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setIsNewOrUpdatedPhoneNumber(e.target.value === AddOrUpdatePhoneOption.Yes);
+  }
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={45} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-6">
+            <p className="mb-4" id="adding-phone">
+              {t('renew-adult:confirm-phone.add-phone')}
+            </p>
+            <InputRadios
+              id="is-new-or-updated-phone-number"
+              name="isNewOrUpdatedPhoneNumber"
+              legend={t('renew-adult:confirm-phone.add-or-update.legend')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-phone.option-yes" />,
+                  value: AddOrUpdatePhoneOption.Yes,
+                  defaultChecked: isNewOrUpdatedPhoneNumber === true,
+                  onChange: handleNewOrUpdatePhoneNumberChanged,
+                  append: isNewOrUpdatedPhoneNumber === true && (
+                    <div className="grid items-end gap-6">
+                      <InputPhoneField
+                        id="phone-number"
+                        name="phoneNumber"
+                        type="tel"
+                        inputMode="tel"
+                        className="w-full"
+                        autoComplete="tel"
+                        defaultValue={defaultState.phoneNumber ?? ''}
+                        errorMessage={errors?.phoneNumber}
+                        label={t('renew-adult:confirm-phone.phone-number')}
+                        maxLength={100}
+                        aria-describedby="adding-phone"
+                      />
+                      <InputPhoneField
+                        id="phone-number-alt"
+                        name="phoneNumberAlt"
+                        type="tel"
+                        inputMode="tel"
+                        className="w-full"
+                        autoComplete="tel"
+                        defaultValue={defaultState.phoneNumberAlt ?? ''}
+                        errorMessage={errors?.phoneNumberAlt}
+                        label={t('renew-adult:confirm-phone.phone-number-alt')}
+                        maxLength={100}
+                        aria-describedby="adding-phone"
+                      />
+                    </div>
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-phone.option-no" />,
+                  value: AddOrUpdatePhoneOption.No,
+                  defaultChecked: isNewOrUpdatedPhoneNumber === false,
+                  onChange: handleNewOrUpdatePhoneNumberChanged,
+                },
+              ]}
+              errorMessage={errors?.isNewOrUpdatedPhoneNumber}
+              required
+            />
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
+                {t('renew-adult:confirm-phone.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
+                {t('renew-adult:confirm-phone.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Contact information click"
+              >
+                {t('renew-adult:confirm-phone.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId={hasMaritalStatusChanged ? 'public/renew/$id/adult/marital-status' : 'public/renew/$id/adult/confirm-marital-status'}
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Contact information click"
+              >
+                {t('renew-adult:confirm-phone.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -698,6 +698,11 @@ export const routes = [
             file: 'routes/public/renew/$id/adult/marital-status.tsx',
             paths: { en: '/:lang/renew/:id/adult/marital-status', fr: '/:lang/renouveller/:id/adulte/etat-civil' },
           },
+          {
+            id: 'public/renew/$id/adult/confirm-phone',
+            file: 'routes/public/renew/$id/adult/confirm-phone.tsx',
+            paths: { en: '/:lang/renew/:id/adult/confirm-phone', fr: '/:lang/renouveller/:id/adulte/confirmer-telephone' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -40,5 +40,26 @@
       "sin-valid": "Must be a valid SIN",
       "sin-unique": "The Social Insurance Number (SIN) must be unique"
     }
+  },
+  "confirm-phone": {
+    "page-title": "Phone Number",
+    "add-phone": "An up-to-date phone number helps the Government of Canada contact you if there's an issue with your renewal. You can find the number we have on file in the letter from Service Canada. If you don't provide a phone number, we'll contact you by mail.",
+    "add-or-update": {
+      "legend": "Would you like to update or add your phone number?"
+    },
+    "phone-number": "Phone number",
+    "phone-number-alt": "Alternate phone number (optional)",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "option-yes": "Yes",
+    "option-no": "No",
+    "error-message": {
+      "add-or-update-required": "Select whether you would like to add or update your phone number",
+      "phone-number-valid": "Invalid phone number",
+      "phone-number-alt-valid": "Invalid phone number",
+      "phone-required": "Enter a phone number"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -40,5 +40,26 @@
       "sin-valid": "Doit être un NAS valide",
       "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
     }
+  },
+  "confirm-phone": {
+    "page-title": "Numéro de téléphone",
+    "add-phone": "Un numéro de téléphone à jour permet au gouvernement du Canada de communiquer avec vous en cas de problème avec votre renouvellement. Vous trouverez le numéro que nous avons en dossier dans la lettre de Service Canada. Si vous ne fournissez pas de numéro de téléphone, nous communiquerons avec vous par la poste.",
+    "add-or-update": {
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre numéro de téléphone?"
+    },
+    "phone-number": "Numéro de téléphone",
+    "phone-number-alt": "Autre numéro de téléphone (facultatif)",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Sauvegarder",
+    "option-yes": "Oui",
+    "option-no": "Non",
+    "error-message": {
+      "add-or-update-required": "Indiquez si vous souhaitez ajouter ou mettre à jour votre numéro de téléphone",
+      "phone-number-valid": "Numéro de téléphone invalide",
+      "phone-number-alt-valid": "Numéro de téléphone invalide",
+      "phone-required": "Entrer un numéro de téléphone"
+    }
   }
 }


### PR DESCRIPTION
### Description
Add confirm-phone page for renew adult flow

### Related Azure Boards Work Items
[AB#4893](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4893)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->