### PR TITLE
fix(frontend): misconfigured otel metrics

### DIFF
--- a/frontend/app/.server/express-server/opentelemetry.server.ts
+++ b/frontend/app/.server/express-server/opentelemetry.server.ts
@@ -24,7 +24,7 @@ function getEnvValue(defaultValue: string, envVar?: string): string {
 }
 
 function getMetricExporter(): PushMetricExporter {
-  if (process.env.OTEL_USE_CONSOLE_EXPORTERS) {
+  if (process.env.OTEL_USE_CONSOLE_EXPORTERS === 'true') {
     log.info(`Exporting metrics to console every %s ms`, process.env.OTEL_METRICS_EXPORT_INTERVAL_MILLIS);
     return new ConsoleMetricExporter();
   }


### PR DESCRIPTION
### Description

OpenTelemetry metrics were always being exported to the console because of a bad truthy/falsy check in `app/.server/express-server/opentelemetry.server.ts`.

### Checklist

- [x] I have tested the changes locally
