### PR TITLE
fix navigation and payload with single child renew behind msca

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -369,11 +369,11 @@ export function loadProtectedRenewStateForReview({ params, request, session, dem
 }
 
 export function isPrimaryApplicantStateComplete(state: ProtectedRenewState, demographicSurveyEnabled: boolean) {
-  return state.previouslyReviewed && state.dentalInsurance !== undefined && (demographicSurveyEnabled ? state.demographicSurvey !== undefined : true);
+  return !!state.previouslyReviewed && state.dentalInsurance !== undefined && (demographicSurveyEnabled ? state.demographicSurvey !== undefined : true);
 }
 
 export function isChildrenStateComplete(state: ProtectedRenewState, demographicSurveyEnabled: boolean) {
-  return state.children.every((child) => child.previouslyReviewed && child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
+  return state.children.every((child) => !!child.previouslyReviewed && child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
 }
 
 interface ValidateProtectedRenewStateForReviewArgs {

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -125,7 +125,7 @@ export interface BenefitRenewalStateMapper {
   mapRenewAdultChildStateToAdultChildBenefitRenewalDto(renewAdultChildState: RenewAdultChildState): AdultChildBenefitRenewalDto;
   mapRenewItaStateToItaBenefitRenewalDto(renewItaState: RenewItaState): ItaBenefitRenewalDto;
   mapRenewChildStateToChildBenefitRenewalDto(renewChildSTate: RenewChildState): ChildBenefitRenewalDto;
-  mapProtectedRenewStateToProtectedBenefitRenewalDto(protectedRenewState: ProtectedRenewState, userId: string): ProtectedBenefitRenewalDto;
+  mapProtectedRenewStateToProtectedBenefitRenewalDto(protectedRenewState: ProtectedRenewState, userId: string, primaryApplicantStateCompleted: boolean): ProtectedBenefitRenewalDto;
 }
 
 interface ToApplicantInformationArgs {
@@ -462,6 +462,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
   mapProtectedRenewStateToProtectedBenefitRenewalDto(
     { applicationYear, children, contactInformation, demographicSurvey, dentalBenefits, dentalInsurance, homeAddress, isHomeAddressSameAsMailingAddress, mailingAddress, maritalStatus, partnerInformation, clientApplication }: ProtectedRenewState,
     userId: string,
+    primaryApplicantStateCompleted: boolean,
   ): ProtectedBenefitRenewalDto {
     return {
       ...clientApplication,
@@ -492,12 +493,14 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
       }),
-      dentalBenefits: this.toDentalBenefits({
-        existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: !!dentalBenefits,
-        renewedDentalBenefits: dentalBenefits,
-      }),
-      dentalInsurance,
+      dentalBenefits: primaryApplicantStateCompleted
+        ? this.toDentalBenefits({
+            existingDentalBenefits: clientApplication.dentalBenefits,
+            hasFederalProvincialTerritorialBenefitsChanged: !!dentalBenefits,
+            renewedDentalBenefits: dentalBenefits,
+          })
+        : [],
+      dentalInsurance: primaryApplicantStateCompleted ? dentalInsurance : undefined,
       partnerInformation: this.toPartnerInformation({
         existingPartnerInformation: clientApplication.partnerInformation,
         hasMaritalStatusChanged: !!maritalStatus,

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -78,6 +78,10 @@ export async function action({ context: { appContainer, session }, params, reque
     return { status: 'select-member' };
   }
 
+  if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
+    return redirect(getPathById('protected/renew/$id/review-child-information', params));
+  }
+
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -71,7 +71,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     viewPayloadEnabled &&
     appContainer
       .get(TYPES.domain.mappers.BenefitRenewalDtoMapper)
-      .mapProtectedBenefitRenewalDtoToBenefitRenewalRequestEntity(appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapProtectedRenewStateToProtectedBenefitRenewalDto(state, userInfoToken.sub));
+      .mapProtectedBenefitRenewalDtoToBenefitRenewalRequestEntity(appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapProtectedRenewStateToProtectedBenefitRenewalDto(state, userInfoToken.sub, isPrimaryApplicantStateComplete(state,demographicSurveyEnabled)));
 
   const children = validatedChildren.map((child) => {
     const immutableChild = state.clientApplication.children.find((c) => c.information.socialInsuranceNumber === child.information?.socialInsuranceNumber);
@@ -141,6 +141,10 @@ export async function action({ context: { appContainer, session }, params, reque
     if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
       return redirect(getPathById('protected/renew/$id/member-selection', params));
     }
+    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+  }
+
+  if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 


### PR DESCRIPTION
### Description
If the user submits renewal ONLY for their dependent, then the `review-child-information` screen should be displayed before the `review-adult-information` screen.  The dental benefits section on the `review-adult-information` screen should not be displayed and the payload needs to be modified to remove the dental benefits for the primary applicant.  

### Related Azure Boards Work Items
[AB#5087](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5087)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`