### PR TITLE
[gitops] Bumping uat1 to `0.0.0-9d86490e-00940`

### DIFF
--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-32989013-0091d
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-9d86490e-00940
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
![image](https://github.com/user-attachments/assets/aff340f7-c722-4d5b-aa23-215ae5dbe045)