### PR TITLE
Adding and mapping `clientId` field to submit renewal request

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -190,6 +190,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           lastName: 'Doe',
           maritalStatus: 'Single',
           socialInsuranceNumber: '800000002',
+          clientId: '00000000-0000-0000-0000-000000000000',
           clientNumber: '00000000000',
         },
         applicationYearId: '2024',
@@ -220,6 +221,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         },
         children: [
           {
+            clientId: '00000000-0000-0000-0000-000000000001',
             clientNumber: '11111111111',
             dentalBenefits: ['New federal program', 'New provincial program'],
             dentalInsurance: true,

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -61,11 +61,13 @@ export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformatio
 
 export type RenewalApplicantInformationDto = ApplicantInformationDto &
   Readonly<{
+    clientId: string;
     clientNumber: string;
   }>;
 
 export type RenewalChildDto = ChildDto &
   Readonly<{
+    clientId: string;
     clientNumber: string;
     demographicSurvey?: DemographicSurveyDto;
   }>;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -126,6 +126,10 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
           BenefitApplicationDetail: this.toBenefitApplicationDetail(demographicSurvey),
           ClientIdentification: [
             {
+              IdentificationID: applicantInformation.clientId,
+              IdentificationCategoryText: 'Client ID',
+            },
+            {
               IdentificationID: applicantInformation.clientNumber,
               IdentificationCategoryText: 'Client Number',
             },
@@ -409,6 +413,10 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       },
       BenefitApplicationDetail: this.toBenefitApplicationDetail(child.demographicSurvey),
       ClientIdentification: [
+        {
+          IdentificationID: child.clientId,
+          IdentificationCategoryText: 'Client ID',
+        },
         {
           IdentificationID: child.clientNumber,
           IdentificationCategoryText: 'Client Number',

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -517,6 +517,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       lastName: existingApplicantInformation.lastName,
       maritalStatus: renewedMaritalStatus,
       socialInsuranceNumber: existingApplicantInformation.socialInsuranceNumber,
+      clientId: existingApplicantInformation.clientId,
       clientNumber:
         existingApplicantInformation.clientNumber ??
         (() => {
@@ -536,6 +537,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }
 
       return {
+        clientId: existingChild.information.clientId,
         clientNumber:
           existingChild.information.clientNumber ??
           (() => {


### PR DESCRIPTION
### Description
As per title.

Continuation of #2844

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/3269a3d1-864a-477d-8649-09c6c9a314fd)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Complete renewal application until you reach the Review page and verify that a `ClientIdentification` with `IdentificationCategoryText === 'Client ID'` exists in the request payload. 