### PR TITLE
Fixing mapping of `dentalBenefits` and `dentalInsurance` DTO fields for child flow

### DIFF
--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -449,6 +449,8 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
       }),
+      dentalBenefits: [],
+      dentalInsurance: undefined,
       partnerInformation: this.toPartnerInformation({
         existingPartnerInformation: clientApplication.partnerInformation,
         hasMaritalStatusChanged,


### PR DESCRIPTION
### Description
For the child flow, since the user is not renewing for themselves, we must set `dentalBenefits` to an empty array and `dentalInsurance` to false. Otherwise, the payload will use the data on file (i.e., what's in `clientApplication`), which is incorrect because we are not renewing for the primary applicant.

### Checklist
- [x] I have tested the changes locally

### Test Instructions
Go through the renewal child flow and check that the payload's `Applicant` object has `InsurancePlanIdentification` set to `[]` and there is no `PrivateDentalInsuranceIndicator` field