### PR TITLE
Remove unnecessary `save` call after session destruction

### DIFF
--- a/frontend/__tests__/.server/web/session.test.ts
+++ b/frontend/__tests__/.server/web/session.test.ts
@@ -140,7 +140,6 @@ describe('Session', () => {
         const session = new ExpressSession(mockLogFactory, mockRequestSession);
         session.destroy();
         expect(mockRequestSession.destroy).toHaveBeenCalledOnce();
-        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
     });
 

--- a/frontend/app/.server/web/session.ts
+++ b/frontend/app/.server/web/session.ts
@@ -168,7 +168,6 @@ export class ExpressSession implements Session {
         this.log.trace('Session destroyed successfully: %s', this.id);
       }
     });
-    this.session.save();
   }
 
   protected sanitizeKey(key: string): string {


### PR DESCRIPTION
### Description
As per title. `save` method is meant to persist session data, but a destroyed session no longer exists.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
I found the issue by doing this:

- Set the following environment variables:
```
SESSION_TIMEOUT_SECONDS=10
SESSION_TIMEOUT_PROMPT_SECONDS=5
```
- Navigate to `/en/renew` or `/en/apply` and you will be redirected to the Terms & Conditions page.
- Either end the session now or wait until the dialog timer reaches zero. You will be redirected to an external CDCP page.
- Click "Back" on browser.

Before this change, you would have been redirected to the Terms & Conditions page in the `/en/renew` or `/en/apply`. 
After this change, you will stay on the external CDCP page.