### PR TITLE
fix behind msca 500ing, typeOfApplication, and member-selection

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -374,7 +374,7 @@ export function isPrimaryApplicantStateComplete(state: ProtectedRenewState, demo
 }
 
 export function isChildrenStateComplete(state: ProtectedRenewState, demographicSurveyEnabled: boolean) {
-  return state.children.every((child) => !!child.previouslyReviewed && child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
+  return state.children.some((child) => !!child.previouslyReviewed && child.isParentOrLegalGuardian !== undefined && child.dentalInsurance !== undefined && (demographicSurveyEnabled ? child.demographicSurvey !== undefined : true));
 }
 
 interface ValidateProtectedRenewStateForReviewArgs {

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -507,7 +507,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedPartnerInformation: partnerInformation,
       }),
       userId,
-      typeOfApplication: children.length === 0 ? 'adult' : 'adult-child',
+      typeOfApplication: applicantStateCompleted === false && children.length > 0 ? 'child' : children.length === 0 ? 'adult' : 'adult-child',
     };
   }
 


### PR DESCRIPTION
### Description
fixes:
- member-selection wasn't allowing a user to proceed if they only wanted to renew for _some_ of their children (i.e. not all)
- review screens were 500ing because of `formatSin()` which was throwing an invalid SIN exception.  For now I think we can just remove SIN formatting if the data we receive is going to be erroneous
- `typeOfApplication` now correctly maps to `child` if the primary applicant doesn't renew for themselves


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`