### PR TITLE
Adding health check for address validation

### DIFF
--- a/frontend/app/.server/container-modules/health.container-module.ts
+++ b/frontend/app/.server/container-modules/health.container-module.ts
@@ -3,7 +3,7 @@ import { ContainerModule } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import { RedisHealthCheck } from '~/.server/health';
+import { AddressValidationHealthCheck, RedisHealthCheck } from '~/.server/health';
 
 function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
   return ({ parentContext }: interfaces.Request) => {
@@ -16,5 +16,6 @@ function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
  * Container module for health components.
  */
 export const healthContainerModule = new ContainerModule((bind) => {
+  bind(TYPES.health.HealthCheck).to(AddressValidationHealthCheck);
   bind(TYPES.health.HealthCheck).to(RedisHealthCheck).when(sessionTypeIs('redis'));
 });

--- a/frontend/app/.server/health/address-validation.health.ts
+++ b/frontend/app/.server/health/address-validation.health.ts
@@ -1,0 +1,47 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { AddressValidationRepository } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+@injectable()
+export class AddressValidationHealthCheck implements HealthCheck {
+  private readonly log: Logger;
+
+  readonly name: string;
+  readonly metadata?: Record<string, string>;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.configs.ServerConfig)
+    private readonly serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL'>,
+    @inject(TYPES.domain.repositories.AddressValidationRepository) private readonly addressValidationRepository: AddressValidationRepository,
+  ) {
+    this.log = logFactory.createLogger('AddressValidationHealthCheck');
+    this.name = 'addressValidation';
+    this.metadata = this.addressValidationRepository.getMetadata();
+
+    this.init();
+  }
+
+  private init(): void {
+    const healthCacheTTL = this.serverConfig.HEALTH_CACHE_TTL;
+    this.log.debug('Initializing AddressValidationHealthCheck with cache TTL of %d ms.', healthCacheTTL);
+
+    this.check = moize.promise(this.check, {
+      maxAge: healthCacheTTL,
+      // transformArgs is required to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
+      transformArgs: () => [],
+      onCacheAdd: () => this.log.info('Cached function for AddressValidationHealthCheck has been initialized.'),
+    });
+
+    this.log.debug('AddressValidationHealthCheck initialization complete.');
+  }
+
+  async check(signal?: AbortSignal): Promise<void> {
+    await this.addressValidationRepository.checkHealth();
+  }
+}

--- a/frontend/app/.server/health/index.ts
+++ b/frontend/app/.server/health/index.ts
@@ -1,1 +1,2 @@
+export * from './address-validation.health';
 export * from './redis.health';


### PR DESCRIPTION
### Description
Since Interop doesn't provide an endpoint to check for the healthiness of address validation, the repository will instead pass an actual address to the existing method, which would throw if the endpoint is unhealthy.

### Screenshots (if applicable)
Healthy (with default repository implementation):
![image](https://github.com/user-attachments/assets/00031d91-f484-401a-ab98-eaf0eb394015)

Unhealthy (with default repository implementation):
![image](https://github.com/user-attachments/assets/b5ccf1ca-3d78-4451-8e92-2178eae2d042)

Healthy (with mock repository):
![image](https://github.com/user-attachments/assets/2dc5fbcb-c8d3-46fb-a738-97abedce268c)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
I modified the `/api/health` route to always be authorized to view details for simplicity. 