### PR TITLE
Adding/updating mock for ITA client and fixing error with ITA client's home address

### DIFF
--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -5,6 +5,7 @@ import { TYPES } from '~/.server/constants';
 import type { ClientApplicationBasicInfoRequestEntity, ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
 import type { LogFactory, Logger } from '~/.server/factories';
 import type { HttpClient } from '~/.server/http';
+import clientApplicationItaJsonDataSource from '~/.server/resources/power-platform/client-application-ita.json';
 import clientApplicationJsonDataSource from '~/.server/resources/power-platform/client-application.json';
 
 /**
@@ -172,12 +173,14 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
       PreviousTaxesFiledIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.PreviousTaxesFiledIndicator,
     };
 
+    const jsonDataSource = clientApplicationFlags.InvitationToApplyIndicator ? clientApplicationItaJsonDataSource : clientApplicationJsonDataSource;
+
     const clientApplicationEntity: ClientApplicationEntity = {
-      ...clientApplicationJsonDataSource,
+      ...jsonDataSource,
       BenefitApplication: {
-        ...clientApplicationJsonDataSource.BenefitApplication,
+        ...jsonDataSource.BenefitApplication,
         Applicant: {
-          ...clientApplicationJsonDataSource.BenefitApplication.Applicant,
+          ...jsonDataSource.BenefitApplication.Applicant,
           PersonName: [
             {
               PersonGivenName: [personGivenName],
@@ -188,7 +191,7 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
             date: personBirthDate,
           },
           ApplicantDetail: {
-            ...clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail,
+            ...jsonDataSource.BenefitApplication.Applicant.ApplicantDetail,
             ...clientApplicationFlags,
           },
         },
@@ -216,17 +219,19 @@ export class MockClientApplicationRepository implements ClientApplicationReposit
       PreviousTaxesFiledIndicator: clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail.PreviousTaxesFiledIndicator,
     };
 
+    const jsonDataSource = clientApplicationFlags.InvitationToApplyIndicator ? clientApplicationItaJsonDataSource : clientApplicationJsonDataSource;
+
     const clientApplicationEntity: ClientApplicationEntity = {
-      ...clientApplicationJsonDataSource,
+      ...jsonDataSource,
       BenefitApplication: {
-        ...clientApplicationJsonDataSource.BenefitApplication,
+        ...jsonDataSource.BenefitApplication,
         Applicant: {
-          ...clientApplicationJsonDataSource.BenefitApplication.Applicant,
+          ...jsonDataSource.BenefitApplication.Applicant,
           PersonSINIdentification: {
             IdentificationID: personSINIdentification,
           },
           ApplicantDetail: {
-            ...clientApplicationJsonDataSource.BenefitApplication.Applicant.ApplicantDetail,
+            ...jsonDataSource.BenefitApplication.Applicant.ApplicantDetail,
             ...clientApplicationFlags,
           },
         },

--- a/frontend/app/.server/resources/power-platform/client-application-ita.json
+++ b/frontend/app/.server/resources/power-platform/client-application-ita.json
@@ -1,0 +1,100 @@
+{
+  "BenefitApplication": {
+    "Applicant": {
+      "PersonBirthDate": {
+        "date": "1983-07-17"
+      },
+      "PersonContactInformation": [
+        {
+          "Address": [
+            {
+              "AddressCategoryCode": {
+                "ReferenceDataName": "Mailing"
+              },
+              "AddressCityName": "Hamilton",
+              "AddressCountry": {
+                "CountryCode": {
+                  "ReferenceDataID": "0cf5389e-97ae-eb11-8236-000d3af4bfc3"
+                }
+              },
+              "AddressPostalCode": "L9B 1A2",
+              "AddressProvince": {
+                "ProvinceCode": {
+                  "ReferenceDataID": "6d861c55-36b3-eb11-8236-0022486d8d5f"
+                }
+              },
+              "AddressSecondaryUnitText": "Apt. No. 50",
+              "AddressStreet": {
+                "StreetName": "50 My Street"
+              }
+            },
+            {
+              "AddressCategoryCode": {
+                "ReferenceDataName": "Home"
+              },
+              "AddressCountry": {
+                "CountryCode": {}
+              },
+              "AddressProvince": {
+                "ProvinceCode": {}
+              },
+              "AddressStreet": {}
+            }
+          ]
+        }
+      ],
+      "PersonLanguage": [
+        {
+          "CommunicationCategoryCode": {
+            "ReferenceDataID": "1033"
+          },
+          "PreferredIndicator": true
+        }
+      ],
+      "PersonMaritalStatus": {
+        "StatusCode": {}
+      },
+      "PersonName": [
+        {
+          "PersonGivenName": ["John"],
+          "PersonSurName": "Doe"
+        }
+      ],
+      "PersonSINIdentification": {
+        "IdentificationID": "999999999"
+      },
+      "MailingSameAsHomeIndicator": false,
+      "PreferredMethodCommunicationCode": {
+        "ReferenceDataID": "775170002"
+      },
+      "ApplicantDetail": {
+        "DisabilityTaxCreditIndicator": false,
+        "InvitationToApplyIndicator": true,
+        "LivingIndependentlyIndicator": false,
+        "PreviousApplicationIndicator": false,
+        "PreviousTaxesFiledIndicator": false,
+        "PrivateDentalInsuranceIndicator": false
+      },
+      "ClientIdentification": [
+        {
+          "IdentificationID": "1e97fe42-0263-ee11-8df0-000d3a09df08",
+          "IdentificationCategoryText": "Client ID"
+        },
+        {
+          "IdentificationID": "10000000002",
+          "IdentificationCategoryText": "Client Number"
+        }
+      ]
+    },
+    "BenefitApplicationCategoryCode": {
+      "ReferenceDataID": "775170000"
+    },
+    "BenefitApplicationYear": {
+      "BenefitApplicationYearIdentification": [
+        {
+          "IdentificationID": "98f8ad43-4069-ee11-9ae7-000d3a09d1b8"
+        }
+      ]
+    }
+  }
+}

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -20,6 +20,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatAddressLine } from '~/utils/string-utils';
 
 enum FormAction {
   Cancel = 'cancel',
@@ -79,12 +80,26 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
+  const homeAddress =
+    parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes
+      ? state.mailingAddress
+        ? state.mailingAddress
+        : {
+            address: formatAddressLine({ address: state.clientApplication.contactInformation.mailingAddress, apartment: state.clientApplication.contactInformation.mailingApartment }),
+            country: state.clientApplication.contactInformation.mailingCountry,
+            province: state.clientApplication.contactInformation.mailingProvince,
+            city: state.clientApplication.contactInformation.mailingCity,
+            postalCode: state.clientApplication.contactInformation.mailingPostalCode,
+          }
+      : undefined;
+
   saveProtectedRenewState({
     params,
     request,
     session,
     state: {
       isHomeAddressSameAsMailingAddress: parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes,
+      homeAddress,
     },
   });
 


### PR DESCRIPTION
### Description
This PR adds an additional mock JSON that more resembles the response for an ITA client (ie. no home address and no marital status). The depending client application repository has been updated to use either this new ITA client JSON data source or the existing (non-ITA) client JSON data source.

This PR also fixes a subsequent issue where the mailing address was not being copied over to the home address state upon answer "Yes" to "Is your home address the same as your mailing address?" for an ITA client in the protected renewal flow, causing the Review adult information page to error.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/15577

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application locally and navigate to `/en/protected/stub-login`. Use SIN `800000002` for an ITA client. Answer "Yes" to the "Is your home address the same as your mailing address?" on `/confirm-address`. You should see the correct address appear when you continue until you reach `/review-adult-information`.  