### PR TITLE
AB#15186 Fix child fpt text for renew flow

### DIFF
--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -282,7 +282,7 @@
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
       "federal-benefits": {
         "title": "Federal benefits",
-        "legend": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+        "legend": "Does {{childName}} have other dental benefits through a federal social program aside from the Canadian Dental Care Plan?",
         "option-yes": "<strong>Yes</strong>, this child has <strong>federal</strong> benefits",
         "option-no": "<strong>No</strong>, this child does not have <strong>federal</strong> benefits",
         "social-programs": {

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -282,7 +282,7 @@
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
       "federal-benefits": {
         "title": "Federal benefits",
-        "legend": "Does {{childName}} have dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+        "legend": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
         "option-yes": "<strong>Yes</strong>, this child has <strong>federal</strong> benefits",
         "option-no": "<strong>No</strong>, this child does not have <strong>federal</strong> benefits",
         "social-programs": {

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -390,7 +390,7 @@
       "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
       "select-one": "Select one",
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
-      "has-benefits-changed": "Does {{childName}} have dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+      "has-benefits-changed": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
       "option-yes": "<strong>Yes</strong>, this child has federal, provincial or territorial dental benefits.",
       "option-no": "<strong>No</strong>, this child does not have federal, provincial or territorial dental benefits.",
       "button": {

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -132,7 +132,7 @@
       "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
       "select-one": "Select one",
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
-      "has-benefits-changed": "Does {{childName}} have dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+      "has-benefits-changed": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
       "option-yes": "<strong>Yes</strong>, this child has federal, provincial or territorial dental benefits.",
       "option-no": "<strong>No</strong>, this child does not have federal, provincial or territorial dental benefits.",
       "button": {
@@ -152,7 +152,7 @@
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
       "federal-benefits": {
         "title": "Federal benefits",
-        "legend": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
+        "legend": "Does {{childName}} have other dental benefits through a federal social program aside from the Canadian Dental Care Plan?",
         "option-yes": "<strong>Yes</strong>, this child has <strong>federal</strong> benefits",
         "option-no": "<strong>No</strong>, this child does not have <strong>federal</strong> benefits",
         "social-programs": {

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -152,7 +152,7 @@
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
       "federal-benefits": {
         "title": "Federal benefits",
-        "legend": "Does {{childName}} have other dental benefits through a federal social program aside from the Canadian Dental Care Plan?",
+        "legend": "Does {{childName}} have other dental benefits through a federal, provincial or territorial social program aside from the Canadian Dental Care Plan?",
         "option-yes": "<strong>Yes</strong>, this child has <strong>federal</strong> benefits",
         "option-no": "<strong>No</strong>, this child does not have <strong>federal</strong> benefits",
         "social-programs": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -282,7 +282,7 @@
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "federal-benefits": {
         "title": "Prestations fédérales",
-        "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral autre que le Régime canadien de soins dentaires?",
+        "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
         "option-yes": "<strong>Oui</strong>, les prestations fédérales de cet enfant ont changé",
         "option-no": "<strong>Non</strong>, les prestations fédérales de cet enfant n'ont pas changé",
         "social-programs": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -282,7 +282,7 @@
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "federal-benefits": {
         "title": "Prestations fédérales",
-        "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
+        "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral autre que le Régime canadien de soins dentaires?",
         "option-yes": "<strong>Oui</strong>, les prestations fédérales de cet enfant ont changé",
         "option-no": "<strong>Non</strong>, les prestations fédérales de cet enfant n'ont pas changé",
         "social-programs": {

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -392,7 +392,7 @@
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
-      "has-benefits-changed": "Est-ce que {{childName}} bénéficie de prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
+      "has-benefits-changed": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
       "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales, provincial ou territorial",
       "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales, provincial ou territorial",
       "button": {

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -133,7 +133,7 @@
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
-      "has-benefits-changed": "Est-ce que {{childName}} bénéficie de prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
+      "has-benefits-changed": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral, provincial ou territorial autre que le Régime canadien de soins dentaires?",
       "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales, provincial ou territorial",
       "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales, provincial ou territorial",
       "button": {


### PR DESCRIPTION
### Description
Fix child's federal, provincial, and territorial screen text on adult-child, child, and protected renewal flow.

### Related Azure Boards Work Items
AB#15186

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->