### PR TITLE
fix back navigation in children/dental-insurance screens

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -52,10 +52,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
 
-  if (!state.isNew) {
-    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/dental-insurance', params));
-  }
-
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const childName = t('renew-adult-child:children.child-number', { childNumber: state.childNumber });

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -52,10 +52,6 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
   const state = loadRenewSingleChildState({ params, request, session });
 
-  if (!state.isNew) {
-    return redirect(getPathById('public/renew/$id/child/children/$childId/dental-insurance', params));
-  }
-
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const childName = t('renew-child:children.child-number', { childNumber: state.childNumber });


### PR DESCRIPTION
### Description
I believe this was a vestige of the Apply Online application.  If memory serves correctly, we put this in because we didn't want users to be able to edit pertinent children attributes after they were initially added (SIN, name, etc).  I've removed the conditional from the loaders which now allows us to back navigate to the children/information screen so the user can make changes if required.

### Related Azure Boards Work Items
[AB#5078](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5078)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`