### PR TITLE
move renewal submission and hcaptcha in protected renew app

### DIFF
--- a/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
@@ -1,20 +1,26 @@
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
-import { isPrimaryApplicantStateComplete, loadProtectedRenewState, loadProtectedRenewStateForReview, saveProtectedRenewState, validateProtectedChildrenStateForReview } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { clearProtectedRenewState, isPrimaryApplicantStateComplete, loadProtectedRenewState, loadProtectedRenewStateForReview, saveProtectedRenewState, validateProtectedChildrenStateForReview } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { UserinfoToken } from '~/.server/utils/raoidc.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -40,13 +46,14 @@ export async function loader({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
+  const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ClientConfig);
+  const hCaptchaEnabled = ENABLED_FEATURES.includes('hcaptcha');
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
   const state = loadProtectedRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:review-submit.page-title') }) };
-
-  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
-  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
   const primaryApplicantName = isPrimaryApplicantStateComplete(state, demographicSurveyEnabled) ? `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}` : undefined;
   const children = validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled);
@@ -55,14 +62,20 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     primaryApplicantName,
     children,
+    siteKey: HCAPTCHA_SITE_KEY,
+    hCaptchaEnabled,
   };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
-
   const formData = await request.formData();
+  securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedRenewState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
@@ -88,9 +101,37 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedRenewReviewSubmit() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { primaryApplicantName, children } = useLoaderData<typeof loader>();
+  const { primaryApplicantName, children, hCaptchaEnabled, siteKey } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
+
+  const { captchaRef } = useHCaptcha();
+  const [submitAction, setSubmitAction] = useState<string>();
+
+  function handleSubmit(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.append(submitter.name, submitter.value);
+
+    setSubmitAction(submitter.value);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    fetcher.submit(formData, { method: 'POST' });
+  }
 
   return (
     <div className="max-w-prose">
@@ -105,15 +146,16 @@ export default function ProtectedRenewReviewSubmit() {
       <p className="mb-4">{t('protected-renew:review-submit.submit-p-proceed')}</p>
       <p className="mb-4">{t('protected-renew:review-submit.submit-p-false-info')}</p>
       <p className="mb-4">{t('protected-renew:review-submit.submit-p-repayment')}</p>
-      <fetcher.Form method="post" noValidate>
+      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
         <CsrfTokenInput />
+        {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={siteKey} ref={captchaRef} />}
         <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
           <LoadingButton
             id="submit-button"
             name="_action"
             value={FormAction.Submit}
             variant="green"
-            loading={isSubmitting}
+            loading={isSubmitting && submitAction === FormAction.Submit}
             endIcon={faChevronRight}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Protected Renew Application Form:Continue - Review and submit click"
           >


### PR DESCRIPTION
### Description
Moves the renewal submission and hCaptcha to its rightful place in `/review-and-submit`.

### Related Azure Boards Work Items
[AB#5037](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5037)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`