### PR TITLE
build(frontend): bump node to v22.13.1

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -24,7 +24,7 @@
 
 
 # Base image used for all future stages
-ARG BASE_IMAGE=docker.io/node:22.13.0-bookworm-slim
+ARG BASE_IMAGE=docker.io/node:22.13.1-bookworm-slim
 FROM $BASE_IMAGE AS base
 ENV NODE_ENV production
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Bump node to v22.13.1 - [2025 Security Releases](https://nodejs.org/en/blog/vulnerability/january-2025-security-releases)