### PR TITLE
remove 'no-update' from fpt section on review-screens

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -113,7 +113,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
 
   const dentalBenefit = {
-    hasChanged: state.hasFederalProvincialTerritorialBenefitsChanged,
     federalBenefit: {
       access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,
@@ -355,20 +354,18 @@ export default function RenewAdultChildReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult-child:review-adult-information.dental-benefit-title')}>
-                {!dentalBenefit.hasChanged && <p>{t('renew-adult-child:review-adult-information.no-update')}</p>}
-                {dentalBenefit.hasChanged &&
-                  (dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
-                    <>
-                      <p>{t('renew-adult-child:review-adult-information.yes')}</p>
-                      <p>{t('renew-adult-child:review-adult-information.dental-benefit-has-access')}</p>
-                      <ul className="ml-6 list-disc">
-                        {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
-                        {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
-                      </ul>
-                    </>
-                  ) : (
-                    <p>{t('renew-adult-child:review-adult-information.no')}</p>
-                  ))}
+                {dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
+                  <>
+                    <p>{t('renew-adult-child:review-adult-information.yes')}</p>
+                    <p>{t('renew-adult-child:review-adult-information.dental-benefit-has-access')}</p>
+                    <ul className="ml-6 list-disc">
+                      {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
+                      {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
+                    </ul>
+                  </>
+                ) : (
+                  <p>{t('renew-adult-child:review-adult-information.no')}</p>
+                )}
                 <div className="mt-4">
                   <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits" params={params}>
                     {t('renew-adult-child:review-adult-information.dental-benefit-change')}

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -87,7 +87,6 @@ export async function loader({ context: { appContainer, session }, params, reque
       isParent: child.information?.isParent,
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
-        hasChanged: child.hasFederalProvincialTerritorialBenefitsChanged,
         federalBenefit: {
           access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectedFederalGovernmentInsurancePlan?.name,
@@ -205,22 +204,20 @@ export default function RenewAdultChildReviewChildInformation() {
                       </p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('renew-adult-child:review-child-information.dental-benefit-title')}>
-                      {!child.dentalInsurance.hasChanged && <p>{t('renew-adult-child:review-child-information.no-update')}</p>}
-                      {child.dentalInsurance.hasChanged &&
-                        (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                          <>
-                            <p>{t('renew-adult-child:review-child-information.yes')}</p>
-                            <p>{t('renew-adult-child:review-child-information.dental-benefit-has-access')}</p>
-                            <div>
-                              <ul className="ml-6 list-disc">
-                                {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                                {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                              </ul>
-                            </div>
-                          </>
-                        ) : (
-                          <>{t('renew-adult-child:review-child-information.no')}</>
-                        ))}
+                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                        <>
+                          <p>{t('renew-adult-child:review-child-information.yes')}</p>
+                          <p>{t('renew-adult-child:review-child-information.dental-benefit-has-access')}</p>
+                          <div>
+                            <ul className="ml-6 list-disc">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        </>
+                      ) : (
+                        <>{t('renew-adult-child:review-child-information.no')}</>
+                      )}
                       <p className="mt-4">
                         <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
                           {t('renew-adult-child:review-child-information.dental-benefit-change')}

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -113,7 +113,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
 
   const dentalBenefit = {
-    hasChanged: state.hasFederalProvincialTerritorialBenefitsChanged,
     federalBenefit: {
       access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,
@@ -349,20 +348,18 @@ export default function RenewAdultReviewAdultInformation() {
                 </div>
               </DescriptionListItem>
               <DescriptionListItem term={t('renew-adult:review-adult-information.dental-benefit-title')}>
-                {!dentalBenefit.hasChanged && <p>{t('renew-adult:review-adult-information.no-update')}</p>}
-                {dentalBenefit.hasChanged &&
-                  (dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
-                    <>
-                      <p>{t('renew-adult:review-adult-information.yes')}</p>
-                      <p>{t('renew-adult:review-adult-information.dental-benefit-has-access')}</p>
-                      <ul className="ml-6 list-disc">
-                        {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
-                        {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
-                      </ul>
-                    </>
-                  ) : (
-                    <p>{t('renew-adult:review-adult-information.no')}</p>
-                  ))}
+                {dentalBenefit.federalBenefit.access || dentalBenefit.provTerrBenefit.access ? (
+                  <>
+                    <p>{t('renew-adult:review-adult-information.yes')}</p>
+                    <p>{t('renew-adult:review-adult-information.dental-benefit-has-access')}</p>
+                    <ul className="ml-6 list-disc">
+                      {dentalBenefit.federalBenefit.access && <li>{dentalBenefit.federalBenefit.benefit}</li>}
+                      {dentalBenefit.provTerrBenefit.access && <li>{dentalBenefit.provTerrBenefit.benefit}</li>}
+                    </ul>
+                  </>
+                ) : (
+                  <p>{t('renew-adult:review-adult-information.no')}</p>
+                )}
                 <div className="mt-4">
                   <InlineLink id="change-dental-benefits" routeId="public/renew/$id/adult/confirm-federal-provincial-territorial-benefits" params={params}>
                     {t('renew-adult:review-adult-information.dental-benefit-change')}

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -80,7 +80,6 @@ export async function loader({ context: { appContainer, session }, params, reque
       isParent: child.information?.isParent,
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
-        hasChanged: child.hasFederalProvincialTerritorialBenefitsChanged,
         federalBenefit: {
           access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectedFederalGovernmentInsurancePlan?.name,
@@ -200,22 +199,20 @@ export default function RenewChildReviewChildInformation() {
                       </p>
                     </DescriptionListItem>
                     <DescriptionListItem term={t('renew-child:review-child-information.dental-benefit-title')}>
-                      {!child.dentalInsurance.hasChanged && <p>{t('renew-child:review-child-information.no-update')}</p>}
-                      {child.dentalInsurance.hasChanged &&
-                        (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                          <>
-                            <p>{t('renew-child:review-child-information.yes')}</p>
-                            <p>{t('renew-child:review-child-information.dental-benefit-has-access')}</p>
-                            <div>
-                              <ul className="ml-6 list-disc">
-                                {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                                {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                              </ul>
-                            </div>
-                          </>
-                        ) : (
-                          <>{t('renew-child:review-child-information.no')}</>
-                        ))}
+                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                        <>
+                          <p>{t('renew-child:review-child-information.yes')}</p>
+                          <p>{t('renew-child:review-child-information.dental-benefit-has-access')}</p>
+                          <div>
+                            <ul className="ml-6 list-disc">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        </>
+                      ) : (
+                        <>{t('renew-child:review-child-information.no')}</>
+                      )}
                       <p className="mt-4">
                         <InlineLink id="change-dental-benefits" routeId="public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
                           {t('renew-child:review-child-information.dental-benefit-change')}


### PR DESCRIPTION
### Description
According to the ADO ticket, the only valid text is "Yes" or "No", depending on what the user selects for the FPT questions. 

### Related Azure Boards Work Items
[AB#5194](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5194)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`