### PR TITLE
feature flag demographic-survey in public renew app

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -70,6 +70,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const renewState = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   const dentalBenefitsChangedSchema = z.object({
     hasFederalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });
@@ -110,7 +113,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/children/$childId/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
 }
 
 export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
@@ -46,6 +46,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateFeatureEnabled('demographic-survey');
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -89,6 +89,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const renewState = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const federalBenefitsSchema = z
@@ -174,7 +177,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/children/$childId/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
 }
 
 export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -61,6 +61,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const dentalBenefitsChangedSchema = z.object({
@@ -97,7 +100,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
 }
 
 export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
@@ -47,6 +47,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateFeatureEnabled('demographic-survey');
+
   const state = loadRenewAdultChildState({ params, request, session });
 
   const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -217,6 +217,8 @@ export default function RenewAdultChildReviewAdultInformation() {
     fetcher.submit(formData, { method: 'POST' });
   }
 
+  const demographicSurveyEnabled = useFeature('demographic-survey');
+
   return (
     <>
       <div className="my-6 sm:my-8">
@@ -376,19 +378,21 @@ export default function RenewAdultChildReviewAdultInformation() {
               </DescriptionListItem>
             </dl>
           </section>
-          <section className="space-y-6">
-            <h2 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-adult-information.demographic-survey-title')}</h2>
-            <dl className="divide-y border-y">
-              <DescriptionListItem term={t('renew-adult-child:review-adult-information.demographic-survey-title')}>
-                <p>{demographicSurvey ? t('renew-adult-child:review-adult-information.demographic-survey-responded') : t('renew-adult-child:review-adult-information.no')}</p>
-                <div className="mt-4">
-                  <InlineLink id="change-demographic-survey" routeId="public/renew/$id/adult-child/demographic-survey" params={params}>
-                    {t('renew-adult-child:review-adult-information.demographic-survey-change')}
-                  </InlineLink>
-                </div>
-              </DescriptionListItem>
-            </dl>
-          </section>
+          {demographicSurveyEnabled && (
+            <section className="space-y-6">
+              <h2 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-adult-information.demographic-survey-title')}</h2>
+              <dl className="divide-y border-y">
+                <DescriptionListItem term={t('renew-adult-child:review-adult-information.demographic-survey-title')}>
+                  <p>{demographicSurvey ? t('renew-adult-child:review-adult-information.demographic-survey-responded') : t('renew-adult-child:review-adult-information.no')}</p>
+                  <div className="mt-4">
+                    <InlineLink id="change-demographic-survey" routeId="public/renew/$id/adult-child/demographic-survey" params={params}>
+                      {t('renew-adult-child:review-adult-information.demographic-survey-change')}
+                    </InlineLink>
+                  </div>
+                </DescriptionListItem>
+              </dl>
+            </section>
+          )}
           {!hasChildren && (
             <section className="space-y-4">
               <h2 className="font-lato text-2xl font-bold">{t('renew-adult-child:review-adult-information.submit-app-title')}</h2>

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -80,6 +80,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const federalBenefitsSchema = z
@@ -159,7 +162,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
 }
 
 export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -61,6 +61,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const dentalBenefitsChangedSchema = z.object({
@@ -97,7 +100,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
 }
 
 export default function RenewAdultConfirmFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
@@ -47,6 +47,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateFeatureEnabled('demographic-survey');
+
   const state = loadRenewAdultState({ params, request, session });
 
   const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -80,6 +80,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const federalBenefitsSchema = z
@@ -159,7 +162,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/adult/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/adult/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
 }
 
 export default function RenewAdultUpdateFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -70,6 +70,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const renewState = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   const dentalBenefitsChangedSchema = z.object({
     hasFederalProvincialTerritorialBenefitsChanged: z.boolean({ errorMap: () => ({ message: t('renew-child:children.confirm-dental-benefits.error-message.federal-provincial-territorial-benefit-required') }) }),
   });
@@ -110,7 +113,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/child/review-child-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/child/children/$childId/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/child/children/$childId/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/child/review-child-information', params));
 }
 
 export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
@@ -47,6 +47,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateFeatureEnabled('demographic-survey');
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -89,6 +89,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const renewState = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const federalBenefitsSchema = z
@@ -174,7 +177,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/child/review-child-information', params));
   }
 
-  return redirect(getPathById('public/renew/$id/child/children/$childId/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/child/children/$childId/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/child/review-child-information', params));
 }
 
 export default function RenewChildUpdateFederalProvincialTerritorialBenefits() {

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -156,6 +156,8 @@ export default function RenewChildReviewChildInformation() {
     fetcher.submit(formData, { method: 'POST' });
   }
 
+  const demographicSurveyEnabled = useFeature('demographic-survey');
+
   return (
     <>
       <div className="my-6 sm:my-8">
@@ -215,19 +217,21 @@ export default function RenewChildReviewChildInformation() {
                     </DescriptionListItem>
                   </dl>
                 </section>
-                <section className="space-y-6">
-                  <h2 className="font-lato text-2xl font-bold">{t('renew-child:review-child-information.demographic-survey-title')}</h2>
-                  <dl className="divide-y border-y">
-                    <DescriptionListItem term={t('renew-child:review-child-information.demographic-survey-title')}>
-                      <p>{child.demographicSurvey ? t('renew-child:review-child-information.demographic-survey-responded') : t('renew-child:review-child-information.no')}</p>
-                      <div className="mt-4">
-                        <InlineLink id="change-demographic-survey" routeId="public/renew/$id/child/children/$childId/demographic-survey" params={childParams}>
-                          {t('renew-child:review-child-information.demographic-survey-change')}
-                        </InlineLink>
-                      </div>
-                    </DescriptionListItem>
-                  </dl>
-                </section>
+                {demographicSurveyEnabled && (
+                  <section className="space-y-6">
+                    <h2 className="font-lato text-2xl font-bold">{t('renew-child:review-child-information.demographic-survey-title')}</h2>
+                    <dl className="divide-y border-y">
+                      <DescriptionListItem term={t('renew-child:review-child-information.demographic-survey-title')}>
+                        <p>{child.demographicSurvey ? t('renew-child:review-child-information.demographic-survey-responded') : t('renew-child:review-child-information.no')}</p>
+                        <div className="mt-4">
+                          <InlineLink id="change-demographic-survey" routeId="public/renew/$id/child/children/$childId/demographic-survey" params={childParams}>
+                            {t('renew-child:review-child-information.demographic-survey-change')}
+                          </InlineLink>
+                        </div>
+                      </DescriptionListItem>
+                    </dl>
+                  </section>
+                )}
               </section>
             );
           })}

--- a/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
@@ -46,6 +46,9 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateFeatureEnabled('demographic-survey');
+
   const state = loadRenewItaState({ params, request, session });
 
   const memberName = `${state.applicantInformation?.firstName} ${state.applicantInformation?.lastName}`;

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -78,6 +78,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // NOTE: state validation schemas are independent otherwise user have to anwser
@@ -155,7 +158,11 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  return redirect(getPathById('public/renew/$id/ita/demographic-survey', params));
+  if (demographicSurveyEnabled) {
+    return redirect(getPathById('public/renew/$id/ita/demographic-survey', params));
+  }
+
+  return redirect(getPathById('public/renew/$id/ita/review-information', params));
 }
 
 export default function RenewItaFederalProvincialTerritorialBenefits() {


### PR DESCRIPTION
### Description
followup to #2846, but this one feature flags the public facing renew application

### Related Azure Boards Work Items
[AB#5034](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5034)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`