### PR TITLE
fix(frontend): fix vitest deprecation warning

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -35,6 +35,5 @@
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
     ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-  ],
-  "vitest.disableWorkspaceWarning": true
+  ]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,10 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { coverageConfigDefaults } from 'vitest/config';
 
+/**
+ * Application build and unit test configuration.
+ * See vite.server.config.ts for the server build config.
+ */
 export default defineConfig({
   build: {
     target: 'es2022',
@@ -43,17 +47,21 @@ export default defineConfig({
     //
     process.env.NODE_ENV === 'test' ? react() : reactRouter(),
   ],
+
+  //
+  // Vitest config. For more test configuration, see vitest.workspace.ts
+  // see: https://vitest.dev/config/
+  //
   test: {
-    setupFiles: ['./__tests__/setup-test-env.ts'],
-    include: ['./__tests__/**/*.test.{ts,tsx}'],
     coverage: {
       include: ['**/app/**/*.{ts,tsx}'],
-      exclude: ['!**/app/[.]client/**', '!**/app/[.]server/**', '**/app/mocks/**', ...coverageConfigDefaults.exclude],
+      exclude: [
+        '!**/app/[.]client/**', //
+        '!**/app/[.]server/**',
+        '**/app/mocks/**',
+        ...coverageConfigDefaults.exclude,
+      ],
     },
-    environmentMatchGlobs: [
-      ['__tests__/components/**', 'jsdom'],
-      ['__tests__/hooks/**', 'jsdom'],
-      ['__tests__/routes/**', 'jsdom'],
-    ],
+    setupFiles: ['./__tests__/setup-test-env.ts'],
   },
 });

--- a/frontend/vitest.workspace.ts
+++ b/frontend/vitest.workspace.ts
@@ -1,0 +1,34 @@
+import { defineWorkspace } from 'vitest/config';
+
+/**
+ * see: https://vitest.dev/guide/workspace
+ */
+export default defineWorkspace([
+  {
+    extends: './vite.config.ts',
+    test: {
+      name: 'jsdom',
+      environment: 'jsdom',
+      include: [
+        './__tests__/components/**/*.test.(ts|tsx)', //
+        './__tests__/hooks/**/*.test.(ts|tsx)',
+        './__tests__/routes/**/*.test.(ts|tsx)',
+      ],
+    },
+  },
+  {
+    extends: './vite.config.ts',
+    test: {
+      name: 'node',
+      environment: 'node',
+      include: [
+        './__tests__/**/*.test.(ts|tsx)', //
+      ],
+      exclude: [
+        './__tests__/components/**', //
+        './__tests__/hooks/**',
+        './__tests__/routes/**',
+      ],
+    },
+  },
+]);


### PR DESCRIPTION
### Description

The `environmentMatchGlobs` configuration option has been deprecated in Vite v6.x in favor of project workspaces. This PR creates two new vitest workspaces, `jsdom` and `node` that mimics the previously configured behavior.

### Checklist

- [x] I have tested the changes locally
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`

### Additional Notes

- <https://main.vitest.dev/config/#environmentmatchglobs>
- <https://vitest.dev/guide/workspace>