### PR TITLE
validate child state on review screens in renew app

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -13,7 +13,7 @@ import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildStateForReview } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
-import { clearRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { clearRenewState, getChildrenState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService);
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService);
 
-  const children = state.children.map((child) => {
+  const children = getChildrenState(state).map((child) => {
     // prettier-ignore
     const selectedFederalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
       ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
@@ -80,11 +80,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
     return {
       id: child.id,
-      firstName: child.information.firstName,
-      lastName: child.information.lastName,
-      birthday: child.information.dateOfBirth,
-      clientNumber: child.information.clientNumber,
-      isParent: child.information.isParent,
+      firstName: child.information?.firstName,
+      lastName: child.information?.lastName,
+      birthday: child.information?.dateOfBirth,
+      clientNumber: child.information?.clientNumber,
+      isParent: child.information?.isParent,
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
         hasChanged: child.hasFederalProvincialTerritorialBenefitsChanged,
@@ -179,7 +179,7 @@ export default function RenewAdultChildReviewChildInformation() {
         <div className="space-y-10">
           {children.map((child) => {
             const childParams = { ...params, childId: child.id };
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday), currentLanguage);
+            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
             return (
               <section key={child.id} className="space-y-8">
                 <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState, validateChildrenStateForReview } from '~/.server/routes/helpers/renew-child-route-helpers';
-import { clearRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { clearRenewState, getChildrenState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService);
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService);
 
-  const children = state.children.map((child) => {
+  const children = getChildrenState(state).map((child) => {
     // prettier-ignore
     const selectedFederalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
       ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)


### PR DESCRIPTION
### Description
By calling `getChildrenState`, we're able to filter out 'incomplete' children that might have accidentally been added by a user when they subsequently back navigate.  This prevents the review screen from `500`ing.

### Related Azure Boards Work Items
[AB#5073](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5073)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
