### PR TITLE
Changing structure of client application DTO and entity

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -128,6 +128,10 @@ describe('DefaultClientApplicationDtoMapper', () => {
             },
             ClientIdentification: [
               {
+                IdentificationID: '00000000-0000-0000-0000-000000000000',
+                IdentificationCategoryText: 'Client ID',
+              },
+              {
                 IdentificationID: '00000000000',
                 IdentificationCategoryText: 'Client Number',
               },
@@ -155,10 +159,12 @@ describe('DefaultClientApplicationDtoMapper', () => {
                   ConsentToSharePersonalInformationIndicator: false,
                   AttestParentOrGuardianIndicator: false,
                 },
-                ClientIdentification: {
-                  IdentificationID: '10000000003',
-                  IdentificationCategoryText: 'Client Number',
-                },
+                ClientIdentification: [
+                  {
+                    IdentificationID: '10000000003',
+                    IdentificationCategoryText: 'Client Number',
+                  },
+                ],
               },
             ],
           },
@@ -184,6 +190,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
           lastName: 'Doe',
           maritalStatus: 'MARRIED',
           socialInsuranceNumber: '80000002',
+          clientId: '00000000-0000-0000-0000-000000000000',
           clientNumber: '00000000000',
         },
         children: [],

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -138,10 +138,12 @@ describe('DefaultClientApplicationService', () => {
               ConsentToSharePersonalInformationIndicator: false,
               AttestParentOrGuardianIndicator: false,
             },
-            ClientIdentification: {
-              IdentificationID: '10000000003',
-              IdentificationCategoryText: 'Client Number',
-            },
+            ClientIdentification: [
+              {
+                IdentificationID: '10000000003',
+                IdentificationCategoryText: 'Client Number',
+              },
+            ],
           },
         ],
       },
@@ -166,6 +168,7 @@ describe('DefaultClientApplicationService', () => {
     applicantInformation: {
       firstName: 'John',
       lastName: 'Doe',
+      clientId: '00000000-0000-0000-0000-000000000000',
       maritalStatus: 'MARRIED',
       socialInsuranceNumber: '80000002',
     },

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -51,6 +51,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
       lastName: 'Doe',
       maritalStatus: 'Married',
       socialInsuranceNumber: '800000002',
+      clientId: '00000000-0000-0000-0000-000000000000',
       clientNumber: '00000000000',
     },
     children: [
@@ -58,6 +59,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         dentalBenefits: ['Original federal benefit', 'Original provincial benefit'],
         dentalInsurance: false,
         information: {
+          clientId: '00000000-0000-0000-0000-000000000001',
           clientNumber: '11111111111',
           dateOfBirth: '2020-01-01',
           firstName: 'John Jr.',

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -17,7 +17,10 @@ export type ClientApplicationDto = ReadonlyDeep<{
   partnerInformation?: ClientPartnerInformationDto;
 }>;
 
-export type ClientApplicantInformationDto = ApplicantInformationDto & { clientNumber?: string };
+export type ClientApplicantInformationDto = ApplicantInformationDto & {
+  clientId: string;
+  clientNumber?: string;
+};
 
 export type ClientChildDto = Omit<ChildDto, 'information'> & {
   information: {
@@ -25,6 +28,7 @@ export type ClientChildDto = Omit<ChildDto, 'information'> & {
     lastName: string;
     dateOfBirth: string;
     isParent: boolean;
+    clientId: string;
     clientNumber?: string;
     socialInsuranceNumber: string;
   };

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -104,10 +104,10 @@ export type ClientApplicationEntity = ReadonlyDeep<{
           ConsentToSharePersonalInformationIndicator?: boolean;
           AttestParentOrGuardianIndicator?: boolean;
         };
-        ClientIdentification: {
+        ClientIdentification: Array<{
           IdentificationID: string;
           IdentificationCategoryText?: string;
-        };
+        }>;
       }>;
     };
     BenefitApplicationChannelCode: {

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -48,6 +48,11 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
       firstName: applicant.PersonName[0].PersonGivenName[0],
       lastName: applicant.PersonName[0].PersonSurName,
       maritalStatus: applicant.PersonMaritalStatus.StatusCode.ReferenceDataID,
+      clientId:
+        applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID ??
+        (() => {
+          throw new Error("Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'");
+        })(),
       clientNumber: applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
       socialInsuranceNumber: applicant.PersonSINIdentification.IdentificationID,
     };
@@ -72,7 +77,12 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
           (() => {
             throw new Error('Expected child.ApplicantDetail.AttestParentOrGuardianIndicator to be defined');
           })(),
-        clientNumber: child.ClientIdentification.IdentificationCategoryText === 'Client Number' ? child.ClientIdentification.IdentificationID : undefined,
+        clientId:
+          child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID ??
+          (() => {
+            throw new Error("Expected child.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'");
+          })(),
+        clientNumber: child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
         socialInsuranceNumber: child.PersonSINIdentification.IdentificationID,
       },
     }));

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -123,10 +123,6 @@
       },
       "ClientIdentification": [
         {
-          "IdentificationID": "4f35f70b-2f83-ee11-8179-000d3a09d000",
-          "IdentificationCategoryText": "Applicant ID"
-        },
-        {
           "IdentificationID": "1e97fe42-0263-ee11-8df0-000d3a09df08",
           "IdentificationCategoryText": "Client ID"
         },
@@ -168,10 +164,16 @@
             ],
             "AttestParentOrGuardianIndicator": true
           },
-          "ClientIdentification": {
-            "IdentificationID": "10000000003",
-            "IdentificationCategoryText": "Client Number"
-          }
+          "ClientIdentification": [
+            {
+              "IdentificationID": "8c840878-844a-46f5-91d4-90f8bc7743bc",
+              "IdentificationCategoryText": "Client ID"
+            },
+            {
+              "IdentificationID": "10000000003",
+              "IdentificationCategoryText": "Client Number"
+            }
+          ]
         },
         {
           "PersonBirthDate": {
@@ -193,10 +195,16 @@
             "PrivateDentalInsuranceIndicator": false,
             "AttestParentOrGuardianIndicator": true
           },
-          "ClientIdentification": {
-            "IdentificationID": "10000000004",
-            "IdentificationCategoryText": "Client Number"
-          }
+          "ClientIdentification": [
+            {
+              "IdentificationID": "5f706beb-7aa1-4acc-aeb4-dd4979574276",
+              "IdentificationCategoryText": "Client ID"
+            },
+            {
+              "IdentificationID": "10000000004",
+              "IdentificationCategoryText": "Client Number"
+            }
+          ]
         },
         {
           "PersonBirthDate": {
@@ -217,10 +225,16 @@
           "ApplicantDetail": {
             "ConsentToSharePersonalInformationIndicator": true
           },
-          "ClientIdentification": {
-            "IdentificationID": "10000000004",
-            "IdentificationCategoryText": "Client Number"
-          }
+          "ClientIdentification": [
+            {
+              "IdentificationID": "2086dfd5-a925-4e8e-8797-3f0463b8473a",
+              "IdentificationCategoryText": "Client ID"
+            },
+            {
+              "IdentificationID": "10000000004",
+              "IdentificationCategoryText": "Client Number"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
### Description
Interop's v1.0.13 spec update changes `ClientIdentification` to be an array instead of an object for `RelatedPerson`
This PR also adds `clientId` field for applicant and children that will be used to submit a renewal.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and verify that you can submit the `/applicant-information` screen

### Additional Notes
Next PR will update `clientId` for benefit renewal DTO and mapper.