### PR TITLE
modify default form state in protected renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -248,7 +248,6 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
     editMode: false,
     applicationYear,
     clientApplication,
-    dentalInsurance: clientApplication.dentalInsurance,
     contactInformation: {
       phoneNumber: clientApplication.contactInformation.phoneNumber,
       phoneNumberAlt: clientApplication.contactInformation.phoneNumberAlt,
@@ -259,12 +258,9 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
       // filter out children who will be 18 or older at the start of the coverage period as they are ineligible for renewal
       .filter((child) => getAgeFromDateString(child.information.dateOfBirth, applicationYear.coverageStartDate) < 18) //
       .map((child) => {
-        const immutableChild = clientApplication.children.find((c) => c.information.socialInsuranceNumber === child.information.socialInsuranceNumber);
         const childStateObj = {
           id: randomUUID(),
           information: child.information,
-          dentalInsurance: immutableChild?.dentalInsurance,
-          isParentOrLegalGuardian: immutableChild?.information.isParent,
         };
         return childStateObj;
       }),

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data, redirect, useLoaderData, useParams } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronLeft, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
@@ -36,7 +36,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatAddressLine, isAllValidInputCharacters } from '~/utils/string-utils';
+import { isAllValidInputCharacters } from '~/utils/string-utils';
 
 enum FormAction {
   Submit = 'submit',
@@ -88,28 +88,12 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
-  const mailingAddressInfo = state.mailingAddress
-    ? {
-        address: state.mailingAddress.address,
-        city: state.mailingAddress.city,
-        province: state.mailingAddress.province,
-        postalCode: state.mailingAddress.postalCode,
-        country: state.mailingAddress.country,
-      }
-    : {
-        address: formatAddressLine({ address: state.clientApplication.contactInformation.mailingAddress, apartment: state.clientApplication.contactInformation.mailingApartment }),
-        city: state.clientApplication.contactInformation.mailingCity,
-        province: state.clientApplication.contactInformation.mailingProvince,
-        postalCode: state.clientApplication.contactInformation.mailingPostalCode,
-        country: state.clientApplication.contactInformation.mailingCountry,
-      };
-
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };
 
   return {
     meta,
     defaultState: {
-      ...mailingAddressInfo,
+      ...state.mailingAddress,
       isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
     },
     countryList,
@@ -277,7 +261,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
   const params = useParams();
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.country);
+  const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.country ?? CANADA_COUNTRY_ID);
   const [mailingCountryRegions, setMailingCountryRegions] = useState<typeof regionList>([]);
   const [copyAddressChecked, setCopyAddressChecked] = useState(defaultState.isHomeAddressSameAsMailingAddress === true);
   const [addressDialogContent, setAddressDialogContent] = useState<AddressResponse | null>(null);
@@ -397,16 +381,7 @@ export default function ProtectedRenewConfirmMailingAddress() {
           <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
               <DialogTrigger asChild>
-                <LoadingButton
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FormAction.Submit}
-                  loading={isSubmitting}
-                  endIcon={faChevronRight}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Update address click"
-                >
+                <LoadingButton variant="primary" id="continue-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Update address click">
                   {t('protected-renew:update-address.save-btn')}
                 </LoadingButton>
               </DialogTrigger>

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -188,7 +188,7 @@ export default function ProtectedRenewReviewChildInformation() {
                           </ul>
                         </>
                         <div className="mt-4">
-                          <InlineLink id="change-dental-benefits" routeId="protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
+                          <InlineLink id="change-dental-benefits" routeId="protected/renew/$id/children/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
                             {t('protected-renew:review-child-information.dental-benefit-change')}
                           </InlineLink>
                         </div>
@@ -198,7 +198,7 @@ export default function ProtectedRenewReviewChildInformation() {
                       <DescriptionListItem term={t('protected-renew:review-child-information.dental-benefit-title')}>
                         <p>{t('protected-renew:review-child-information.no')}</p>
                         <div className="mt-4">
-                          <InlineLink id="change-dental-benefits" routeId="protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
+                          <InlineLink id="change-dental-benefits" routeId="protected/renew/$id/children/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
                             {t('protected-renew:review-child-information.dental-benefit-change')}
                           </InlineLink>
                         </div>

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -101,9 +101,9 @@ export const routes = [
                 paths: { en: '/:lang/protected/renew/:id/children/:childId/demographic-survey', fr: '/:lang/protege/renouveller/:id/enfants/:childId/questionnaire-demographique' },
               },
               {
-                id: 'protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits',
+                id: 'protected/renew/$id/children/$childId/confirm-federal-provincial-territorial-benefits',
                 file: 'routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx',
-                paths: { en: '/:lang/protected/renew/:id/children/childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/protege/renouveller/:id/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
+                paths: { en: '/:lang/protected/renew/:id/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/protege/renouveller/:id/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
               },
             ],
           },


### PR DESCRIPTION
### Description
Reverts default values for form state in protected renew app (dental-insurance/parent-legal-guardian).  For edits screens, defaults to the fetched `clientApplication`.  Home/mailing address has default state cleared initially.

NOTE: 
the phone number parsing library we use errors for our mock client application data which is why nothing appears to be initially populated as the default state.  It's working correctly!

### Related Azure Boards Work Items
[AB#5068](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5068)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`