### PR TITLE
Adding application status health check and changing base URLs to be consistent with application status repository

### DIFF
--- a/frontend/app/.server/container-modules/health.container-module.ts
+++ b/frontend/app/.server/container-modules/health.container-module.ts
@@ -3,7 +3,7 @@ import { ContainerModule } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import { AddressValidationHealthCheck, ApplicantHealthCheck, RedisHealthCheck } from '~/.server/health';
+import { AddressValidationHealthCheck, ApplicantHealthCheck, ApplicationStatusHealthCheck, RedisHealthCheck } from '~/.server/health';
 
 function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
   return ({ parentContext }: interfaces.Request) => {
@@ -18,5 +18,6 @@ function sessionTypeIs(sessionType: ServerConfig['SESSION_STORAGE_TYPE']) {
 export const healthContainerModule = new ContainerModule((bind) => {
   bind(TYPES.health.HealthCheck).to(AddressValidationHealthCheck);
   bind(TYPES.health.HealthCheck).to(ApplicantHealthCheck);
+  bind(TYPES.health.HealthCheck).to(ApplicationStatusHealthCheck);
   bind(TYPES.health.HealthCheck).to(RedisHealthCheck).when(sessionTypeIs('redis'));
 });

--- a/frontend/app/.server/domain/repositories/address-validation.repository.ts
+++ b/frontend/app/.server/domain/repositories/address-validation.repository.ts
@@ -16,8 +16,19 @@ export interface AddressValidationRepository {
    */
   getAddressCorrectionResult(addressCorrectionRequestEntity: AddressCorrectionRequestEntity): Promise<AddressCorrectionResultEntity>;
 
+  /**
+   * Retrieves metadata associated with the address validation repository.
+   *
+   * @returns A record where the keys and values are strings representing metadata information.
+   */
   getMetadata(): Record<string, string>;
 
+  /**
+   * Performs a health check to ensure that the address validation repository is operational.
+   *
+   * @throws An error if the health check fails or the repository is unavailable.
+   * @returns A promise that resolves when the health check completes successfully.
+   */
   checkHealth(): Promise<void>;
 }
 
@@ -32,14 +43,14 @@ export class DefaultAddressValidationRepository implements AddressValidationRepo
     @inject(TYPES.http.HttpClient) private readonly httpClient: HttpClient,
   ) {
     this.log = logFactory.createLogger('DefaultAddressValidationRepository');
-    this.baseUrl = `${this.serverConfig.INTEROP_API_BASE_URI}/address/validation/v1/CAN/correct`;
+    this.baseUrl = `${this.serverConfig.INTEROP_API_BASE_URI}/address/validation/v1`;
   }
 
   async getAddressCorrectionResult(addressCorrectionRequestEntity: AddressCorrectionRequestEntity): Promise<AddressCorrectionResultEntity> {
     this.log.trace('Checking correctness of address for addressCorrectionRequest: [%j]', addressCorrectionRequestEntity);
     const { address, city, postalCode, provinceCode } = addressCorrectionRequestEntity;
 
-    const url = new URL(this.baseUrl);
+    const url = new URL(`${this.baseUrl}/CAN/correct`);
     url.searchParams.set('AddressFullText', address);
     url.searchParams.set('AddressCityName', city);
     url.searchParams.set('AddressPostalCode', postalCode);

--- a/frontend/app/.server/domain/repositories/applicant-repository.ts
+++ b/frontend/app/.server/domain/repositories/applicant-repository.ts
@@ -46,13 +46,13 @@ export class DefaultApplicantRepository implements ApplicantRepository {
     @inject(TYPES.http.HttpClient) private readonly httpClient: HttpClient,
   ) {
     this.log = logFactory.createLogger('DefaultApplicantRepository');
-    this.baseUrl = `${this.serverConfig.INTEROP_APPLICANT_API_BASE_URI ?? this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/applicant`;
+    this.baseUrl = `${this.serverConfig.INTEROP_APPLICANT_API_BASE_URI ?? this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1`;
   }
 
   async findApplicantBySin(applicantRequestEntity: ApplicantRequestEntity): Promise<ApplicantResponseEntity | null> {
     this.log.trace('Fetching applicant for sin [%j]', applicantRequestEntity);
 
-    const url = new URL(this.baseUrl);
+    const url = `${this.baseUrl}/applicant`;
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.client-application_by-sin.posts', url, {
       proxyUrl: this.serverConfig.HTTP_PROXY_URL,
       method: 'POST',

--- a/frontend/app/.server/health/application-status.health.ts
+++ b/frontend/app/.server/health/application-status.health.ts
@@ -1,0 +1,47 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { ApplicationStatusRepository } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+@injectable()
+export class ApplicationStatusHealthCheck implements HealthCheck {
+  private readonly log: Logger;
+
+  readonly name: string;
+  readonly metadata?: Record<string, string>;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.configs.ServerConfig)
+    private readonly serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL'>,
+    @inject(TYPES.domain.repositories.ApplicationStatusRepository) private readonly applicationStatusRepository: ApplicationStatusRepository,
+  ) {
+    this.log = logFactory.createLogger('ApplicationStatusHealthCheck');
+    this.name = 'applicationStatus';
+    this.metadata = this.applicationStatusRepository.getMetadata();
+
+    this.init();
+  }
+
+  private init(): void {
+    const healthCacheTTL = this.serverConfig.HEALTH_CACHE_TTL;
+    this.log.debug('Initializing ApplicationStatusHealthCheck with cache TTL of %d ms.', healthCacheTTL);
+
+    this.check = moize.promise(this.check, {
+      maxAge: healthCacheTTL,
+      // transformArgs is required to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
+      transformArgs: () => [],
+      onCacheAdd: () => this.log.info('Cached function for ApplicationStatusHealthCheck has been initialized.'),
+    });
+
+    this.log.debug('ApplicationStatusHealthCheck initialization complete.');
+  }
+
+  async check(signal?: AbortSignal): Promise<void> {
+    await this.applicationStatusRepository.checkHealth();
+  }
+}

--- a/frontend/app/.server/health/index.ts
+++ b/frontend/app/.server/health/index.ts
@@ -1,3 +1,4 @@
 export * from './address-validation.health';
 export * from './applicant.health';
+export * from './application-status.health';
 export * from './redis.health';


### PR DESCRIPTION
### Description
![image](https://github.com/user-attachments/assets/fc95a5fe-9c23-4edc-9e22-58baafb7c845)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
I modified the `/api/health` route to always be authorized to view details for simplicity.