### PR TITLE
Fixing client application entity and DTO; Updating routes and mappers to accomodate ITA clients

### DIFF
--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -1,12 +1,12 @@
 import type { ReadonlyDeep } from 'type-fest';
 
-import type { ApplicantInformationDto, ChildDto, CommunicationPreferencesDto, ContactInformationDto } from '~/.server/domain/dtos/benefit-application.dto';
+import type { ChildDto, CommunicationPreferencesDto } from '~/.server/domain/dtos/benefit-application.dto';
 
 export type ClientApplicationDto = ReadonlyDeep<{
   applicantInformation: ClientApplicantInformationDto;
   children: ClientChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
-  contactInformation: ContactInformationDto;
+  contactInformation: ClientContactInformationDto;
   dateOfBirth: string;
   dentalBenefits: string[];
   dentalInsurance?: boolean;
@@ -17,10 +17,14 @@ export type ClientApplicationDto = ReadonlyDeep<{
   partnerInformation?: ClientPartnerInformationDto;
 }>;
 
-export type ClientApplicantInformationDto = ApplicantInformationDto & {
+export type ClientApplicantInformationDto = Readonly<{
+  firstName: string;
+  lastName: string;
+  maritalStatus?: string; // optional because ITA clients initially have no marital status
+  socialInsuranceNumber: string;
   clientId: string;
   clientNumber?: string;
-};
+}>;
 
 export type ClientChildDto = Omit<ChildDto, 'information'> & {
   information: {
@@ -33,6 +37,26 @@ export type ClientChildDto = Omit<ChildDto, 'information'> & {
     socialInsuranceNumber: string;
   };
 };
+
+export type ClientContactInformationDto = ReadonlyDeep<{
+  copyMailingAddress: boolean;
+  // home address fields are optional because ITA clients initially have no home address
+  homeAddress?: string;
+  homeApartment?: string;
+  homeCity?: string;
+  homeCountry?: string;
+  homePostalCode?: string;
+  homeProvince?: string;
+  mailingAddress: string;
+  mailingApartment?: string;
+  mailingCity: string;
+  mailingCountry: string;
+  mailingPostalCode?: string;
+  mailingProvince?: string;
+  phoneNumber?: string;
+  phoneNumberAlt?: string;
+  email?: string;
+}>;
 
 export type ClientPartnerInformationDto = ReadonlyDeep<{
   confirm: boolean;

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -11,21 +11,21 @@ export type ClientApplicationEntity = ReadonlyDeep<{
           AddressCategoryCode: {
             ReferenceDataName: string;
           };
-          AddressCityName: string;
+          AddressCityName?: string;
           AddressCountry: {
-            CountryCode: {
-              ReferenceDataID: string;
+            CountryCode?: {
+              ReferenceDataID?: string;
             };
           };
           AddressPostalCode?: string;
           AddressProvince?: {
-            ProvinceCode: {
+            ProvinceCode?: {
               ReferenceDataID?: string;
             };
           };
           AddressSecondaryUnitText?: string;
-          AddressStreet: {
-            StreetName: string;
+          AddressStreet?: {
+            StreetName?: string;
           };
         }>;
         EmailAddress?: Array<{
@@ -45,8 +45,8 @@ export type ClientApplicationEntity = ReadonlyDeep<{
         PreferredIndicator: boolean;
       }>;
       PersonMaritalStatus: {
-        StatusCode: {
-          ReferenceDataID: string;
+        StatusCode?: {
+          ReferenceDataID?: string;
         };
       };
       PersonName: Array<{

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -54,7 +54,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
     const applicantInformation = {
       firstName: applicant.PersonName[0].PersonGivenName[0],
       lastName: applicant.PersonName[0].PersonSurName,
-      maritalStatus: applicant.PersonMaritalStatus.StatusCode.ReferenceDataID,
+      maritalStatus: applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID,
       clientId:
         applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID ??
         (() => {
@@ -109,18 +109,30 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
     const contactInformation = {
       copyMailingAddress: applicant.MailingSameAsHomeIndicator,
-      homeAddress: homeAddress.AddressStreet.StreetName,
+      homeAddress: homeAddress.AddressStreet?.StreetName,
       homeApartment: homeAddress.AddressSecondaryUnitText,
       homeCity: homeAddress.AddressCityName,
-      homeCountry: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
+      homeCountry: homeAddress.AddressCountry.CountryCode?.ReferenceDataID,
       homePostalCode: homeAddress.AddressPostalCode,
-      homeProvince: homeAddress.AddressProvince?.ProvinceCode.ReferenceDataID,
-      mailingAddress: mailingAddress.AddressStreet.StreetName,
+      homeProvince: homeAddress.AddressProvince?.ProvinceCode?.ReferenceDataID,
+      mailingAddress:
+        mailingAddress.AddressStreet?.StreetName ??
+        (() => {
+          throw new Error('Expected mailingAddress.AddressStreet.StreetName to be defined');
+        })(),
       mailingApartment: mailingAddress.AddressSecondaryUnitText,
-      mailingCity: mailingAddress.AddressCityName,
-      mailingCountry: mailingAddress.AddressCountry.CountryCode.ReferenceDataID,
+      mailingCity:
+        mailingAddress.AddressCityName ??
+        (() => {
+          throw new Error('Expected mailingAddress.AddressCityName to be defined');
+        })(),
+      mailingCountry:
+        mailingAddress.AddressCountry.CountryCode?.ReferenceDataID ??
+        (() => {
+          throw new Error('Expected mailingAddress.AddressCountry.CountryCode.ReferenceDataID to be defined');
+        })(),
       mailingPostalCode: mailingAddress.AddressPostalCode,
-      mailingProvince: mailingAddress.AddressProvince?.ProvinceCode.ReferenceDataID,
+      mailingProvince: mailingAddress.AddressProvince?.ProvinceCode?.ReferenceDataID,
       phoneNumber: applicant.PersonContactInformation[0].TelephoneNumber?.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Primary')?.TelephoneNumberCategoryCode.ReferenceDataID,
       phoneNumberAlt: applicant.PersonContactInformation[0].TelephoneNumber?.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Alternate')?.TelephoneNumberCategoryCode.ReferenceDataID,
       email: applicant.PersonContactInformation[0].EmailAddress?.at(0)?.EmailAddressID,

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -284,7 +284,8 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
   return initialState;
 }
 
-export function renewStateHasPartner(maritalStatus: string) {
+export function renewStateHasPartner(maritalStatus?: string) {
+  if (!maritalStatus) return false;
   const { MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW } = getEnv();
   return [MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW].includes(Number(maritalStatus));
 }

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -74,7 +74,11 @@ export async function loader({ context: { appContainer, session }, params, reque
     : appContainer.get(TYPES.domain.services.PreferredCommunicationMethodService).getLocalizedPreferredCommunicationMethodById(state.clientApplication.communicationPreferences.preferredMethod, locale);
   const maritalStatus = state.maritalStatus
     ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name
-    : appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.clientApplication.applicantInformation.maritalStatus, locale).name;
+    : state.clientApplication.applicantInformation.maritalStatus
+      ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.clientApplication.applicantInformation.maritalStatus, locale).name
+      : (() => {
+          throw new Error('Expected state.clientApplication.applicantInformation.maritalStatus to be defined');
+        })();
   const preferredLanguage = state.communicationPreferences?.preferredLanguage
     ? appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name
     : appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
@@ -93,7 +97,11 @@ export async function loader({ context: { appContainer, session }, params, reque
     : appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.mailingCountry, locale).name;
   const homeCountryAbbr = state.homeAddress?.country
     ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name
-    : appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.homeCountry, locale).name;
+    : state.clientApplication.contactInformation.homeCountry
+      ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.clientApplication.contactInformation.homeCountry, locale).name
+      : (() => {
+          throw new Error('Expected state.clientApplication.contactInformation.homeCountry to be defined');
+        })();
 
   const userInfo = {
     firstName: state.clientApplication.applicantInformation.firstName,
@@ -146,8 +154,16 @@ export async function loader({ context: { appContainer, session }, params, reque
         country: homeCountryAbbr,
       }
     : {
-        address: state.clientApplication.contactInformation.homeAddress,
-        city: state.clientApplication.contactInformation.homeCity,
+        address: state.clientApplication.contactInformation.homeAddress
+          ? state.clientApplication.contactInformation.homeAddress
+          : (() => {
+              throw new Error('Expected state.clientApplication.contactInformation.homeAddress to be defined');
+            })(),
+        city: state.clientApplication.contactInformation.homeCity
+          ? state.clientApplication.contactInformation.homeCity
+          : (() => {
+              throw new Error('Expected state.clientApplication.contactInformation.homeCity to be defined');
+            })(),
         province: clientApplicationMailingProvinceTerritoryStateAbbr,
         postalCode: state.clientApplication.contactInformation.homePostalCode,
         country: homeCountryAbbr,


### PR DESCRIPTION
### Description
ITA clients will have no marital status and home address initially. This PR changes
- the client application entity and DTO to make these fields optional
- depending files (routes, route helper, mappers) to accommodate the above changes, including
  - `/review-adult-information` and `/benefit-renewal-state.mapper` will throw if we attempt to default to these client application fields and they don't exist - this should never happen because at that point ITA clients should have these fields populated in state and non-ITA clients will have these fields set

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
Mocks and tests will be updated in a future PR.