### PR TITLE
AB#4895 Renew adult confirm address

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -116,6 +116,7 @@ export const pageIds = {
         maritalStatus: 'CDCP-RENW-AD-0002',
         confirmPhone: 'CDCP-RENW-AD-0003',
         confirmEmail: 'CDCP-RENW-AD-0004',
+        confirmAddress: 'CDCP-RENW-AD-0005',
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -1,0 +1,166 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { data, redirect } from '@remix-run/node';
+import { useFetcher, useLoaderData, useParams } from '@remix-run/react';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+}
+
+enum AddressRadioOptions {
+  No = 'no',
+  Yes = 'yes',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adult.confirmAddress,
+  pageTitleI18nKey: 'renew-adult:confirm-address.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const state = loadRenewAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-address.page-title') }) };
+
+  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+  const state = loadRenewAdultState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const confirmAddressSchema = z.object({
+    hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+      errorMap: () => ({ message: t('renew-adult:confirm-address.error-message.has-address-changed-required') }),
+    }),
+  });
+
+  const parsedDataResult = confirmAddressSchema.safeParse({
+    hasAddressChanged: formData.get('hasAddressChanged'),
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveRenewState({
+    params,
+    session,
+    state: {
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
+      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.homeAddress,
+      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.mailingAddress,
+    },
+  });
+
+  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes) {
+    return redirect(getPathById('public/renew/$id/adult/update-mailing-address', params));
+  }
+
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
+  }
+  return redirect(getPathById('public/renew/$id/adult/dental-insurance', params));
+}
+
+export default function RenewAdultConfirmAddress() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    hasAddressChanged: 'input-radio-has-address-changed-option-0',
+  });
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={22} size="lg" label={t('renew:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('renew:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="space-y-6">
+            <InputRadios
+              id="has-address-changed"
+              name="hasAddressChanged"
+              legend={t('renew-adult:confirm-address.have-you-moved')}
+              options={[
+                { value: AddressRadioOptions.Yes, children: t('renew-adult:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
+                { value: AddressRadioOptions.No, children: t('renew-adult:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
+              ]}
+              helpMessagePrimary={t('renew-adult:confirm-address.help-message')}
+              errorMessage={errors?.hasAddressChanged}
+              required
+            />
+          </div>
+
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Confirm address click">
+                {t('renew-adult:confirm-address.save-btn')}
+              </Button>
+              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Confirm address click">
+                {t('renew-adult:confirm-address.cancel-btn')}
+              </Button>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Confirm address click">
+                {t('renew-adult:confirm-address.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/renew/$id/adult/confirm-email"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Confirm address click"
+              >
+                {t('renew-adult:confirm-address.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -708,6 +708,11 @@ export const routes = [
             file: 'routes/public/renew/$id/adult/confirm-email.tsx',
             paths: { en: '/:lang/renew/:id/adult/confirm-email', fr: '/:lang/renouveller/:id/adulte/confirmer-courriel' },
           },
+          {
+            id: 'public/renew/$id/adult/confirm-address',
+            file: 'routes/public/renew/$id/adult/confirm-address.tsx',
+            paths: { en: '/:lang/renew/:id/adult/confirm-address', fr: '/:lang/renouveller/:id/adulte/confirmer-adresse' },
+          },
         ],
       },
       {

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -88,5 +88,22 @@
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"
     }
+  },
+  "confirm-address": {
+    "page-title": "Address",
+    "have-you-moved": "Would you like to update your home or mailing address?",
+    "radio-options": {
+      "yes": "Yes",
+      "no": "No"
+    },
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
+    "error-message": {
+      "has-address-changed-required": "Select whether you have moved or changed your mailing address",
+      "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"
+    },
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save"
   }
 }

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -88,5 +88,22 @@
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"
     }
+  },
+  "confirm-address": {
+    "page-title": "Adresse",
+    "have-you-moved": "Souhaitez-vous mettre à jour l'adresse de votre domicile ou votre adresse postale?",
+    "radio-options": {
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "help-message": "L'adresse que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
+    "error-message": {
+      "has-address-changed-required": "Sélectionnez si vous avez déménagé ou changé d'adresse postale",
+      "is-home-address-same-as-mailing-address-required": "Sélectionnez si votre adresse postale et votre adresse domicile sont identiques ou non"
+    },
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer"
   }
 }


### PR DESCRIPTION
### Description
Add confirm-address for renew adult flow

### Related Azure Boards Work Items
[AB#4895](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/4895)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->