### PR TITLE
fix address ternary for validation

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -113,9 +113,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
     address: String(formData.get('mailingAddress')),
     countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : '',
+    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
     city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : '',
+    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
   });
 
   if (!validatedResult.success) {

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -113,9 +113,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
     address: String(formData.get('mailingAddress')),
     countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : '',
+    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
     city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : '',
+    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
   });
 
   if (!validatedResult.success) {


### PR DESCRIPTION
### Description
Was looking into the address validator 'bug' ticket in ADO (btw I don't think this is easily solvable and is more of a byproduct of react/remix/asynchronous code in general).  This PR, however, fixes errors on submit because empty strings are truthy based on the zod validation. 