### PR TITLE
update dental-insurance adult screens

### DIFF
--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -25,11 +25,12 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 enum FormAction {
   Continue = 'continue',
   Save = 'save',
+  Back = 'back',
 }
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
-  pageTitleI18nKey: 'protected-renew:dental-insurance.page-title',
+  pageTitleI18nKey: 'protected-renew:dental-insurance.title',
   pageIdentifier: pageIds.protected.renew.dentalInsurance,
 };
 
@@ -46,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const memberName = `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}`;
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.page-title', { memberName }) }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.title', { memberName }) }) };
 
   return { id: state, meta, defaultState: state.dentalInsurance, hasAddressChanged: state.hasAddressChanged, editMode: state.editMode, i18nOptions: { memberName } };
 }
@@ -112,26 +113,31 @@ export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion(
 
   const helpMessage = (
     <div className="my-4 space-y-4">
-      <ul className="list-disc pl-7">
-        <li>{t('dental-insurance.list.employment')}</li>
-        <li>{t('dental-insurance.list.pension')}</li>
-        <li>{t('dental-insurance.list.purchased')}</li>
-        <li>{t('dental-insurance.list.professional')}</li>
-      </ul>
       <Collapsible summary={t('dental-insurance.detail.additional-info.title')}>
         <div className="space-y-4">
-          <p>{t('dental-insurance.detail.additional-info.not-eligible')}</p>
-          <ul className="list-disc space-y-1 pl-7">
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-employer')}</li>
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-pension')}</li>
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-organization')}</li>
-          </ul>
-          <p>{t('dental-insurance.detail.additional-info.not-eligible-note')}</p>
-          <p>{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
           <p>{t('dental-insurance.detail.additional-info.eligible')}</p>
           <ul className="list-disc space-y-1 pl-7">
-            <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
-            <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.employment-benefits')}</li>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.professional-student')}</li>
+            <p className="pl-4">{t('dental-insurance.detail.additional-info.eligible-list.organization.note')}</p>
+            <ul className="list-disc space-y-1 pl-12">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.not-take')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.pay-premium')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.not-use')}</li>
+            </ul>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.pension-benefits')}</li>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.federal-provincial-territorial')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.eligible')}</li>
+              <ul className="list-disc space-y-1 pl-7">
+                <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.opted-out')}</li>
+                <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.opt-back')}</li>
+              </ul>
+            </ul>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.purchased-coverage.purchased-through')}</li>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.purchased-coverage.purchased-privately')}</li>
+            </ul>
           </ul>
         </div>
       </Collapsible>

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -101,26 +101,31 @@ export default function RenewAdultChildAccessToDentalInsuranceQuestion() {
 
   const helpMessage = (
     <div className="my-4 space-y-4">
-      <ul className="list-disc pl-7">
-        <li>{t('dental-insurance.list.employment')}</li>
-        <li>{t('dental-insurance.list.pension')}</li>
-        <li>{t('dental-insurance.list.purchased')}</li>
-        <li>{t('dental-insurance.list.professional')}</li>
-      </ul>
       <Collapsible summary={t('dental-insurance.detail.additional-info.title')}>
         <div className="space-y-4">
-          <p>{t('dental-insurance.detail.additional-info.not-eligible')}</p>
-          <ul className="list-disc space-y-1 pl-7">
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-employer')}</li>
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-pension')}</li>
-            <li>{t('dental-insurance.detail.additional-info.not-eligible-organization')}</li>
-          </ul>
-          <p>{t('dental-insurance.detail.additional-info.not-eligible-note')}</p>
-          <p>{t('dental-insurance.detail.additional-info.not-eligible-purchased')}</p>
           <p>{t('dental-insurance.detail.additional-info.eligible')}</p>
           <ul className="list-disc space-y-1 pl-7">
-            <li>{t('dental-insurance.detail.additional-info.list.opted')}</li>
-            <li>{t('dental-insurance.detail.additional-info.list.cannot-opt')}</li>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.employment-benefits')}</li>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.professional-student')}</li>
+            <p className="pl-4">{t('dental-insurance.detail.additional-info.eligible-list.organization.note')}</p>
+            <ul className="list-disc space-y-1 pl-12">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.not-take')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.pay-premium')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.organization.not-use')}</li>
+            </ul>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.pension-benefits')}</li>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.federal-provincial-territorial')}</li>
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.eligible')}</li>
+              <ul className="list-disc space-y-1 pl-7">
+                <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.opted-out')}</li>
+                <li>{t('dental-insurance.detail.additional-info.eligible-list.pension.exceptions.opt-back')}</li>
+              </ul>
+            </ul>
+            <li>{t('dental-insurance.detail.additional-info.eligible-list.purchased-coverage.purchased-through')}</li>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t('dental-insurance.detail.additional-info.eligible-list.purchased-coverage.purchased-privately')}</li>
+            </ul>
           </ul>
         </div>
       </Collapsible>

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -116,12 +116,12 @@
     }
   },
   "dental-insurance": {
-    "page-title": "{{memberName}}: Access to other dental insurance",
-    "legend": "Do you have access to dental insurance or coverage:",
+    "title": "{{memberName}}: access to private dental insurance",
+    "legend": "Do you have access to private dental insurance or coverage?",
     "list": {
-      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
-      "pension": "Through your pension benefits or a family member's pension benefits",
-      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "employment": "Through a parent or legal guardian's employment benefits including health and wellness accounts",
+      "pension": "Through a parent or legal guardian's pension benefits",
+      "purchased": "Purchased by a parent or legal guardian from an insurance or benefits company",
       "professional": "Through a professional or student organization"
     },
     "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
@@ -134,18 +134,31 @@
     },
     "detail": {
       "additional-info": {
-        "title": "Additional information",
-        "eligible": "Exception: You may still be eligible if you are retired and:",
-        "list": {
-          "opted": "you opted out of pension benefits before December 11, 2023, and",
-          "cannot-opt": "you can't opt back in under the pension rules"
-        },
-        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
-        "not-eligible-employer": "employer",
-        "not-eligible-pension": "pension (see exception)",
-        "not-eligible-organization": "professional or student organization.",
-        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
-        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+        "title": "What does it mean to have access to private dental insurance or coverage?",
+        "eligible": "It means you do not have access to any type of dental insurance or coverage through:",
+        "eligible-list": {
+          "employment-benefits": "your employment benefits or a family member's employment benefits, including health and wellness accounts",
+          "organization": {
+            "professional-student": "a professional or student organization",
+            "note": "Note: If you're eligible for dental coverage through your employment benefits or through a professional or student organization, you're not eligible for CDCP. This is true even if:",
+            "not-take": "you decide not to take it",
+            "pay-premium": "you have to pay a premium for it",
+            "not-use": "you don't use it"
+          },
+          "pension": {
+            "pension-benefits": "your pension benefits or a family member's pension benefits",
+            "federal-provincial-territorial": "this includes federal, provincial and territorial government employer pension plans",
+            "exceptions": {
+              "eligible": "Exception: You may be eligible for the CDCP if you're retired and:",
+              "opted-out": "you opted out of pension benefits before December 11, 2023, and",
+              "opt-back": "you can't opt back in under the pension rules"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "coverage bought by you or a family member or through a group plan from an insurance or benefits company",
+            "purchased-privately": "if you purchased your current dental insurance policy privately  (and not as part of any of the coverage described above), you're not eligible for the CDCP while that coverage is in effect."
+          }
+        }
       }
     },
     "error-message": {

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -232,12 +232,12 @@
     }
   },
   "dental-insurance": {
-    "title": "Access to other dental insurance",
-    "legend": "Do you have access to dental insurance or coverage:",
+    "title": "Access to private dental insurance",
+    "legend": "Do you have access to private dental insurance or coverage?",
     "list": {
-      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
-      "pension": "Through your pension benefits or a family member's pension benefits",
-      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "employment": "Through a parent or legal guardian's employment benefits including health and wellness accounts",
+      "pension": "Through a parent or legal guardian's pension benefits",
+      "purchased": "Purchased by a parent or legal guardian from an insurance or benefits company",
       "professional": "Through a professional or student organization"
     },
     "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
@@ -250,18 +250,31 @@
     },
     "detail": {
       "additional-info": {
-        "title": "Additional information",
-        "eligible": "Exception: You may still be eligible if you are retired and:",
-        "list": {
-          "opted": "you opted out of pension benefits before December 11, 2023, and",
-          "cannot-opt": "you can't opt back in under the pension rules"
-        },
-        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
-        "not-eligible-employer": "employer",
-        "not-eligible-pension": "pension (see exception)",
-        "not-eligible-organization": "professional or student organization.",
-        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
-        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+        "title": "What does it mean to have access to private dental insurance or coverage?",
+        "eligible": "It means you do not have access to any type of dental insurance or coverage through:",
+        "eligible-list": {
+          "employment-benefits": "your employment benefits or a family member's employment benefits, including health and wellness accounts",
+          "organization": {
+            "professional-student": "a professional or student organization",
+            "note": "Note: If you're eligible for dental coverage through your employment benefits or through a professional or student organization, you're not eligible for CDCP. This is true even if:",
+            "not-take": "you decide not to take it",
+            "pay-premium": "you have to pay a premium for it",
+            "not-use": "you don't use it"
+          },
+          "pension": {
+            "pension-benefits": "your pension benefits or a family member's pension benefits",
+            "federal-provincial-territorial": "this includes federal, provincial and territorial government employer pension plans",
+            "exceptions": {
+              "eligible": "Exception: You may be eligible for the CDCP if you're retired and:",
+              "opted-out": "you opted out of pension benefits before December 11, 2023, and",
+              "opt-back": "you can't opt back in under the pension rules"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "coverage bought by you or a family member or through a group plan from an insurance or benefits company",
+            "purchased-privately": "if you purchased your current dental insurance policy privately  (and not as part of any of the coverage described above), you're not eligible for the CDCP while that coverage is in effect."
+          }
+        }
       }
     },
     "error-message": {

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -188,12 +188,12 @@
     }
   },
   "dental-insurance": {
-    "title": "Access to other dental insurance",
-    "legend": "Do you have access to dental insurance or coverage:",
+    "title": "Access to private dental insurance",
+    "legend": "Do you have access to private dental insurance or coverage?",
     "list": {
-      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
-      "pension": "Through your pension benefits or a family member's pension benefits",
-      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
+      "employment": "Through a parent or legal guardian's employment benefits including health and wellness accounts",
+      "pension": "Through a parent or legal guardian's pension benefits",
+      "purchased": "Purchased by a parent or legal guardian from an insurance or benefits company",
       "professional": "Through a professional or student organization"
     },
     "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
@@ -206,18 +206,31 @@
     },
     "detail": {
       "additional-info": {
-        "title": "Additional information",
-        "eligible": "Exception: You may still be eligible if you are retired and:",
-        "list": {
-          "opted": "you opted out of pension benefits before December 11, 2023, and",
-          "cannot-opt": "you can't opt back in under the pension rules"
-        },
-        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
-        "not-eligible-employer": "employer",
-        "not-eligible-pension": "pension (see exception)",
-        "not-eligible-organization": "professional or student organization.",
-        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
-        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+        "title": "What does it mean to have access to private dental insurance or coverage?",
+        "eligible": "It means you do not have access to any type of dental insurance or coverage through:",
+        "eligible-list": {
+          "employment-benefits": "your employment benefits or a family member's employment benefits, including health and wellness accounts",
+          "organization": {
+            "professional-student": "a professional or student organization",
+            "note": "Note: If you're eligible for dental coverage through your employment benefits or through a professional or student organization, you're not eligible for CDCP. This is true even if:",
+            "not-take": "you decide not to take it",
+            "pay-premium": "you have to pay a premium for it",
+            "not-use": "you don't use it"
+          },
+          "pension": {
+            "pension-benefits": "your pension benefits or a family member's pension benefits",
+            "federal-provincial-territorial": "this includes federal, provincial and territorial government employer pension plans",
+            "exceptions": {
+              "eligible": "Exception: You may be eligible for the CDCP if you're retired and:",
+              "opted-out": "you opted out of pension benefits before December 11, 2023, and",
+              "opt-back": "you can't opt back in under the pension rules"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "coverage bought by you or a family member or through a group plan from an insurance or benefits company",
+            "purchased-privately": "if you purchased your current dental insurance policy privately  (and not as part of any of the coverage described above), you're not eligible for the CDCP while that coverage is in effect."
+          }
+        }
       }
     },
     "error-message": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -116,40 +116,53 @@
     }
   },
   "dental-insurance": {
-    "page-title": "{{memberName}}\u00a0: Access to other dental insurance",
-    "legend": "Do you have access to dental insurance or coverage:",
+    "title": "{{memberName}}\u00a0: accès à une assurance dentaire privée",
+    "legend": "Avez-vous accès à une assurance dentaire privée ou une couverture dentaire?",
     "list": {
-      "employment": "Through your employment benefits or a family member's employment benefits, including health and wellness accounts",
-      "pension": "Through your pension benefits or a family member's pension benefits",
-      "purchased": "Purchased by you or a family member or through a group plan from an insurance or benefits company",
-      "professional": "Through a professional or student organization"
+      "employment": "dans le cadre des avantages sociaux de l'employeur d'un parent ou d'un tuteur légal, y compris les comptes de santé et de bien-être",
+      "pension": "par le biais de prestations de retraite d'un parent ou d'un tuteur légal",
+      "purchased": "achetée individuellement par un parent ou un tuteur légal auprès d'une compagnie d'assurance ou de prestations",
+      "professional": "par l'intermédiaire d'une organisation professionnelle ou étudiante"
     },
-    "option-yes": "<strong>Yes</strong>, I have access to dental insurance or coverage",
-    "option-no": "<strong>No</strong>, I do not have access to dental insurance or coverage",
+    "option-yes": "<strong>Oui</strong>, j'ai accès à une assurance ou une couverture dentaire",
+    "option-no": "<strong>Non</strong>, je n'ai pas accès à une assurance ou une couverture dentaire",
     "button": {
-      "back": "Back",
-      "continue": "Continue",
-      "cancel-btn": "Cancel",
-      "save-btn": "Save"
+      "back": "Retour",
+      "continue": "Continuer",
+      "cancel-btn": "Annuler",
+      "save-btn": "Sauvegarder"
     },
     "detail": {
       "additional-info": {
-        "title": "Additional information",
-        "eligible": "Exception: You may still be eligible if you are retired and:",
-        "list": {
-          "opted": "you opted out of pension benefits before December 11, 2023, and",
-          "cannot-opt": "you can't opt back in under the pension rules"
-        },
-        "not-eligible": "You are still considered to have access to dental insurance or coverage if you choose to opt out of benefits provided through your or a family member's:",
-        "not-eligible-employer": "employer",
-        "not-eligible-pension": "pension (see exception)",
-        "not-eligible-organization": "professional or student organization.",
-        "not-eligible-note": "As such, you are not eligible for the Canadian Dental Care Plan.",
-        "not-eligible-purchased": "If you purchased your current dental insurance policy privately on your own, you are not eligible for the Canadian Dental Care Plan while that coverage is in effect."
+        "title": "Que signifie avoir accès à une assurance dentaire privée?",
+        "eligible": "Cela signifie que vous n'avez accès à aucun type d'assurance ou de couverture dentaire\u00a0:",
+        "eligible-list": {
+          "employment-benefits": "dans le cadre des avantages sociaux de votre employeur ou de l'employeur d'un membre de votre famille, y compris les comptes de santé et de bien-être",
+          "organization": {
+            "professional-student": "par une organisation professionnelle ou étudiante",
+            "note": "Remarque\u00a0: Si vous êtes admissible à la protection dentaire au moyen de vos avantages sociaux ou par une organisation professionnelle ou étudiante, vous n'êtes pas admissible au RCSD. Cela est vrai, même si\u00a0:",
+            "not-take": "vous décidez de ne pas opter pour cette protection",
+            "pay-premium": "vous devez verser une prime d'assurance sur cette protection",
+            "not-use": "vous ne l'utilisez pas"
+          },
+          "pension": {
+            "pension-benefits": "par le biais de votre pension ou des prestations de retraite d'un membre de votre famille",
+            "federal-provincial-territorial": "Cela comprend les régimes de retraite des gouvernements fédéral, provinciaux et territoriaux",
+            "exceptions": {
+              "eligible": "Exception\u00a0: Vous pourriez être admissible au RCSD si vous êtes à la retraite et si à la fois\u00a0:",
+              "opted-out": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023",
+              "opt-back": "vous ne pouvez pas opter pour celles-ci de nouveau selon les règles relatives à la pension"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "achetée individuellement par vous, par un membre de votre famille ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+            "purchased-privately": "Si vous souscrivez actuellement une assurance dentaire privée (qui ne fait pas partie des types de protection indiqués ci-dessus), vous n'êtes pas admissible au RCSD pendant la durée de cette couverture."
+          }
+        }
       }
     },
     "error-message": {
-      "dental-insurance-required": "Select whether you have access to dental insurance"
+      "dental-insurance-required": "Sélectionnez si vous avez une assurance dentaire"
     }
   },
   "demographic-survey": {

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -233,12 +233,12 @@
     }
   },
   "dental-insurance": {
-    "title": "Accès à d'autres assurances dentaires",
-    "legend": "Avoir accès à une assurance dentaire signifie que vous avez accès à une assurance ou à une couverture dentaire\u00a0:",
+    "title": "Accès à une assurance dentaire privée",
+    "legend": "Avez-vous accès à une assurance dentaire privée ou une couverture dentaire?",
     "list": {
-      "employment": "dans le cadre des avantages sociaux de votre employeur ou de l'employeur d'un membre de votre famille, y compris les comptes de santé et de bien-être",
-      "pension": "par le biais de votre pension ou des prestations de retraite d'un membre de votre famille",
-      "purchased": "achetée individuellement par vous, par un membre de votre famille ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+      "employment": "dans le cadre des avantages sociaux de l'employeur d'un parent ou d'un tuteur légal, y compris les comptes de santé et de bien-être",
+      "pension": "par le biais de prestations de retraite d'un parent ou d'un tuteur légal",
+      "purchased": "achetée individuellement par un parent ou un tuteur légal auprès d'une compagnie d'assurance ou de prestations",
       "professional": "par l'intermédiaire d'une organisation professionnelle ou étudiante"
     },
     "option-yes": "<strong>Oui</strong>, j'ai accès à une assurance ou une couverture dentaire",
@@ -247,22 +247,35 @@
       "back": "Retour",
       "continue": "Continuer",
       "cancel-btn": "Annuler",
-      "save-btn": "Enregistrer"
+      "save-btn": "Sauvegarder"
     },
     "detail": {
       "additional-info": {
-        "title": "Renseignements supplémentaires",
-        "eligible": "Exception\u00a0: Vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
-        "list": {
-          "opted": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023, et",
-          "cannot-opt": "vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite"
-        },
-        "not-eligible": "Vous êtes toujours considéré comme ayant accès à l'assurance ou à la couverture dentaire si vous choisissez de ne pas bénéficier des prestations fournies par votre assurance ou celle d'un membre de votre famille\u00a0:",
-        "not-eligible-employer": "un employeur;",
-        "not-eligible-pension": "un régime de retraite (voir exception);",
-        "not-eligible-organization": "une organisation professionnelle ou étudiante.",
-        "not-eligible-note": "À ce titre, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
-        "not-eligible-purchased": "Si vous avez souscrit votre police d'assurance dentaire actuelle de votre propre chef, vous n'êtes pas admissible au Régime canadien de soins dentaires pendant que cette protection est en vigueur."
+        "title": "Que signifie avoir accès à une assurance dentaire privée?",
+        "eligible": "Cela signifie que vous n'avez accès à aucun type d'assurance ou de couverture dentaire\u00a0:",
+        "eligible-list": {
+          "employment-benefits": "dans le cadre des avantages sociaux de votre employeur ou de l'employeur d'un membre de votre famille, y compris les comptes de santé et de bien-être",
+          "organization": {
+            "professional-student": "par une organisation professionnelle ou étudiante",
+            "note": "Remarque\u00a0: Si vous êtes admissible à la protection dentaire au moyen de vos avantages sociaux ou par une organisation professionnelle ou étudiante, vous n'êtes pas admissible au RCSD. Cela est vrai, même si\u00a0:",
+            "not-take": "vous décidez de ne pas opter pour cette protection",
+            "pay-premium": "vous devez verser une prime d'assurance sur cette protection",
+            "not-use": "vous ne l'utilisez pas"
+          },
+          "pension": {
+            "pension-benefits": "par le biais de votre pension ou des prestations de retraite d'un membre de votre famille",
+            "federal-provincial-territorial": "Cela comprend les régimes de retraite des gouvernements fédéral, provinciaux et territoriaux",
+            "exceptions": {
+              "eligible": "Exception\u00a0: Vous pourriez être admissible au RCSD si vous êtes à la retraite et si à la fois\u00a0:",
+              "opted-out": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023",
+              "opt-back": "vous ne pouvez pas opter pour celles-ci de nouveau selon les règles relatives à la pension"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "achetée individuellement par vous, par un membre de votre famille ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+            "purchased-privately": "Si vous souscrivez actuellement une assurance dentaire privée (qui ne fait pas partie des types de protection indiqués ci-dessus), vous n'êtes pas admissible au RCSD pendant la durée de cette couverture."
+          }
+        }
       }
     },
     "error-message": {

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -189,12 +189,12 @@
     }
   },
   "dental-insurance": {
-    "title": "Accès à d'autres assurances dentaires",
-    "legend": "Avoir accès à une assurance dentaire signifie que vous avez accès à une assurance ou à une couverture dentaire\u00a0:",
+    "title": "Accès à une assurance dentaire privée",
+    "legend": "Avez-vous accès à une assurance dentaire privée ou une couverture dentaire?",
     "list": {
-      "employment": "dans le cadre des avantages sociaux de votre employeur ou de l'employeur d'un membre de votre famille, y compris les comptes de santé et de mieux-être",
-      "pension": "par le biais de votre pension ou des prestations de retraite d'un membre de votre famille",
-      "purchased": "achetée individuellement par vous, par un membre de votre famille ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+      "employment": "dans le cadre des avantages sociaux de l'employeur d'un parent ou d'un tuteur légal, y compris les comptes de santé et de bien-être",
+      "pension": "par le biais de prestations de retraite d'un parent ou d'un tuteur légal",
+      "purchased": "achetée individuellement par un parent ou un tuteur légal auprès d'une compagnie d'assurance ou de prestations",
       "professional": "par l'intermédiaire d'une organisation professionnelle ou étudiante"
     },
     "option-yes": "<strong>Oui</strong>, j'ai accès à une assurance ou une couverture dentaire",
@@ -203,26 +203,39 @@
       "back": "Retour",
       "continue": "Continuer",
       "cancel-btn": "Annuler",
-      "save-btn": "sauvegarder"
+      "save-btn": "Sauvegarder"
     },
     "detail": {
       "additional-info": {
-        "title": "Renseignements supplémentaires",
-        "eligible": "Exception: Vous pourriez toujours être admissible si vous avez pris votre retraite et\u00a0:",
-        "list": {
-          "opted": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023, et",
-          "cannot-opt": "vous ne pouvez pas vous réinscrire en vertu des règles relatives aux régimes de retraite"
-        },
-        "not-eligible": "Vous êtes toujours considéré comme ayant accès à l'assurance ou à la couverture dentaire si vous choisissez de ne pas bénéficier des prestations fournies par votre assurance ou celle d'un membre de votre famille\u00a0:",
-        "not-eligible-employer": "par le biais d'un employeur;",
-        "not-eligible-pension": "par le biais d'un régime de retraite (voir exception);",
-        "not-eligible-organization": "par le biais d'une organisation professionnelle ou étudiante.",
-        "not-eligible-note": "À ce titre, vous n'êtes pas admissible au Régime canadien de soins dentaires.",
-        "not-eligible-purchased": "Si vous avez souscrit vous-même à votre police d'assurance dentaire actuelle, vous n'êtes pas admissible au Régime canadien de soins dentaires pendant que cette protection est en vigueur."
+        "title": "Que signifie avoir accès à une assurance dentaire privée?",
+        "eligible": "Cela signifie que vous n'avez accès à aucun type d'assurance ou de couverture dentaire\u00a0:",
+        "eligible-list": {
+          "employment-benefits": "dans le cadre des avantages sociaux de votre employeur ou de l'employeur d'un membre de votre famille, y compris les comptes de santé et de bien-être",
+          "organization": {
+            "professional-student": "par une organisation professionnelle ou étudiante",
+            "note": "Remarque\u00a0: Si vous êtes admissible à la protection dentaire au moyen de vos avantages sociaux ou par une organisation professionnelle ou étudiante, vous n'êtes pas admissible au RCSD. Cela est vrai, même si\u00a0:",
+            "not-take": "vous décidez de ne pas opter pour cette protection",
+            "pay-premium": "vous devez verser une prime d'assurance sur cette protection",
+            "not-use": "vous ne l'utilisez pas"
+          },
+          "pension": {
+            "pension-benefits": "par le biais de votre pension ou des prestations de retraite d'un membre de votre famille",
+            "federal-provincial-territorial": "Cela comprend les régimes de retraite des gouvernements fédéral, provinciaux et territoriaux",
+            "exceptions": {
+              "eligible": "Exception\u00a0: Vous pourriez être admissible au RCSD si vous êtes à la retraite et si à la fois\u00a0:",
+              "opted-out": "vous avez renoncé aux prestations de retraite avant le 11 décembre 2023",
+              "opt-back": "vous ne pouvez pas opter pour celles-ci de nouveau selon les règles relatives à la pension"
+            }
+          },
+          "purchased-coverage": {
+            "purchased-through": "achetée individuellement par vous, par un membre de votre famille ou par le biais d'un plan de groupe d'une compagnie d'assurance ou de prestations",
+            "purchased-privately": "Si vous souscrivez actuellement une assurance dentaire privée (qui ne fait pas partie des types de protection indiqués ci-dessus), vous n'êtes pas admissible au RCSD pendant la durée de cette couverture."
+          }
+        }
       }
     },
     "error-message": {
-      "dental-insurance-required": "Sélectionnez si vous avez accès à une assurance dentaire"
+      "dental-insurance-required": "Sélectionnez si vous avez une assurance dentaire"
     }
   },
   "review-information": {


### PR DESCRIPTION
### Description
updates `/dental-insurance` screens across the code base for adults.  In a separate PR, I will update the child screen since.

### Related Azure Boards Work Items
[AB#5015](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5015), [AB#5023](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5023)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`