### PR TITLE
AB#5043 Renew ITA flow text fix

### DIFF
--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -45,8 +45,8 @@
   "confirm-email": {
     "page-title": "Email",
     "add-or-update": {
-      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada?",
-      "help-message": "Email communication will help the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan membership. Otherwise we'll contact you by mail."
+      "legend": "Would you like to receive email communication from Sun Life and the Government of Canada about your Canadian Dental Care Plan coverage?",
+      "help-message": "Email communication will help the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan coverage. Otherwise, we'll contact you by mail."
     },
     "email": "Email address",
     "confirm-email": "Confirm email address",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -46,8 +46,8 @@
     "page-title": "Adresse courriel",
     "add-email": "Adresse courriel",
     "add-or-update": {
-      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de la Sun Life et du gouvernement du Canada?",
-      "help-message": "La communication par courriel aidera au gouvernement du Canada et à Sun Life de vous contacter au sujet de votre adhésion au Régime canadien de soins dentaires. Sinon, nous vous contacterons par la poste."
+      "legend": "Souhaitez-vous recevoir des communications par courriel de la part de Sun Life et du gouvernement du Canada concernant votre couverture du Régime canadien de soins dentaires?",
+      "help-message": "La communication par courriel aidera au gouvernement du Canada et à Sun Life de vous contacter au sujet de votre adhésion au Régime canadien de soins dentaires. Sinon, nous contacterons avec vous par la poste."
     },
     "email": "Adresse courriel",
     "confirm-email": "Confirmer l'adresse courriel",


### PR DESCRIPTION
### Description
Update English/French text for renew ITA flow `confirm-email` screen.

### Related Azure Boards Work Items
[AB#5043](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5043)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Use client number `10000000001` to enter ITA flow. Compare the text with Figma

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->