### PR TITLE
AB#15297 French translation error on child FPT page

### DIFF
--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -277,14 +277,14 @@
     },
     "update-dental-benefits": {
       "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
-      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
+      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "federal-benefits": {
         "title": "Prestations fédérales",
         "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral autre que le Régime canadien de soins dentaires?",
-        "option-yes": "<strong>Oui</strong>, les prestations fédérales de cet enfant ont changé",
-        "option-no": "<strong>Non</strong>, les prestations fédérales de cet enfant n'ont pas changé",
+        "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales",
+        "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales",
         "social-programs": {
           "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
         }
@@ -292,8 +292,8 @@
       "provincial-territorial-benefits": {
         "title": "Prestations provinciales ou territoriales",
         "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social provincial ou territorial autre que le Régime canadien de soins dentaires?",
-        "option-yes": "<strong>Oui</strong, les prestations provinciales ou territoriales de cet enfant ont changé",
-        "option-no": "<strong>Non</strong, les prestations provinciales ou territoriales de cet enfant n'ont pas changé",
+        "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires provinciales ou territoriales",
+        "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires provinciales ou territoriales",
         "social-programs": {
           "input-legend": "Par l'entremise de quelle province ou de quel territoire?",
           "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -171,14 +171,14 @@
   },
   "update-dental-benefits": {
     "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
-    "access-to-dental": "L'accès à une assurance dentaire dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur votre admissibilité au Régime canadien de soins dentaires.",
+    "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
     "select-one": "Sélectionnez une option",
     "eligibility-criteria": "Si vous répondez à tous les critères d'admissibilité, votre couverture sera coordonnée entre les régimes afin qu'il n'y ait pas de lacunes ou de dédoublement dans la couverture.",
     "federal-benefits": {
       "title": "Prestations fédérales",
       "legend": "Bénéficiez-vous d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral autre que le Régime canadien de soins dentaires?",
-      "option-yes": "<strong>Oui</strong>, j'ai des prestations <strong>fédérales</strong> pour soins dentaires",
-      "option-no": "<strong>Non</strong>, je n'ai pas des prestations <strong>fédérales</strong> pour soins dentaires",
+      "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales",
+      "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales",
       "social-programs": {
         "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
       }
@@ -186,8 +186,8 @@
     "provincial-territorial-benefits": {
       "title": "Prestations provinciales ou territoriales",
       "legend": "Bénéficiez-vous d'autres prestations pour soins dentaires dans le cadre d'un programme social provincial ou territorial autre que le Régime canadien de soins dentaires?",
-      "option-yes": "<strong>Oui</strong>, j'ai des prestations <strong>provinciales ou territoriales</strong> pour soins dentaires",
-      "option-no": "<strong>Non</strong>, je n'ai pas des prestations <strong>provinciales ou territoriales</strong> pour soins dentaires",
+      "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires provinciales ou territoriales",
+      "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires provinciales ou territoriales",
       "social-programs": {
         "input-legend": "Par l'entremise de quelle province ou de quel territoire?",
         "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -148,14 +148,14 @@
     },
     "update-dental-benefits": {
       "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
-      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
+      "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",
       "federal-benefits": {
         "title": "Prestations fédérales",
         "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social fédéral autre que le Régime canadien de soins dentaires?",
-        "option-yes": "<strong>Oui</strong>, les prestations fédérales de cet enfant ont changé",
-        "option-no": "<strong>Non</strong>, les prestations fédérales de cet enfant n'ont pas changé",
+        "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires fédérales",
+        "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires fédérales",
         "social-programs": {
           "legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."
         }
@@ -163,8 +163,8 @@
       "provincial-territorial-benefits": {
         "title": "Prestations provinciales ou territoriales",
         "legend": "Est-ce que {{childName}} bénéficie d'autres prestations pour soins dentaires dans le cadre d'un programme social provincial ou territorial autre que le Régime canadien de soins dentaires?",
-        "option-yes": "<strong>Oui</strong, les prestations provinciales ou territoriales de cet enfant ont changé",
-        "option-no": "<strong>Non</strong, les prestations provinciales ou territoriales de cet enfant n'ont pas changé",
+        "option-yes": "<strong>Oui</strong>, l'enfant bénéficie de prestations dentaires provinciales ou territoriales",
+        "option-no": "<strong>Non</strong>, l'enfant ne bénéficie pas de prestations dentaires provinciales ou territoriales",
         "social-programs": {
           "input-legend": "Par l'entremise de quelle province ou de quel territoire?",
           "radio-legend": "Veuillez sélectionner le programme de protection sociale avec lequel vous êtes assuré. Si vous en avez plus d'un, veuillez sélectionner celui que vous utilisez le plus."


### PR DESCRIPTION
### Description
Update the French content on child's federal provincial territorial benefits page for child, adult-child, and protected flow. 

### Related Azure Boards Work Items
AB#15297

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->