### PR TITLE
fix phone number issues in protected renew app

### DIFF
--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -59,13 +59,13 @@
             {
               "TelephoneNumberCategoryCode": {
                 "ReferenceDataName": "Primary",
-                "ReferenceDataID": "555-555-5555"
+                "ReferenceDataID": "+15195555555"
               }
             },
             {
               "TelephoneNumberCategoryCode": {
                 "ReferenceDataName": "Alternate",
-                "ReferenceDataID": "555-555-5556"
+                "ReferenceDataID": "+15195555556"
               }
             }
           ]

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -350,7 +350,9 @@
     "save-btn": "Save",
     "error-message": {
       "phone-number-valid": "Invalid phone number",
-      "phone-number-alt-valid": "Invalid phone number"
+      "phone-number-valid-international": "Phone number does not exist. If it's an international phone number, add '+' in front",
+      "phone-number-alt-valid": "Invalid phone number",
+      "phone-number-alt-valid-international": "Phone number does not exist. If it's an international phone number, add '+' in front"
     }
   },
   "confirm-email": {

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -350,7 +350,9 @@
     "save-btn": "Sauvegarder",
     "error-message": {
       "phone-number-valid": "Numéro de téléphone invalide",
-      "phone-number-alt-valid": "Numéro de téléphone invalide"
+      "phone-number-valid-international": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant",
+      "phone-number-alt-valid": "Numéro de téléphone invalide",
+      "phone-number-alt-valid-international": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant"
     }
   },
   "confirm-email": {


### PR DESCRIPTION
### Description
fixes:
- cancel button is now a `ButtonLink` so it routes back to the review screen without submitting to the page action
- `client-application.json` updated phone numbers that conform to E.164 (the former data was erroring when it was being parsed, which made it subsequently not able to render)

### Related Azure Boards Work Items
[AB#5188](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5188)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`