### PR TITLE
Removing unused `applicationYears` from apply state

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -35,7 +35,6 @@ describe('apply-adult-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
-      applicationYears: [],
       children: [],
     } satisfies ApplyState;
 

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -34,7 +34,6 @@ describe('apply-adult-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: true,
       lastUpdatedOn: '2000-01-01',
-      applicationYears: [],
       children: [],
     } satisfies ApplyState;
 

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -35,7 +35,6 @@ describe('apply-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
-      applicationYears: [],
       children: [],
     } satisfies ApplyState;
 

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -19,10 +19,6 @@ export type ApplyState = ReadonlyDeep<{
   editMode: boolean;
   lastUpdatedOn: string;
   allChildrenUnder18?: boolean;
-  applicationYears: {
-    applicationYearId: string;
-    taxYear: string;
-  }[];
   applicantInformation?: {
     firstName: string;
     lastName: string;
@@ -106,7 +102,6 @@ export type ApplyState = ReadonlyDeep<{
 }>;
 
 export type ApplicantInformationState = NonNullable<ApplyState['applicantInformation']>;
-export type ApplicationYearsState = ApplyState['applicationYears'];
 export type ChildrenState = ApplyState['children'];
 export type ChildState = ChildrenState[number];
 export type ChildDentalBenefitsState = NonNullable<ChildState['dentalBenefits']>;
@@ -184,8 +179,8 @@ export function loadApplyState({ params, session }: LoadStateArgs) {
 interface SaveStateArgs {
   params: Params;
   session: Session;
-  state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn' | 'applicationYears'>>;
-  remove?: keyof OmitStrict<ApplyState, 'children' | 'editMode' | 'id' | 'lastUpdatedOn' | 'applicationYears'>;
+  state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn'>>;
+  remove?: keyof OmitStrict<ApplyState, 'children' | 'editMode' | 'id' | 'lastUpdatedOn'>;
 }
 
 /**
@@ -232,7 +227,6 @@ export function clearApplyState({ params, session }: ClearStateArgs) {
 }
 
 interface StartArgs {
-  applicationYears: ApplicationYearsState;
   id: string;
   session: Session;
 }
@@ -242,7 +236,7 @@ interface StartArgs {
  * @param args - The arguments.
  * @returns The initial apply state.
  */
-export function startApplyState({ applicationYears, id, session }: StartArgs) {
+export function startApplyState({ id, session }: StartArgs) {
   const log = getLogger('apply-route-helpers.server/startApplyState');
   const parsedId = idSchema.parse(id);
 
@@ -250,7 +244,6 @@ export function startApplyState({ applicationYears, id, session }: StartArgs) {
     id: parsedId,
     editMode: false,
     lastUpdatedOn: new UTCDate().toISOString(),
-    applicationYears,
     children: [],
   };
 

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -5,11 +5,9 @@ import { useLoaderData, useNavigate, useParams } from 'react-router';
 
 import { randomUUID } from 'crypto';
 
-import { TYPES } from '~/.server/constants';
 import { startApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
-import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -31,10 +29,7 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   const locale = getLocale(request);
 
   const id = randomUUID().toString();
-  const currentDate = getCurrentDateString(locale);
-  const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
-  const applicationYears = await applicationYearService.listApplicationYears({ date: currentDate, userId: 'anonymous' });
-  const state = startApplyState({ id, session, applicationYears });
+  const state = startApplyState({ id, session });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:index.page-title') }) };
 


### PR DESCRIPTION
### Description
The result of the application year service call is not currently needed in the apply flow. This PR removes the unnecessary service call and all references to its result from the state object.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
The result of an application year service call may be needed in the future, but it would need to be mapped to a DTO specific to the apply flow.