### PR TITLE
Fixing back navigation to address pages

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -66,7 +66,10 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {
     if (state.hasAddressChanged) {
-      return redirect(getPathById('public/renew/$id/adult-child/update-mailing-address', params));
+      if (state.isHomeAddressSameAsMailingAddress) {
+        return redirect(getPathById('public/renew/$id/adult-child/update-mailing-address', params));
+      }
+      return redirect(getPathById('public/renew/$id/adult-child/update-home-address', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
   }

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -66,7 +66,10 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {
     if (state.hasAddressChanged) {
-      return redirect(getPathById('public/renew/$id/adult/update-mailing-address', params));
+      if (state.isHomeAddressSameAsMailingAddress) {
+        return redirect(getPathById('public/renew/$id/adult/update-mailing-address', params));
+      }
+      return redirect(getPathById('public/renew/$id/adult/update-home-address', params));
     }
     return redirect(getPathById('public/renew/$id/adult/confirm-address', params));
   }

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-address.page-title') }) };
 
-  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
+  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
@@ -70,7 +70,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const parsedDataResult = confirmAddressSchema.safeParse({
     hasAddressChanged: formData.get('hasAddressChanged'),
-    isHomeAddressSameAsMailingAddress: formData.get('isHomeAddressSameAsMailingAddress') ?? '',
   });
 
   if (!parsedDataResult.success) {

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -110,7 +110,15 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {
-    saveRenewState({ params, session, state: {} });
+    saveRenewState({ params, session, state: { editMode: false } });
+
+    const state = loadRenewChildState({ params, request, session });
+    if (state.hasAddressChanged) {
+      if (state.isHomeAddressSameAsMailingAddress) {
+        return redirect(getPathById('public/renew/$id/child/update-mailing-address', params));
+      }
+      return redirect(getPathById('public/renew/$id/child/update-home-address', params));
+    }
     return redirect(getPathById('public/renew/$id/child/confirm-address', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -66,9 +66,15 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   if (formAction === FormAction.Back) {
     if (state.hasAddressChanged) {
-      return redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
+      if (state.isHomeAddressSameAsMailingAddress) {
+        return redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
+      }
+      return redirect(getPathById('public/renew/$id/ita/update-home-address', params));
     }
-    return redirect(getPathById('public/renew/$id/ita/confirm-address', params));
+    if (state.isHomeAddressSameAsMailingAddress) {
+      return redirect(getPathById('public/renew/$id/ita/confirm-address', params));
+    }
+    return redirect(getPathById('public/renew/$id/ita/update-home-address', params));
   }
 
   const parsedDataResult = dentalInsuranceSchema.safeParse({


### PR DESCRIPTION
### Description
This PR fixes the "Back" navigation to the various address pages.

(Also sneaked in a fix to remove unused `isHomeAddressSameAsMailingAddress` reference from `/child/confirm-address`)

### Related Azure Boards Work Items
Originates from https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/15446 for child flow.

### Checklist
- [x] I have tested the changes locally

### Test Instructions
- Fill out some address form(s) with different combinations
- Click "Back" on the dental insurance screens for adult, adult-child, ITA flows.
- Click "Back" on review child information screen on child flow.
- Verify that you are redirected to the correct page

### Additional Notes
The related ADO indicates that there is a 500 occurring for certain scenarios but I have been unable to reproduce locally or in testing environment.