### PR TITLE
Changing protected renew flow to use RAOIDC logout

### DIFF
--- a/frontend/app/routes/protected/renew/layout.tsx
+++ b/frontend/app/routes/protected/renew/layout.tsx
@@ -27,7 +27,7 @@ export async function loader({ context: { appContainer, session }, request }: Lo
 }
 
 export default function Layout() {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
 
   const navigate = useNavigate();
   const params = useParams();
@@ -47,7 +47,7 @@ export default function Layout() {
   const apiSession = useApiSession();
 
   async function handleOnSessionEnd() {
-    await apiSession.submit({ action: 'end', locale, redirectTo: 'cdcp-website-apply' });
+    await navigate('/auth/logout');
   }
 
   async function handleOnSessionExtend() {


### PR DESCRIPTION
### Description
When the session timeout expires or when the user chooses to end their session in the protected area, we should be using `/auth/logout` to trigger RAODIC's logout mechanism.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`