### PR TITLE
Removing apartment from address renewal state objects and fixing resulting issues

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -97,7 +97,6 @@ export interface ProtectedRenewState {
   readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly mailingAddress?: {
     readonly address: string;
-    readonly apartment?: string;
     readonly city: string;
     readonly country: string;
     readonly postalCode?: string;
@@ -105,7 +104,6 @@ export interface ProtectedRenewState {
   };
   readonly homeAddress?: {
     readonly address: string;
-    readonly apartment?: string;
     readonly city: string;
     readonly country: string;
     readonly postalCode?: string;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -73,7 +73,6 @@ export interface RenewState {
   readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly mailingAddress?: {
     address: string;
-    apartment?: string;
     city: string;
     country: string;
     postalCode?: string;
@@ -81,7 +80,6 @@ export interface RenewState {
   };
   readonly homeAddress?: {
     address: string;
-    apartment?: string;
     city: string;
     country: string;
     postalCode?: string;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -500,7 +500,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       return mailingAddress
         ? {
             homeAddress: mailingAddress.address,
-            homeApartment: mailingAddress.apartment,
+            homeApartment: undefined,
             homeCity: mailingAddress.city,
             homeCountry: mailingAddress.country,
             homePostalCode: mailingAddress.postalCode,
@@ -519,7 +519,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return homeAddress
       ? {
           homeAddress: homeAddress.address,
-          homeApartment: homeAddress.apartment,
+          homeApartment: undefined,
           homeCity: homeAddress.city,
           homeCountry: homeAddress.country,
           homePostalCode: homeAddress.postalCode,
@@ -539,7 +539,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return mailingAddress
       ? {
           mailingAddress: mailingAddress.address,
-          mailingApartment: mailingAddress.apartment,
+          mailingApartment: undefined,
           mailingCity: mailingAddress.city,
           mailingCountry: mailingAddress.country,
           mailingPostalCode: mailingAddress.postalCode,

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -35,7 +35,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { isAllValidInputCharacters } from '~/utils/string-utils';
+import { formatAddressLine, isAllValidInputCharacters } from '~/utils/string-utils';
 
 enum FormAction {
   Submit = 'submit',
@@ -94,15 +94,13 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: state.homeAddress.province,
         postalCode: state.homeAddress.postalCode,
         country: state.homeAddress.country,
-        apartment: state.homeAddress.apartment,
       }
     : {
-        address: state.clientApplication.contactInformation.homeAddress,
+        address: formatAddressLine({ address: state.clientApplication.contactInformation.homeAddress, apartment: state.clientApplication.contactInformation.homeApartment }),
         city: state.clientApplication.contactInformation.homeCity,
         province: state.clientApplication.contactInformation.homeProvince,
         postalCode: state.clientApplication.contactInformation.homePostalCode,
         country: state.clientApplication.contactInformation.homeCountry,
-        apartment: state.clientApplication.contactInformation.homeApartment,
       };
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.home-address.page-title') }) };

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -36,7 +36,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { isAllValidInputCharacters } from '~/utils/string-utils';
+import { formatAddressLine, isAllValidInputCharacters } from '~/utils/string-utils';
 
 enum FormAction {
   Submit = 'submit',
@@ -95,15 +95,13 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: state.mailingAddress.province,
         postalCode: state.mailingAddress.postalCode,
         country: state.mailingAddress.country,
-        apartment: state.mailingAddress.apartment,
       }
     : {
-        address: state.clientApplication.contactInformation.mailingAddress,
+        address: formatAddressLine({ address: state.clientApplication.contactInformation.mailingAddress, apartment: state.clientApplication.contactInformation.mailingApartment }),
         city: state.clientApplication.contactInformation.mailingCity,
         province: state.clientApplication.contactInformation.mailingProvince,
         postalCode: state.clientApplication.contactInformation.mailingPostalCode,
         country: state.clientApplication.contactInformation.mailingCountry,
-        apartment: state.clientApplication.contactInformation.mailingApartment,
       };
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -65,16 +65,16 @@ export async function loader({ context: { appContainer, session }, params, reque
   const preferredLanguage = state.communicationPreferences?.preferredLanguage
     ? appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name
     : appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province
-    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr
-    : state.clientApplication.contactInformation.mailingProvince
-      ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.mailingProvince).abbr
-      : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province
-    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr
-    : state.clientApplication.contactInformation.homeProvince
-      ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince).abbr
-      : undefined;
+
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
+  const clientApplicationMailingProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.mailingProvince
+    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.mailingProvince).abbr
+    : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const clientApplicationHomeProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.homeProvince
+    ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince).abbr
+    : undefined;
+
   const mailingCountryAbbr = state.mailingAddress?.country
     ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale).name
     : appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.mailingCountry, locale).name;
@@ -106,23 +106,39 @@ export async function loader({ context: { appContainer, session }, params, reque
       }
     : undefined;
 
-  const mailingAddressInfo = {
-    address: state.mailingAddress?.address ?? state.clientApplication.contactInformation.mailingAddress,
-    city: state.mailingAddress?.city ?? state.clientApplication.contactInformation.mailingCity,
-    province: mailingProvinceTerritoryStateAbbr,
-    postalCode: state.mailingAddress?.postalCode ?? state.clientApplication.contactInformation.mailingPostalCode,
-    country: mailingCountryAbbr,
-    apartment: state.mailingAddress?.apartment ?? state.clientApplication.contactInformation.mailingApartment,
-  };
+  const mailingAddressInfo = state.mailingAddress
+    ? {
+        address: state.mailingAddress.address,
+        city: state.mailingAddress.city,
+        province: mailingProvinceTerritoryStateAbbr,
+        postalCode: state.mailingAddress.postalCode,
+        country: mailingCountryAbbr,
+      }
+    : {
+        address: state.clientApplication.contactInformation.mailingAddress,
+        city: state.clientApplication.contactInformation.mailingCity,
+        province: clientApplicationHomeProvinceTerritoryStateAbbr,
+        postalCode: state.clientApplication.contactInformation.mailingPostalCode,
+        country: mailingCountryAbbr,
+        apartment: state.clientApplication.contactInformation.mailingApartment,
+      };
 
-  const homeAddressInfo = {
-    address: state.homeAddress?.address ?? state.clientApplication.contactInformation.homeAddress,
-    city: state.homeAddress?.city ?? state.clientApplication.contactInformation.homeCity,
-    province: homeProvinceTerritoryStateAbbr,
-    postalCode: state.homeAddress?.postalCode ?? state.clientApplication.contactInformation.homePostalCode,
-    country: homeCountryAbbr,
-    apartment: state.homeAddress?.apartment ?? state.clientApplication.contactInformation.homeApartment,
-  };
+  const homeAddressInfo = state.homeAddress
+    ? {
+        address: state.homeAddress.address,
+        city: state.homeAddress.city,
+        province: homeProvinceTerritoryStateAbbr,
+        postalCode: state.homeAddress.postalCode,
+        country: homeCountryAbbr,
+      }
+    : {
+        address: state.clientApplication.contactInformation.homeAddress,
+        city: state.clientApplication.contactInformation.homeCity,
+        province: clientApplicationMailingProvinceTerritoryStateAbbr,
+        postalCode: state.clientApplication.contactInformation.homePostalCode,
+        country: homeCountryAbbr,
+        apartment: state.clientApplication.contactInformation.homeApartment,
+      };
 
   const dentalInsurance = state.dentalInsurance;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -89,7 +89,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
-        apartment: state.mailingAddress.apartment,
       }
     : null;
 
@@ -100,7 +99,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
-        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -257,7 +255,6 @@ export default function RenewAdultChildConfirm() {
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,
-                    apartment: mailingAddressInfo.apartment,
                   }}
                 />
               ) : (
@@ -273,7 +270,6 @@ export default function RenewAdultChildConfirm() {
                     provinceState: homeAddressInfo.province,
                     postalZipCode: homeAddressInfo.postalCode,
                     country: homeAddressInfo.country,
-                    apartment: homeAddressInfo.apartment,
                   }}
                 />
               ) : (

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -90,7 +90,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress?.postalCode,
         country: countryMailing,
-        apartment: state.mailingAddress?.apartment,
       }
     : undefined;
 
@@ -101,7 +100,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress?.postalCode,
         country: countryHome,
-        apartment: state.homeAddress?.apartment,
       }
     : undefined;
 
@@ -311,7 +309,6 @@ export default function RenewAdultChildReviewAdultInformation() {
                       provinceState: mailingAddressInfo.province,
                       postalZipCode: mailingAddressInfo.postalCode,
                       country: mailingAddressInfo.country?.name ?? '',
-                      apartment: mailingAddressInfo.apartment,
                     }}
                   />
                 ) : (
@@ -332,7 +329,6 @@ export default function RenewAdultChildReviewAdultInformation() {
                       provinceState: homeAddressInfo.province,
                       postalZipCode: homeAddressInfo.postalCode,
                       country: homeAddressInfo.country?.name ?? '',
-                      apartment: homeAddressInfo.apartment,
                     }}
                   />
                 ) : (

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -82,7 +82,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
-        apartment: state.mailingAddress.apartment,
       }
     : null;
 
@@ -93,7 +92,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
-        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -269,7 +267,6 @@ export default function RenewAdultChildConfirm() {
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,
-                    apartment: mailingAddressInfo.apartment,
                   }}
                 />
               ) : (
@@ -285,7 +282,6 @@ export default function RenewAdultChildConfirm() {
                     provinceState: homeAddressInfo.province,
                     postalZipCode: homeAddressInfo.postalCode,
                     country: homeAddressInfo.country,
-                    apartment: homeAddressInfo.apartment,
                   }}
                 />
               ) : (

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -90,7 +90,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress?.postalCode,
         country: countryMailing,
-        apartment: state.mailingAddress?.apartment,
       }
     : undefined;
 
@@ -101,7 +100,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress?.postalCode,
         country: countryHome,
-        apartment: state.homeAddress?.apartment,
       }
     : undefined;
 
@@ -277,7 +275,6 @@ export default function RenewChildReviewAdultInformation() {
                       provinceState: mailingAddressInfo.province,
                       postalZipCode: mailingAddressInfo.postalCode,
                       country: mailingAddressInfo.country?.name ?? '',
-                      apartment: mailingAddressInfo.apartment,
                     }}
                   />
                 ) : (
@@ -298,7 +295,6 @@ export default function RenewChildReviewAdultInformation() {
                       provinceState: homeAddressInfo.province,
                       postalZipCode: homeAddressInfo.postalCode,
                       country: homeAddressInfo.country?.name ?? '',
-                      apartment: homeAddressInfo.apartment,
                     }}
                   />
                 ) : (

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -96,7 +96,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
-        apartment: state.mailingAddress.apartment,
       }
     : null;
 
@@ -107,7 +106,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
-        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -235,7 +233,6 @@ export default function RenewFlowConfirm() {
                     provinceState: mailingAddressInfo.province,
                     postalZipCode: mailingAddressInfo.postalCode,
                     country: mailingAddressInfo.country,
-                    apartment: mailingAddressInfo.apartment,
                   }}
                 />
               ) : (
@@ -251,7 +248,6 @@ export default function RenewFlowConfirm() {
                     provinceState: homeAddressInfo.province,
                     postalZipCode: homeAddressInfo.postalCode,
                     country: homeAddressInfo.country,
-                    apartment: homeAddressInfo.apartment,
                   }}
                 />
               ) : (

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -90,7 +90,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing,
-        apartment: state.mailingAddress.apartment,
       }
     : null;
 
@@ -101,7 +100,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         province: homeProvinceTerritoryStateAbbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome,
-        apartment: state.homeAddress.apartment,
       }
     : null;
 
@@ -301,7 +299,6 @@ export default function RenewItaReviewInformation() {
                       provinceState: mailingAddressInfo.province,
                       postalZipCode: mailingAddressInfo.postalCode,
                       country: mailingAddressInfo.country?.name ?? '',
-                      apartment: mailingAddressInfo.apartment,
                     }}
                   />
                 ) : (
@@ -322,7 +319,6 @@ export default function RenewItaReviewInformation() {
                       provinceState: homeAddressInfo.province,
                       postalZipCode: homeAddressInfo.postalCode,
                       country: homeAddressInfo.country?.name ?? '',
-                      apartment: homeAddressInfo.apartment,
                     }}
                   />
                 ) : (

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -123,7 +123,7 @@ interface FormatAddressLineArguments {
  * @param params Address line formatting parameters
  * @returns Formatted address line
  */
-function formatAddressLine({ address, apartment }: FormatAddressLineArguments): string {
+export function formatAddressLine({ address, apartment }: FormatAddressLineArguments): string {
   if (!apartment?.trim()) {
     return address;
   }


### PR DESCRIPTION
### Description
Renewal doesn't require an `apartment` field as it doesn't exist in all address forms.

This PR also fixes issues in the protected flow where:
- Default address line isn't populated with the client application's apartment on file with use of `formatAddressLine(..)`
- `/review-adult-information` was rendering the client application's address info even if the address has been updated

### Screenshots (if applicable)
Before:
(province and postal code rendered for international country)
![image](https://github.com/user-attachments/assets/eef11ba1-856d-487d-a8ad-88e2563504e5)

(no apartment, even though client application has one)
![image](https://github.com/user-attachments/assets/b7224d6a-d351-42af-9550-d52b853e7ba0)

After:
![image](https://github.com/user-attachments/assets/265a9415-22f0-4e06-a0dc-6f9d6dfcdea7)
![image](https://github.com/user-attachments/assets/0834f07e-9b65-45b9-a697-a0d9fd03efa1)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`