### PR TITLE
fix(gitops): rejig squid config

### DIFF
--- a/gitops/base/squid-proxy/deployments.yaml
+++ b/gitops/base/squid-proxy/deployments.yaml
@@ -28,10 +28,10 @@ spec:
               port: squid
           resources:
             requests:
-              cpu: 100m
-              memory: 32Mi
-            limits:
-              cpu: 200m
+              cpu: 250m
               memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/gitops/overlays/shared/configs/squid-proxy/config.conf
+++ b/gitops/overlays/shared/configs/squid-proxy/config.conf
@@ -1,0 +1,31 @@
+#
+# see https://www.squid-cache.org/Doc/config/
+#
+
+# disable caching to reduce resource usage
+cache deny all
+
+# ensure lookups of onprem services works
+dns_nameservers 10.72.49.4
+
+#
+# configure some lenient timeouts to accommodate slow onprem services 💩
+#
+
+client_lifetime 30 minutes
+
+connect_timeout 30 seconds
+read_timeout 60 seconds
+request_timeout 90 seconds
+
+pconn_timeout 300 seconds
+client_idle_pconn_timeout 30 seconds
+server_idle_pconn_timeout 30 seconds
+
+#
+# disable k8s livez/readyz request logging
+#
+
+acl kubernetes src 172.18.65.0/24
+access_log none kubernetes
+http_access allow kubernetes

--- a/gitops/overlays/shared/kustomization.yaml
+++ b/gitops/overlays/shared/kustomization.yaml
@@ -20,3 +20,9 @@ labels:
 resources:
   - ../../base/maintenance/
   - ../../base/squid-proxy/
+patches:
+  - path: ./patches/deployments.yaml
+configMapGenerator:
+  - name: squid-proxy
+    files:
+      - ./configs/squid-proxy/config.conf

--- a/gitops/overlays/shared/patches/deployments.yaml
+++ b/gitops/overlays/shared/patches/deployments.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: squid-proxy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squid-proxy
+  template:
+    spec:
+      containers:
+        - name: squid-proxy
+          volumeMounts:
+            - name: squid-proxy-conf
+              mountPath: /etc/squid/conf.d/dshp.conf
+              subPath: config.conf
+      volumes:
+        - name: squid-proxy-conf
+          configMap:
+            name: squid-proxy


### PR DESCRIPTION
### Description

Suppress the k8s probe request logging in squid and tweak some settings to make calls to slow onprem services a little more resilient.

### Additional Notes

These changes have already been depoloyed to the cluster.