### PR TITLE
Adding `applicationYearId` and missing `Client Number` category text to client application requests

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ClientApplicationBasicInfoRequestDto, ClientApplicationDto, ClientApplicationSinRequestDto } from '~/.server/domain/dtos';
-import type { ClientApplicationBasicInfoRequestEntity, ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
+import type { ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
 import { DefaultClientApplicationDtoMapper } from '~/.server/domain/mappers';
 
 describe('DefaultClientApplicationDtoMapper', () => {
@@ -249,15 +249,17 @@ describe('DefaultClientApplicationDtoMapper', () => {
         lastName: 'Doe',
         dateOfBirth: '2000-01-01',
         clientNumber: 'ABC123',
+        applicationYearId: '00000000-0000-0000-0000-000000000000',
         userId: 'test-user',
       };
 
-      const mockClientApplicationBasicInfoRequestEntity: ClientApplicationBasicInfoRequestEntity = {
+      const mockClientApplicationBasicInfoRequestEntity = {
         Applicant: {
           PersonName: { PersonGivenName: ['John'], PersonSurName: 'Doe' },
           PersonBirthDate: { date: '2000-01-01' },
-          ClientIdentification: [{ IdentificationID: 'ABC123' }],
+          ClientIdentification: [{ IdentificationID: 'ABC123', IdentificationCategoryText: 'Client Number' }],
         },
+        BenefitApplicationYear: { IdentificationID: '00000000-0000-0000-0000-000000000000' },
       };
 
       // Act
@@ -273,11 +275,13 @@ describe('DefaultClientApplicationDtoMapper', () => {
       // Arrange
       const mockClientApplicationSinRequestDto: ClientApplicationSinRequestDto = {
         sin: '123456789',
+        applicationYearId: '00000000-0000-0000-0000-000000000000',
         userId: 'test-user',
       };
 
       const mockClientApplicationSinRequestEntity: ClientApplicationSinRequestEntity = {
         Applicant: { PersonSINIdentification: { IdentificationID: '123456789' } },
+        BenefitApplicationYear: { IdentificationID: '00000000-0000-0000-0000-000000000000' },
       };
 
       // Act

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -47,6 +47,7 @@ export type ClientApplicationBasicInfoRequestDto = Readonly<{
   dateOfBirth: string;
   firstName: string;
   lastName: string;
+  applicationYearId: string;
 
   /** A unique identifier for the user making the request - used for auditing */
   userId: string;
@@ -54,6 +55,7 @@ export type ClientApplicationBasicInfoRequestDto = Readonly<{
 
 export type ClientApplicationSinRequestDto = Readonly<{
   sin: string;
+  applicationYearId: string;
 
   /** A unique identifier for the user making the request - used for auditing */
   userId: string;

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -137,6 +137,9 @@ export type ClientApplicationBasicInfoRequestEntity = ReadonlyDeep<{
       IdentificationID: string;
     }>;
   };
+  BenefitApplicationYear: {
+    IdentificationID: string;
+  };
 }>;
 
 export type ClientApplicationSinRequestEntity = ReadonlyDeep<{
@@ -144,5 +147,8 @@ export type ClientApplicationSinRequestEntity = ReadonlyDeep<{
     PersonSINIdentification: {
       IdentificationID: string;
     };
+  };
+  BenefitApplicationYear: {
+    IdentificationID: string;
   };
 }>;

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -25,8 +25,12 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
         ClientIdentification: [
           {
             IdentificationID: clientApplicationBasicInfoRequestDto.clientNumber,
+            IdentificationCategoryText: 'Client Number',
           },
         ],
+      },
+      BenefitApplicationYear: {
+        IdentificationID: clientApplicationBasicInfoRequestDto.applicationYearId,
       },
     };
   }
@@ -37,6 +41,9 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
         PersonSINIdentification: {
           IdentificationID: clientApplicationSinRequestDto.sin,
         },
+      },
+      BenefitApplicationYear: {
+        IdentificationID: clientApplicationSinRequestDto.applicationYearId,
       },
     };
   }

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -39,16 +39,16 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const userInfoToken = session.get<UserinfoToken>('userInfoToken');
   invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
 
-  const clientApplicationService = appContainer.get(TYPES.domain.services.ClientApplicationService);
-  const clientApplication = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, userId: userInfoToken.sub });
-  if (!clientApplication) {
-    throw redirect(getPathById('protected/data-unavailable'));
-  }
-
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
   const applicationYear = await applicationYearService.findRenewalApplicationYear({ date: currentDate, userId: userInfoToken.sub });
   invariant(applicationYear?.renewalYearId, 'Expected applicationYear.renewalYearId to be defined'); // TODO this should redirect to the protected apply flow when introduced
+
+  const clientApplicationService = appContainer.get(TYPES.domain.services.ClientApplicationService);
+  const clientApplication = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.intakeYearId, userId: userInfoToken.sub });
+  if (!clientApplication) {
+    throw redirect(getPathById('protected/data-unavailable'));
+  }
 
   const id = randomUUID().toString();
   const state = startProtectedRenewState({

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -144,6 +144,7 @@ export async function action({ context: { appContainer, session }, params, reque
     lastName: parsedDataResult.data.lastName,
     dateOfBirth: parsedDataResult.data.dateOfBirth,
     clientNumber: parsedDataResult.data.clientNumber,
+    applicationYearId: state.applicationYear.intakeYearId,
     userId: 'anonymous',
   });
 


### PR DESCRIPTION
### Description
As per title to conform with Interop v1.0.14 specs.

Continuation of #2847

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`