### PR TITLE
update confirm-email for ITA clients in protected renew app

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -96,7 +96,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 
-  return redirect(getPathById('protected/renew/$id/confirm-email', params));
+  return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
 }
 
 export default function ProtectedRenewProtectedConfirmAddress() {

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -1,23 +1,19 @@
-import { useState } from 'react';
-
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data, redirect, useFetcher, useLoaderData } from 'react-router';
 
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
-import { InputRadios } from '~/components/input-radios';
-import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -26,15 +22,8 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 enum FormAction {
-  Continue = 'continue',
   Cancel = 'cancel',
   Save = 'save',
-  Back = 'back',
-}
-
-enum ShouldReceiveEmailCommunicationOption {
-  Yes = 'yes',
-  No = 'no',
 }
 
 export const handle = {
@@ -54,20 +43,12 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
-    throw new Response('Not Found', { status: 404 });
-  }
-
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-email.page-title') }) };
 
-  return {
-    meta,
-    defaultState: {
-      email: state.contactInformation?.email,
-      shouldReceiveEmailCommunication: state.contactInformation?.shouldReceiveEmailCommunication,
-    },
-    editMode: state.editMode,
-  };
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-email', { userId: idToken.sub });
+
+  return { meta, defaultState: { email: state.contactInformation?.email } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -80,24 +61,13 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
-    if (!state.isHomeAddressSameAsMailingAddress) {
-      return redirect(getPathById('protected/renew/$id/confirm-home-address', params));
-    }
-    return redirect(getPathById('protected/renew/$id/confirm-address', params));
-  }
-
   const emailSchema = z
     .object({
-      shouldReceiveEmailCommunication: z.nativeEnum(ShouldReceiveEmailCommunicationOption, {
-        errorMap: () => ({ message: t('protected-renew:confirm-email.error-message.add-or-update-required') }),
-      }),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes) {
+      if (val.email ?? val.confirmEmail) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {
@@ -112,14 +82,9 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
-    })
-    .transform((val) => ({
-      ...val,
-      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes,
-    }));
+    });
 
   const parsedDataResult = emailSchema.safeParse({
-    shouldReceiveEmailCommunication: formData.get('shouldReceiveEmailCommunication') ?? '',
     email: formData.get('email') ? String(formData.get('email')) : undefined,
     confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail')) : undefined,
   });
@@ -128,18 +93,22 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveProtectedRenewState({ params, request, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+  saveProtectedRenewState({
+    params,
+    request,
+    session,
+    state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } },
+  });
 
-  if (state.editMode) {
-    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
-  }
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-email', { userId: idToken.sub });
 
-  return redirect(getPathById('protected/renew/$id/dental-insurance', params));
+  return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 
-export default function ProtectedRenewProtectedConfirmEmail() {
+export default function ProtectedRenewConfirmEmail() {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const { defaultState } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -147,104 +116,52 @@ export default function ProtectedRenewProtectedConfirmEmail() {
   const errorSummary = useErrorSummary(errors, {
     email: 'email',
     confirmEmail: 'confirm-email',
-    shouldReceiveEmailCommunication: 'input-radio-should-receive-email-communication-option-0',
   });
-
-  const [shouldReceiveEmailCommunication, setShouldReceiveEmailCommunication] = useState(defaultState.shouldReceiveEmailCommunication);
-
-  function handleShouldReceiveEmailCommunicationChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setShouldReceiveEmailCommunication(e.target.value === ShouldReceiveEmailCommunicationOption.Yes);
-  }
 
   return (
     <div className="max-w-prose">
-      <p className="mb-4 italic">{t('renew:required-label')}</p>
+      <p className="mb-4 italic">{t('renew:all-optional-label')}</p>
       <errorSummary.ErrorSummary />
       <fetcher.Form method="post" noValidate>
         <CsrfTokenInput />
         <div className="mb-6">
-          <p id="adding-email" className="mb-4">
-            {t('protected-renew:confirm-email.add-email')}
-          </p>
-          <InputRadios
-            id="should-receive-email-communication"
-            name="shouldReceiveEmailCommunication"
-            legend={t('protected-renew:confirm-email.add-or-update.legend')}
-            options={[
-              {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-yes" />,
-                value: ShouldReceiveEmailCommunicationOption.Yes,
-                defaultChecked: shouldReceiveEmailCommunication === true,
-                onChange: handleShouldReceiveEmailCommunicationChanged,
-                append: shouldReceiveEmailCommunication === true && (
-                  <div className="grid gap-6 md:grid-cols-2">
-                    <InputField
-                      id="email"
-                      name="email"
-                      type="email"
-                      inputMode="email"
-                      className="w-full"
-                      autoComplete="email"
-                      defaultValue={defaultState.email}
-                      errorMessage={errors?.email}
-                      label={t('protected-renew:confirm-email.email')}
-                      maxLength={64}
-                      aria-describedby="adding-email"
-                    />
-                    <InputField
-                      id="confirm-email"
-                      name="confirmEmail"
-                      type="email"
-                      inputMode="email"
-                      className="w-full"
-                      autoComplete="email"
-                      defaultValue={defaultState.email}
-                      errorMessage={errors?.confirmEmail}
-                      label={t('protected-renew:confirm-email.confirm-email')}
-                      maxLength={64}
-                      aria-describedby="adding-email"
-                    />
-                  </div>
-                ),
-              },
-              {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-no" />,
-                value: ShouldReceiveEmailCommunicationOption.No,
-                defaultChecked: shouldReceiveEmailCommunication === false,
-                onChange: handleShouldReceiveEmailCommunicationChanged,
-              },
-            ]}
-            errorMessage={errors?.shouldReceiveEmailCommunication}
-            required
-          />
+          <div className="grid gap-6 md:grid-cols-2">
+            <InputField
+              id="email"
+              name="email"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              autoComplete="email"
+              defaultValue={defaultState.email}
+              errorMessage={errors?.email}
+              label={t('protected-renew:confirm-email.email')}
+              maxLength={64}
+              aria-describedby="adding-email"
+            />
+            <InputField
+              id="confirm-email"
+              name="confirmEmail"
+              type="email"
+              inputMode="email"
+              className="w-full"
+              autoComplete="email"
+              defaultValue={defaultState.email}
+              errorMessage={errors?.confirmEmail}
+              label={t('protected-renew:confirm-email.confirm-email')}
+              maxLength={64}
+              aria-describedby="adding-email"
+            />
+          </div>
         </div>
-        {editMode ? (
-          <div className="flex flex-wrap items-center gap-3">
-            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
-              {t('protected-renew:confirm-email.save-btn')}
-            </Button>
-            <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Email click">
-              {t('protected-renew:confirm-email.cancel-btn')}
-            </Button>
-          </div>
-        ) : (
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton
-              id="continue-button"
-              name="_action"
-              value={FormAction.Continue}
-              variant="primary"
-              loading={isSubmitting}
-              endIcon={faChevronRight}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Email click"
-            >
-              {t('protected-renew:confirm-email.continue-btn')}
-            </LoadingButton>
-            <LoadingButton id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Email click">
-              {t('protected-renew:confirm-email.back-btn')}
-            </LoadingButton>
-          </div>
-        )}
+        <div className="flex flex-wrap items-center gap-3">
+          <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
+            {t('protected-renew:confirm-email.save-btn')}
+          </Button>
+          <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Email click">
+            {t('protected-renew:confirm-email.cancel-btn')}
+          </Button>
+        </div>
       </fetcher.Form>
     </div>
   );

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -147,7 +147,7 @@ export async function action({ context: { appContainer, session }, params, reque
   if (canProceedToReview) {
     saveProtectedRenewState({ params, request, session, state: { homeAddress } });
     if (state.clientApplication.isInvitationToApplyClient) {
-      return redirect(getPathById('protected/renew/$id/confirm-email', params));
+      return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
 
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -70,7 +70,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {
     if (state.clientApplication.isInvitationToApplyClient) {
-      return redirect(getPathById('protected/renew/$id/confirm-email', params));
+      return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
   }
 

--- a/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react';
+
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { data, redirect, useFetcher, useLoaderData } from 'react-router';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import { TYPES } from '~/.server/constants';
+import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+enum FormAction {
+  Continue = 'continue',
+  Cancel = 'cancel',
+  Save = 'save',
+  Back = 'back',
+}
+
+enum ShouldReceiveEmailCommunicationOption {
+  Yes = 'yes',
+  No = 'no',
+}
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.confirmEmail,
+  pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
+  return data ? getTitleMetaTags(data.meta.title) : [];
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const state = loadProtectedRenewState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+    throw new Response('Not Found', { status: 404 });
+  }
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-email.page-title') }) };
+
+  return {
+    meta,
+    defaultState: {
+      email: state.contactInformation?.email,
+      shouldReceiveEmailCommunication: state.contactInformation?.shouldReceiveEmailCommunication,
+    },
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadProtectedRenewState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  if (formAction === FormAction.Back) {
+    if (!state.isHomeAddressSameAsMailingAddress) {
+      return redirect(getPathById('protected/renew/$id/confirm-home-address', params));
+    }
+    return redirect(getPathById('protected/renew/$id/confirm-address', params));
+  }
+
+  const emailSchema = z
+    .object({
+      shouldReceiveEmailCommunication: z.nativeEnum(ShouldReceiveEmailCommunicationOption, {
+        errorMap: () => ({ message: t('protected-renew:confirm-email.error-message.add-or-update-required') }),
+      }),
+      email: z.string().trim().max(64).optional(),
+      confirmEmail: z.string().trim().max(64).optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes) {
+        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-required'), path: ['email'] });
+        } else if (!validator.isEmail(val.email)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-valid'), path: ['email'] });
+        }
+
+        if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.confirm-email-required'), path: ['confirmEmail'] });
+        } else if (!validator.isEmail(val.confirmEmail)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.confirm-email-valid'), path: ['confirmEmail'] });
+        } else if (val.email !== val.confirmEmail) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
+        }
+      }
+    })
+    .transform((val) => ({
+      ...val,
+      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes,
+    }));
+
+  const parsedDataResult = emailSchema.safeParse({
+    shouldReceiveEmailCommunication: formData.get('shouldReceiveEmailCommunication') ?? '',
+    email: formData.get('email') ? String(formData.get('email')) : undefined,
+    confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail')) : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveProtectedRenewState({ params, request, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  if (state.editMode) {
+    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+  }
+
+  return redirect(getPathById('protected/renew/$id/dental-insurance', params));
+}
+
+export default function ProtectedRenewProtectedConfirmEmail() {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    email: 'email',
+    confirmEmail: 'confirm-email',
+    shouldReceiveEmailCommunication: 'input-radio-should-receive-email-communication-option-0',
+  });
+
+  const [shouldReceiveEmailCommunication, setShouldReceiveEmailCommunication] = useState(defaultState.shouldReceiveEmailCommunication);
+
+  function handleShouldReceiveEmailCommunicationChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    setShouldReceiveEmailCommunication(e.target.value === ShouldReceiveEmailCommunicationOption.Yes);
+  }
+
+  return (
+    <div className="max-w-prose">
+      <p className="mb-4 italic">{t('renew:required-label')}</p>
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <div className="mb-6">
+          <p id="adding-email" className="mb-4">
+            {t('protected-renew:confirm-email.add-email')}
+          </p>
+          <InputRadios
+            id="should-receive-email-communication"
+            name="shouldReceiveEmailCommunication"
+            legend={t('protected-renew:confirm-email.add-or-update.legend')}
+            options={[
+              {
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-yes" />,
+                value: ShouldReceiveEmailCommunicationOption.Yes,
+                defaultChecked: shouldReceiveEmailCommunication === true,
+                onChange: handleShouldReceiveEmailCommunicationChanged,
+                append: shouldReceiveEmailCommunication === true && (
+                  <div className="grid gap-6 md:grid-cols-2">
+                    <InputField
+                      id="email"
+                      name="email"
+                      type="email"
+                      inputMode="email"
+                      className="w-full"
+                      autoComplete="email"
+                      defaultValue={defaultState.email}
+                      errorMessage={errors?.email}
+                      label={t('protected-renew:confirm-email.email')}
+                      maxLength={64}
+                      aria-describedby="adding-email"
+                    />
+                    <InputField
+                      id="confirm-email"
+                      name="confirmEmail"
+                      type="email"
+                      inputMode="email"
+                      className="w-full"
+                      autoComplete="email"
+                      defaultValue={defaultState.email}
+                      errorMessage={errors?.confirmEmail}
+                      label={t('protected-renew:confirm-email.confirm-email')}
+                      maxLength={64}
+                      aria-describedby="adding-email"
+                    />
+                  </div>
+                ),
+              },
+              {
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-no" />,
+                value: ShouldReceiveEmailCommunicationOption.No,
+                defaultChecked: shouldReceiveEmailCommunication === false,
+                onChange: handleShouldReceiveEmailCommunicationChanged,
+              },
+            ]}
+            errorMessage={errors?.shouldReceiveEmailCommunication}
+            required
+          />
+        </div>
+        {editMode ? (
+          <div className="flex flex-wrap items-center gap-3">
+            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
+              {t('protected-renew:confirm-email.save-btn')}
+            </Button>
+            <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Email click">
+              {t('protected-renew:confirm-email.cancel-btn')}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton
+              id="continue-button"
+              name="_action"
+              value={FormAction.Continue}
+              variant="primary"
+              loading={isSubmitting}
+              endIcon={faChevronRight}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Email click"
+            >
+              {t('protected-renew:confirm-email.continue-btn')}
+            </LoadingButton>
+            <LoadingButton id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Email click">
+              {t('protected-renew:confirm-email.back-btn')}
+            </LoadingButton>
+          </div>
+        )}
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -108,6 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     communicationPreference: communicationPreference.name,
     preferredLanguage: preferredLanguage,
     clientApplicationEmail: state.clientApplication.communicationPreferences.email,
+    isItaClient: state.clientApplication.isInvitationToApplyClient,
   };
 
   const hasPartner = renewStateHasPartner(state.maritalStatus ? state.maritalStatus : state.clientApplication.applicantInformation.maritalStatus);
@@ -333,7 +334,7 @@ export default function ProtectedRenewReviewAdultInformation() {
               <DescriptionListItem term={t('protected-renew:review-adult-information.email')}>
                 <p>{userInfo.contactInformationEmail}</p>
                 <div className="mt-4">
-                  <InlineLink id="change-email" routeId="protected/renew/$id/confirm-email" params={params}>
+                  <InlineLink id="change-email" routeId={userInfo.isItaClient ? 'protected/renew/$id/ita/confirm-email' : 'protected/renew/$id/confirm-email'} params={params}>
                     {t('protected-renew:review-adult-information.email-change')}
                   </InlineLink>
                 </div>

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -118,6 +118,11 @@ export const routes = [
             paths: { en: '/:lang/protected/renew/:id/confirm-email', fr: '/:lang/protege/renouveller/:id/confirmer-courriel' },
           },
           {
+            id: 'protected/renew/$id/ita/confirm-email',
+            file: 'routes/protected/renew/$id/ita/confirm-email.tsx',
+            paths: { en: '/:lang/protected/renew/:id/ita/confirm-email', fr: '/:lang/protege/renouveller/:id/ita/confirmer-courriel' },
+          },
+          {
             id: 'protected/renew/$id/confirm-communication-preference',
             file: 'routes/protected/renew/$id/confirm-communication-preference.tsx',
             paths: { en: '/:lang/protected/renew/:id/confirm-communication-preference', fr: '/:lang/protege/renouveller/:id/confirmer-preference-communication' },


### PR DESCRIPTION
### Description
Instead of having a lot of conditional logic inside of `confirm-email` for ITA client, I believe it's better to split it out into its own route.  This PR accomplishes that.

### Related Azure Boards Work Items
[AB#5088](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5088)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`