### PR TITLE
Renew adult flow exit application page

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -125,7 +125,7 @@ export const pageIds = {
         demographicSurvey: 'CDCP-RENW-AD-0011',
         reviewAdultInformation: 'CDCP-RENW-AD-0012',
         confirmation: 'CDCP-RENW-AD-0013',
-        exitApplication: 'CDCP-RENW-AD-0014'
+        exitApplication: 'CDCP-RENW-AD-0014',
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -125,6 +125,7 @@ export const pageIds = {
         demographicSurvey: 'CDCP-RENW-AD-0011',
         reviewAdultInformation: 'CDCP-RENW-AD-0012',
         confirmation: 'CDCP-RENW-AD-0013',
+        exitApplication: 'CDCP-RENW-AD-0014'
       },
       ita: {
         maritalStatus: 'CDCP-RENW-ITA-0001',

--- a/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
@@ -1,0 +1,83 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { useFetcher, useParams } from '@remix-run/react';
+
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import { TYPES } from '~/.server/constants';
+import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
+import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.public.renew.adult.exitApplication,
+  pageTitleI18nKey: 'renew-adult:exit-application.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const { id } = loadRenewAdultState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:exit-application.page-title') }) };
+
+  return { id, meta };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  clearRenewState({ params, session });
+  return redirect(t('exit-application.exit-link'));
+}
+
+export default function RenewAdultExitApplication() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+
+  const params = useParams();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <div className="max-w-prose">
+      <div className="mb-8 space-y-4">
+        <p>{t('renew-adult:exit-application.are-you-sure')}</p>
+        <p>{t('renew-adult:exit-application.click-back')}</p>
+      </div>
+      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+        <CsrfTokenInput />
+        <ButtonLink
+          id="back-button"
+          routeId="public/renew/$id/adult/review-adult-information"
+          params={params}
+          disabled={isSubmitting}
+          startIcon={faChevronLeft}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Exiting the application click"
+        >
+          {t('renew-adult:exit-application.back-btn')}
+        </ButtonLink>
+        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Exit - Exiting the application click">
+          {t('renew-adult:exit-application.exit-btn')}
+        </LoadingButton>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -409,11 +409,11 @@ export default function RenewAdultReviewAdultInformation() {
             {t('renew-adult:review-adult-information.back-button')}
           </Button>
         </fetcher.Form>
-        {/* <div className="mt-8">
+        <div className="mt-8">
           <InlineLink routeId="public/renew/$id/adult/exit-application" params={params}>
             {t('renew-adult:review-adult-information.exit-button')}
           </InlineLink>
-        </div> */}
+        </div>
       </div>
       {payload && (
         <div className="mt-8">

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -746,7 +746,7 @@ export const routes = [
           {
             id: 'public/renew/$id/adult/review-adult-information',
             file: 'routes/public/renew/$id/adult/review-adult-information.tsx',
-            paths: { en: '/:lang/renew/:id/adult/review-adult-information', fr: '/:lang/renouveller/:id/renew/revue-renseignements-adulte' },
+            paths: { en: '/:lang/renew/:id/adult/review-adult-information', fr: '/:lang/renouveller/:id/adulte/revue-renseignements-adulte' },
           },
           {
             id: 'public/renew/$id/adult/exit-application',

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -746,7 +746,12 @@ export const routes = [
           {
             id: 'public/renew/$id/adult/review-adult-information',
             file: 'routes/public/renew/$id/adult/review-adult-information.tsx',
-            paths: { en: '/:lang/renew/:id/adult/review-adult-information', fr: '/:lang/renouveller/:id/adulte/revue-renseignements-adulte' },
+            paths: { en: '/:lang/renew/:id/adult/review-adult-information', fr: '/:lang/renouveller/:id/renew/revue-renseignements-adulte' },
+          },
+          {
+            id: 'public/renew/$id/adult/exit-application',
+            file: 'routes/public/renew/$id/adult/exit-application.tsx',
+            paths: { en: '/:lang/renew/:id/adult/exit-application', fr: '/:lang/renouveller/:id/adulte/quitter-demande' },
           },
         ],
       },

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -409,5 +409,13 @@
       "back-btn": "Back",
       "close-btn": "Close application"
     }
+  },
+  "exit-application": {
+    "page-title": "Exiting the application",
+    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and the information will be lost.",
+    "click-back": "Click \"Back\" to return to the form.",
+    "back-btn": "Back",
+    "exit-btn": "Exit",
+    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
   }
 }

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -513,12 +513,12 @@
     "no-update": "Aucun changement"
   },
   "exit-application": {
-    "page-title": "Exiting the application",
-    "are-you-sure": "Are you sure you want to exit this application? If you click \"Exit\", the form will reset and the information will be lost.",
-    "click-back": "Click \"Back\" to return to the form.",
-    "back-btn": "Back",
-    "exit-btn": "Exit",
-    "exit-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+    "page-title": "Quitter la demande",
+    "are-you-sure": "Êtes-vous certain de vouloir quitter cette demande? Si vous cliquez sur «\u00a0Quitter\u00a0», le formulaire sera réinitialisé et vos renseignements seront perdus.",
+    "click-back": "Cliquez sur «\u00a0Retour\u00a0» pour retourner au formulaire.",
+    "back-btn": "Retour",
+    "exit-btn": "Quitter",
+    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   },
   "confirm": {
     "page-title": "Votre demande de renouvellement au Régime canadien de soins dentaires est terminée!",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -409,5 +409,13 @@
       "back-btn": "Retour",
       "close-btn": "Fermer la demande"
     }
+  },
+  "exit-application": {
+    "page-title": "Quitter la demande",
+    "are-you-sure": "Êtes-vous certain de vouloir quitter cette demande? Si vous cliquez sur «\u00a0Quitter\u00a0», le formulaire sera réinitialisé et vos renseignements seront perdus.",
+    "click-back": "Cliquez sur «\u00a0Retour\u00a0» pour retourner au formulaire.",
+    "back-btn": "Retour",
+    "exit-btn": "Quitter",
+    "exit-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
   }
 }


### PR DESCRIPTION
### Description
The `exit-application` page is missing on the renew adult flow. This pr adds the exit-application. The navigation link to the exit-application is on the `review-adult-information` page.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->