### PR TITLE
AB#5077 Back button fix on /children pages results in different error

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -82,11 +82,19 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewAdultChildState({ params, request, session });
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+    if (demographicSurveyEnabled) {
+      return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
+    }
+    if (state.hasFederalProvincialTerritorialBenefitsChanged) {
+      return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
+    }
+    return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
   }
 
   if (formAction === FormAction.Add) {

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -86,10 +86,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
 
   if (formAction === FormAction.Back) {
-    if (state.hasFederalProvincialTerritorialBenefitsChanged) {
-      return redirect(getPathById('public/renew/$id/child/update-federal-provincial-territorial-benefits', params));
-    }
-    return redirect(getPathById('public/renew/$id/child/confirm-federal-provincial-territorial-benefits', params));
+    return redirect(getPathById('public/renew/$id/type-renewal', params));
   }
 
   if (formAction === FormAction.Add) {


### PR DESCRIPTION
### Description

- Fix the 500 Error for renew child flow when hit back button on children index page
- Fix the 400 Error for renew adult-child flow when hit back button on children index page

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->