### PR TITLE
Adding health check for applicant endpoint

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -393,3 +393,6 @@ HEALTH_AUTH_TOKEN_AUDIENCE=00000000-0000-0000-0000-000000000000
 # Expected issuer to be used during JWT verification for the /api/health endpoint
 # (optional; default: https://auth.example.com/)
 HEALTH_AUTH_TOKEN_ISSUER=https://auth.example.com/
+# Placeholder value used as generic input when sending requests for health checks when actual data is unavailable
+# (optional; default: CDCP_HEALTH_CHECK)
+HEALTH_PLACEHOLDER_REQUEST_VALUE=CDCP_HEALTH_CHECK

--- a/frontend/app/.server/container-modules/health.container-module.ts
+++ b/frontend/app/.server/container-modules/health.container-module.ts
@@ -3,7 +3,7 @@ import { ContainerModule } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import { AddressValidationHealthCheck, RedisHealthCheck } from '~/.server/health';
+import { AddressValidationHealthCheck, ApplicantHealthCheck, RedisHealthCheck } from '~/.server/health';
 
 function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
   return ({ parentContext }: interfaces.Request) => {
@@ -17,5 +17,6 @@ function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
  */
 export const healthContainerModule = new ContainerModule((bind) => {
   bind(TYPES.health.HealthCheck).to(AddressValidationHealthCheck);
+  bind(TYPES.health.HealthCheck).to(ApplicantHealthCheck);
   bind(TYPES.health.HealthCheck).to(RedisHealthCheck).when(sessionTypeIs('redis'));
 });

--- a/frontend/app/.server/health/applicant.health.ts
+++ b/frontend/app/.server/health/applicant.health.ts
@@ -1,0 +1,47 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { ApplicantRepository } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+@injectable()
+export class ApplicantHealthCheck implements HealthCheck {
+  private readonly log: Logger;
+
+  readonly name: string;
+  readonly metadata?: Record<string, string>;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.configs.ServerConfig)
+    private readonly serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL'>,
+    @inject(TYPES.domain.repositories.ApplicantRepository) private readonly applicantRepository: ApplicantRepository,
+  ) {
+    this.log = logFactory.createLogger('ApplicantHealthCheck');
+    this.name = 'applicant';
+    this.metadata = this.applicantRepository.getMetadata();
+
+    this.init();
+  }
+
+  private init(): void {
+    const healthCacheTTL = this.serverConfig.HEALTH_CACHE_TTL;
+    this.log.debug('Initializing ApplicantHealthCheck with cache TTL of %d ms.', healthCacheTTL);
+
+    this.check = moize.promise(this.check, {
+      maxAge: healthCacheTTL,
+      // transformArgs is required to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
+      transformArgs: () => [],
+      onCacheAdd: () => this.log.info('Cached function for ApplicantHealthCheck has been initialized.'),
+    });
+
+    this.log.debug('ApplicantHealthCheck initialization complete.');
+  }
+
+  async check(signal?: AbortSignal): Promise<void> {
+    await this.applicantRepository.checkHealth();
+  }
+}

--- a/frontend/app/.server/health/index.ts
+++ b/frontend/app/.server/health/index.ts
@@ -1,2 +1,3 @@
 export * from './address-validation.health';
+export * from './applicant.health';
 export * from './redis.health';

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -191,6 +191,7 @@ const serverEnv = clientEnvSchema.extend({
   HEALTH_AUTH_ROLE: z.string().default('HealthCheck.ViewDetails'),
   HEALTH_AUTH_TOKEN_AUDIENCE: z.string().default('00000000-0000-0000-0000-000000000000'), // intentional default to enforce an audience check when verifying JWTs
   HEALTH_AUTH_TOKEN_ISSUER: z.string().default('https://auth.example.com/'), // intentional default to enforce an issuer check when verifying JWTs
+  HEALTH_PLACEHOLDER_REQUEST_VALUE: z.string().default('CDCP_HEALTH_CHECK'),
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;


### PR DESCRIPTION
### Description
Also introduces configuration for placeholder value sent in requests to downstream APIs since Interop doesn't provide an endpoint to check for health.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c469133e-e889-45b1-9234-f3c1a12c5d00)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
I modified the `/api/health` route to always be authorized to view details for simplicity.