### PR TITLE
[gitops] Bumping uat1 to `0.0.0-8fbef31c-008cc` and updating configs

### DIFF
--- a/gitops/overlays/uat1/configs/frontend/config.conf
+++ b/gitops/overlays/uat1/configs/frontend/config.conf
@@ -16,7 +16,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,status-checker-redirects
+ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application
 
 #
 # Session/redis configuration
@@ -48,13 +48,3 @@ INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
 # Adobe Analytics Script URL
 #
 ADOBE_ANALYTICS_SRC=https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js
-
-#
-# CDCP API configuration
-#
-CDCP_API_BASE_URI=https://api.cdcp.example.com
-
-#
-# SIN edit stub page configuration
-#
-SHOW_SIN_EDIT_STUB_PAGE=true

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.6.0-RC123
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-8fbef31c-008cc
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
Unneeded configs removed and should also be removed when we go to production with renewals release.

![image](https://github.com/user-attachments/assets/2f135d55-4978-4fc2-bf3c-680924538ada)