### PR TITLE
AB#5103 -- Correcting error message when email field is empty

### DIFF
--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -366,7 +366,7 @@
       "add-or-update-required": "Select whether you would like to add or update your email",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
     }
@@ -426,7 +426,7 @@
     "error-message": {
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "preferred-language-required": "Select preferred language of communication",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -83,7 +83,7 @@
       "add-or-update-required": "Select whether you would like to add or update your email",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -83,7 +83,7 @@
       "add-or-update-required": "Select whether you would like to add or update your email",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -232,7 +232,7 @@
       "add-or-update-required": "Select whether you would like to add or update your email",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -60,7 +60,7 @@
       "add-or-update-required": "Select if you would like to receive email communication",
       "email-match": "The email addresses entered do not match",
       "confirm-email-required": "Confirm email address",
-      "email-required": "Enter email address",
+      "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
     }

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -366,7 +366,7 @@
       "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com"
     }
@@ -426,7 +426,7 @@
     "error-message": {
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "preferred-language-required": "Sélectionnez la langue de communication préférée",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -84,7 +84,7 @@
       "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -83,7 +83,7 @@
       "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -234,7 +234,7 @@
       "add-or-update-required": "Sélectionnez si vous souhaitez mettre à jour ou ajouter une adresse courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com",
       "receive-comms-required": "Select whether you would like to receive email communication"

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -61,7 +61,7 @@
       "add-or-update-required": "Sélectionnez si vous souhaitez recevoir des communications par courriel",
       "email-match": "Les adresses courriel entrées ne concordent pas",
       "confirm-email-required": "Confirmez l'adresse courriel",
-      "email-required": "Entrez l'adresse courriel",
+      "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@example.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@example.com"
     }


### PR DESCRIPTION
### Description
As per title.

Only changed renewal flows' error messages

### Related Azure Boards Work Items
AB#5103

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/8eb1f3fe-ab05-4aef-9d84-8862714b1714)
![image](https://github.com/user-attachments/assets/e7abe8a3-baf5-416e-bc7e-e4e5103e4046)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`