### PR TITLE
AB#5089 Protected route Marital status

### DIFF
--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -114,7 +114,7 @@
             ]
           }
         ],
-        "InvitationToApplyIndicator": false,
+        "InvitationToApplyIndicator": true,
         "LivingIndependentlyIndicator": true,
         "PreviousApplicationIndicator": false,
         "PreviousTaxesFiledIndicator": false,

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -76,7 +76,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     defaultState: {
-      maritalStatus: state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus,
+      maritalStatus: state.maritalStatus ? state.maritalStatus : state.clientApplication.isInvitationToApplyClient ? undefined : state.clientApplication.applicantInformation.maritalStatus,
       partnerInformation,
     },
     maritalStatuses,

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -121,7 +121,14 @@ export default function ProtectedRenewMemberSelection() {
       <fetcher.Form method="post" noValidate>
         <CsrfTokenInput />
         <div className="mt-6 space-y-8">
-          <CardLink id="primary-applicant" key={applicantName} title={applicantName} previouslyReviewed={previouslyReviewed} routeId="protected/renew/$id/dental-insurance" params={params} />
+          <CardLink
+            id="primary-applicant"
+            key={applicantName}
+            title={applicantName}
+            previouslyReviewed={previouslyReviewed}
+            routeId={clientApplication.isInvitationToApplyClient ? 'protected/renew/$id/confirm-marital-status' : 'protected/renew/$id/dental-insurance'}
+            params={params}
+          />
           {children.map((child) => {
             const childName = `${child.information?.firstName} ${child.information?.lastName}`;
             return <CardLink key={childName} title={childName} previouslyReviewed={child.previouslyReviewed} routeId="protected/renew/$id/$childId/parent-or-guardian" params={{ ...params, childId: child.id }} />;


### PR DESCRIPTION
### Description
Refactor Marital status page for ITA applicant. 
Applicant should be able to access the marital status page if they are ita flagged. If applicant is not ita, they will receive 404 if thet attempt to access this page.

Note: `InvitationToApplyIndicator` is set to `true` in the clientApplication.json for the purpose of testing. 

### Related Azure Boards Work Items
[AB#5088](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5088)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->