### PR TITLE
Using address validation service within `adult-child` renew flow.

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -8,16 +8,12 @@ import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
-import validator from 'validator';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
-import type { MailingAddressState } from '~/.server/routes/helpers/renew-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { formatPostalCode, isValidCanadianPostalCode, isValidPostalCode } from '~/.server/utils/postal-zip-code.utils';
-import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -38,7 +34,6 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { isAllValidInputCharacters } from '~/utils/string-utils';
 
 enum FormAction {
   Submit = 'submit',
@@ -102,7 +97,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const locale = getLocale(request);
-  const t = await getFixedT(request, handle.i18nNamespaces);
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
   const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
@@ -114,75 +108,31 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultChildState({ params, request, session });
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
-  const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
-  const mailingAddressSchema = z
-    .object({
-      address: z.string().trim().max(30).refine(isAllValidInputCharacters, t('renew-adult-child:update-address.error-message.characters-valid')),
-      country: z.string().trim(),
-      province: z.string().trim().optional(),
-      city: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-adult-child:update-address.error-message.characters-valid')),
-      postalCode: z.string().trim().max(100).refine(isAllValidInputCharacters, t('renew-adult-child:update-address.error-message.characters-valid')).optional(),
-    })
-    .superRefine((val, ctx) => {
-      if (!val.address || validator.isEmpty(val.address)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.address-required'), path: ['address'] });
-      }
-
-      if (!val.country || validator.isEmpty(val.country)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.country-required'), path: ['country'] });
-      }
-
-      if (!val.city || validator.isEmpty(val.city)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.city-required'), path: ['city'] });
-      }
-
-      if (val.country === CANADA_COUNTRY_ID || val.country === USA_COUNTRY_ID) {
-        if (!val.province || validator.isEmpty(val.province)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.province-required'), path: ['province'] });
-        }
-        if (!val.postalCode || validator.isEmpty(val.postalCode)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.postal-code-required'), path: ['postalCode'] });
-        } else if (!isValidPostalCode(val.country, val.postalCode)) {
-          const message = val.country === CANADA_COUNTRY_ID ? t('renew-adult-child:update-address.error-message.mailing-address.postal-code-valid') : t('renew-adult-child:update-address.error-message.mailing-address.zip-code-valid');
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ['postalCode'] });
-        } else if (val.country === CANADA_COUNTRY_ID && val.province && !isValidCanadianPostalCode(val.province, val.postalCode)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.invalid-postal-code-for-province'), path: ['postalCode'] });
-        }
-      }
-
-      if (val.country && val.country !== CANADA_COUNTRY_ID && val.postalCode && isValidPostalCode(CANADA_COUNTRY_ID, val.postalCode)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:update-address.error-message.mailing-address.invalid-postal-code-for-country'), path: ['country'] });
-      }
-    })
-    .transform((val) => ({
-      ...val,
-      postalCode: val.country && val.postalCode ? formatPostalCode(val.country, val.postalCode) : val.postalCode,
-    })) satisfies z.ZodType<MailingAddressState>;
-
-  const parsedDataResult = mailingAddressSchema.safeParse({
+  const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
+  const parsedDataResult = await mailingAddressValidator.validateMailingAddress({
     address: String(formData.get('mailingAddress')),
-    country: String(formData.get('mailingCountry')),
-    province: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
+    countryId: String(formData.get('mailingCountry')),
+    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
     city: String(formData.get('mailingCity')),
-    postalCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
+    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
-    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+    return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
   const mailingAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
-    country: parsedDataResult.data.country,
-    postalCode: parsedDataResult.data.postalCode,
-    province: parsedDataResult.data.province,
+    country: parsedDataResult.data.countryId,
+    postalCode: parsedDataResult.data.postalZipCode,
+    province: parsedDataResult.data.provinceStateId,
   };
 
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
-  const isNotCanada = parsedDataResult.data.country !== clientConfig.CANADA_COUNTRY_ID;
+  const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
   const isUseInvalidAddressAction = formAction === 'use-invalid-address';
   const isUseSelectedAddressAction = formAction === 'use-selected-address';
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
@@ -206,18 +156,18 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   // Validate Canadian adddress
-  invariant(parsedDataResult.data.postalCode, 'Postal zip code is required for Canadian addresses');
-  invariant(parsedDataResult.data.province, 'Province state is required for Canadian addresses');
+  invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
+  invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
-    countryId: parsedDataResult.data.country,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.country, locale).name,
-    postalZipCode: parsedDataResult.data.postalCode,
-    provinceStateId: parsedDataResult.data.province,
-    provinceState: parsedDataResult.data.province && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.province, locale).abbr,
+    countryId: parsedDataResult.data.countryId,
+    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    postalZipCode: parsedDataResult.data.postalZipCode,
+    provinceStateId: parsedDataResult.data.provinceStateId,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -287,10 +237,10 @@ export default function RenewAdultChildUpdateAddress() {
   const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
   const errorSummary = useErrorSummary(errors, {
     address: 'mailing-address',
-    province: 'mailing-province',
-    country: 'mailing-country',
+    provinceStateId: 'mailing-province',
+    countryId: 'mailing-country',
     city: 'mailing-city',
-    postalCode: 'mailing-postal-code',
+    postalZipCode: 'mailing-postal-code',
     copyMailingAddress: 'copy-mailing-address',
   });
 
@@ -374,7 +324,7 @@ export default function RenewAdultChildUpdateAddress() {
                   maxLength={100}
                   autoComplete="postal-code"
                   defaultValue={defaultState.mailingAddress?.postalCode}
-                  errorMessage={errors?.postalCode}
+                  errorMessage={errors?.postalZipCode}
                   required={isPostalCodeRequired}
                 />
               </div>
@@ -386,7 +336,7 @@ export default function RenewAdultChildUpdateAddress() {
                   className="w-full sm:w-1/2"
                   label={t('renew-adult-child:update-address.address-field.province')}
                   defaultValue={defaultState.mailingAddress?.province}
-                  errorMessage={errors?.province}
+                  errorMessage={errors?.provinceStateId}
                   options={[dummyOption, ...mailingRegions]}
                   required
                 />
@@ -398,7 +348,7 @@ export default function RenewAdultChildUpdateAddress() {
                 label={t('renew-adult-child:update-address.address-field.country')}
                 autoComplete="country"
                 defaultValue={defaultState.mailingAddress?.country}
-                errorMessage={errors?.country}
+                errorMessage={errors?.countryId}
                 options={countries}
                 onChange={mailingCountryChangeHandler}
                 required


### PR DESCRIPTION
### Description
As per title

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
