### PR TITLE
Updating protected renew children paths and route helper

### DIFF
--- a/frontend/__tests__/route-helpers/protected-renew-route-helpers.test.ts
+++ b/frontend/__tests__/route-helpers/protected-renew-route-helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformAdobeAnalyticsUrl, transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/protected-renew-route-helpers';
+
+describe('protected-renew-route-helpers', () => {
+  describe('transformAdobeAnalyticsUrl', () => {
+    it.each([['https://example.com/en/'], ['https://example.com/fr/'], ['https://example.com/en/renew'], ['https://example.com/fr/renouveller']])('should return as is for %s when not matching the protected renew route regex', (url) => {
+      const actual = transformAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(url));
+    });
+
+    it.each([
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/protected/renew/somepage/'],
+      ['https://example.com/fr/protected/renew/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/protected/renew/somepage/'],
+      ['https://example.com/en/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/protege/renouveller/somepage/'],
+      ['https://example.com/fr/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/protege/renouveller/somepage/'],
+    ])('should remove the session id path segment for %s when matching the protected renew route regex', (url, expectedUrl) => {
+      const actual = transformAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(expectedUrl));
+    });
+  });
+
+  describe('transformChildrenRouteAdobeAnalyticsUrl', () => {
+    it.each([
+      ['https://example.com/en/'],
+      ['https://example.com/fr/'],
+      ['https://example.com/en/renew'],
+      ['https://example.com/fr/renouveller'],
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/somepage/'],
+      ['https://example.com/en/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/'],
+    ])('should return as is for %s when not matching the protected renew route regex', (url) => {
+      const actual = transformChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(url));
+    });
+
+    it.each([
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/protected/renew/children/somepage/'],
+      ['https://example.com/fr/protected/renew/00000000-0000-0000-0000-000000000000/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/protected/renew/children/somepage/'],
+      ['https://example.com/en/protege/renouveller/00000000-0000-0000-0000-000000000000/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/protege/renouveller/enfants/somepage/'],
+      ['https://example.com/fr/protege/renouveller/00000000-0000-0000-0000-000000000000/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/protege/renouveller/enfants/somepage/'],
+    ])('should remove the session id path segment for %s when matching the protected renew children route regex', (url, expectedUrl) => {
+      const actual = transformChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(expectedUrl));
+    });
+  });
+});

--- a/frontend/app/route-helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/route-helpers/protected-renew-route-helpers.ts
@@ -9,8 +9,7 @@ import { removePathSegment } from '~/utils/url-utils';
  */
 export function transformAdobeAnalyticsUrl(url: string | URL) {
   const urlObj = new URL(url);
-  // TODO: add translated route segments
-  const protectedRenewRouteRegex = /^\/(en|fr)\/protected\/(renew)\//i;
+  const protectedRenewRouteRegex = /^\/(en|fr)\/(protected|protege)\/(renew|renouveller)\//i;
   if (!protectedRenewRouteRegex.test(urlObj.pathname)) return urlObj;
   return new URL(removePathSegment(urlObj, 3));
 }
@@ -24,12 +23,11 @@ export function transformAdobeAnalyticsUrl(url: string | URL) {
  */
 export function transformChildrenRouteAdobeAnalyticsUrl(url: string | URL) {
   const urlObj = new URL(url);
-  // TODO: add translated route segments
-  const protectedRenewRouteRegex = /^\/(en|fr)\/protected\/(renew)\//i;
+  const protectedRenewRouteRegex = /^\/(en|fr)\/(protected|protege)\/(renew|renouveller)\/.*\/(children|enfants)\//i;
   if (!protectedRenewRouteRegex.test(urlObj.pathname)) return urlObj;
   // remove protected renew state id
-  let transofrmedUrl = removePathSegment(urlObj, 3);
+  let transformedUrl = removePathSegment(urlObj, 3);
   // remove protected renew child state id
-  transofrmedUrl = removePathSegment(transofrmedUrl, 3);
-  return new URL(transofrmedUrl);
+  transformedUrl = removePathSegment(transformedUrl, 4);
+  return new URL(transformedUrl);
 }

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -83,27 +83,27 @@ export const routes = [
               {
                 id: 'protected/renew/$id/$childId/parent-or-guardian',
                 file: 'routes/protected/renew/$id/$childId/parent-or-guardian.tsx',
-                paths: { en: '/:lang/protected/renew/:id/:childId/parent-or-guardian', fr: '/:lang/protege/renouveller/:id/:childId/parent-ou-tuteur' },
+                paths: { en: '/:lang/protected/renew/:id/children/:childId/parent-or-guardian', fr: '/:lang/protege/renouveller/:id/enfants/:childId/parent-ou-tuteur' },
               },
               {
                 id: 'protected/renew/$id/$childId/parent-or-guardian-required',
                 file: 'routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx',
-                paths: { en: '/:lang/protected/renew/:id/:childId/parent-or-guardian-required', fr: '/:lang/protege/renouveller/:id/:childId/parent-ou-tuteur-requis' },
+                paths: { en: '/:lang/protected/renew/:id/children/:childId/parent-or-guardian-required', fr: '/:lang/protege/renouveller/:id/enfants/:childId/parent-ou-tuteur-requis' },
               },
               {
                 id: 'protected/renew/$id/$childId/dental-insurance',
                 file: 'routes/protected/renew/$id/$childId/dental-insurance.tsx',
-                paths: { en: '/:lang/protected/renew/:id/:childId/dental-insurance', fr: '/:lang/protege/renouveller/:id/:childId/assurance-dentaire' },
+                paths: { en: '/:lang/protected/renew/:id/children/:childId/dental-insurance', fr: '/:lang/protege/renouveller/:id/enfants/:childId/assurance-dentaire' },
               },
               {
                 id: 'protected/renew/$id/$childId/demographic-survey',
                 file: 'routes/protected/renew/$id/$childId/demographic-survey.tsx',
-                paths: { en: '/:lang/protected/renew/:id/:childId/demographic-survey', fr: '/:lang/protege/renouveller/:id/:childId/questionnaire-demographique' },
+                paths: { en: '/:lang/protected/renew/:id/children/:childId/demographic-survey', fr: '/:lang/protege/renouveller/:id/enfants/:childId/questionnaire-demographique' },
               },
               {
                 id: 'protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits',
                 file: 'routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx',
-                paths: { en: '/:lang/protected/renew/:id/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/protege/renouveller/:id/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
+                paths: { en: '/:lang/protected/renew/:id/children/childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/protege/renouveller/:id/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
               },
             ],
           },


### PR DESCRIPTION
### Description
Adding `children/enfants` to the path in the protected renew flow. This change ensures that the application can differentiate between `children` and non-`children` paths, as path identifiers are not sent to Adobe Analytics.

Resolving `TODO` in `transformAdobeAnalyticsUrl(..)` functions for the protected renewal routes.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
Route helper will need to be added for public renew flows too.