### PR TITLE
AB#4894 Adult flow confirm email

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -115,6 +115,7 @@ export const pageIds = {
         confirmMaritalStatus: 'CDCP-RENW-AD-0001',
         maritalStatus: 'CDCP-RENW-AD-0002',
         confirmPhone: 'CDCP-RENW-AD-0003',
+        confirmEmail: 'CDCP-RENW-AD-0004'
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -115,7 +115,7 @@ export const pageIds = {
         confirmMaritalStatus: 'CDCP-RENW-AD-0001',
         maritalStatus: 'CDCP-RENW-AD-0002',
         confirmPhone: 'CDCP-RENW-AD-0003',
-        confirmEmail: 'CDCP-RENW-AD-0004'
+        confirmEmail: 'CDCP-RENW-AD-0004',
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -1,0 +1,297 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+enum AddOrUpdateEmailOption {
+  Yes = 'yes',
+  No = 'no',
+}
+
+enum ShouldReceiveEmailCommunicationOption {
+  Yes = 'yes',
+  No = 'no',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adult.confirmEmail,
+  pageTitleI18nKey: 'renew-adult:confirm-email.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-email.page-title') }) };
+
+  return {
+    id: state.id,
+
+    meta,
+    defaultState: {
+      isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,
+      email: state.contactInformation?.email,
+      shouldReceiveEmailCommunication: state.contactInformation?.shouldReceiveEmailCommunication,
+    },
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const emailSchema = z
+    .object({
+      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
+        errorMap: () => ({ message: t('renew-adult:confirm-email.error-message.add-or-update-required') }),
+      }),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
+      shouldReceiveEmailCommunication: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+        if (!val.email) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.email-required'), path: ['email'] });
+        }
+      }
+
+      if (val.email ?? val.confirmEmail) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.email-required'), path: ['email'] });
+        } else if (!validator.isEmail(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.email-valid'), path: ['email'] });
+        }
+
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.confirm-email-required'), path: ['confirmEmail'] });
+        } else if (!validator.isEmail(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.confirm-email-valid'), path: ['confirmEmail'] });
+        } else if (val.email !== val.confirmEmail) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
+        }
+      }
+
+      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+        if (val.shouldReceiveEmailCommunication === undefined) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
+        }
+      }
+    })
+    .transform((val) => ({
+      ...val,
+      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
+      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes : undefined,
+    }));
+
+  const parsedDataResult = emailSchema.safeParse({
+    isNewOrUpdatedEmail: formData.get('isNewOrUpdatedEmail'),
+    email: formData.get('email') ? String(formData.get('email')) : undefined,
+    confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail')) : undefined,
+    shouldReceiveEmailCommunication: formData.get('shouldReceiveEmailCommunication') ? String(formData.get('shouldReceiveEmailCommunication')) : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/confirm-address', params));
+}
+
+export default function RenewAdultChildConfirmEmail() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    isNewOrUpdatedEmail: 'input-radio-is-new-or-updated-email-option-0',
+    email: 'email',
+    confirmEmail: 'confirm-email',
+    shouldReceiveEmailCommunication: 'input-radio-should-receive-email-communication-option-0',
+  });
+
+  const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
+
+  function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
+  }
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={45} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-6">
+            <p id="adding-email" className="mb-4">
+              {t('renew-adult:confirm-email.add-email')}
+            </p>
+            <InputRadios
+              id="is-new-or-updated-email"
+              name="isNewOrUpdatedEmail"
+              legend={t('renew-adult:confirm-email.add-or-update.legend')}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-yes" />,
+                  value: AddOrUpdateEmailOption.Yes,
+                  defaultChecked: isNewOrUpdatedEmail === true,
+                  onChange: handleNewOrUpdateEmailChanged,
+                  append: isNewOrUpdatedEmail === true && (
+                    <div className="grid gap-6 md:grid-cols-2">
+                      <InputField
+                        id="email"
+                        name="email"
+                        type="email"
+                        inputMode="email"
+                        className="w-full"
+                        autoComplete="email"
+                        defaultValue={defaultState.email}
+                        errorMessage={errors?.email}
+                        label={t('renew-adult:confirm-email.email')}
+                        maxLength={64}
+                        aria-describedby="adding-email"
+                      />
+                      <InputField
+                        id="confirm-email"
+                        name="confirmEmail"
+                        type="email"
+                        inputMode="email"
+                        className="w-full"
+                        autoComplete="email"
+                        defaultValue={defaultState.email}
+                        errorMessage={errors?.confirmEmail}
+                        label={t('renew-adult:confirm-email.confirm-email')}
+                        maxLength={64}
+                        aria-describedby="adding-email"
+                      />
+                    </div>
+                  ),
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-no" />,
+                  value: AddOrUpdateEmailOption.No,
+                  defaultChecked: isNewOrUpdatedEmail === false,
+                  onChange: handleNewOrUpdateEmailChanged,
+                },
+              ]}
+              errorMessage={errors?.isNewOrUpdatedEmail}
+              required
+            />
+          </div>
+          {isNewOrUpdatedEmail && (
+            <div className="mb-6">
+              <InputRadios
+                id="should-receive-email-communication"
+                name="shouldReceiveEmailCommunication"
+                legend={t('renew-adult:confirm-email.receive-comms.legend')}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-yes" />,
+                    value: ShouldReceiveEmailCommunicationOption.Yes,
+                    defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-no" />,
+                    value: ShouldReceiveEmailCommunicationOption.No,
+                    defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
+                  },
+                ]}
+                errorMessage={errors?.shouldReceiveEmailCommunication}
+                required
+              />
+            </div>
+          )}
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
+                {t('renew-adult:confirm-email.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
+                {t('renew-adult:confirm-email.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FormAction.Continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Contact information click"
+              >
+                {t('renew-adult:confirm-email.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult/confirm-phone"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Contact information click"
+              >
+                {t('renew-adult:confirm-email.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -146,7 +146,7 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-address', params));
 }
 
-export default function RenewAdultChildConfirmEmail() {
+export default function RenewAdultConfirmEmail() {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, editMode } = useLoaderData<typeof loader>();
   const params = useParams();

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -703,6 +703,11 @@ export const routes = [
             file: 'routes/public/renew/$id/adult/confirm-phone.tsx',
             paths: { en: '/:lang/renew/:id/adult/confirm-phone', fr: '/:lang/renouveller/:id/adulte/confirmer-telephone' },
           },
+          {
+            id: 'public/renew/$id/adult/confirm-email',
+            file: 'routes/public/renew/$id/adult/confirm-email.tsx',
+            paths: { en: '/:lang/renew/:id/adult/confirm-email', fr: '/:lang/renouveller/:id/adulte/confirmer-courriel' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -61,5 +61,32 @@
       "phone-number-alt-valid": "Invalid phone number",
       "phone-required": "Enter a phone number"
     }
+  },
+  "confirm-email": {
+    "page-title": "Email",
+    "add-email": "An up-to-date email helps the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan coverage. You can find the email we have on file in the letter from Service Canada.",
+    "add-or-update": {
+      "legend": "Would you like to update or add your email address?"
+    },
+    "receive-comms": {
+      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?"
+    },
+    "email": "Email address",
+    "confirm-email": "Confirm email address",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "option-yes": "Yes",
+    "option-no": "No",
+    "error-message": {
+      "add-or-update-required": "Select whether you would like to add or update your email",
+      "email-match": "The email addresses entered do not match",
+      "confirm-email-required": "Confirm email address",
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com",
+      "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
+    }
   }
 }

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -66,8 +66,7 @@
     "page-title": "Adresse courriel",
     "add-email": "Une adresse courriel à jour permet au gouvernement du Canada et à la Sun Life de communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires. Vous trouverez l'adresse courriel que nous avons dans nos dossiers dans la lettre de Service Canada.",
     "add-or-update": {
-      "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
-      "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?"
     },
     "receive-comms": {
       "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?"

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -61,5 +61,33 @@
       "phone-number-alt-valid": "Numéro de téléphone invalide",
       "phone-required": "Entrer un numéro de téléphone"
     }
+  },
+  "confirm-email": {
+    "page-title": "Adresse courriel",
+    "add-email": "Une adresse courriel à jour permet au gouvernement du Canada et à la Sun Life de communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires. Vous trouverez l'adresse courriel que nous avons dans nos dossiers dans la lettre de Service Canada.",
+    "add-or-update": {
+      "legend": "Souhaitez-vous mettre à jour ou ajouter votre adresse courriel?",
+      "help-message": "L'adresse courriel que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada."
+    },
+    "receive-comms": {
+      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?"
+    },
+    "email": "Adresse courriel",
+    "confirm-email": "Confirmer l'adresse courriel",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Sauvegarder",
+    "option-yes": "Oui",
+    "option-no": "Non",
+    "error-message": {
+      "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
+      "email-match": "Les adresses courriel entrées ne concordent pas",
+      "confirm-email-required": "Confirmez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
+      "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
+      "receive-comms-required": "Select whether you would like to receive email communication"
+    }
   }
 }


### PR DESCRIPTION
### Description
Add confirm-email for renew adult flow

### Related Azure Boards Work Items
[AB#4894](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4894)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->