### PR TITLE
Removing TODO comments that are no longer relevant

### DIFF
--- a/frontend/app/.server/domain/services/letter-type.service.ts
+++ b/frontend/app/.server/domain/services/letter-type.service.ts
@@ -64,7 +64,6 @@ export class DefaultLetterTypeService implements LetterTypeService {
 
   private init(): void {
     // Configure caching for letter type operations
-    // TODO new config for getLetterTypeById?
     const allLetterTypesCacheTTL = 1000 * this.serverConfig.LOOKUP_SVC_ALL_LETTER_TYPES_CACHE_TTL_SECONDS;
     const letterTypeCacheTTL = 1000 * this.serverConfig.LOOKUP_SVC_LETTER_TYPE_CACHE_TTL_SECONDS;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -46,7 +46,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadRenewAdultSingleChildState({ params, request, session });
 
-  // TODO: The link is unsure at the moment. For now, the 'Proceed to apply for yourself' button will return to the chhildren index
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 


### PR DESCRIPTION
### Description
There is a separate configuration to cache `getLetterTypeById`.
The redirect to `public/renew/$id/adult-child/children/index` has been verified by designers.