### PR TITLE
Add missing `isHomeAddressSameAsMailingAddress` to adult/child state object used for submitting

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -141,6 +141,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     dentalInsurance,
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
+    isHomeAddressSameAsMailingAddress,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -221,6 +222,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     hasAddressChanged,
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
+    isHomeAddressSameAsMailingAddress,
   };
 }
 


### PR DESCRIPTION
### Description
As per title. Found when testing against Interop's actual renewal submission API.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and go through the adult-child flow. Continue until you reach the Review page. The request payload should include the `MailingSameAsHomeIndicator` field.

### Additional Notes
Other flows correctly include this field.