### PR TITLE
Adding TODOs so that renewal works in integration environment

### DIFF
--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -31,10 +31,10 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
       coverageEndDate: applicationYear.BenefitApplicationYearCoveragePeriod.EndDate.date,
       intakeStartDate: applicationYear.BenefitApplicationYearIntakePeriod.StartDate.date,
       intakeEndDate: applicationYear.BenefitApplicationYearIntakePeriod.EndDate?.date,
-      intakeYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
+      intakeYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID, // TODO this is incorrect but tentatively used to make integration work; Interop may change/remove the application year endpoint
       renewalStartDate: applicationYear.BenefitApplicationYearRenewalPeriod.StartDate?.date,
       renewalEndDate: applicationYear.BenefitApplicationYearRenewalPeriod.EndDate?.date,
-      renewalYearId: applicationYear.BenefitApplicationYearNext.BenefitApplicationYearIdentification?.IdentificationID,
+      renewalYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
     }));
 
     return applicationYears;

--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -60,7 +60,8 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
       return data;
     }
 
-    if (response.status === 204) {
+    // TODO this 404 should eventually be changed to a 204 by Interop
+    if (response.status === 404) {
       this.log.trace('Client application not found for basic info [%j]', clientApplicationBasicInfoRequestEntity);
       return null;
     }


### PR DESCRIPTION
### Description

- Application year identifier endpoint may be changed to be included in fetch client application response.
- Interop currently returns a 404 if no client application is found. They will change this to a 204 barring time constraints.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`