### PR TITLE
populate missing client application state in protected renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -248,6 +248,7 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
     editMode: false,
     applicationYear,
     clientApplication,
+    dentalInsurance: clientApplication.dentalInsurance,
     contactInformation: {
       phoneNumber: clientApplication.contactInformation.phoneNumber,
       phoneNumberAlt: clientApplication.contactInformation.phoneNumberAlt,
@@ -263,6 +264,7 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
           id: randomUUID(),
           information: child.information,
           dentalInsurance: immutableChild?.dentalInsurance,
+          isParentOrLegalGuardian: immutableChild?.information.isParent,
         };
         return childStateObj;
       }),
@@ -356,11 +358,11 @@ export function loadProtectedRenewStateForReview({ params, session, demographicS
 }
 
 export function isPrimaryApplicantStateComplete(state: ProtectedRenewState, demographicSurveyEnabled: boolean) {
-  return state.dentalInsurance !== undefined && (demographicSurveyEnabled ? state.demographicSurvey !== undefined : true);
+  return state.previouslyReviewed && state.dentalInsurance !== undefined && (demographicSurveyEnabled ? state.demographicSurvey !== undefined : true);
 }
 
 export function isChildrenStateComplete(state: ProtectedRenewState, demographicSurveyEnabled: boolean) {
-  return state.children.every((child) => child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
+  return state.children.every((child) => child.previouslyReviewed && child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
 }
 
 interface ValidateProtectedRenewStateForReviewArgs {

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -49,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:dental-insurance.title', { memberName }) }) };
 
-  return { id: state, meta, defaultState: state.dentalInsurance, hasAddressChanged: state.hasAddressChanged, editMode: state.editMode, i18nOptions: { memberName } };
+  return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode, i18nOptions: { memberName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {


### PR DESCRIPTION
### Description
adds missing default values to form fields in the protected renew app

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`