### PR TITLE
3138 online renewal fix fpt-benefits navigation in adult flow

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -88,7 +88,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
-      dentalBenefits: undefined,
+      dentalBenefits: state.editMode ? state.dentalBenefits : undefined,
     },
   });
 


### PR DESCRIPTION
### Description
Fixes navigation in fpt-screens in renew adult flow.

### Related Azure Boards Work Items
[AB#5138](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5138)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`