### PR TITLE
refactor(frontend): reusable phone zod validation schema

### DIFF
--- a/frontend/__tests__/.server/validation/phone-schema.test.ts
+++ b/frontend/__tests__/.server/validation/phone-schema.test.ts
@@ -1,0 +1,135 @@
+import { assert, describe, expect, it } from 'vitest';
+
+import { phoneSchema } from '~/.server/validation/phone-schema';
+
+describe('phoneSchema', () => {
+  it('should pass validation for a valid Canadian phone number', () => {
+    const result = phoneSchema().safeParse('613-555-1212');
+    assert(result.success);
+    expect(result.data).toBe('+1 613 555 1212');
+  });
+
+  it('should pass validation for a valid international phone number', () => {
+    const result = phoneSchema().safeParse('+44 20 7183 8750');
+    assert(result.success);
+    expect(result.data).toBe('+44 20 7183 8750');
+  });
+
+  it('should pass validation for a valid Canadian phone number with leading +1', () => {
+    const result = phoneSchema().safeParse('+1 613 555 1212');
+    assert(result.success);
+    expect(result.data).toBe('+1 613 555 1212');
+  });
+
+  it('should fail validation for an invalid Canadian phone number', () => {
+    const result = phoneSchema().safeParse('123-4567');
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'custom',
+        fatal: true,
+        message: 'Invalid Canadian phone number, received 123-4567',
+        path: [],
+      },
+    ]);
+  });
+
+  it('should fail validation for an invalid international phone number', () => {
+    const result = phoneSchema().safeParse('+12 345 555 1212');
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'custom',
+        fatal: true,
+        message: 'Invalid international phone number, received +12 345 555 1212',
+        path: [],
+      },
+    ]);
+  });
+
+  it('should fail validation for undefined phone number', () => {
+    const result = phoneSchema().safeParse(undefined);
+
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Phone number is required',
+        path: [],
+        received: 'undefined',
+      },
+    ]);
+  });
+
+  it('should fail validation for null phone number', () => {
+    const result = phoneSchema().safeParse(null);
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Invalid phone number type. Expected string, received null',
+        path: [],
+        received: 'null',
+      },
+    ]);
+  });
+
+  it('should fail validation for an empty phone number', () => {
+    const result = phoneSchema().safeParse('');
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'too_small',
+        exact: false,
+        inclusive: true,
+        message: 'Phone number is required',
+        minimum: 1,
+        path: [],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should fail validation for a phone number with only spaces', () => {
+    const result = phoneSchema().safeParse('   ');
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'too_small',
+        exact: false,
+        inclusive: true,
+        message: 'Phone number is required',
+        minimum: 1,
+        path: [],
+        type: 'string',
+      },
+    ]);
+  });
+
+  it('should correctly format a valid Canadian phone number with spaces', () => {
+    const result = phoneSchema().safeParse('613 555 1212');
+    assert(result.success);
+    expect(result.data).toBe('+1 613 555 1212');
+  });
+
+  it('should correctly format a valid Canadian phone number with parenthesis and spaces', () => {
+    const result = phoneSchema().safeParse('(613) 555-1212');
+    assert(result.success);
+    expect(result.data).toBe('+1 613 555 1212');
+  });
+
+  it('should handle phone number with invalid characters', () => {
+    const result = phoneSchema().safeParse('613-555-1212!');
+    assert(!result.success);
+    expect(result.error.errors).toStrictEqual([
+      {
+        code: 'custom',
+        fatal: true,
+        message: 'Invalid Canadian phone number, received 613-555-1212!',
+        path: [],
+      },
+    ]);
+  });
+});

--- a/frontend/app/.server/validation/index.ts
+++ b/frontend/app/.server/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './phone-schema';

--- a/frontend/app/.server/validation/phone-schema.ts
+++ b/frontend/app/.server/validation/phone-schema.ts
@@ -1,0 +1,121 @@
+import { isValidPhoneNumber, parsePhoneNumberWithError } from 'libphonenumber-js';
+import { z } from 'zod';
+
+import { expandTemplate, extractDigits } from '~/utils/string-utils';
+
+/**
+ * Error messages for phone number validation
+ */
+export type PhoneSchemaErrorMessage = {
+  /**
+   * Error message for invalid Canadian phone number
+   * @default 'Invalid Canadian phone number, received {received}'
+   */
+  invalid_phone_canadian_error?: string;
+
+  /**
+   * Error message for invalid international phone number
+   * @default 'Invalid international phone number, received {received}'
+   */
+  invalid_phone_international_error?: string;
+
+  /**
+   * Error message for invalid phone number type
+   * @default 'Invalid type. Expected string, received {received}'
+   */
+  invalid_type_error?: string;
+
+  /**
+   * Error message for required phone number
+   * @default 'Phone number is required'
+   */
+  required_error?: string;
+};
+
+/**
+ * Default error messages for phone number validation
+ */
+const DEFAULT_ERROR_MESSAGES = {
+  invalid_phone_canadian_error: 'Invalid Canadian phone number, received {received}',
+  invalid_phone_international_error: 'Invalid international phone number, received {received}',
+  invalid_type_error: 'Invalid phone number type. Expected string, received {received}',
+  required_error: 'Phone number is required',
+} as const satisfies Required<PhoneSchemaErrorMessage>;
+
+/**
+ * Validates phone number based on the following conditions:
+ * - Validates Canadian phone number if digit length is less than or equal to 11
+ * - Validates international phone number if digit length is greater than 11
+ *
+ * Format phone number to international format if valid
+ *
+ * @param errorMessage - Error messages for phone number validation
+ * @returns Zod string schema with phone number validation
+ */
+export function phoneSchema(
+  errorMessage: PhoneSchemaErrorMessage = {}, //
+): z.ZodEffects<z.ZodEffects<z.ZodString, string, string>, string, string> {
+  const message: Required<PhoneSchemaErrorMessage> = {
+    ...DEFAULT_ERROR_MESSAGES,
+    ...errorMessage,
+  };
+
+  return z
+    .string({
+      errorMap: (issue, ctx) => {
+        const inputData = String(ctx.data);
+
+        // Handle undefined input data
+        if (inputData === 'undefined') {
+          return {
+            message: message.required_error,
+          };
+        }
+
+        // Handle invalid phone number type
+        if (issue.code === 'invalid_type') {
+          return {
+            message: expandTemplate(message.invalid_type_error, { received: inputData }),
+          };
+        }
+
+        // Handle other
+        return {
+          message: ctx.defaultError,
+        };
+      },
+    })
+    .trim()
+    .nonempty(message.required_error)
+    .superRefine((phoneNumber, ctx) => {
+      if (!phoneNumber) return;
+
+      const phoneDigits = extractDigits(phoneNumber);
+
+      // Determine validation type based on digit length
+      const requiresCanadianValidation = phoneDigits.length <= 11;
+
+      // Validate based on number format
+      const isValid = requiresCanadianValidation //
+        ? isValidPhoneNumber(phoneNumber, 'CA')
+        : isValidPhoneNumber(phoneNumber);
+
+      // Return early if valid
+      if (isValid) return;
+
+      // Add appropriate error message based on validation type
+      const issueMessage = requiresCanadianValidation //
+        ? message.invalid_phone_canadian_error
+        : message.invalid_phone_international_error;
+
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: expandTemplate(issueMessage, { received: phoneNumber }),
+        fatal: true,
+      });
+    })
+    .transform((phoneNumber) => {
+      // Format valid phone number to international format
+      return parsePhoneNumberWithError(phoneNumber, 'CA').formatInternational();
+    });
+}

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -89,12 +89,14 @@ export function formatPercent(value: number, locale: string) {
 }
 
 /**
- *
- * @param input - A string
- * @returns The given string with removed spaces
+ * Extracts only digits from a string by removing all non-digit characters
+ * @param input - The input string to process
+ * @returns A string containing only digits (0-9)
+ * @example
+ * extractDigits("123-456-7890") // returns "1234567890"
  */
 export function extractDigits(input: string) {
-  return input.replace(/\D/g, '');
+  return input.match(/\d/g)?.join('') ?? '';
 }
 
 /**


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->
This PR introduces a reusable Zod schema for phone number validation and formatting, supporting both Canadian and international phone numbers. It includes comprehensive test cases to verify the functionality.

#### Changes

1. **Phone Schema Validation and Formatting**
   - Added a reusable Zod schema for phone number validation and formatting in `phone-schema.ts`.
   - Validates and formats Canadian and international phone numbers.

2. **Test Cases**
   - Added test cases in `phone-schema.test.ts` to cover various scenarios, including:
     - Valid and invalid phone numbers
     - Phone numbers with extensions
     - Edge cases (undefined, null, empty, and invalid characters)


### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#5097](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5097)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`