### PR TITLE
Moving logic to set application year request date in service

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { ServerConfig } from '~/.server/configs';
 import type { ApplicationYearRequestDto, ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 import type { ApplicationYearDtoMapper } from '~/.server/domain/mappers';
@@ -90,8 +91,9 @@ describe('DefaultApplicationYearService', () => {
   describe('findRenewalApplicationYear', () => {
     it('should return the correct renewal application year if given date is within a renewal period', async () => {
       const mockAuditService = mock<AuditService>();
+      const mockServerConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE'> = { APPLICATION_YEAR_REQUEST_DATE: undefined };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
       const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
         date: '2025-01-01',
         userId: 'userId',
@@ -119,8 +121,9 @@ describe('DefaultApplicationYearService', () => {
 
     it('should return the correct renewal application year when the given date is on or after the renewal start date and no renewal end date is provided', async () => {
       const mockAuditService = mock<AuditService>();
+      const mockServerConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE'> = { APPLICATION_YEAR_REQUEST_DATE: undefined };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
       const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
         date: '2026-01-01',
         userId: 'userId',
@@ -145,8 +148,9 @@ describe('DefaultApplicationYearService', () => {
 
     it('should return null if given date is not within any renewal period', async () => {
       const mockAuditService = mock<AuditService>();
+      const mockServerConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE'> = { APPLICATION_YEAR_REQUEST_DATE: undefined };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService);
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
       const mockApplicationYearRequestDto: ApplicationYearRequestDto = {
         date: '2024-01-01',
         userId: 'userId',

--- a/frontend/app/.server/domain/repositories/application-year.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-year.repository.ts
@@ -22,7 +22,7 @@ export class DefaultApplicationYearRepository implements ApplicationYearReposito
 
   constructor(
     @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
-    @inject(TYPES.configs.ServerConfig) private readonly serverConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE' | 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY'>,
+    @inject(TYPES.configs.ServerConfig) private readonly serverConfig: Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY'>,
     @inject(TYPES.http.HttpClient) private readonly httpClient: HttpClient,
   ) {
     this.log = logFactory.createLogger('DefaultApplicationYearRepository');
@@ -32,7 +32,7 @@ export class DefaultApplicationYearRepository implements ApplicationYearReposito
     this.log.trace('Fetching all application year entities for date: [%s]', date);
 
     const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/applicant-information/dts/v1/retrieve-benefit-application-config-dates`);
-    url.searchParams.set('date', this.serverConfig.APPLICATION_YEAR_REQUEST_DATE ?? date);
+    url.searchParams.set('date', date);
 
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.retrieve-benefit-application-config-dates.gets', url, {
       proxyUrl: this.serverConfig.HTTP_PROXY_URL,


### PR DESCRIPTION
### Description
#3018 didn't take into account that the request date is used for some other business logic, not just the API call :facepalm: