### PR TITLE
Modifying client application mock to include ITA client by SIN

### DIFF
--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -134,7 +134,7 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
     [
       '800000002',
       {
-        InvitationToApplyIndicator: false,
+        InvitationToApplyIndicator: true,
         PreviousTaxesFiledIndicator: true,
       },
     ],

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -114,7 +114,7 @@
             ]
           }
         ],
-        "InvitationToApplyIndicator": true,
+        "InvitationToApplyIndicator": false,
         "LivingIndependentlyIndicator": true,
         "PreviousApplicationIndicator": false,
         "PreviousTaxesFiledIndicator": false,


### PR DESCRIPTION
### Description
A previous change in `client-application.json` resulted in online renewal client numbers to default as ITA client (in order to test the protected renew ITA pages). This PR adds a SIN that can be used as an ITA client for the protected renew pages. 

To impersonate an ITA client in the protected renew flow, navigate to `/en/protected/stub-login` and use `800000002` as the SIN. Then navigate to `/en/protected/renew`.

### Checklist
- [x] I have tested the changes locally
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
