### PR TITLE
feature flag demographic survey in protected renew app

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -47,7 +47,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env-utils.server.ts for valid values
 # (optional; default: "")
-ENABLED_FEATURES=address-validation,doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,stub-login
+ENABLED_FEATURES=address-validation,doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,stub-login,demographic-survey
 
 # hCaptcha maximum allowed score denoting malicious activity
 # (optional; default: 0.79)

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -47,6 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateFeatureEnabled('demographic-survey');
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -47,6 +47,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateFeatureEnabled('demographic-survey');
 
   const state = loadProtectedRenewState({ params, session });
 

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -60,6 +60,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
   // state validation schema
   const dentalInsuranceSchema = z.object({
@@ -79,6 +81,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       dentalInsurance: parsedDataResult.data.dentalInsurance,
+      previouslyReviewed: demographicSurveyEnabled ? undefined : true,
     },
   });
 
@@ -90,7 +93,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('protected/renew/$id/confirm-federal-provincial-territorial-benefits', params));
   }
 
-  return redirect(getPathById('protected/renew/$id/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('protected/renew/$id/demographic-survey', params));
+  }
+
+  return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
 export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion() {

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -65,8 +65,10 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
 
   const state = loadProtectedRenewState({ params, session });
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  if (!isPrimaryApplicantStateComplete(state) && !isChildrenStateComplete(state)) {
+  if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled) && !isChildrenStateComplete(state, demographicSurveyEnabled)) {
     return { status: 'select-member' };
   }
 

--- a/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
@@ -45,8 +45,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:review-submit.page-title') }) };
 
-  const primaryApplicantName = isPrimaryApplicantStateComplete(state) ? `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}` : undefined;
-  const children = validateProtectedChildrenStateForReview(state.children);
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
+  const primaryApplicantName = isPrimaryApplicantStateComplete(state, demographicSurveyEnabled) ? `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}` : undefined;
+  const children = validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled);
 
   return {
     meta,
@@ -61,8 +64,11 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formData = await request.formData();
 
-  const state = loadProtectedRenewStateForReview({ params, session });
-  const children = validateProtectedChildrenStateForReview(state.children);
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
+  const state = loadProtectedRenewStateForReview({ params, session, demographicSurveyEnabled });
+  const children = validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled);
 
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const validFeatureNames = ['address-validation', 'doc-upload', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-messages', 'view-payload'] as const;
+const validFeatureNames = ['address-validation', 'doc-upload', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-messages', 'view-payload', 'demographic-survey'] as const;
 
 export type FeatureName = (typeof validFeatureNames)[number];
 


### PR DESCRIPTION
### Description
to make feature flagging the demographic survey more digestible, I'm going to split into a few PRs.  This one handles the protected renew app.  I've tested every permutation of applicant (adult, child only, adult with child).

### Related Azure Boards Work Items
[AB#5034](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5034)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
