### PR TITLE
[gitops] Mocking `raodic` and `subscription` in UAT2

### DIFF
--- a/gitops/overlays/uat2/configs/frontend/config.conf
+++ b/gitops/overlays/uat2/configs/frontend/config.conf
@@ -14,6 +14,11 @@ OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
 
 #
+# Global mock configuration
+#
+ENABLED_MOCKS=raoidc,subscription
+
+#
 # Application feature flags configuration
 #
 ENABLED_FEATURES=doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,status-checker-redirects
@@ -29,10 +34,11 @@ REDIS_SENTINEL_PORT=26379
 #
 # RAOIDC configuration
 #
-AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
-AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
+AUTH_LOGOUT_REDIRECT_URL=https://cdcp-uat2.dev-dp.dts-stn.com/
+AUTH_RAOIDC_BASE_URL=https://cdcp-uat2.dev-dp-internal.dts-stn.com/oidc
 AUTH_RAOIDC_CLIENT_ID=CDCP
-AUTH_RASCL_LOGOUT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/rascl/Support/GlobalLogout.aspx
+AUTH_RASCL_LOGOUT_URL=https://cdcp-uat2.dev-dp.dts-stn.com/
+MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-uat2.dev-dp.dts-stn.com/auth/callback/raoidc
 
 #
 # hCaptcha configuration


### PR DESCRIPTION
### Description
These configuration changes are in an attempt to use the `/stub-login` route instead of an ECAS environment to test the Interop change that fixes the date of birth being `null` production issue.

The current production build's `/stub-login` route has a dependency to the `subscription` feature that we have to mock. Since UAT2 is currently not being used by any ECAS environment, `raoidc` feature is also mocked.