### PR TITLE
Fixing benefit renewal mappers to no longer map `hasFederalProvincialTerritorialBenefitsChanged`; Reseting `dentalBenefits` in state object when `confirm-federal-provincial-territorial-benefits` form is submitted

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -163,7 +163,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         dentalInsurance: true,
         hasAddressChanged: true,
         hasMaritalStatusChanged: true,
-        hasFederalProvincialTerritorialBenefitsChanged: true,
         homeAddress: {
           address: '123 New Fake Street',
           city: 'Home City',
@@ -218,7 +217,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
           hasEmailChanged: true,
           hasMaritalStatusChanged: true,
           hasPhoneChanged: true,
-          hasFederalProvincialTerritorialBenefitsChanged: true,
         },
         children: [
           {

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -10,7 +10,6 @@ export type AdultChangeIndicators = Readonly<{
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
   hasPhoneChanged: boolean;
-  hasFederalProvincialTerritorialBenefitsChanged: boolean;
 }>;
 
 export type AdultChildBenefitRenewalDto = BenefitRenewalDto &
@@ -23,7 +22,6 @@ export type AdultChildChangeIndicators = Readonly<{
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
   hasPhoneChanged: boolean;
-  hasFederalProvincialTerritorialBenefitsChanged: boolean;
 }>;
 
 export type ItaBenefitRenewalDto = BenefitRenewalDto &
@@ -36,7 +34,6 @@ export type ItaChangeIndicators = Readonly<{
 }>;
 
 export type ChildBenefitRenewalDto = BenefitRenewalDto &
-  BenefitRenewalDto &
   Readonly<{
     changeIndicators: ChildChangeIndicators;
   }>;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -65,7 +65,6 @@ interface ToChangeIndicatorsArgs {
   hasEmailChanged?: boolean;
   hasMaritalStatusChanged?: boolean;
   hasPhoneChanged?: boolean;
-  hasFederalProvincialTerritorialBenefitsChanged?: boolean;
 }
 
 interface ToEmailAddressArgs {
@@ -203,13 +202,12 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       return {};
     }
 
-    const { hasAddressChanged, hasEmailChanged, hasMaritalStatusChanged, hasPhoneChanged, hasFederalProvincialTerritorialBenefitsChanged } = changeIndicators;
+    const { hasAddressChanged, hasEmailChanged, hasMaritalStatusChanged, hasPhoneChanged } = changeIndicators;
     return {
       AddressChangedIndicator: hasAddressChanged,
       EmailChangedIndicator: hasEmailChanged,
       MaritalStatusChangedIndicator: hasMaritalStatusChanged,
       PhoneChangedIndicator: hasPhoneChanged,
-      PublicInsuranceChangedIndicator: hasFederalProvincialTerritorialBenefitsChanged,
     };
   }
 

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -51,7 +51,6 @@ export interface RenewAdultState {
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   hasAddressChanged: boolean;
-  hasFederalProvincialTerritorialBenefitsChanged: boolean;
   hasMaritalStatusChanged: boolean;
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
@@ -69,7 +68,6 @@ export interface RenewAdultChildState {
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   hasAddressChanged: boolean;
-  hasFederalProvincialTerritorialBenefitsChanged: boolean;
   hasMaritalStatusChanged: boolean;
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
@@ -205,7 +203,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     mailingAddress,
     maritalStatus,
     partnerInformation,
-    hasFederalProvincialTerritorialBenefitsChanged,
   }: RenewAdultState): AdultBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
@@ -231,7 +228,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         hasMaritalStatusChanged,
         hasPhoneChanged,
-        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
       },
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
@@ -252,7 +248,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
+        hasFederalProvincialTerritorialBenefitsChanged: true,
         renewedDentalBenefits: dentalBenefits,
       }),
       dentalInsurance,
@@ -281,7 +277,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     mailingAddress,
     maritalStatus,
     partnerInformation,
-    hasFederalProvincialTerritorialBenefitsChanged,
   }: RenewAdultChildState): AdultChildBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
@@ -310,7 +305,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         hasMaritalStatusChanged,
         hasPhoneChanged,
-        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
       },
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
@@ -331,7 +325,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: hasFederalProvincialTerritorialBenefitsChanged,
+        hasFederalProvincialTerritorialBenefitsChanged: true,
         renewedDentalBenefits: dentalBenefits,
       }),
       dentalInsurance,
@@ -551,7 +545,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
           })(),
         dentalBenefits: this.toDentalBenefits({
           existingDentalBenefits: existingChild.dentalBenefits,
-          hasFederalProvincialTerritorialBenefitsChanged: !!renewedChild.dentalBenefits,
+          hasFederalProvincialTerritorialBenefitsChanged: true,
           renewedDentalBenefits: renewedChild.dentalBenefits,
         }),
         demographicSurvey: renewedChild.demographicSurvey,

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -100,6 +100,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
+          dentalBenefits: undefined,
         };
       }),
     },

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -89,6 +89,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
+      dentalBenefits: undefined,
     },
   });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -89,6 +89,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
+      dentalBenefits: undefined,
     },
   });
 


### PR DESCRIPTION
### Description
Since `confirm-federal-provincial-territorial-benefits` no longer asks the applicant whether their federal and provincial/territorial benefits has changed but rather if they have any benefits at all, there is no need to map the `hasFederalProvincialTerritorialBenefitsChanged` as a `ChangeIndicator` flag when submitting a renewal application.

For all online renewal flows, the applicant's specified federal and provincial/territorial benefits (rather than the `dentalBenefits` on file from `clientApplication`) will be submitted in the request payload for a renewal application.

Also fixed an issue where the `dentalBenefits` weren't being reset each time the applicant completes the `confirm-federal-provincial-territorial-benefits` form.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e