### PR TITLE
Fixing mapping logic to renewal application year result DTO and updating mock, DTO, and tests

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -15,44 +15,44 @@ describe('DefaultApplicationYearService', () => {
 
   const mockApplicationYearResultDtos: ApplicationYearResultDto[] = [
     {
-      // all fields set
+      // optional dates not set except nextApplicationYearId
       applicationYear: '2024',
+      applicationYearId: '2024',
       taxYear: '2024',
       coverageStartDate: '2024-01-01',
       coverageEndDate: '2024-12-31',
       intakeStartDate: '2024-01-01',
-      intakeEndDate: '2024-12-31',
-      intakeYearId: '2024',
-      renewalStartDate: '2024-01-01',
-      renewalEndDate: '2024-12-31',
-      renewalYearId: '2024',
+      nextApplicationYearId: '2025',
     },
+    // all fields set
     {
-      // optional dates not set
       applicationYear: '2025',
+      applicationYearId: '2025',
       taxYear: '2025',
       coverageStartDate: '2025-01-01',
       coverageEndDate: '2025-12-31',
       intakeStartDate: '2025-01-01',
-      intakeYearId: '2024',
+      intakeEndDate: '2025-12-31',
+      nextApplicationYearId: '2026',
+      renewalStartDate: '2025-01-01',
+      renewalEndDate: '2025-12-31',
     },
     {
       // optional end dates not set
       applicationYear: '2026',
+      applicationYearId: '2026',
       taxYear: '2026',
       coverageStartDate: '2026-01-01',
       coverageEndDate: '2026-12-31',
       intakeStartDate: '2026-01-01',
-      intakeYearId: '2024',
       renewalStartDate: '2026-01-01',
     },
   ];
 
   const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = {
     intakeYearId: '2024',
-    taxYear: '2024',
-    coverageStartDate: '2024-01-01',
-    coverageEndDate: '2024-12-31',
+    taxYear: '2025',
+    coverageStartDate: '2025-01-01',
   };
   const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
   mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
@@ -93,11 +93,27 @@ describe('DefaultApplicationYearService', () => {
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
       const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
-        date: '2024-01-01',
+        date: '2025-01-01',
         userId: 'userId',
       };
 
       const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+
+      expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
+        intakeYearId: '2024',
+        applicationYearResultDto: {
+          applicationYear: '2025',
+          applicationYearId: '2025',
+          taxYear: '2025',
+          coverageStartDate: '2025-01-01',
+          coverageEndDate: '2025-12-31',
+          intakeStartDate: '2025-01-01',
+          intakeEndDate: '2025-12-31',
+          nextApplicationYearId: '2026',
+          renewalStartDate: '2025-01-01',
+          renewalEndDate: '2025-12-31',
+        },
+      });
       expect(result).toEqual(mockRenewalApplicationYearResultDto);
     });
 
@@ -111,6 +127,19 @@ describe('DefaultApplicationYearService', () => {
       };
 
       const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+
+      expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
+        intakeYearId: '2025',
+        applicationYearResultDto: {
+          applicationYear: '2026',
+          applicationYearId: '2026',
+          taxYear: '2026',
+          coverageStartDate: '2026-01-01',
+          coverageEndDate: '2026-12-31',
+          intakeStartDate: '2026-01-01',
+          renewalStartDate: '2026-01-01',
+        },
+      });
       expect(result).toEqual(mockRenewalApplicationYearResultDto);
     });
 
@@ -119,7 +148,7 @@ describe('DefaultApplicationYearService', () => {
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
       const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
-        date: '2025-01-01',
+        date: '2024-01-01',
         userId: 'userId',
       };
 

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -14,13 +14,13 @@ export type ApplicationYearRequestDto = Readonly<{
  */
 export type ApplicationYearResultDto = Readonly<{
   applicationYear: string;
+  applicationYearId: string;
   taxYear: string;
   intakeStartDate: string;
   intakeEndDate?: string;
-  intakeYearId: string;
+  nextApplicationYearId?: string;
   renewalStartDate?: string;
   renewalEndDate?: string;
-  renewalYearId?: string;
   coverageStartDate: string;
   coverageEndDate: string;
 }>;
@@ -28,7 +28,12 @@ export type ApplicationYearResultDto = Readonly<{
 /**
  * Represents a Data Transfer Object (DTO) for a renewal application year result.
  */
-export type RenewalApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate'>;
+export type RenewalApplicationYearResultDto = Readonly<{
+  intakeYearId: string;
+  renewalYearId?: string;
+  taxYear: string;
+  coverageStartDate: string;
+}>;
 
 /**
  * Represents a Data Transfer Object (DTO) for an intake application year result.

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -6,18 +6,22 @@ import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 export interface ApplicationYearDtoMapper {
   mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto>;
 
-  mapApplicationYearResultDtoToRenewalApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): RenewalApplicationYearResultDto;
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto(toRenewalApplicationYearResultDtoArgs: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto;
+}
+
+interface ToRenewalApplicationYearResultDtoArgs {
+  intakeYearId: string;
+  applicationYearResultDto: ApplicationYearResultDto;
 }
 
 @injectable()
 export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper {
-  mapApplicationYearResultDtoToRenewalApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): RenewalApplicationYearResultDto {
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ intakeYearId, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
     return {
-      intakeYearId: applicationYearResultDto.intakeYearId,
+      intakeYearId: intakeYearId,
       taxYear: applicationYearResultDto.taxYear,
       coverageStartDate: applicationYearResultDto.coverageStartDate,
-      coverageEndDate: applicationYearResultDto.coverageEndDate,
-      renewalYearId: applicationYearResultDto.renewalYearId,
+      renewalYearId: applicationYearResultDto.applicationYearId,
     };
   }
 
@@ -26,15 +30,15 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
 
     const applicationYears = applicationYearData.map((applicationYear) => ({
       applicationYear: applicationYear.BenefitApplicationYearEffectivePeriod.StartDate.YearDate,
-      taxYear: applicationYear.BenefitApplicationYearTaxYear.YearDate,
+      applicationYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
       coverageStartDate: applicationYear.BenefitApplicationYearCoveragePeriod.StartDate.date,
       coverageEndDate: applicationYear.BenefitApplicationYearCoveragePeriod.EndDate.date,
       intakeStartDate: applicationYear.BenefitApplicationYearIntakePeriod.StartDate.date,
       intakeEndDate: applicationYear.BenefitApplicationYearIntakePeriod.EndDate?.date,
-      intakeYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID, // TODO this is incorrect but tentatively used to make integration work; Interop may change/remove the application year endpoint
+      nextApplicationYearId: applicationYear.BenefitApplicationYearNext.BenefitApplicationYearIdentification?.IdentificationID,
       renewalStartDate: applicationYear.BenefitApplicationYearRenewalPeriod.StartDate?.date,
       renewalEndDate: applicationYear.BenefitApplicationYearRenewalPeriod.EndDate?.date,
-      renewalYearId: applicationYear.BenefitApplicationYearIdentification[0].IdentificationID,
+      taxYear: applicationYear.BenefitApplicationYearTaxYear.YearDate,
     }));
 
     return applicationYears;

--- a/frontend/app/.server/domain/repositories/application-year.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-year.repository.ts
@@ -78,7 +78,7 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
         {
           BenefitApplicationYearIdentification: [
             {
-              IdentificationID: '37e5aa05-813c-ef11-a317-000d3af4f3ef',
+              IdentificationID: '98f8ad43-4069-ee11-9ae7-000d3a09d1b8',
             },
           ],
           BenefitApplicationYearEffectivePeriod: {
@@ -94,13 +94,10 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
               date: '2024-05-01',
             },
             EndDate: {
-              date: '2025-03-31',
+              date: '2025-04-30',
             },
           },
-          BenefitApplicationYearRenewalPeriod: {
-            StartDate: {},
-            EndDate: {},
-          },
+          BenefitApplicationYearRenewalPeriod: {},
           BenefitApplicationYearNext: {
             BenefitApplicationYearIdentification: {
               IdentificationID: '9bb21bc9-028c-ef11-8a69-000d3a0a1a29',
@@ -118,7 +115,7 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
         {
           BenefitApplicationYearIdentification: [
             {
-              IdentificationID: '37e5aa05-813c-ef11-a317-000d3af4f3ef',
+              IdentificationID: '9bb21bc9-028c-ef11-8a69-000d3a0a1a29',
             },
           ],
           BenefitApplicationYearEffectivePeriod: {
@@ -131,28 +128,20 @@ export class MockApplicationYearRepository implements ApplicationYearRepository 
           },
           BenefitApplicationYearIntakePeriod: {
             StartDate: {
-              date: '2025-02-14',
-            },
-            EndDate: {
-              date: '2026-06-30',
+              date: '2025-05-01',
             },
           },
           BenefitApplicationYearRenewalPeriod: {
             StartDate: {
               date: '2024-12-01',
             },
-            EndDate: {
-              date: '2025-06-30',
-            },
           },
           BenefitApplicationYearNext: {
-            BenefitApplicationYearIdentification: {
-              IdentificationID: '9bb21bc9-028c-ef11-8a69-000d3a0a1a29',
-            },
+            BenefitApplicationYearIdentification: {},
           },
           BenefitApplicationYearCoveragePeriod: {
             StartDate: {
-              date: '2025-04-01',
+              date: '2025-06-01',
             },
             EndDate: {
               date: '2026-06-30',

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import invariant from 'tiny-invariant';
 
 import { TYPES } from '~/.server/constants';
 import type { ApplicationYearRequestDto, ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
@@ -69,7 +70,14 @@ export class DefaultApplicationYearService implements ApplicationYearService {
       return null;
     }
 
-    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto(matchingRenewalApplicationYear);
+    // Find the intake year corresponding to the matching renewal application year.
+    // This happens when the `nextApplicationYearId` of an application year matches the `applicationYearId` of the matching renewal application year.
+    const intakeYear = applicationYearResultDtos.find((applicationYear) => {
+      return applicationYear.nextApplicationYearId === matchingRenewalApplicationYear.applicationYearId;
+    });
+    invariant(intakeYear, 'Expected intakeYear to be defined');
+
+    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ intakeYearId: intakeYear.applicationYearId, applicationYearResultDto: matchingRenewalApplicationYear });
 
     this.log.trace('Returning renewal application year result: [%j]', renewalApplicationYearResultDto);
     return renewalApplicationYearResultDto;

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -20,7 +20,7 @@ export type ApplyState = ReadonlyDeep<{
   lastUpdatedOn: string;
   allChildrenUnder18?: boolean;
   applicationYears: {
-    intakeYearId: string;
+    applicationYearId: string;
     taxYear: string;
   }[];
   applicantInformation?: {


### PR DESCRIPTION
### Description
**Before:**
The current date would be used to filter for an application year object based on the renewal period. A 1-to-1 mapping would be performed on the matching application year to map to the renewal application year result DTO.

**After:**
The current date would be used to filter for an application year object based on the renewal period. The `intakeYearId` in the renewal application year result DTO would be determined by finding the intake year that corresponds to the matching renewal application year. This is done by matching the `nextApplicationYearId` of an application year object with the `applicationYearId` of the renewal application year result DTO.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
If application year repository mock is enabled (via `power-platform` enabled mocks feature flag), for today's date, `98f8ad43-4069-ee11-9ae7-000d3a09d1b8` application year identifier should be in the request payload to retrieve client application and `9bb21bc9-028c-ef11-8a69-000d3a0a1a29'` application year identifier should be in the request payload to submit renewal application. Logs (set to `trace` level) should indicate that this is the case. 