### PR TITLE
Adding `transformAdobeAnalyticsUrl` for public renewal flows

### DIFF
--- a/frontend/__tests__/route-helpers/renew-route-helpers.test.ts
+++ b/frontend/__tests__/route-helpers/renew-route-helpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformAdobeAnalyticsUrl, transformAdultChildChildrenRouteAdobeAnalyticsUrl, transformChildChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
+
+describe('renew-route-helpers', () => {
+  describe('transformAdobeAnalyticsUrl', () => {
+    it.each([
+      ['https://example.com/en/'],
+      ['https://example.com/fr/'],
+      ['https://example.com/en/status'],
+      ['https://example.com/fr/etat'],
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/somepage/'],
+      ['https://example.com/fr/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/'],
+    ])('should return as is for %s when not matching the renew route regex', (url) => {
+      const actual = transformAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(url));
+    });
+
+    it.each([
+      ['https://example.com/en/renew/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renew/somepage/'],
+      ['https://example.com/fr/renew/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renew/somepage/'],
+      ['https://example.com/en/renouveller/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renouveller/somepage/'],
+      ['https://example.com/fr/renouveller/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renouveller/somepage/'],
+    ])('should remove the session id path segment for %s when matching the renew route regex', (url, expectedUrl) => {
+      const actual = transformAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(expectedUrl));
+    });
+  });
+
+  describe('transformAdultChildChildrenRouteAdobeAnalyticsUrl', () => {
+    it.each([
+      ['https://example.com/en/'],
+      ['https://example.com/fr/'],
+      ['https://example.com/en/status'],
+      ['https://example.com/fr/etat'],
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/somepage/'],
+      ['https://example.com/fr/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/'],
+    ])('should return as is for %s when not matching the renew adult child route regex', (url) => {
+      const actual = transformAdultChildChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(url));
+    });
+
+    it.each([
+      ['https://example.com/en/renew/00000000-0000-0000-0000-000000000000/adult-child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renew/adult-child/children/somepage/'],
+      ['https://example.com/fr/renew/00000000-0000-0000-0000-000000000000/adult-child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renew/adult-child/children/somepage/'],
+      ['https://example.com/en/renouveller/00000000-0000-0000-0000-000000000000/adulte-enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renouveller/adulte-enfant/enfants/somepage/'],
+      ['https://example.com/fr/renouveller/00000000-0000-0000-0000-000000000000/adulte-enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renouveller/adulte-enfant/enfants/somepage/'],
+    ])('should remove the session id and child id path segments for %s when matching the renew adult child flow children route regex', (url, expectedUrl) => {
+      const actual = transformAdultChildChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(expectedUrl));
+    });
+  });
+
+  describe('transformChildChildrenRouteAdobeAnalyticsUrl', () => {
+    it.each([
+      ['https://example.com/en/'],
+      ['https://example.com/fr/'],
+      ['https://example.com/en/status'],
+      ['https://example.com/fr/etat'],
+      ['https://example.com/en/protected/renew/00000000-0000-0000-0000-000000000000/somepage/'],
+      ['https://example.com/fr/protege/renouveller/00000000-0000-0000-0000-000000000000/somepage/'],
+    ])('should return as is for %s when not matching the renew child flow route regex', (url) => {
+      const actual = transformChildChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(url));
+    });
+
+    it.each([
+      ['https://example.com/en/renew/00000000-0000-0000-0000-000000000000/child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renew/child/children/somepage/'],
+      ['https://example.com/fr/renew/00000000-0000-0000-0000-000000000000/child/children/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renew/child/children/somepage/'],
+      ['https://example.com/en/renouveller/00000000-0000-0000-0000-000000000000/enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/en/renouveller/enfant/enfants/somepage/'],
+      ['https://example.com/fr/renouveller/00000000-0000-0000-0000-000000000000/enfant/enfants/00000000-0000-0000-0000-000000000000/somepage/', 'https://example.com/fr/renouveller/enfant/enfants/somepage/'],
+    ])('should remove the session id and child id path segments for %s when matching the renew child flow children route regex', (url, expectedUrl) => {
+      const actual = transformChildChildrenRouteAdobeAnalyticsUrl(url);
+      expect(actual).toEqual(new URL(expectedUrl));
+    });
+  });
+});

--- a/frontend/app/route-helpers/renew-route-helpers.ts
+++ b/frontend/app/route-helpers/renew-route-helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Adobe Analytics needs us to clean up URLs before sending event data. This ensures their reports focus
+ * on the core content, not things like tracking codes, because they don't want those to mess up their
+ * website visitor categories.
+ */
+import { removePathSegment } from '~/utils/url-utils';
+
+export function transformAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  const renewRouteRegex = /^\/(en|fr)\/(renew|renouveller)\//i;
+  if (!renewRouteRegex.test(urlObj.pathname)) return urlObj;
+  return new URL(removePathSegment(urlObj, 2));
+}
+
+export function transformAdultChildChildrenRouteAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  const adultChildRenewRouteRegex = /^\/(en|fr)\/(renew|renouveller)\/.*\/(adult-child|adulte-enfant)\/(children|enfants)\//i;
+  if (!adultChildRenewRouteRegex.test(urlObj.pathname)) return urlObj;
+  // remove protected renew state id
+  let transformedUrl = removePathSegment(urlObj, 2);
+  // remove protected renew child state id
+  transformedUrl = removePathSegment(transformedUrl, 4);
+  return new URL(transformedUrl);
+}
+
+export function transformChildChildrenRouteAdobeAnalyticsUrl(url: string | URL) {
+  const urlObj = new URL(url);
+  const childRenewRouteRegex = /^\/(en|fr)\/(renew|renouveller)\/.*\/(child|enfant)\/(children|enfants)\//i;
+  if (!childRenewRouteRegex.test(urlObj.pathname)) return urlObj;
+  // remove protected renew state id
+  let transformedUrl = removePathSegment(urlObj, 2);
+  // remove protected renew child state id
+  transformedUrl = removePathSegment(transformedUrl, 4);
+  return new URL(transformedUrl);
+}

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/layout.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/layout.tsx
@@ -1,10 +1,10 @@
 import { Outlet } from '@remix-run/react';
 
-import { transformAdultChildChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
+import { transformChildChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
-  transformAdobeAnalyticsUrl: transformAdultChildChildrenRouteAdobeAnalyticsUrl,
+  transformAdobeAnalyticsUrl: transformChildChildrenRouteAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
 /**

--- a/frontend/app/routes/public/renew/layout.tsx
+++ b/frontend/app/routes/public/renew/layout.tsx
@@ -7,6 +7,7 @@ import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
 import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
+import { transformAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
 import { useApiSession } from '~/utils/api-session-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -14,6 +15,7 @@ import { getPathById } from '~/utils/route-utils';
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
+  transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
### Description
As per title

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`