### PR TITLE
Distinguishing application year identifiers between intake and renewal

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -16,39 +16,40 @@ describe('DefaultApplicationYearService', () => {
   const mockApplicationYearResultDtos: ApplicationYearResultDto[] = [
     {
       // all fields set
-      id: '1',
       applicationYear: '2024',
       taxYear: '2024',
       coverageStartDate: '2024-01-01',
       coverageEndDate: '2024-12-31',
       intakeStartDate: '2024-01-01',
       intakeEndDate: '2024-12-31',
+      intakeYearId: '2024',
       renewalStartDate: '2024-01-01',
       renewalEndDate: '2024-12-31',
+      renewalYearId: '2024',
     },
     {
       // optional dates not set
-      id: '2',
       applicationYear: '2025',
       taxYear: '2025',
       coverageStartDate: '2025-01-01',
       coverageEndDate: '2025-12-31',
       intakeStartDate: '2025-01-01',
+      intakeYearId: '2024',
     },
     {
       // optional end dates not set
-      id: '3',
       applicationYear: '2026',
       taxYear: '2026',
       coverageStartDate: '2026-01-01',
       coverageEndDate: '2026-12-31',
       intakeStartDate: '2026-01-01',
+      intakeYearId: '2024',
       renewalStartDate: '2026-01-01',
     },
   ];
 
   const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = {
-    id: '1',
+    intakeYearId: '2024',
     taxYear: '2024',
     coverageStartDate: '2024-01-01',
     coverageEndDate: '2024-12-31',

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -109,7 +109,8 @@ describe('DefaultBenefitRenewalStateMapper', () => {
     it('should map a valid RenewAdultChildState to AdultChildBenefitRenewalDto with information changed', () => {
       const renewAdultChildState: RenewAdultChildState = {
         applicationYear: {
-          id: '2024',
+          intakeYearId: '2024',
+          renewalYearId: '2024',
           taxYear: '2024',
           coverageStartDate: '2024-01-01',
         },

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -13,13 +13,14 @@ export type ApplicationYearRequestDto = Readonly<{
  * Represents a Data Transfer Object (DTO) for an application year result.
  */
 export type ApplicationYearResultDto = Readonly<{
-  id: string;
   applicationYear: string;
   taxYear: string;
   intakeStartDate: string;
   intakeEndDate?: string;
+  intakeYearId: string;
   renewalStartDate?: string;
   renewalEndDate?: string;
+  renewalYearId?: string;
   coverageStartDate: string;
   coverageEndDate: string;
 }>;
@@ -32,4 +33,4 @@ export type RenewalApplicationYearResultDto = Omit<ApplicationYearResultDto, 'ap
 /**
  * Represents a Data Transfer Object (DTO) for an intake application year result.
  */
-export type IntakeApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate' | 'coverageStartDate' | 'coverageEndDate'>;
+export type IntakeApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate' | 'renewalYearId' | 'coverageStartDate' | 'coverageEndDate'>;

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -13,10 +13,11 @@ export interface ApplicationYearDtoMapper {
 export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper {
   mapApplicationYearResultDtoToRenewalApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): RenewalApplicationYearResultDto {
     return {
-      id: applicationYearResultDto.id,
+      intakeYearId: applicationYearResultDto.intakeYearId,
       taxYear: applicationYearResultDto.taxYear,
       coverageStartDate: applicationYearResultDto.coverageStartDate,
       coverageEndDate: applicationYearResultDto.coverageEndDate,
+      renewalYearId: applicationYearResultDto.renewalYearId,
     };
   }
 
@@ -24,15 +25,16 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
     const applicationYearData = applicationYearResultEntity['BenefitApplicationYear'];
 
     const applicationYears = applicationYearData.map((applicationYear) => ({
-      id: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
       applicationYear: applicationYear.BenefitApplicationYearEffectivePeriod.StartDate.YearDate,
       taxYear: applicationYear.BenefitApplicationYearTaxYear.YearDate,
       coverageStartDate: applicationYear.BenefitApplicationYearCoveragePeriod.StartDate.date,
       coverageEndDate: applicationYear.BenefitApplicationYearCoveragePeriod.EndDate.date,
       intakeStartDate: applicationYear.BenefitApplicationYearIntakePeriod.StartDate.date,
       intakeEndDate: applicationYear.BenefitApplicationYearIntakePeriod.EndDate?.date,
+      intakeYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
       renewalStartDate: applicationYear.BenefitApplicationYearRenewalPeriod.StartDate?.date,
       renewalEndDate: applicationYear.BenefitApplicationYearRenewalPeriod.EndDate?.date,
+      renewalYearId: applicationYear.BenefitApplicationYearNext.BenefitApplicationYearIdentification?.IdentificationID,
     }));
 
     return applicationYears;

--- a/frontend/app/.server/domain/repositories/application-year.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-year.repository.ts
@@ -146,7 +146,9 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
             },
           },
           BenefitApplicationYearNext: {
-            BenefitApplicationYearIdentification: {},
+            BenefitApplicationYearIdentification: {
+              IdentificationID: '9bb21bc9-028c-ef11-8a69-000d3a0a1a29',
+            },
           },
           BenefitApplicationYearCoveragePeriod: {
             StartDate: {

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -20,7 +20,7 @@ export type ApplyState = ReadonlyDeep<{
   lastUpdatedOn: string;
   allChildrenUnder18?: boolean;
   applicationYears: {
-    id: string;
+    intakeYearId: string;
     taxYear: string;
   }[];
   applicantInformation?: {

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -18,7 +18,8 @@ export interface ProtectedRenewState {
   readonly id: string;
   readonly editMode: boolean;
   readonly applicationYear: {
-    id: string;
+    intakeYearId: string;
+    renewalYearId: string;
     taxYear: string;
     coverageStartDate: string;
   };

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -15,7 +15,8 @@ export interface RenewState {
   readonly id: string;
   readonly editMode: boolean;
   readonly applicationYear: {
-    id: string;
+    intakeYearId: string;
+    renewalYearId: string;
     taxYear: string;
     coverageStartDate: string;
   };

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -224,7 +224,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedMaritalStatus: maritalStatus,
       }),
-      applicationYearId: applicationYear.id,
+      applicationYearId: applicationYear.renewalYearId,
       children: [],
       changeIndicators: {
         hasAddressChanged,
@@ -294,7 +294,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedMaritalStatus: maritalStatus,
       }),
-      applicationYearId: applicationYear.id,
+      applicationYearId: applicationYear.renewalYearId,
       children: this.toChildren({
         existingChildren: clientApplication.children,
         renewedChildren: children,
@@ -360,7 +360,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: true,
         renewedMaritalStatus: maritalStatus,
       }),
-      applicationYearId: applicationYear.id,
+      applicationYearId: applicationYear.renewalYearId,
       changeIndicators: {
         hasAddressChanged,
       },
@@ -428,7 +428,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedMaritalStatus: maritalStatus,
       }),
-      applicationYearId: applicationYear.id,
+      applicationYearId: applicationYear.renewalYearId,
       children: this.toChildren({
         existingChildren: clientApplication.children,
         renewedChildren: children,
@@ -470,7 +470,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         renewedMaritalStatus: maritalStatus,
       }),
-      applicationYearId: applicationYear.id,
+      applicationYearId: applicationYear.renewalYearId,
       demographicSurvey,
       children: this.toChildren({
         existingChildren: clientApplication.children,

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -48,10 +48,20 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
   const applicationYear = await applicationYearService.findRenewalApplicationYear({ date: currentDate, userId: userInfoToken.sub });
-  invariant(applicationYear, 'Expected applicationYear to be defined'); // TODO this should redirect to the protected apply flow when introduced
+  invariant(applicationYear?.renewalYearId, 'Expected applicationYear.renewalYearId to be defined'); // TODO this should redirect to the protected apply flow when introduced
 
   const id = randomUUID().toString();
-  const state = startProtectedRenewState({ applicationYear, clientApplication, id, session });
+  const state = startProtectedRenewState({
+    applicationYear: {
+      intakeYearId: applicationYear.intakeYearId,
+      renewalYearId: applicationYear.renewalYearId,
+      taxYear: applicationYear.taxYear,
+      coverageStartDate: applicationYear.coverageStartDate,
+    },
+    clientApplication,
+    id,
+    session,
+  });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:index.page-title') }) };
 

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -36,11 +36,20 @@ export async function loader({ context: { appContainer, session }, params, reque
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
   const applicationYear = await applicationYearService.findRenewalApplicationYear({ date: currentDate, userId: 'anonymous' });
-  if (!applicationYear) {
+  if (!applicationYear?.renewalYearId) {
     throw redirect(getPathById('public/apply/index', params));
   }
 
-  const state = startRenewState({ applicationYear, id, session });
+  const state = startRenewState({
+    applicationYear: {
+      intakeYearId: applicationYear.intakeYearId,
+      renewalYearId: applicationYear.renewalYearId,
+      taxYear: applicationYear.taxYear,
+      coverageStartDate: applicationYear.coverageStartDate,
+    },
+    id,
+    session,
+  });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:terms-and-conditions.page-title') }) };
 


### PR DESCRIPTION
### Description

- `intakeYearId`: Used to query for client application data. 
  - Future PR will be introduced to add an application year identifier parameter for getting client application data.
  - Is mapped from `BenefitApplicationYearIdentification` from Interop
- `renewalYearId`: Passed in the request body to submit a renewal
  - Is mapped from `BenefitApplicationYearNext` from Interop

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/28f680eb-d8c2-4b57-a0bd-68241a66c0a7)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Complete renewal flow until you reach Review screen. Verify that the `BenefitApplicationYearIdentification` field in the request payload matches the `BenefitApplicationYearIdentification` field from the `BenefitApplicationYearNext` identifier in `application-year.repository`. 