### PR TITLE
[gitops] Bumping uat1 to `0.0.0-a0c4c04b-008ff`

### DIFF
--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-8fbef31c-008cc
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-a0c4c04b-008ff
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
![image](https://github.com/user-attachments/assets/28bfa5a1-e7e6-450e-ab4a-e3a02eb34c8a)
