### PR TITLE
Add missing `/api/renew-state` route

### DIFF
--- a/frontend/app/routes/api/routes.ts
+++ b/frontend/app/routes/api/routes.ts
@@ -27,6 +27,11 @@ export const routes = [
     paths: { en: '/api/readyz', fr: '/api/readyz' },
   },
   {
+    id: 'api/renew-state',
+    file: 'routes/api/renew-state.ts',
+    paths: { en: '/api/renew-state', fr: '/api/renew-state' },
+  },
+  {
     id: 'api/session',
     file: 'routes/api/session.ts',
     paths: { en: '/api/session', fr: '/api/session' },


### PR DESCRIPTION
### Description
Extending the session timeout dialog would previously result in 404 page for `/renew` pages.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`