### PR TITLE
fix state issues in protected-renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -249,6 +249,12 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
     editMode: false,
     applicationYear,
     clientApplication,
+    contactInformation: {
+      phoneNumber: clientApplication.contactInformation.phoneNumber,
+      phoneNumberAlt: clientApplication.contactInformation.phoneNumberAlt,
+      email: clientApplication.contactInformation.email,
+    },
+    communicationPreferences: clientApplication.communicationPreferences,
     children: clientApplication.children
       // filter out children who will be 18 or older at the start of the coverage period as they are ineligible for renewal
       .filter((child) => getAgeFromDateString(child.information.dateOfBirth, applicationYear.coverageStartDate) < 18) //

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -61,9 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     preferredCommunicationMethods,
     preferredLanguages,
-    defaultState: {
-      ...(state.communicationPreferences ?? state.clientApplication.communicationPreferences),
-    },
+    defaultState: { ...state.communicationPreferences, email: state.contactInformation?.email },
     isReadOnlyEmail: !!state.contactInformation?.email,
   };
 }

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -45,13 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-email.page-title') }) };
 
-  return {
-    id: state.id,
-    meta,
-    defaultState: {
-      email: state.contactInformation?.email ?? state.clientApplication.contactInformation.email,
-    },
-  };
+  return { meta, defaultState: { email: state.contactInformation?.email } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -114,53 +108,51 @@ export default function ProtectedRenewConfirmEmail() {
   });
 
   return (
-    <>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t('renew:all-optional-label')}</p>
-        <errorSummary.ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <div className="grid gap-6 md:grid-cols-2">
-              <InputField
-                id="email"
-                name="email"
-                type="email"
-                inputMode="email"
-                className="w-full"
-                autoComplete="email"
-                defaultValue={defaultState.email}
-                errorMessage={errors?.email}
-                label={t('protected-renew:confirm-email.email')}
-                maxLength={64}
-                aria-describedby="adding-email"
-              />
-              <InputField
-                id="confirm-email"
-                name="confirmEmail"
-                type="email"
-                inputMode="email"
-                className="w-full"
-                autoComplete="email"
-                defaultValue={defaultState.email}
-                errorMessage={errors?.confirmEmail}
-                label={t('protected-renew:confirm-email.confirm-email')}
-                maxLength={64}
-                aria-describedby="adding-email"
-              />
-            </div>
+    <div className="max-w-prose">
+      <p className="mb-4 italic">{t('renew:all-optional-label')}</p>
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <div className="mb-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            <InputField
+              id="email"
+              name="email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              autoComplete="email"
+              defaultValue={defaultState.email}
+              errorMessage={errors?.email}
+              label={t('protected-renew:confirm-email.email')}
+              maxLength={64}
+              aria-describedby="adding-email"
+            />
+            <InputField
+              id="confirm-email"
+              name="confirmEmail"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              autoComplete="email"
+              defaultValue={defaultState.email}
+              errorMessage={errors?.confirmEmail}
+              label={t('protected-renew:confirm-email.confirm-email')}
+              maxLength={64}
+              aria-describedby="adding-email"
+            />
           </div>
+        </div>
 
-          <div className="flex flex-wrap items-center gap-3">
-            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
-              {t('protected-renew:confirm-email.save-btn')}
-            </Button>
-            <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
-              {t('protected-renew:confirm-email.cancel-btn')}
-            </Button>
-          </div>
-        </fetcher.Form>
-      </div>
-    </>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Contact information click">
+            {t('protected-renew:confirm-email.save-btn')}
+          </Button>
+          <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Contact information click">
+            {t('protected-renew:confirm-email.cancel-btn')}
+          </Button>
+        </div>
+      </fetcher.Form>
+    </div>
   );
 }

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -49,8 +49,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     id: state.id,
     meta,
     defaultState: {
-      phoneNumber: state.contactInformation?.phoneNumber ?? state.clientApplication.contactInformation.phoneNumber,
-      phoneNumberAlt: state.contactInformation?.phoneNumberAlt ?? state.clientApplication.contactInformation.phoneNumber,
+      phoneNumber: state.contactInformation?.phoneNumber,
+      phoneNumberAlt: state.contactInformation?.phoneNumberAlt,
     },
   };
 }

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -58,7 +58,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const communicationPreference = appContainer.get(TYPES.domain.services.PreferredCommunicationMethodService).getLocalizedPreferredCommunicationMethodById(state.clientApplication.communicationPreferences.preferredMethod, locale);
+  const communicationPreference = state.communicationPreferences
+    ? appContainer.get(TYPES.domain.services.PreferredCommunicationMethodService).getLocalizedPreferredCommunicationMethodById(state.communicationPreferences.preferredMethod, locale)
+    : appContainer.get(TYPES.domain.services.PreferredCommunicationMethodService).getLocalizedPreferredCommunicationMethodById(state.clientApplication.communicationPreferences.preferredMethod, locale);
   const maritalStatus = state.maritalStatus
     ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name
     : appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.clientApplication.applicantInformation.maritalStatus, locale).name;
@@ -87,14 +89,14 @@ export async function loader({ context: { appContainer, session }, params, reque
     lastName: state.clientApplication.applicantInformation.lastName,
     sin: state.clientApplication.applicantInformation.socialInsuranceNumber,
     clientNumber: state.clientApplication.applicantInformation.clientNumber,
-    phoneNumber: state.contactInformation?.phoneNumber ?? state.clientApplication.contactInformation.phoneNumber,
-    altPhoneNumber: state.contactInformation?.phoneNumberAlt ?? state.clientApplication.contactInformation.phoneNumberAlt,
+    phoneNumber: state.contactInformation?.phoneNumber,
+    altPhoneNumber: state.contactInformation?.phoneNumberAlt,
     birthday: toLocaleDateString(parseDateString(state.clientApplication.dateOfBirth), locale),
     maritalStatus: maritalStatus,
-    contactInformationEmail: state.contactInformation?.email ?? state.clientApplication.contactInformation.email,
+    contactInformationEmail: state.contactInformation?.email,
     communicationPreference: communicationPreference.name,
     preferredLanguage: preferredLanguage,
-    communicationPreferenceEmail: state.clientApplication.communicationPreferences.email,
+    clientApplicationEmail: state.clientApplication.communicationPreferences.email,
   };
 
   const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
@@ -305,7 +307,7 @@ export default function ProtectedRenewReviewAdultInformation() {
             <h2 className="font-lato text-2xl font-bold">{t('protected-renew:review-adult-information.contact-info-title')}</h2>
             <dl className="divide-y border-y">
               <DescriptionListItem term={t('protected-renew:review-adult-information.phone-title')}>
-                <p>{userInfo.phoneNumber ?? t('protected-renew:review-adult-information.no-update')}</p>
+                <p>{userInfo.phoneNumber}</p>
                 <div className="mt-4">
                   <InlineLink id="change-phone-number" routeId="protected/renew/$id/confirm-phone" params={params}>
                     {t('protected-renew:review-adult-information.phone-change')}
@@ -313,7 +315,7 @@ export default function ProtectedRenewReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('protected-renew:review-adult-information.alt-phone-title')}>
-                <p>{userInfo.altPhoneNumber ?? t('protected-renew:review-adult-information.no-update')}</p>
+                <p>{userInfo.altPhoneNumber}</p>
                 <div className="mt-4">
                   <InlineLink id="change-alternate-phone-number" routeId="protected/renew/$id/confirm-phone" params={params}>
                     {t('protected-renew:review-adult-information.alt-phone-change')}
@@ -321,7 +323,7 @@ export default function ProtectedRenewReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('protected-renew:review-adult-information.email')}>
-                <p>{userInfo.contactInformationEmail ?? t('protected-renew:review-adult-information.no-update')}</p>
+                <p>{userInfo.contactInformationEmail}</p>
                 <div className="mt-4">
                   <InlineLink id="change-email" routeId="protected/renew/$id/confirm-email" params={params}>
                     {t('protected-renew:review-adult-information.email-change')}


### PR DESCRIPTION
### Description
Proposed fixes for some 'bugs' in the protected space

Most of these issues happen because of the nullish coalesce with the clientApplication data.  I feel like we need to initially seed the state from the clientApplication in the `startProtectedRenewState` function in the route-helper, especially for mutable data.  

Note: the phone numbers aren't initially populated in their respective fields because the mock data we have uses fake data that errors based on the phone validation library we use.  I also don't think the "no update" text in the review screen is necessary, based on Figma

### Related Azure Boards Work Items
[AB#5027](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5027), [AB#5026](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5026), [AB#5028](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5028)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`