### PR TITLE
AB#5104 Update French eligibility link

### DIFF
--- a/frontend/public/locales/fr/renew.json
+++ b/frontend/public/locales/fr/renew.json
@@ -95,7 +95,7 @@
     "renew-client-number": "Pour renouveler votre adhésion, vous devez avoir un numéro de client.",
     "apply-to-cdcp": "Si vous n'en avez pas, vous devrez présenter une demande au Régime canadien de soins dentaires.",
     "check-eligibility": "<eligibilityLink>Vérifiez si vous pouvez présenter une demande au Régime canadien de soins dentaires.</eligibilityLink>",
-    "eligibility-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan/qualify.html",
+    "eligibility-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/admissibilite.html",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
     "cancel-btn": "Annuler",


### PR DESCRIPTION
### Description
The French eligibility link on renew applicant information page opens the English page. Open this pr to fix it.

### Related Azure Boards Work Items
[AB#5104](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5104)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->