### PR TITLE
Fixing text on `/confirm-address` to match Figma

### DIFF
--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -97,7 +97,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "help-message": "The address we have on file can be found in the letter you received from Service Canada.",
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
       "has-address-changed-required": "Select whether you would like to update your mailing address",
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -96,7 +96,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "help-message": "The address we have on file can be found in the letter you received from Service Canada.",
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
       "has-address-changed-required": "Select whether you would like to update your mailing address",
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -288,7 +288,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "help-message": "The address we have on file can be found in the letter you received from Service Canada.",
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
       "has-address-changed-required": "Select whether you would like to update your mailing address",
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -73,7 +73,7 @@
       "yes": "Yes",
       "no": "No"
     },
-    "help-message": "The address we have on file can be found in the letter you received from Service Canada.",
+    "help-message": "The address we have on file can also be found on the renewal letter you received from Service Canada.",
     "error-message": {
       "has-address-changed-required": "Select whether you would like to update your mailing address",
       "is-home-address-same-as-mailing-address-required": "Select whether or not your mailing address and home address are the same"


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/15299

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/465cb116-19e8-4288-9d37-663769ebea85)

### Checklist
- [x] I have tested the changes locally

### Test Instructions
Go to `/confirm-address` and verify the text has been changed to match the screenshot/ADO above.