### PR TITLE
Changing incorrect response.ok check to response.status === 200 in client application repository

### DIFF
--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -54,7 +54,7 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
       body: JSON.stringify(clientApplicationBasicInfoRequestEntity),
     });
 
-    if (response.ok) {
+    if (response.status === 200) {
       const data = await response.json();
       this.log.trace('Client application [%j]', data);
       return data;
@@ -89,7 +89,7 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
       body: JSON.stringify(clientApplicationSinRequestEntity),
     });
 
-    if (response.ok) {
+    if (response.status === 200) {
       const data = await response.json();
       this.log.trace('Client application [%j]', data);
       return data;


### PR DESCRIPTION
### Description
`response.ok` covers HTTP statuses in the 200-299 range, which means the `response.status === 204` check is never hit.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`