### PR TITLE
Adding lifespan to renew sessions and configs for external CDCP renewal pages

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -369,6 +369,10 @@ DYNATRACE_API_RUM_SCRIPT_URI_CACHE_TTL_SECONDS=3600
 #CDCP_WEBSITE_APPLY_URL_EN=https://www.example.com
 # (optional; default: https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html)
 #CDCP_WEBSITE_APPLY_URL_FR=https://www.example.com
+# (optional; default: https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html)
+#CDCP_WEBSITE_RENEW_URL_EN=https://www.example.com
+# (optional; default: https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html)
+#CDCP_WEBSITE_RENEW_URL_FR=https://www.example.com
 # (optional; default: https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#status)
 #CDCP_WEBSITE_STATUS_URL_EN=https://www.example.com
 # (optional; default: https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#etat)

--- a/frontend/app/.server/utils/api-session.utils.ts
+++ b/frontend/app/.server/utils/api-session.utils.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '~/.server/utils/logging.utils';
-import { getCdcpWebsiteApplyUrl, getCdcpWebsiteStatusUrl, getCdcpWebsiteUrl } from '~/.server/utils/url.utils';
+import { getCdcpWebsiteApplyUrl, getCdcpWebsiteRenewUrl, getCdcpWebsiteStatusUrl, getCdcpWebsiteUrl } from '~/.server/utils/url.utils';
 import type { ApiSessionRedirectTo } from '~/routes/api/session';
 
 /**
@@ -24,6 +24,10 @@ export function getApiSessionRedirectToUrl(redirectTo: ApiSessionRedirectTo, loc
 
     case 'cdcp-website-apply': {
       return getCdcpWebsiteApplyUrl(locale);
+    }
+
+    case 'cdcp-website-renew': {
+      return getCdcpWebsiteRenewUrl(locale);
     }
 
     case 'cdcp-website-status': {

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -180,6 +180,8 @@ const serverEnv = clientEnvSchema.extend({
   // CDCP Website URLs
   CDCP_WEBSITE_APPLY_URL_EN: z.string().url().default('https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html'),
   CDCP_WEBSITE_APPLY_URL_FR: z.string().url().default('https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html'),
+  CDCP_WEBSITE_RENEW_URL_EN: z.string().url().default('https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html'),
+  CDCP_WEBSITE_RENEW_URL_FR: z.string().url().default('https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html'),
   CDCP_WEBSITE_STATUS_URL_EN: z.string().url().default('https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#status'),
   CDCP_WEBSITE_STATUS_URL_FR: z.string().url().default('https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires/demande.html#etat'),
   CDCP_WEBSITE_URL_EN: z.string().url().default('https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html'),

--- a/frontend/app/.server/utils/url.utils.ts
+++ b/frontend/app/.server/utils/url.utils.ts
@@ -13,6 +13,18 @@ export function getCdcpWebsiteApplyUrl(locale: AppLocale) {
 }
 
 /**
+ * Returns the URL for renewing on the Canadian Dental Care Plan (CDCP) website
+ * based on the provided locale from the public environment variables.
+ *
+ * @param locale - The application locale ('en' or 'fr').
+ * @returns The URL for renewing on the CDCP website.
+ */
+export function getCdcpWebsiteRenewUrl(locale: AppLocale) {
+  const { CDCP_WEBSITE_RENEW_URL_EN, CDCP_WEBSITE_RENEW_URL_FR } = getEnv();
+  return locale === 'fr' ? CDCP_WEBSITE_RENEW_URL_FR : CDCP_WEBSITE_RENEW_URL_EN;
+}
+
+/**
  * Returns the URL for checking the status of an application on the CDCP website
  * based on the provided locale from the public environment variables.
  *

--- a/frontend/app/routes/api/renew-state.ts
+++ b/frontend/app/routes/api/renew-state.ts
@@ -1,0 +1,50 @@
+/**
+ * An API route that can be used to perform actions with user's renew state.
+ */
+import type { ActionFunctionArgs } from 'react-router';
+
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { getLogger } from '~/.server/utils/logging.utils';
+
+const API_RENEW_STATE_ACTIONS = ['extend'] as const;
+export type ApiRenewStateAction = (typeof API_RENEW_STATE_ACTIONS)[number];
+
+export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
+
+  const log = getLogger('routes/api/renew-state');
+  const sessionId = session.id;
+  log.debug("Action with with user's renew state; sessionId: [%s]", sessionId);
+
+  const bodySchema = z.object({
+    action: z.enum(API_RENEW_STATE_ACTIONS),
+    id: z.string(),
+  });
+
+  const requestBody = await request.json();
+  const parsedBody = bodySchema.safeParse(requestBody);
+
+  if (!parsedBody.success) {
+    log.debug('Invalid request body [%j]; sessionId: [%s]', requestBody, sessionId);
+    return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
+  }
+
+  const params = { id: parsedBody.data.id };
+
+  switch (parsedBody.data.action) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    case 'extend': {
+      log.debug("Extending user's renew state; id: [%s], sessionId: [%s]", params.id, sessionId);
+      saveRenewState({ params, session, state: {} });
+      return new Response(null, { status: 204 });
+    }
+
+    default: {
+      throw Error(`Action '${parsedBody.data.action}' not implemented; sessionId: [${sessionId}]`);
+    }
+  }
+}

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -14,7 +14,7 @@ import { APP_LOCALES } from '~/utils/locale-utils';
 const API_SESSION_ACTIONS = ['end', 'extend'] as const;
 export type ApiSessionAction = (typeof API_SESSION_ACTIONS)[number];
 
-const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', 'cdcp-website-status'] as const;
+const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', 'cdcp-website-renew', 'cdcp-website-status'] as const;
 export type ApiSessionRedirectTo = (typeof API_SESSION_REDIRECT_TO_OPTIONS)[number];
 
 export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {

--- a/frontend/app/routes/public/renew/layout.tsx
+++ b/frontend/app/routes/public/renew/layout.tsx
@@ -8,6 +8,7 @@ import { getLocale } from '~/.server/utils/locale.utils';
 import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
+import { useApiRenewState } from '~/utils/api-renew-state-utils';
 import { useApiSession } from '~/utils/api-session-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -42,13 +43,22 @@ export default function Route() {
     }
   }, [navigate, path]);
 
+  const apiRenewState = useApiRenewState();
   const apiSession = useApiSession();
 
   async function handleOnSessionEnd() {
-    await apiSession.submit({ action: 'end', locale, redirectTo: 'cdcp-website-status' });
+    await apiSession.submit({ action: 'end', locale, redirectTo: 'cdcp-website-renew' });
   }
 
   async function handleOnSessionExtend() {
+    // extends the renew state if 'id' param exists
+    const id = params.id;
+    if (typeof id === 'string') {
+      await apiRenewState.submit({ action: 'extend', id });
+      return;
+    }
+
+    // extends the user's session
     await apiSession.submit({ action: 'extend' });
   }
 

--- a/frontend/app/utils/api-renew-state-utils.ts
+++ b/frontend/app/utils/api-renew-state-utils.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+import { useSubmit } from 'react-router';
+
+import type { ApiRenewStateAction } from '~/routes/api/renew-state';
+
+interface ApiRenewStateSubmitFuncArgs {
+  action: ApiRenewStateAction;
+  id: string;
+}
+
+/**
+ * A custom hook for submitting API requests to the renew state endpoint.
+ */
+export function useApiRenewState() {
+  const rrSubmit = useSubmit();
+
+  /**
+   * Submits a request to the renew state API endpoint.
+   *
+   * @example
+   * submit({ action: ApiRenewStateAction.Extend, id: '00000000-0000-0000-0000-000000000000' });
+   */
+  const submit = useCallback(
+    async ({ action, id }: ApiRenewStateSubmitFuncArgs) => {
+      await rrSubmit(
+        { action, id },
+        {
+          action: '/api/renew-state',
+          encType: 'application/json',
+          method: 'POST',
+          navigate: false,
+        },
+      );
+    },
+    [rrSubmit],
+  );
+
+  return { submit };
+}


### PR DESCRIPTION
### Description
- The renewal session lifespan implementation is based off the existing apply implementation. Currently when a user in the renewal flow times out, they are (incorrect) redirected to the external CDCP status page.
- For flexibility, separate configs have been added for external CDCP renewal pages, even though their values are the same for the apply pages.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`