### PR TITLE
Bump vitest to `v3.0.2`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,8 +89,8 @@
         "@types/source-map-support": "^0.5.10",
         "@types/validator": "^13.12.2",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^3.0.0-beta.4",
-        "@vitest/ui": "^3.0.0-beta.4",
+        "@vitest/coverage-v8": "^3.0.2",
+        "@vitest/ui": "^3.0.2",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.18.0",
         "eslint-import-resolver-typescript": "^3.7.0",
@@ -116,7 +116,7 @@
         "vite": "^6.0.7",
         "vite-plugin-static-copy": "^2.2.0",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.0-beta.4",
+        "vitest": "^3.0.2",
         "vitest-mock-extended": "^2.0.2"
       },
       "engines": {
@@ -705,9 +705,9 @@
       }
     },
     "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.1.tgz",
-      "integrity": "sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5073,14 +5073,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.0-beta.4.tgz",
-      "integrity": "sha512-vvg9etiUUBYNB6TX29za69xBkcil+tfUQh8M0h7WQVlJXM6va7AJqHCVp+UpcXLA7vqBJY1b5PTODuNFHjkCHQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.2.tgz",
+      "integrity": "sha512-U+hZYb0FtgNDb6B3E9piAHzXXIuxuBw2cd6Lvepc9sYYY4KjgiwCBmo3Sird9ZRu3ggLpLBTfw1ZRr77ipiSfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.1",
+        "@bcoe/v8-coverage": "^1.0.2",
         "debug": "^4.4.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -5090,14 +5090,14 @@
         "magicast": "^0.3.5",
         "std-env": "^3.8.0",
         "test-exclude": "^7.0.1",
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.0.0-beta.4",
-        "vitest": "3.0.0-beta.4"
+        "@vitest/browser": "3.0.2",
+        "vitest": "3.0.2"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -5106,29 +5106,29 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.0-beta.4.tgz",
-      "integrity": "sha512-wBBhMoM1z5M8exSDA8IkCjy4a83T10qwLmFHYjGiLQ3rV8OlexjGNOm28rRokcG+oYgR2+zcH3GU6sl/IKf/3g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.2.tgz",
+      "integrity": "sha512-dKSHLBcoZI+3pmP5hiZ7I5grNru2HRtEW8Z5Zp4IXog8QYcxhlox7JUPyIIFWfN53+3HW3KPLIl6nSzUGgKSuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.0-beta.4",
-        "@vitest/utils": "3.0.0-beta.4",
+        "@vitest/spy": "3.0.2",
+        "@vitest/utils": "3.0.2",
         "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.0-beta.4.tgz",
-      "integrity": "sha512-VjQu8F5N57SvSvD7xOfl6r2R78/qOtj7ySHaG9OQLTc6O6jb+AYBGsDE+N6spFf25BuIwZIcUFlk+wvXMNEHEQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.2.tgz",
+      "integrity": "sha512-Hr09FoBf0jlwwSyzIF4Xw31OntpO3XtZjkccpcBf8FeVW3tpiyKlkeUzxS/txzHqpUCNIX157NaTySxedyZLvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.0-beta.4",
+        "@vitest/spy": "3.0.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -5149,65 +5149,65 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.0-beta.4.tgz",
-      "integrity": "sha512-uwgWpsHabr96/YnrzNY+NQUgnza8rFq6wYW/yR1FrgRfQtVTS1loOPQSydRkUDk307bUzMVyyh7aVRwtLgHkDg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.2.tgz",
+      "integrity": "sha512-yBohcBw/T/p0/JRgYD+IYcjCmuHzjC3WLAKsVE4/LwiubzZkE8N49/xIQ/KGQwDRA8PaviF8IRO8JMWMngdVVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.0-beta.4.tgz",
-      "integrity": "sha512-+tTASu585TT23AeO+bOBSQ/2nin66nPqOznDCB1HQJ8+Mb3gtOw9faJwQEZ9uPRNhi/mLNau4k9Zig1p/AnntQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.2.tgz",
+      "integrity": "sha512-GHEsWoncrGxWuW8s405fVoDfSLk6RF2LCXp6XhevbtDjdDme1WV/eNmUueDfpY1IX3MJaCRelVCEXsT9cArfEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.0-beta.4",
-        "pathe": "^2.0.0"
+        "@vitest/utils": "3.0.2",
+        "pathe": "^2.0.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/pathe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
-      "integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.0-beta.4.tgz",
-      "integrity": "sha512-z8WLahOEDpRkPf6OvOYhjK6Mhl3Z4U4m536kAxUeFD5If0o1e2rdvSzD6oNPfs25rKs+UT7dla+4MSFU1JVjPA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.2.tgz",
+      "integrity": "sha512-h9s67yD4+g+JoYG0zPCo/cLTabpDqzqNdzMawmNPzDStTiwxwkyYM1v5lWE8gmGv3SVJ2DcxA2NpQJZJv9ym3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.0-beta.4",
+        "@vitest/pretty-format": "3.0.2",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.0"
+        "pathe": "^2.0.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot/node_modules/pathe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
-      "integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/spy": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.0-beta.4.tgz",
-      "integrity": "sha512-3Re3ofS3cYq0rCgyiwk51gOzAZyQQ15caJHkuqjcF7dzK7zMGKZpjwQFDaMZq0eAq+AZg+Qo39qrDI8S1dIYSg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.2.tgz",
+      "integrity": "sha512-8mI2iUn+PJFMT44e3ISA1R+K6ALVs47W6eriDTfXe6lFqlflID05MB4+rIFhmDSLBj8iBsZkzBYlgSkinxLzSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5218,44 +5218,44 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.0-beta.4.tgz",
-      "integrity": "sha512-ZZg8zzZ8Z6GIKthzBUYCagCkVQILLJKz7l/Le0ETQrw1sNYFRGpfTQ0GRtc26pUlMYVnj+qqp9wu5FKbPQbiSQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.2.tgz",
+      "integrity": "sha512-R0E4nG0OAafsCKwKnENLdjpMbxAyDqT/hdbJp71eeAR1wE+C7IFv1G158sRj5gUfJ7pM7IxtcwIqa34beYzLhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.0-beta.4",
+        "@vitest/utils": "3.0.2",
         "fflate": "^0.8.2",
         "flatted": "^3.3.2",
-        "pathe": "^2.0.0",
+        "pathe": "^2.0.1",
         "sirv": "^3.0.0",
         "tinyglobby": "^0.2.10",
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.0.0-beta.4"
+        "vitest": "3.0.2"
       }
     },
     "node_modules/@vitest/ui/node_modules/pathe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
-      "integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/utils": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.0-beta.4.tgz",
-      "integrity": "sha512-ea90t+ajEQd5+jA60nuE5SemTlogk49T2Ttiq2ct2ZJpsSj4a7QEQBPsvWaqhKtE3+eVIhT4Qp/Mml2qqIMGEg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.2.tgz",
+      "integrity": "sha512-Qu01ZYZlgHvDP02JnMBRpX43nRaZtNpIzw3C1clDXmn8eakgX6iQVGzTQ/NjkIr64WD8ioqOjkaYRVvHQI5qiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.0-beta.4",
+        "@vitest/pretty-format": "3.0.2",
         "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -13486,9 +13486,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -13524,9 +13524,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14877,31 +14877,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.0-beta.4.tgz",
-      "integrity": "sha512-lGRvQzzv4AOifGc7lhQ+s+1Bm0CtzLOZBwRIQiU6u9a968YTjxK5IGQLGJieI5OFh6V/Z+apsvCrm7CB29DkPw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.2.tgz",
+      "integrity": "sha512-5bzaHakQ0hmVVKLhfh/jXf6oETDBtgPo8tQCHYB+wftNgFJ+Hah67IsWc8ivx4vFL025Ow8UiuTf4W57z4izvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.0-beta.4",
-        "@vitest/mocker": "3.0.0-beta.4",
-        "@vitest/pretty-format": "^3.0.0-beta.4",
-        "@vitest/runner": "3.0.0-beta.4",
-        "@vitest/snapshot": "3.0.0-beta.4",
-        "@vitest/spy": "3.0.0-beta.4",
-        "@vitest/utils": "3.0.0-beta.4",
+        "@vitest/expect": "3.0.2",
+        "@vitest/mocker": "3.0.2",
+        "@vitest/pretty-format": "^3.0.2",
+        "@vitest/runner": "3.0.2",
+        "@vitest/snapshot": "3.0.2",
+        "@vitest/spy": "3.0.2",
+        "@vitest/utils": "3.0.2",
         "chai": "^5.1.2",
         "debug": "^4.4.0",
         "expect-type": "^1.1.0",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.0",
+        "pathe": "^2.0.1",
         "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinypool": "^1.0.2",
-        "tinyrainbow": "^1.2.0",
+        "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.0-beta.4",
+        "vite-node": "3.0.2",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -14916,8 +14916,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.0-beta.4",
-        "@vitest/ui": "3.0.0-beta.4",
+        "@vitest/browser": "3.0.2",
+        "@vitest/ui": "3.0.2",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -14957,23 +14957,23 @@
       }
     },
     "node_modules/vitest/node_modules/pathe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
-      "integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
+      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/vite-node": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.0-beta.4.tgz",
-      "integrity": "sha512-dzWen17ftEjmJWCsY7iMZ3lz4npzDsMYKEqkCnIiyABHiQCp9usrFnyzqNJJDIVZYZsG+UXgizOwjrV2cl2QYw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.2.tgz",
+      "integrity": "sha512-hsEQerBAHvVAbv40m3TFQe/lTEbOp7yDpyqMJqr2Tnd+W58+DEYOt+fluQgekOePcsNBmR77lpVAnIU2Xu4SvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^2.0.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.1",
         "vite": "^5.0.0 || ^6.0.0"
       },
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,8 +105,8 @@
     "@types/source-map-support": "^0.5.10",
     "@types/validator": "^13.12.2",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^3.0.0-beta.4",
-    "@vitest/ui": "^3.0.0-beta.4",
+    "@vitest/coverage-v8": "^3.0.2",
+    "@vitest/ui": "^3.0.2",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.18.0",
     "eslint-import-resolver-typescript": "^3.7.0",
@@ -132,7 +132,7 @@
     "vite": "^6.0.7",
     "vite-plugin-static-copy": "^2.2.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.0-beta.4",
+    "vitest": "^3.0.2",
     "vitest-mock-extended": "^2.0.2"
   },
   "engines": {
@@ -166,7 +166,6 @@
   "overrides": {
     "vite": {
       "rollup": "npm:@rollup/wasm-node@^4.30.1"
-    },
-    "vitest": "^3.0.0-beta.4"
+    }
   }
 }


### PR DESCRIPTION
### Description
```
 @vitest/coverage-v8  ^3.0.0-beta.4  →  ^3.0.2
 @vitest/ui           ^3.0.0-beta.4  →  ^3.0.2
 vitest               ^3.0.0-beta.4  →  ^3.0.2
```
Also removed the unneeded `override` for `vitest`.

Will close #3011 when this gets merged.

### Checklist
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`