### PR TITLE
refactor(frontend): Route Module Type Safety

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -26,7 +26,7 @@ describe('apply-adult-child-route-helpers', () => {
   });
 
   describe('validateApplyAdultChildStateForReview', () => {
-    const params: Params = {
+    const params = {
       lang: 'en',
       id: '00000000-0000-0000-0000-000000000000',
     };

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -25,7 +25,7 @@ describe('apply-adult-route-helpers', () => {
   });
 
   describe('validateApplyAdultStateForReview', () => {
-    const params: Params = {
+    const params = {
       lang: 'en',
       id: '00000000-0000-0000-0000-000000000000',
     };

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -26,7 +26,7 @@ describe('apply-child-route-helpers', () => {
   });
 
   describe('validateApplyChildStateForReview', () => {
-    const params: Params = {
+    const params = {
       lang: 'en',
       id: '00000000-0000-0000-0000-000000000000',
     };

--- a/frontend/__tests__/routes/protected/letters/index.test.tsx
+++ b/frontend/__tests__/routes/protected/letters/index.test.tsx
@@ -53,7 +53,7 @@ describe('Letters Page', () => {
       const response = await loader({
         request: new Request('http://localhost/letters?sort=desc'),
         context: mockAppLoadContext,
-        params: {},
+        params: { lang: 'en' },
       });
 
       expect(response.letters).toHaveLength(3);
@@ -99,7 +99,7 @@ describe('Letters Page', () => {
     const response = await loader({
       request: new Request('http://localhost/letters'),
       context: mockAppLoadContext,
-      params: {},
+      params: { lang: 'en' },
     });
 
     expect(response.letterTypes.includes({ id: 'DEN', nameEn: 'DENIED', nameFr: '(FR) DENIED' }));

--- a/frontend/__tests__/routes/public/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/public/application-delegate.test.tsx
@@ -24,7 +24,7 @@ describe('_public.apply.id.application-delegate', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/application-delegate'),
         context: mock<AppLoadContext>(),
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/public/communication-preference.test.tsx
@@ -53,7 +53,7 @@ describe('_public.apply.id.communication-preference', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/communication-preference'),
         context: mockAppLoadContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toMatchObject({
@@ -90,7 +90,7 @@ describe('_public.apply.id.communication-preference', () => {
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
         context: mockAppLoadContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({
@@ -119,7 +119,7 @@ describe('_public.apply.id.communication-preference', () => {
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
         context: mockAppLoadContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({
@@ -150,7 +150,7 @@ describe('_public.apply.id.communication-preference', () => {
       const response = await action({
         request: new Request('http://localhost:3000/apply/123/communication-preference', { method: 'POST', body: formData }),
         context: mockAppLoadContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/contact-information.test.tsx
+++ b/frontend/__tests__/routes/public/contact-information.test.tsx
@@ -39,7 +39,7 @@ describe('_public.apply.id.contact-information', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/apply/123/contact-information'),
         context: mockAppLoadContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toMatchObject({

--- a/frontend/__tests__/routes/public/date-of-birth.test.tsx
+++ b/frontend/__tests__/routes/public/date-of-birth.test.tsx
@@ -44,7 +44,7 @@ describe('_public.apply.id.date-of-birth', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth'),
         context: mockContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toMatchObject({
@@ -65,7 +65,7 @@ describe('_public.apply.id.date-of-birth', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/adult/date-of-birth', { method: 'POST', body: new FormData() }),
         context: mockContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/dob-eligibility.test.tsx
+++ b/frontend/__tests__/routes/public/dob-eligibility.test.tsx
@@ -24,7 +24,7 @@ describe('_public.apply.id.dob-eligibility', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/dob-eligibility'),
         context: mock<AppLoadContext>(),
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/file-taxes.test.tsx
+++ b/frontend/__tests__/routes/public/file-taxes.test.tsx
@@ -24,7 +24,7 @@ describe('_public.apply.id.file-your-taxes', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/file-your-taxes'),
         context: mock<AppLoadContext>(),
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/public/tax-filing.test.tsx
@@ -35,7 +35,7 @@ describe('_public.apply.id.tax-filing', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing'),
         context: mock<AppLoadContext>(),
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toMatchObject({
@@ -54,7 +54,7 @@ describe('_public.apply.id.tax-filing', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/adult/tax-filing', { method: 'POST', body: new FormData() }),
         context: mockContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/routes/public/type-application.test.tsx
+++ b/frontend/__tests__/routes/public/type-application.test.tsx
@@ -32,7 +32,7 @@ describe('_public.apply.id.type-of-application', () => {
       const response = await loader({
         request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application'),
         context: mock<AppLoadContext>(),
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toMatchObject({
@@ -51,7 +51,7 @@ describe('_public.apply.id.type-of-application', () => {
       const response = await action({
         request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: new FormData() }),
         context: mockContext,
-        params: {},
+        params: { id: '123', lang: 'en' },
       });
 
       expect(response).toEqual({

--- a/frontend/__tests__/utils/meta-utils.test.ts
+++ b/frontend/__tests__/utils/meta-utils.test.ts
@@ -1,45 +1,11 @@
-import type { MetaArgs } from 'react-router';
 import type { CreateMetaArgs } from 'react-router/route-module';
 
 import { describe, expect, it } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import { mergeMeta, mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 
 describe('mergeMeta', () => {
-  it('should merge parent and leaf meta correctly', () => {
-    const parentMeta = [
-      { title: 'Parent Title' }, //
-      { name: 'description', content: 'Parent Description' },
-    ];
-
-    const leafMeta = () => [{ title: 'Leaf Title' }];
-
-    const args: MetaArgs = {
-      data: undefined,
-      location: mock<MetaArgs['location']>({ pathname: '/leaf' }),
-      matches: [
-        {
-          data: undefined,
-          id: 'parent',
-          meta: parentMeta,
-          params: {},
-          pathname: '/',
-        },
-      ],
-      params: {},
-    };
-
-    const mergedMeta = mergeMeta(leafMeta)(args);
-
-    expect(mergedMeta).toEqual([
-      { title: 'Leaf Title' }, //
-      { name: 'description', content: 'Parent Description' },
-    ]);
-  });
-});
-
-describe('mergeRouteModuleMeta', () => {
   it('should merge parent and leaf meta correctly', () => {
     const parentMeta = [
       { title: 'Parent Title' }, //
@@ -66,7 +32,7 @@ describe('mergeRouteModuleMeta', () => {
       params: {},
     };
 
-    const mergedMeta = mergeRouteModuleMeta(leafMeta)(args);
+    const mergedMeta = mergeMeta(leafMeta)(args);
 
     expect(mergedMeta).toEqual([
       { title: 'Leaf Title' }, //

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -1,9 +1,8 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
 import { z } from 'zod';
 
-import type { ApplyState, ChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
+import type { ApplyState, ApplyStateParams, ChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
 import { applicantInformationStateHasPartner, getAgeCategoryFromDateString, getChildrenState, isNewChildState, loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -11,7 +10,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadApplyAdultChildStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -50,7 +49,7 @@ export function loadApplyAdultChildState({ params, request, session }: LoadApply
 }
 
 interface LoadApplyAdultSingleChildStateArgs {
-  params: Params;
+  params: ApplyStateParams & { childId: string };
   request: Request;
   session: Session;
 }
@@ -92,7 +91,7 @@ export function loadApplyAdultSingleChildState({ params, request, session }: Loa
 }
 
 interface LoadApplyAdultChildStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -117,7 +116,7 @@ export function loadApplyAdultChildStateForReview({ params, request, session }: 
 }
 
 interface ValidateApplyAdultChildStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   state: ApplyState;
 }
 
@@ -257,7 +256,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
 
 interface ValidateChildrenStateForReviewArgs {
   childrenState: ChildrenState;
-  params: Params;
+  params: ApplyStateParams;
 }
 
 function validateChildrenStateForReview({ childrenState, params }: ValidateChildrenStateForReviewArgs) {

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -1,7 +1,6 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
-import type { ApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import type { ApplyState, ApplyStateParams } from '~/.server/routes/helpers/apply-route-helpers';
 import { applicantInformationStateHasPartner, getAgeCategoryFromDateString, loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -9,7 +8,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadApplyAdultStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -48,7 +47,7 @@ export function loadApplyAdultState({ params, request, session }: LoadApplyAdult
 }
 
 interface LoadApplyAdultStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -73,7 +72,7 @@ export function loadApplyAdultStateForReview({ params, request, session }: LoadA
 }
 
 interface ValidateApplyAdultStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   state: ApplyState;
 }
 

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -1,9 +1,8 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
 import { z } from 'zod';
 
-import type { ApplyState, ChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
+import type { ApplyState, ApplyStateParams, ChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
 import { applicantInformationStateHasPartner, getAgeCategoryFromDateString, getChildrenState, isNewChildState, loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -11,7 +10,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadApplyChildStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -50,7 +49,7 @@ export function loadApplyChildState({ params, request, session }: LoadApplyChild
 }
 
 interface LoadApplyChildStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   request: Request;
   session: Session;
 }
@@ -75,7 +74,7 @@ export function loadApplyChildStateForReview({ params, request, session }: LoadA
 }
 
 interface LoadApplySingleChildStateArgs {
-  params: Params;
+  params: ApplyStateParams & { childId: string };
   request: Request;
   session: Session;
 }
@@ -117,7 +116,7 @@ export function loadApplySingleChildState({ params, request, session }: LoadAppl
 }
 
 interface ValidateStateForReviewArgs {
-  params: Params;
+  params: ApplyStateParams;
   state: ApplyState;
 }
 
@@ -191,7 +190,7 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
 
 interface ValidateChildrenStateForReviewArgs {
   childrenState: ChildrenState;
-  params: Params;
+  params: ApplyStateParams;
 }
 
 function validateChildrenStateForReview({ childrenState, params }: ValidateChildrenStateForReviewArgs) {

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -1,5 +1,4 @@
 import { redirectDocument } from 'react-router';
-import type { Params } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { differenceInMinutes } from 'date-fns';
@@ -131,8 +130,13 @@ function getSessionName(id: string) {
   return `apply-flow-${idSchema.parse(id)}`;
 }
 
+export type ApplyStateParams = {
+  id: string;
+  lang: string;
+};
+
 interface LoadStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   session: Session;
 }
 
@@ -177,7 +181,7 @@ export function loadApplyState({ params, session }: LoadStateArgs) {
 }
 
 interface SaveStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   session: Session;
   state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn'>>;
   remove?: keyof OmitStrict<ApplyState, 'children' | 'editMode' | 'id' | 'lastUpdatedOn'>;
@@ -209,7 +213,7 @@ export function saveApplyState({ params, session, state, remove = undefined }: S
 }
 
 interface ClearStateArgs {
-  params: Params;
+  params: ApplyStateParams;
   session: Session;
 }
 

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -1,5 +1,4 @@
 import { redirect, redirectDocument } from 'react-router';
-import type { Params } from 'react-router';
 
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
@@ -144,13 +143,13 @@ function getSessionName(id: string) {
   return `protected-renew-flow-${idSchema.parse(id)}`;
 }
 
-export function getProtectedRenewStateIdFromUrl(url: string | URL) {
-  const { searchParams } = new URL(url);
-  return searchParams.get('id');
-}
+export type ProtectedRenewStateParams = {
+  id: string;
+  lang: string;
+};
 
 interface LoadStateArgs {
-  params: Params;
+  params: ProtectedRenewStateParams;
   request: Request;
   session: Session;
 }
@@ -194,7 +193,7 @@ export function loadProtectedRenewState({ params, request, session }: LoadStateA
 }
 
 interface SaveStateArgs {
-  params: Params;
+  params: ProtectedRenewStateParams;
   request: Request;
   session: Session;
   state: Partial<OmitStrict<ProtectedRenewState, 'id'>>;
@@ -222,7 +221,7 @@ export function saveProtectedRenewState({ params, request, session, state }: Sav
 }
 
 interface ClearStateArgs {
-  params: Params;
+  params: ProtectedRenewStateParams;
   request: Request;
   session: Session;
 }
@@ -302,7 +301,7 @@ export function getProtectedChildrenState<TState extends Pick<ProtectedRenewStat
 }
 
 interface LoadProtectedRenewSingleChildStateArgs {
-  params: Params;
+  params: ProtectedRenewStateParams & { childId: string };
   request: Request;
   session: Session;
 }
@@ -344,7 +343,7 @@ export function loadProtectedRenewSingleChildState({ params, request, session }:
 }
 
 interface LoadProtectedRenewStateForReviewArgs {
-  params: Params;
+  params: ProtectedRenewStateParams;
   request: Request;
   session: Session;
   demographicSurveyEnabled: boolean;
@@ -378,7 +377,7 @@ export function isChildrenStateComplete(state: ProtectedRenewState, demographicS
 }
 
 interface ValidateProtectedRenewStateForReviewArgs {
-  params: Params;
+  params: ProtectedRenewStateParams;
   state: ProtectedRenewState;
   demographicSurveyEnabled: boolean;
 }

--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -1,17 +1,16 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
 import { z } from 'zod';
 
 import { getChildrenState, isNewChildState, loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
-import type { ChildState, RenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import type { ChildState, RenewState, RenewStateParams } from '~/.server/routes/helpers/renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadRenewAdultChildStateArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -50,7 +49,7 @@ export function loadRenewAdultChildState({ params, request, session }: LoadRenew
 }
 
 interface LoadRenewAdultSingleChildStateArgs {
-  params: Params;
+  params: RenewStateParams & { childId: string };
   request: Request;
   session: Session;
 }
@@ -92,7 +91,7 @@ export function loadRenewAdultSingleChildState({ params, request, session }: Loa
 }
 
 interface LoadRenewAdultChildStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -117,7 +116,7 @@ export function loadRenewAdultChildStateForReview({ params, request, session }: 
 }
 
 interface ValidateRenewAdultChildStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   state: RenewState;
 }
 
@@ -228,7 +227,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
 
 interface ValidateChildrenStateForReviewArgs {
   childrenState: ChildState[];
-  params: Params;
+  params: RenewStateParams;
 }
 
 function validateChildrenStateForReview({ childrenState, params }: ValidateChildrenStateForReviewArgs) {

--- a/frontend/app/.server/routes/helpers/renew-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-route-helpers.ts
@@ -1,7 +1,6 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
-import type { RenewState } from '~/.server/routes//helpers/renew-route-helpers';
+import type { RenewState, RenewStateParams } from '~/.server/routes//helpers/renew-route-helpers';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -9,7 +8,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadRenewAdultStateArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -48,7 +47,7 @@ export function loadRenewAdultState({ params, request, session }: LoadRenewAdult
 }
 
 interface LoadRenewAdultStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -73,7 +72,7 @@ export function loadRenewAdultStateForReview({ params, request, session }: LoadR
 }
 
 interface ValidateRenewAdultStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   state: RenewState;
 }
 

--- a/frontend/app/.server/routes/helpers/renew-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-child-route-helpers.ts
@@ -1,9 +1,8 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
 import { z } from 'zod';
 
-import type { ChildState, RenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import type { ChildState, RenewState, RenewStateParams } from '~/.server/routes/helpers/renew-route-helpers';
 import { getChildrenState, isNewChildState, loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -11,7 +10,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadRenewChildStateArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -50,7 +49,7 @@ export function loadRenewChildState({ params, request, session }: LoadRenewChild
 }
 
 interface LoadRenewChildStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -75,7 +74,7 @@ export function loadRenewChildStateForReview({ params, request, session }: LoadR
 }
 
 interface LoadRenewSingleChildStateArgs {
-  params: Params;
+  params: RenewStateParams & { childId: string };
   request: Request;
   session: Session;
 }
@@ -117,7 +116,7 @@ export function loadRenewSingleChildState({ params, request, session }: LoadRene
 }
 
 interface ValidateStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   state: RenewState;
 }
 
@@ -214,7 +213,7 @@ export function validateRenewChildStateForReview({ params, state }: ValidateStat
 
 interface ValidateChildrenStateForReviewArgs {
   childrenState: ChildState[];
-  params: Params;
+  params: RenewStateParams;
 }
 
 export function validateChildrenStateForReview({ childrenState, params }: ValidateChildrenStateForReviewArgs) {

--- a/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
@@ -1,7 +1,6 @@
 import { redirect } from 'react-router';
-import type { Params } from 'react-router';
 
-import type { RenewState } from '~/.server/routes//helpers/renew-route-helpers';
+import type { RenewState, RenewStateParams } from '~/.server/routes//helpers/renew-route-helpers';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
@@ -9,7 +8,7 @@ import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
 interface LoadRenewItaStateArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -48,7 +47,7 @@ export function loadRenewItaState({ params, request, session }: LoadRenewItaStat
 }
 
 interface LoadRenewItaStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   request: Request;
   session: Session;
 }
@@ -73,7 +72,7 @@ export function loadRenewItaStateForReview({ params, request, session }: LoadRen
 }
 
 interface ValidateRenewItaStateForReviewArgs {
-  params: Params;
+  params: RenewStateParams;
   state: RenewState;
 }
 

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -1,5 +1,4 @@
 import { redirectDocument } from 'react-router';
-import type { Params } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { differenceInMinutes } from 'date-fns';
@@ -143,13 +142,13 @@ function getSessionName(id: string) {
   return `renew-flow-${idSchema.parse(id)}`;
 }
 
-export function getRenewStateIdFromUrl(url: string | URL) {
-  const { searchParams } = new URL(url);
-  return searchParams.get('id');
-}
+export type RenewStateParams = {
+  id: string;
+  lang: string;
+};
 
 interface LoadStateArgs {
-  params: Params;
+  params: RenewStateParams;
   session: Session;
 }
 
@@ -194,7 +193,7 @@ export function loadRenewState({ params, session }: LoadStateArgs) {
 }
 
 interface SaveStateArgs {
-  params: Params;
+  params: RenewStateParams;
   session: Session;
   state: Partial<OmitStrict<RenewState, 'id'>>;
   remove?: keyof OmitStrict<RenewState, 'id'>;
@@ -222,7 +221,7 @@ export function saveRenewState({ params, session, state }: SaveStateArgs) {
 }
 
 interface ClearStateArgs {
-  params: Params;
+  params: RenewStateParams;
   session: Session;
 }
 

--- a/frontend/app/.server/routes/helpers/status-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/status-route-helpers.ts
@@ -1,5 +1,4 @@
 import { redirectDocument } from 'react-router';
-import type { Params } from 'react-router';
 
 import { z } from 'zod';
 
@@ -28,6 +27,10 @@ function getSessionName(id: string) {
   return `status-flow-${idSchema.parse(id)}`;
 }
 
+export type StatusStateParams = {
+  lang: string;
+};
+
 export function getStatusStateIdFromUrl(url: string | URL) {
   const { searchParams } = new URL(url);
   return searchParams.get('id');
@@ -35,7 +38,7 @@ export function getStatusStateIdFromUrl(url: string | URL) {
 
 interface LoadStateArgs {
   id: string | null;
-  params: Params;
+  params: StatusStateParams;
   session: Session;
 }
 
@@ -68,7 +71,7 @@ export function loadStatusState({ id, params, session }: LoadStateArgs) {
 
 interface SaveStateArgs {
   id: string;
-  params: Params;
+  params: StatusStateParams;
   session: Session;
   state: Partial<OmitStrict<StatusState, 'id' | 'statusCheckResult'>>;
   remove?: keyof OmitStrict<StatusState, 'id' | 'statusCheckResult'>;
@@ -96,7 +99,7 @@ export function saveStatusState({ id, params, session, state }: SaveStateArgs) {
 
 interface ClearStateArgs {
   id: string;
-  params: Params;
+  params: StatusStateParams;
   session: Session;
 }
 
@@ -139,7 +142,7 @@ export function startStatusState({ id, session }: StartArgs) {
 
 interface GetStatusResultUrlArgs {
   id: string;
-  params: Params;
+  params: StatusStateParams;
 }
 
 export function getStatusResultUrl({ id, params }: GetStatusResultUrlArgs) {

--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -1,9 +1,9 @@
 /**
  * An API route that can be used to perform actions with user's apply state.
  */
-import type { ActionFunctionArgs } from 'react-router';
-
 import { z } from 'zod';
+
+import type { Route } from './+types/apply-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
@@ -12,7 +12,7 @@ import { getLogger } from '~/.server/utils/logging.utils';
 const API_APPLY_STATE_ACTIONS = ['extend'] as const;
 export type ApiApplyStateAction = (typeof API_APPLY_STATE_ACTIONS)[number];
 
-export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
 

--- a/frontend/app/routes/api/apply-state.ts
+++ b/frontend/app/routes/api/apply-state.ts
@@ -7,6 +7,7 @@ import type { Route } from './+types/apply-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import type { ApplyStateParams } from '~/.server/routes/helpers/apply-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 
 const API_APPLY_STATE_ACTIONS = ['extend'] as const;
@@ -33,7 +34,10 @@ export async function action({ context: { appContainer, session }, request }: Ro
     return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
-  const params = { id: parsedBody.data.id };
+  const params = {
+    id: parsedBody.data.id,
+    lang: 'en',
+  } as const satisfies ApplyStateParams;
 
   switch (parsedBody.data.action) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/frontend/app/routes/api/buildinfo.ts
+++ b/frontend/app/routes/api/buildinfo.ts
@@ -1,11 +1,11 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import type { Route } from './+types/buildinfo';
 
 import { TYPES } from '~/.server/constants';
 
 /**
  * An API endpoint that returns the build info.
  */
-export function loader({ context: { appContainer }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer }, params, request }: Route.LoaderArgs) {
   const buildInfo = appContainer.get(TYPES.core.BuildInfoService).getBuildInfo();
   const imageTag = `${buildInfo.buildVersion}-${buildInfo.buildRevision}-${buildInfo.buildId}`;
 

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -1,12 +1,12 @@
-import type { LoaderFunctionArgs } from 'react-router';
-
 import type { HealthCheckOptions } from '@dts-stn/health-checks';
 import { HealthCheckConfig, execute, getHttpStatusCode } from '@dts-stn/health-checks';
 import { isEmpty } from 'moderndash';
 
+import type { Route } from './+types/health';
+
 import { TYPES } from '~/.server/constants';
 
-export async function loader({ context, request }: LoaderFunctionArgs) {
+export async function loader({ context, request }: Route.LoaderArgs) {
   const { include, exclude, timeout } = Object.fromEntries(new URL(request.url).searchParams);
 
   const allHealthChecks = context.appContainer.findAll(TYPES.health.HealthCheck);
@@ -34,7 +34,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 /**
  * Returns true if the incoming request is authorized to view detailed responses.
  */
-async function isAuthorized({ context, request }: Omit<LoaderFunctionArgs, 'params'>): Promise<boolean> {
+async function isAuthorized({ context, request }: Omit<Route.LoaderArgs, 'params'>): Promise<boolean> {
   const bearerTokenResolver = context.appContainer.get(TYPES.auth.BearerTokenResolver);
   const serverConfig = context.appContainer.get(TYPES.configs.ServerConfig);
   const tokenRolesExtractor = context.appContainer.get(TYPES.auth.HealthTokenRolesExtractor);

--- a/frontend/app/routes/api/jwks.ts
+++ b/frontend/app/routes/api/jwks.ts
@@ -1,6 +1,6 @@
-import type { LoaderFunctionArgs } from 'react-router';
-
 import { subtle } from 'node:crypto';
+
+import type { Route } from './+types/jwks';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
@@ -37,7 +37,7 @@ async function getJwks(serverConfig: Pick<ServerConfig, 'AUTH_JWT_PUBLIC_KEY'>) 
  * A JSON endpoint that contains a list of the application's public keys that
  * can be used by an auth provider to verify private key JWTs.
  */
-export async function loader({ context: { appContainer } }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer } }: Route.LoaderArgs) {
   const { AUTH_JWT_PUBLIC_KEY } = appContainer.get(TYPES.configs.ServerConfig);
   const keys = await getJwks({ AUTH_JWT_PUBLIC_KEY });
   const headers = { 'Content-Type': 'application/json' };

--- a/frontend/app/routes/api/protected-renew-state.ts
+++ b/frontend/app/routes/api/protected-renew-state.ts
@@ -1,9 +1,9 @@
 /**
  * An API route that can be used to perform actions with user's protected renew state.
  */
-import type { ActionFunctionArgs } from 'react-router';
-
 import { z } from 'zod';
+
+import type { Route } from './+types/protected-renew-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -12,7 +12,7 @@ import { getLogger } from '~/.server/utils/logging.utils';
 const API_PROTECTED_RENEW_STATE_ACTIONS = ['extend'] as const;
 export type ApiProtectedRenewStateAction = (typeof API_PROTECTED_RENEW_STATE_ACTIONS)[number];
 
-export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
 

--- a/frontend/app/routes/api/protected-renew-state.ts
+++ b/frontend/app/routes/api/protected-renew-state.ts
@@ -7,6 +7,7 @@ import type { Route } from './+types/protected-renew-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import type { ProtectedRenewStateParams } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 
 const API_PROTECTED_RENEW_STATE_ACTIONS = ['extend'] as const;
@@ -33,7 +34,10 @@ export async function action({ context: { appContainer, session }, request }: Ro
     return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
-  const params = { id: parsedBody.data.id };
+  const params = {
+    id: parsedBody.data.id,
+    lang: 'en',
+  } as const satisfies ProtectedRenewStateParams;
 
   switch (parsedBody.data.action) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/frontend/app/routes/api/readyz.ts
+++ b/frontend/app/routes/api/readyz.ts
@@ -1,10 +1,10 @@
-import type { LoaderFunctionArgs } from 'react-router';
+import type { Route } from './+types/readyz';
 
 /**
  * A basic readiness endpoint to be used by kubernetes container probes
  *
  * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
  */
-export function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   return Response.json({ ready: true });
 }

--- a/frontend/app/routes/api/renew-state.ts
+++ b/frontend/app/routes/api/renew-state.ts
@@ -1,9 +1,9 @@
 /**
  * An API route that can be used to perform actions with user's renew state.
  */
-import type { ActionFunctionArgs } from 'react-router';
-
 import { z } from 'zod';
+
+import type { Route } from './+types/renew-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -12,7 +12,7 @@ import { getLogger } from '~/.server/utils/logging.utils';
 const API_RENEW_STATE_ACTIONS = ['extend'] as const;
 export type ApiRenewStateAction = (typeof API_RENEW_STATE_ACTIONS)[number];
 
-export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
 

--- a/frontend/app/routes/api/renew-state.ts
+++ b/frontend/app/routes/api/renew-state.ts
@@ -7,6 +7,7 @@ import type { Route } from './+types/renew-state';
 
 import { TYPES } from '~/.server/constants';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import type { RenewStateParams } from '~/.server/routes/helpers/renew-route-helpers';
 import { getLogger } from '~/.server/utils/logging.utils';
 
 const API_RENEW_STATE_ACTIONS = ['extend'] as const;
@@ -33,7 +34,10 @@ export async function action({ context: { appContainer, session }, request }: Ro
     return Response.json({ errors: parsedBody.error.flatten().fieldErrors }, { status: 400 });
   }
 
-  const params = { id: parsedBody.data.id };
+  const params = {
+    id: parsedBody.data.id,
+    lang: 'en',
+  } as const satisfies RenewStateParams;
 
   switch (parsedBody.data.action) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/frontend/app/routes/api/routes.ts
+++ b/frontend/app/routes/api/routes.ts
@@ -22,6 +22,11 @@ export const routes = [
     paths: { en: '/api/health', fr: '/api/health' },
   },
   {
+    id: 'api/protected-renew-state',
+    file: 'routes/api/protected-renew-state.ts',
+    paths: { en: '/api/protected-renew-state', fr: '/api/protected-renew-state' },
+  },
+  {
     id: 'api/readyz',
     file: 'routes/api/readyz.ts',
     paths: { en: '/api/readyz', fr: '/api/readyz' },

--- a/frontend/app/routes/api/session.ts
+++ b/frontend/app/routes/api/session.ts
@@ -1,10 +1,11 @@
 /**
  * An API route that can be used to perform actions with user's server-side session.
  */
-import type { ActionFunctionArgs } from 'react-router';
 import { redirectDocument } from 'react-router';
 
 import { z } from 'zod';
+
+import type { Route } from './+types/session';
 
 import { TYPES } from '~/.server/constants';
 import { getApiSessionRedirectToUrl } from '~/.server/utils/api-session.utils';
@@ -17,7 +18,7 @@ export type ApiSessionAction = (typeof API_SESSION_ACTIONS)[number];
 const API_SESSION_REDIRECT_TO_OPTIONS = ['cdcp-website', 'cdcp-website-apply', 'cdcp-website-renew', 'cdcp-website-status'] as const;
 export type ApiSessionRedirectTo = (typeof API_SESSION_REDIRECT_TO_OPTIONS)[number];
 
-export async function action({ context: { appContainer, session }, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateRequestMethod({ request, allowedMethods: ['POST'] });
 

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunctionArgs } from 'react-router';
 import { redirectDocument } from 'react-router';
+
+import type { Route } from './+types/$';
 
 import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
@@ -12,7 +13,7 @@ const defaultProviderId = 'raoidc';
 /**
  * A do-all authentication handler for the application
  */
-export async function loader({ context, params, request }: LoaderFunctionArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const log = getLogger('auth.$/loader');
   const { '*': slug } = params;
   const instrumentationService = context.appContainer.get(TYPES.observability.InstrumentationService);
@@ -42,7 +43,7 @@ export async function loader({ context, params, request }: LoaderFunctionArgs) {
 /**
  * Handler for /auth/login requests
  */
-function handleLoginRequest({ context: { appContainer }, request }: LoaderFunctionArgs) {
+function handleLoginRequest({ context: { appContainer }, request }: Route.LoaderArgs) {
   const log = getLogger('auth.$/handleLoginRequest');
   log.debug('Handling login request');
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
@@ -58,7 +59,7 @@ function handleLoginRequest({ context: { appContainer }, request }: LoaderFuncti
 /**
  * Handler for /auth/logout requests
  */
-function handleLogoutRequest({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+function handleLogoutRequest({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const log = getLogger('auth.$/handleLogoutRequest');
   log.debug('Handling RAOIDC logout request');
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
@@ -89,7 +90,7 @@ function handleLogoutRequest({ context: { appContainer, session }, request }: Lo
 /**
  * Handler for /auth/login/raoidc requests
  */
-async function handleRaoidcLoginRequest({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+async function handleRaoidcLoginRequest({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const log = getLogger('auth.$/handleRaoidcLoginRequest');
   log.debug('Handling RAOIDC login request');
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
@@ -124,7 +125,7 @@ async function handleRaoidcLoginRequest({ context: { appContainer, session }, re
 /**
  * Handler for /auth/callback/raoidc requests
  */
-async function handleRaoidcCallbackRequest({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+async function handleRaoidcCallbackRequest({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const log = getLogger('auth.$/handleRaoidcCallbackRequest');
   log.debug('Handling RAOIDC callback request');
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);

--- a/frontend/app/routes/catchall.tsx
+++ b/frontend/app/routes/catchall.tsx
@@ -7,7 +7,7 @@ import { getFixedT } from '~/.server/utils/locale.utils';
 import { BilingualNotFoundError, NotFoundError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import { pageIds } from '~/page-ids';
 import { isAppLocale } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -16,7 +16,7 @@ export const handle = {
   pageIdentifier: pageIds.public.notFound,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/language-chooser.tsx
+++ b/frontend/app/routes/language-chooser.tsx
@@ -1,5 +1,7 @@
 import type { MetaFunction } from 'react-router';
 
+import type { Route } from './+types/language-chooser';
+
 import { ButtonLink } from '~/components/buttons';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
@@ -39,7 +41,7 @@ export const meta: MetaFunction = mergeMeta((args) => {
   ];
 });
 
-export default function LanguageChooser() {
+export default function LanguageChooser({ loaderData, params }: Route.ComponentProps) {
   return (
     <main role="main" className="flex h-svh bg-splash-page bg-cover bg-center" property="mainContentOfPage">
       <div className="m-auto w-[300px] bg-white md:w-[400px] lg:w-[500px]">

--- a/frontend/app/routes/language-chooser.tsx
+++ b/frontend/app/routes/language-chooser.tsx
@@ -1,5 +1,3 @@
-import type { MetaFunction } from 'react-router';
-
 import type { Route } from './+types/language-chooser';
 
 import { ButtonLink } from '~/components/buttons';
@@ -13,7 +11,7 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // Meta tags are constructed for a bilingual page.
-export const meta: MetaFunction = mergeMeta((args) => {
+export const meta: Route.MetaFunction = mergeMeta((args) => {
   const title = 'Canadian Dental Care Plan | Régime canadien de soins dentaires - Canada.ca';
   const description =
     'The Canadian Dental Care Plan (CDCP) will help cover some of the cost of various ' +

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -1,7 +1,6 @@
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useLoaderData, useParams } from 'react-router';
-
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/data-unavailable';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -10,7 +9,7 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -21,12 +20,11 @@ export const handle = {
   pageTitleI18nKey: 'data-unavailable:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -41,10 +39,9 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   return { meta, SCCH_BASE_URI };
 }
 
-export default function DataUnavailable() {
+export default function DataUnavailable({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { SCCH_BASE_URI } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { SCCH_BASE_URI } = loaderData;
 
   const doyouqualify = <InlineLink to={t('data-unavailable:do-you-qualify.href')} className="external-link" newTabIndicator target="_blank" />;
   const howtoapply = <InlineLink to={t('data-unavailable:how-to-apply.href')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -9,7 +9,7 @@ import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -20,7 +20,7 @@ export const handle = {
   pageTitleI18nKey: 'data-unavailable:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/home.tsx
+++ b/frontend/app/routes/protected/home.tsx
@@ -12,7 +12,7 @@ import { AppLink } from '~/components/app-link';
 import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -22,7 +22,7 @@ export const handle = {
   pageTitleI18nKey: 'index:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/home.tsx
+++ b/frontend/app/routes/protected/home.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react';
 
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useParams } from 'react-router';
-
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/home';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -13,7 +12,7 @@ import { AppLink } from '~/components/app-link';
 import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,12 +22,11 @@ export const handle = {
   pageTitleI18nKey: 'index:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -41,9 +39,8 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   return { meta };
 }
 
-export default function Index() {
+export default function Index({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const params = useParams();
 
   return (
     <>

--- a/frontend/app/routes/protected/layout.tsx
+++ b/frontend/app/routes/protected/layout.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from 'react-router';
+import { Outlet, isRouteErrorResponse, useNavigate, useRouteError } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { NotFoundError, ProtectedLayout, ServerError, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
@@ -12,7 +13,7 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
@@ -27,8 +28,8 @@ export function ErrorBoundary() {
   return <ServerError error={error} />;
 }
 
-export default function Layout() {
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+export default function Layout({ loaderData, params }: Route.ComponentProps) {
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
   const navigate = useNavigate();
   const apiSession = useApiSession();
 

--- a/frontend/app/routes/protected/letters/$id.download.ts
+++ b/frontend/app/routes/protected/letters/$id.download.ts
@@ -1,15 +1,16 @@
 import { data } from 'react-router';
-import type { LoaderFunctionArgs } from 'react-router';
 
 import { Buffer } from 'node:buffer';
 import { sanitize } from 'sanitize-filename-ts';
+
+import type { Route } from './+types/$id.download';
 
 import { TYPES } from '~/.server/constants';
 import type { LetterDto } from '~/.server/domain/dtos';
 import { getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('view-letters');
   await securityHandler.validateAuthSession({ request, session });

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -18,7 +18,7 @@ import { InputSelect } from '~/components/input-select';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'letters:index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewSingleChildState, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -21,7 +22,7 @@ import { InputSelect } from '~/components/input-select';
 import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,11 +42,11 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.confirmFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -102,7 +103,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -204,10 +205,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/review-child-information', params));
 }
 
-export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefits() {
+export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState.hasFederalBenefits);

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -22,7 +22,7 @@ import { InputSelect } from '~/components/input-select';
 import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,7 +42,7 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.confirmFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewSingleChildState, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateFeatureEnabled('demographic-survey');
@@ -85,7 +86,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -164,13 +165,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedChildrenDemographicSurveyQuestions() {
+export default function ProtectedChildrenDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewSingleChildState, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -18,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -28,12 +29,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -105,10 +105,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedRenewChildrenDentalInsurance() {
+export default function ProtectedRenewChildrenDentalInsurance({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
@@ -19,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,7 +29,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/layout.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router';
 
+import type { Route } from './+types/layout';
+
 import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/protected-renew-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
@@ -11,6 +13,6 @@ export const handle = {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
@@ -13,7 +13,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.parent-or-guardian-required.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/parent-or-guardian-required';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -12,7 +13,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.parent-or-guardian-required.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -41,7 +42,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -54,10 +55,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedRenewFlowParentOrGuardianRequired() {
+export default function ProtectedRenewFlowParentOrGuardianRequired({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
@@ -18,7 +18,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewSingleChildState, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -17,7 +18,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -56,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.isParentOrLegalGuardian, childName, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -107,10 +108,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/$childId/dental-insurance', params));
 }
 
-export default function ProtectedRenewParentOrGuardian() {
+export default function ProtectedRenewParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -17,7 +17,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,7 +39,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -16,7 +17,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,11 +39,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -58,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -114,10 +115,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
 }
 
-export default function ProtectedRenewProtectedConfirmAddress() {
+export default function ProtectedRenewProtectedConfirmAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-communication-preference';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -21,7 +22,7 @@ import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -32,11 +33,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -69,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -132,10 +133,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 
-export default function ProtectedRenewConfirmCommunicationPreference() {
+export default function ProtectedRenewConfirmCommunicationPreference({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, isReadOnlyEmail } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, isReadOnlyEmail } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod);

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -22,7 +22,7 @@ import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -33,7 +33,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -17,7 +17,7 @@ import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -33,7 +33,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -16,7 +17,7 @@ import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -32,11 +33,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -51,7 +52,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: { email: state.contactInformation?.email } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -106,12 +107,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 
-export default function ProtectedRenewConfirmEmail() {
+export default function ProtectedRenewConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
+  const { defaultState } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -22,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -48,11 +49,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:update-dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -107,7 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -214,10 +215,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefits() {
+export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -23,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -49,7 +49,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:update-dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-home-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -28,7 +29,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,11 +71,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -104,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -217,11 +218,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function ProtectedRenewConfirmHomeAddress() {
+export default function ProtectedRenewConfirmHomeAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -29,7 +29,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -71,7 +71,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -30,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,7 +70,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -26,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, renewStateHasPartner, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -25,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,11 +44,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -85,7 +86,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -157,10 +158,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/confirm-address', params));
 }
 
-export default function ProtectedRenewMaritalStatus() {
+export default function ProtectedRenewMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, maritalStatuses, editMode } = loaderData;
+
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-phone';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -16,7 +17,7 @@ import { useErrorSummary } from '~/components/error-summary';
 import { InputPhoneField } from '~/components/input-phone-field';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -32,11 +33,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -58,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -101,12 +102,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 
-export default function ProtectedRenewConfirmPhone() {
+export default function ProtectedRenewConfirmPhone({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
+  const { defaultState } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -17,7 +17,7 @@ import { useErrorSummary } from '~/components/error-summary';
 import { InputPhoneField } from '~/components/input-phone-field';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -33,7 +33,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { clearProtectedRenewState, isPrimaryApplicantStateComplete, loadProtectedRenewState, validateProtectedChildrenStateForReview } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,11 +30,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -110,7 +111,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -128,11 +129,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI }));
 }
 
-export default function ProtectedRenewConfirm() {
+export default function ProtectedRenewConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const { primaryApplicantInfo, children } = useLoaderData<typeof loader>();
+  const { primaryApplicantInfo, children } = loaderData;
 
   const cdcpLink = <InlineLink to={t('protected-renew:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
 

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateFeatureEnabled('demographic-survey');
@@ -82,7 +83,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -159,13 +160,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedDemographicSurveyQuestions() {
+export default function ProtectedDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -18,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -34,11 +35,11 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.dentalInsurance,
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -55,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode, i18nOptions: { memberName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -115,10 +116,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 
-export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion() {
+export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -19,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -35,7 +35,7 @@ export const handle = {
   pageIdentifier: pageIds.protected.renew.dentalInsurance,
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/protected/renew/$id/file-taxes.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/protected/renew/$id/file-taxes.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/file-taxes';
 
 import { TYPES } from '~/.server/constants';
 import { clearProtectedRenewState, loadProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -45,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta, taxYear: applicationYear.taxYear };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -63,10 +64,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI }));
 }
 
-export default function ProtectedRenewFileYourTaxes() {
+export default function ProtectedRenewFileYourTaxes({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { taxYear } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { taxYear } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
@@ -21,7 +21,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -20,7 +21,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,11 +44,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -70,7 +71,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -137,9 +138,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/dental-insurance', params));
 }
 
-export default function ProtectedRenewProtectedConfirmEmail() {
+export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, editMode } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -22,7 +22,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,7 +40,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:member-selection.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -28,7 +28,7 @@ import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-adult-information';
 
 import { TYPES } from '~/.server/constants';
 import {
@@ -27,7 +28,7 @@ import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,11 +44,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -211,7 +212,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -250,10 +251,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   return redirect(getPathById('protected/renew/$id/review-child-information', params));
 }
-export default function ProtectedRenewReviewAdultInformation() {
-  const params = useParams();
+export default function ProtectedRenewReviewAdultInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefits, hasChildren, primaryApplicantStateCompleted } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefits, hasChildren, primaryApplicantStateCompleted } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,7 +39,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:review-submit.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -20,7 +20,7 @@ import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,7 +36,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-child-information';
 
 import { TYPES } from '~/.server/constants';
 import { clearProtectedRenewState, isPrimaryApplicantStateComplete, loadProtectedRenewState, saveProtectedRenewState, validateProtectedChildrenStateForReview } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -19,7 +20,7 @@ import { pageIds } from '~/page-ids';
 import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,11 +36,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -108,7 +109,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, children, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -148,11 +149,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/renew/$id/review-and-submit', params));
 }
 
-export default function ProtectedRenewReviewChildInformation() {
+export default function ProtectedRenewReviewChildInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
-  const params = useParams();
+
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children } = useLoaderData<typeof loader>();
+  const { children } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/protected/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/$id/tax-filing.tsx
@@ -18,7 +18,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/terms-and-conditions';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -16,7 +17,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -27,11 +28,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -46,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request, params }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -66,7 +67,7 @@ export async function action({ context: { appContainer, session }, request, para
   return redirect(getPathById('protected/renew/$id/tax-filing', params));
 }
 
-export default function RenewTermsAndConditions() {
+export default function RenewTermsAndConditions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { SCCH_BASE_URI } = useClientEnv();
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -17,7 +17,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,7 +28,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useLoaderData, useNavigate, useParams } from 'react-router';
+import { redirect, useNavigate } from 'react-router';
 
 import { randomUUID } from 'crypto';
 import invariant from 'tiny-invariant';
+
+import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { startProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
@@ -13,7 +14,7 @@ import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -24,11 +25,11 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -70,9 +71,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, locale, meta };
 }
 
-export default function ProtectedRenewIndex() {
-  const { id } = useLoaderData<typeof loader>();
-  const params = useParams();
+export default function ProtectedRenewIndex({ loaderData, params }: Route.ComponentProps) {
+  const { id } = loaderData;
+
   const navigate = useNavigate();
 
   const path = getPathById('protected/renew/$id/terms-and-conditions', { ...params, id });

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -14,7 +14,7 @@ import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,7 +25,7 @@ export const handle = {
   pageTitleI18nKey: 'protected-renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/renew/layout.tsx
+++ b/frontend/app/routes/protected/renew/layout.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, useLoaderData, useNavigate, useParams } from 'react-router';
+import { Outlet, useNavigate } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
@@ -20,17 +21,16 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
-export default function Layout() {
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+export default function Layout({ loaderData, params }: Route.ComponentProps) {
+  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
-  const params = useParams();
 
   const path = getPathById('protected/renew/index', params);
 

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/stub-login';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -13,7 +14,7 @@ import { Button } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -24,12 +25,11 @@ export const handle = {
   pageTitleI18nKey: 'stub-login:index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('stub-login');
 
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   return { meta, defaultValues };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('stub-login');
 
@@ -114,9 +114,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('protected/home', params));
 }
 
-export default function StubLogin() {
+export default function StubLogin({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultValues } = useLoaderData<typeof loader>();
+  const { defaultValues } = loaderData;
   const fetcher = useFetcher<typeof action>();
 
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -14,7 +14,7 @@ import { Button } from '~/components/buttons';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,7 +25,7 @@ export const handle = {
   pageTitleI18nKey: 'stub-login:index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/unable-to-process-request.tsx
+++ b/frontend/app/routes/protected/unable-to-process-request.tsx
@@ -8,7 +8,7 @@ import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -18,7 +18,7 @@ export const handle = {
   pageTitleI18nKey: 'unable-to-process-request:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/protected/unable-to-process-request.tsx
+++ b/frontend/app/routes/protected/unable-to-process-request.tsx
@@ -1,6 +1,6 @@
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/unable-to-process-request';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -8,7 +8,7 @@ import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -18,11 +18,11 @@ export const handle = {
   pageTitleI18nKey: 'unable-to-process-request:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -35,7 +35,7 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   return { meta };
 }
 
-export default function ProtectedUnableToProcessRequest() {
+export default function ProtectedUnableToProcessRequest({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const noWrap = <span className="whitespace-nowrap" />;

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { useEnhancedFetcher } from '~/hooks';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -64,7 +64,7 @@ export const handle = {
   pageTitleI18nKey: 'address-validation:index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -191,7 +191,7 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   );
 }
 
-export default function AddressValidationIndexRoute({ loaderData, actionData }: Route.ComponentProps) {
+export default function AddressValidationIndexRoute({ loaderData, params }: Route.ComponentProps) {
   const { countries, defaultMailingAddress, provinceTerritoryStates } = loaderData;
 
   const { t } = useTranslation(handle.i18nNamespaces);
@@ -205,7 +205,7 @@ export default function AddressValidationIndexRoute({ loaderData, actionData }: 
 
   const [addressDialogContent, setAddressDialogContent] = useState<AddressResponse | null>(null);
 
-  const errors = actionData && 'errors' in actionData ? actionData.errors : undefined;
+  const errors = fetcher.data && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
   const errorSummary = useErrorSummary(errors, {
     address: 'address',
     city: 'city',
@@ -215,8 +215,8 @@ export default function AddressValidationIndexRoute({ loaderData, actionData }: 
   });
 
   useEffect(() => {
-    setAddressDialogContent(isAddressResponse(actionData) ? actionData : null);
-  }, [actionData]);
+    setAddressDialogContent(isAddressResponse(fetcher.data) ? fetcher.data : null);
+  }, [fetcher.data]);
 
   function onDialogOpenChangeHandler(open: boolean) {
     if (!open) {

--- a/frontend/app/routes/public/address-validation/review.tsx
+++ b/frontend/app/routes/public/address-validation/review.tsx
@@ -11,7 +11,7 @@ import { Address } from '~/components/address';
 import { ButtonLink } from '~/components/buttons';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -20,7 +20,7 @@ export const handle = {
   pageTitleI18nKey: 'address-validation:review.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/address-validation/review.tsx
+++ b/frontend/app/routes/public/address-validation/review.tsx
@@ -1,4 +1,4 @@
-import { redirect, useParams } from 'react-router';
+import { redirect } from 'react-router';
 
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
@@ -55,11 +55,10 @@ export async function loader({ context: { appContainer, session }, request }: Ro
   };
 }
 
-export default function AddressValidationReviewRoute({ loaderData }: Route.ComponentProps) {
+export default function AddressValidationReviewRoute({ loaderData, params }: Route.ComponentProps) {
   const { mailingAddress } = loaderData;
 
   const { t } = useTranslation(handle.i18nNamespaces);
-  const params = useParams();
 
   return (
     <PublicLayout>

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -27,7 +27,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -26,7 +27,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, maritalStatuses, meta, defaultState: state.applicantInformation, ageCategory, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -152,10 +153,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { ageCategory, defaultState, maritalStatuses, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { ageCategory, defaultState, maritalStatuses, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/apply-children';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.apply-children.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,9 +50,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/children/index', params));
 }
 
-export default function ApplyFlowApplyChildren() {
+export default function ApplyFlowApplyChildren({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-children.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.apply-children.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
+
+import type { Route } from './+types/apply-yourself';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -15,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.apply-yourself.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
 }
 
-export default function ApplyForYourself() {
+export default function ApplyForYourself({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
@@ -16,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.apply-yourself.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.cannot-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/cannot-apply-child';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.cannot-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/review-information', params));
 }
 
-export default function ApplyForYourself() {
+export default function ApplyForYourself({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -19,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,7 +29,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -18,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -28,12 +29,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -88,10 +88,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -23,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -22,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -42,12 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -79,7 +79,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -177,10 +177,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode, childName } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode, childName } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -30,7 +30,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -47,7 +47,7 @@ export const handle = {
   pageIdentifier: pageIds.public.apply.adultChild.childInformation,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/layout.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router';
 
+import type { Route } from './+types/layout';
+
 import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/apply-adult-child-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
@@ -11,6 +13,6 @@ export const handle = {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -16,7 +16,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -15,7 +16,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/review-information', params));
 }
 
-export default function ApplyFlowParentOrGuardian() {
+export default function ApplyFlowParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight, faEdit, faPlus, faRemove } from '@fortawesome/free-solid-svg-icons';
 import { randomUUID } from 'crypto';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -24,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -76,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, children, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -110,11 +111,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
 }
 
-export default function ApplyFlowChildSummary() {
+export default function ApplyFlowChildSummary({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { children, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const hasChildren = children.length > 0;

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -25,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -26,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -1,13 +1,14 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/communication-preference';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -25,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
@@ -73,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -131,10 +132,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/dental-insurance', params));
 }
 
-export default function ApplyFlowCommunicationPreferencePage() {
+export default function ApplyFlowCommunicationPreferencePage({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -20,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -167,7 +168,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -180,11 +181,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function ApplyFlowConfirm() {
+export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const viewLettersEnabled = useFeature('view-letters-online-application');
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = useLoaderData<typeof loader>();
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -21,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
@@ -1,11 +1,12 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
+
+import type { Route } from './+types/contact-apply-child';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -17,7 +18,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,11 +29,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:contact-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -59,10 +60,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult-child:contact-apply-child.return-btn-link'));
 }
 
-export default function ApplyFlowContactApplyChild() {
+export default function ApplyFlowContactApplyChild({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
@@ -18,7 +18,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -29,7 +29,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:contact-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -31,7 +31,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:contact-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-information.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/contact-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -30,7 +31,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,11 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:contact-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -68,7 +69,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -229,11 +230,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/communication-preference', params));
 }
 
-export default function ApplyFlowPersonalInformation() {
+export default function ApplyFlowPersonalInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, maritalStatus, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, maritalStatus, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
@@ -24,7 +24,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,7 +40,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.date-of-birth.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,11 +30,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -42,7 +43,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -72,10 +73,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/federal-provincial-territorial-benefits', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:disability-tax-credit.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -1,10 +1,11 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/disability-tax-credit';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:disability-tax-credit.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -56,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -111,10 +112,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
 }
 
-export default function ApplyFlowDisabilityTaxCredit() {
+export default function ApplyFlowDisabilityTaxCredit({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/dob-eligibility';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult-child:eligibility.dob-eligibility.return-btn-link'));
 }
 
-export default function ApplyFlowDobEligibility() {
+export default function ApplyFlowDobEligibility({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dob-eligibility.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult-child:exit-application.exit-link'));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -43,11 +44,11 @@ export const handle = {
   pageIdentifier: pageIds.public.apply.adultChild.federalProvincialTerritorialBenefits,
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
@@ -72,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -162,10 +163,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -44,7 +44,7 @@ export const handle = {
   pageIdentifier: pageIds.public.apply.adultChild.federalProvincialTerritorialBenefits,
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/file-taxes.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/file-taxes';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,10 +52,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult-child:eligibility.file-your-taxes.return-btn-link'));
 }
 
-export default function ApplyFlowFileYourTaxes() {
+export default function ApplyFlowFileYourTaxes({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/living-independently';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:living-independently.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.livingIndependently };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -77,10 +78,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
 }
 
-export default function ApplyFlowLivingIndependently() {
+export default function ApplyFlowLivingIndependently({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:living-independently.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -17,7 +17,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,7 +28,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -1,11 +1,12 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -16,7 +17,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -27,11 +28,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, ageCategory };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -59,10 +60,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult-child:parent-or-guardian.return-btn-link'));
 }
 
-export default function ApplyFlowParentOrGuardian() {
+export default function ApplyFlowParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { ageCategory } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { ageCategory } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -26,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,7 +39,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/partner-information.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/partner-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -25,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,11 +39,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.partnerInformation, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -160,11 +161,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -26,7 +26,7 @@ import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-adult-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildStateForReview } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -25,7 +26,7 @@ import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,11 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -147,7 +148,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
@@ -168,10 +169,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));
 }
 
-export default function ReviewInformation() {
-  const params = useParams();
+export default function ReviewInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, siteKey, hCaptchaEnabled } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, siteKey, hCaptchaEnabled } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const { captchaRef } = useHCaptcha();

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-child-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildStateForReview } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -28,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
@@ -106,7 +107,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, children, meta, payload };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
@@ -131,11 +132,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/confirmation', params));
 }
 
-export default function ReviewInformation() {
+export default function ReviewInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
-  const params = useParams();
+
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, payload } = useLoaderData<typeof loader>();
+  const { children, payload } = loaderData;
   const hCaptchaEnabled = useFeature('hcaptcha');
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/tax-filing';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.taxFiling2023 };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -78,10 +79,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult-child/date-of-birth', params));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult-child:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -26,7 +27,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { ageCategory, defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -146,10 +147,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { ageCategory, defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { ageCategory, defaultState, editMode, maritalStatuses } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -27,7 +27,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -1,13 +1,14 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/communication-preference';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -25,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
@@ -72,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -130,10 +131,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
 }
 
-export default function ApplyFlowCommunicationPreferencePage() {
+export default function ApplyFlowCommunicationPreferencePage({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -26,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -20,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -130,7 +131,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -143,11 +144,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function ApplyFlowConfirm() {
+export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const viewLettersEnabled = useFeature('view-letters-online-application');
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -21,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/contact-information.tsx
@@ -31,7 +31,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:contact-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/date-of-birth';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -20,7 +21,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -31,11 +32,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.date-of-birth.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -45,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { dateOfBirth }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -145,11 +146,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
 }
 
-export default function ApplyFlowDateOfBirth() {
+export default function ApplyFlowDateOfBirth({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/date-of-birth.tsx
@@ -21,7 +21,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -32,7 +32,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.date-of-birth.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,11 +30,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -42,7 +43,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -73,10 +74,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/federal-provincial-territorial-benefits', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:disability-tax-credit.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -1,10 +1,11 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/disability-tax-credit';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:disability-tax-credit.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -56,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.disabilityTaxCredit, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -99,10 +100,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
 }
 
-export default function ApplyFlowDisabilityTaxCredit() {
+export default function ApplyFlowDisabilityTaxCredit({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/dob-eligibility';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult:eligibility.dob-eligibility.return-btn-link'));
 }
 
-export default function ApplyFlowDobEligibility() {
+export default function ApplyFlowDobEligibility({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dob-eligibility.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.dob-eligibility.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('exit-application.exit-link'));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -23,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -43,11 +44,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
@@ -71,7 +72,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -158,10 +159,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/review-information', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -24,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/file-taxes.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/file-taxes';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,10 +52,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-adult:eligibility.file-your-taxes.return-btn-link'));
 }
 
-export default function ApplyFlowFileYourTaxes() {
+export default function ApplyFlowFileYourTaxes({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/living-independently';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:living-independently.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -85,10 +86,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/parent-or-guardian', params));
 }
 
-export default function ApplyFlowLivingIndependently() {
+export default function ApplyFlowLivingIndependently({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:living-independently.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -17,7 +17,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,7 +28,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -26,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,7 +39,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/partner-information.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/partner-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -25,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,11 +39,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.partnerInformation, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -154,11 +155,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -29,7 +29,7 @@ import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:review-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultStateForReview } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -28,7 +29,7 @@ import { useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:review-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -152,7 +153,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
@@ -177,10 +178,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/confirmation', params));
 }
 
-export default function ReviewInformation() {
-  const params = useParams();
+export default function ReviewInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, payload, siteKey } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, payload, siteKey } = loaderData;
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/tax-filing';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.taxFiling2023 };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -78,10 +79,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/adult/date-of-birth', params));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-adult:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/application-delegate';
 
 import { TYPES } from '~/.server/constants';
 import { clearApplyState, loadApplyState } from '~/.server/routes/helpers/apply-route-helpers';
@@ -15,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'apply:application-delegate.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,9 +52,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply:application-delegate.return-btn-link'));
 }
 
-export default function ApplyFlowApplicationDelegate() {
+export default function ApplyFlowApplicationDelegate({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -16,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'apply:application-delegate.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -30,7 +30,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -49,7 +49,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -29,7 +30,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -48,11 +49,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, maritalStatuses, meta, defaultState: state.applicantInformation, dateOfBirth: state.dateOfBirth, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -228,11 +229,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, dateOfBirth, maritalStatuses, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, dateOfBirth, maritalStatuses, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -25,7 +25,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.cannot-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/cannot-apply-child';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplySingleChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,11 +25,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.cannot-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -37,7 +38,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -50,10 +51,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-child:children.cannot-apply-child.return-btn-link'));
 }
 
-export default function ApplyForYourself() {
+export default function ApplyForYourself({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -19,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,7 +29,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState, loadApplySingleChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -18,7 +19,7 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -28,12 +29,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -88,10 +88,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -23,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState, loadApplySingleChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -22,7 +23,7 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -42,12 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplySingleChildState({ params, request, session });
 
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
@@ -79,7 +79,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -177,10 +177,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/children/index', params));
 }
 
-export default function AccessToDentalInsuranceQuestion() {
+export default function AccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode, childName } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, regions, defaultState, editMode, childName } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -30,7 +30,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -47,7 +47,7 @@ export const handle = {
   pageIdentifier: pageIds.public.apply.child.childInformation,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState, loadApplySingleChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -29,7 +30,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,12 +47,11 @@ export const handle = {
   pageIdentifier: pageIds.public.apply.child.childInformation,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -221,11 +221,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/children/$childId/dental-insurance', params));
 }
 
-export default function ApplyFlowChildInformation() {
+export default function ApplyFlowChildInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode, isNew } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode, isNew } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber);

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/layout.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router';
 
+import type { Route } from './+types/layout';
+
 import { transformChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/apply-child-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
@@ -11,6 +13,6 @@ export const handle = {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplySingleChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -15,7 +16,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,10 +53,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-child:children.parent-or-guardian.return-btn-link'));
 }
 
-export default function ApplyFlowParentOrGuardian() {
+export default function ApplyFlowParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -16,7 +16,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight, faEdit, faPlus, faRemove } from '@fortawesome/free-solid-svg-icons';
 import { randomUUID } from 'crypto';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -24,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -77,7 +78,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, children, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -103,11 +104,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/applicant-information', params));
 }
 
-export default function ApplyFlowChildSummary() {
+export default function ApplyFlowChildSummary({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { children, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const hasChildren = children.length > 0;

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -25,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -26,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -1,13 +1,14 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/communication-preference';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -25,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyChildState({ params, request, session });
@@ -73,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -138,10 +139,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/review-child-information', params));
 }
 
-export default function ApplyFlowCommunicationPreferencePage() {
+export default function ApplyFlowCommunicationPreferencePage({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, editMode, isReadOnlyEmail } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod ?? '');

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -21,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -20,7 +21,7 @@ import { useFeature } from '~/root';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -153,7 +154,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -166,11 +167,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function ApplyFlowConfirm() {
+export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const viewLettersEnabled = useFeature('view-letters-online-application');
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo } = useLoaderData<typeof loader>();
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -18,7 +18,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -29,7 +29,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:contact-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -1,11 +1,12 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
+
+import type { Route } from './+types/contact-apply-child';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -17,7 +18,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,11 +29,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:contact-apply-child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -59,10 +60,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-child:contact-apply-child.return-btn-link'));
 }
 
-export default function ApplyFlowContactApplyChild() {
+export default function ApplyFlowContactApplyChild({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -31,7 +31,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:contact-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/contact-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-information.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/contact-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -30,7 +31,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,11 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:contact-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -67,7 +68,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -228,11 +229,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/communication-preference', params));
 }
 
-export default function ApplyFlowPersonalInformation() {
+export default function ApplyFlowPersonalInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, maritalStatus, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, maritalStatus, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID, MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState?.mailingCountry ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/child/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('exit-application.exit-link'));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/child/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/file-taxes';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -16,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,11 +27,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadApplyChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -39,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,10 +52,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('apply-child:eligibility.file-your-taxes.return-btn-link'));
 }
 
-export default function ApplyFlowFileYourTaxes() {
+export default function ApplyFlowFileYourTaxes({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/child/file-taxes.tsx
@@ -17,7 +17,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -27,7 +27,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:eligibility.file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -26,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -39,7 +39,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/partner-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/partner-information.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/partner-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -25,7 +26,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,11 +39,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:partner-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.partnerInformation, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -159,11 +160,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/contact-information', params));
 }
 
-export default function ApplyFlowApplicationInformation() {
+export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-adult-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildStateForReview } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -28,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildStateForReview({ params, request, session });
 
   invariant(state.contactInformation.homeCountry, `Unexpected home address country: ${state.contactInformation.homeCountry}`);
@@ -127,7 +128,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
@@ -151,10 +152,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/confirmation', params));
 }
 
-export default function ReviewInformation() {
-  const params = useParams();
+export default function ReviewInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, payload } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, preferredLanguage, homeAddressInfo, mailingAddressInfo, payload } = loaderData;
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -27,7 +27,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/tax-filing';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.taxFiling2023 };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -78,10 +79,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/child/children/index', params));
 }
 
-export default function ApplyFlowTaxFiling() {
+export default function ApplyFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'apply-child:eligibility.tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/index.tsx
+++ b/frontend/app/routes/public/apply/$id/index.tsx
@@ -1,12 +1,13 @@
-import type { LoaderFunctionArgs } from 'react-router';
 import { redirect } from 'react-router';
+
+import type { Route } from './+types/index';
 
 import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getPathById } from '~/utils/route-utils';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplyState({ params, session });
   saveApplyState({ params, session, state: {} });
-  return redirect(getPathById('public/apply/$id/type-application', params));
+  return redirect(getPathById('public/apply/$id/terms-and-conditions', params));
 }

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'apply:terms-and-conditions.page-heading',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/terms-and-conditions';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,18 +26,18 @@ export const handle = {
   pageTitleI18nKey: 'apply:terms-and-conditions.page-heading',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:terms-and-conditions.page-title') }) };
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request, params }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -47,7 +48,7 @@ export async function action({ context: { appContainer, session }, request, para
   return redirect(getPathById('public/apply/$id/type-application', params));
 }
 
-export default function ApplyIndex() {
+export default function ApplyIndex({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'apply:type-of-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/type-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'apply:type-of-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.typeOfApplication };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -98,10 +99,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/apply/$id/application-delegate', params));
 }
 
-export default function ApplyFlowTypeOfApplication() {
+export default function ApplyFlowTypeOfApplication({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from 'react';
 
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useLoaderData, useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 
 import { randomUUID } from 'crypto';
+
+import type { Route } from './+types/index';
 
 import { startApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -20,11 +21,11 @@ export const handle = {
   pageTitleI18nKey: 'apply:terms-and-conditions.page-heading',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -36,9 +37,9 @@ export async function loader({ context: { appContainer, session }, request }: Lo
   return { id: state.id, locale, meta };
 }
 
-export default function ApplyIndex() {
-  const { id } = useLoaderData<typeof loader>();
-  const params = useParams();
+export default function ApplyIndex({ loaderData, params }: Route.ComponentProps) {
+  const { id } = loaderData;
+
   const navigate = useNavigate();
 
   const path = getPathById('public/apply/$id/terms-and-conditions', { ...params, id });

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -10,7 +10,7 @@ import { startApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -21,7 +21,7 @@ export const handle = {
   pageTitleI18nKey: 'apply:terms-and-conditions.page-heading',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/apply/layout.tsx
+++ b/frontend/app/routes/public/apply/layout.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, useLoaderData, useNavigate, useParams } from 'react-router';
+import { Outlet, useNavigate } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
@@ -20,17 +21,16 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
-export default function Layout() {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+export default function Layout({ loaderData, params }: Route.ComponentProps) {
+  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
-  const params = useParams();
 
   const path = getPathById('public/apply/index', params);
 

--- a/frontend/app/routes/public/layout.tsx
+++ b/frontend/app/routes/public/layout.tsx
@@ -1,11 +1,12 @@
-import type { LoaderFunctionArgs } from 'react-router';
 import { Outlet, data, isRouteErrorResponse, useParams, useRouteError } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { BilingualNotFoundError, NotFoundError, ServerError } from '~/components/layouts/public-layout';
 import { isAppLocale } from '~/utils/locale-utils';
 
-export function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const logFactory = appContainer.get(TYPES.factories.LogFactory);
   const log = logFactory.createLogger('public/layout/loader');
 
@@ -34,6 +35,6 @@ export function ErrorBoundary() {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -22,7 +22,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.confirmFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -21,7 +22,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.confirmFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -120,10 +121,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {
+export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [federalProvincialTerritorialBenefitChangedValue, setFederalProvincialTerrirorialBenefitChangedValue] = useState(defaultState);

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('demographic-survey');
 
@@ -81,7 +82,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -155,13 +156,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildChildrenDemographicSurveyQuestions() {
+export default function RenewAdultChildChildrenDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,12 +30,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,10 +89,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits', params));
 }
 
-export default function RenewAdultChildChildrenDentalInsurance() {
+export default function RenewAdultChildChildrenDentalInsurance({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/information';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -28,7 +29,7 @@ import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,12 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -65,7 +65,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.information, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -207,11 +207,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/$childId/dental-insurance', params));
 }
 
-export default function RenewFlowChildInformation() {
+export default function RenewFlowChildInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -29,7 +29,7 @@ import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/layout.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router';
 
+import type { Route } from './+types/layout';
+
 import { transformAdultChildChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
@@ -11,6 +13,6 @@ export const handle = {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -15,7 +15,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -14,7 +15,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,10 +50,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewFlowParentOrGuardian() {
+export default function RenewFlowParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -51,7 +51,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.updateFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState, loadRenewAdultSingleChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -50,11 +51,11 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.updateFederalProvincialTerritorialBenefits,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
@@ -85,7 +86,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -209,10 +210,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits() {
+export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -25,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -96,10 +97,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/dental-insurance', params));
 }
 
-export default function RenewAdultChildConfirmAddress() {
+export default function RenewAdultChildConfirmAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -49,11 +50,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -72,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -145,10 +146,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
 }
 
-export default function RenewAdultChildConfirmEmail() {
+export default function RenewAdultChildConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -50,7 +50,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -36,7 +36,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -35,11 +36,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -52,7 +53,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -107,10 +108,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {
+export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [federalProvincialTerritorialBenefitChangedValue, setFederalProvincialTerrirorialBenefitChangedValue] = useState(defaultState);

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -93,10 +94,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirm-phone', params));
 }
 
-export default function RenewAdultChildConfirmMaritalStatus() {
+export default function RenewAdultChildConfirmMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-phone';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -69,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -123,10 +124,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirm-email', params));
 }
 
-export default function RenewAdultChildConfirmPhone() {
+export default function RenewAdultChildConfirmPhone({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, hasMaritalStatusChanged, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -18,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -17,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -158,7 +159,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -170,10 +171,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function RenewAdultChildConfirm() {
+export default function RenewAdultChildConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = useLoaderData<typeof loader>();
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = loaderData;
 
   const cdcpLink = <InlineLink to={t('renew-adult-child:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLink = <InlineLink to={t('renew-adult-child:confirm.msca-link')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,11 +42,11 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('demographic-survey');
 
@@ -79,7 +80,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -154,13 +155,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildDemographicSurveyQuestions() {
+export default function RenewAdultChildDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,7 +42,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adultChild.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -91,10 +92,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
 }
 
-export default function RenewAdultChildAccessToDentalInsuranceQuestion() {
+export default function RenewAdultChildAccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('exit-application.exit-link'));
 }
 
-export default function RenewAdultChildExitApplication() {
+export default function RenewAdultChildExitApplication({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -27,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -26,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   if (!state.hasMaritalStatusChanged) {
     return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -126,11 +127,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirm-phone', params));
 }
 
-export default function RenewAdultChildMaritalStatus() {
+export default function RenewAdultChildMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = loaderData;
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-adult-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildStateForReview } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -28,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true
@@ -148,7 +149,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -179,10 +180,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
 }
 
-export default function RenewAdultChildReviewAdultInformation() {
-  const params = useParams();
+export default function RenewAdultChildReviewAdultInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, demographicSurvey, hasChildren, payload } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, demographicSurvey, hasChildren, payload } = loaderData;
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-child-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildStateForReview } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -28,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true
@@ -104,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, children, meta, payload };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -130,11 +131,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/confirmation', params));
 }
 
-export default function RenewAdultChildReviewChildInformation() {
+export default function RenewAdultChildReviewChildInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
-  const params = useParams();
+
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, payload } = useLoaderData<typeof loader>();
+  const { children, payload } = loaderData;
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -23,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -49,11 +50,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultChildState({ params, request, session });
@@ -77,7 +78,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -188,10 +189,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 
-export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits() {
+export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -24,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -50,7 +50,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -30,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,7 +70,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-home-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -29,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -69,11 +70,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -93,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -197,11 +198,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewAdultChildUpdateAddress() {
+export default function RenewAdultChildUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -31,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -71,7 +71,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-mailing-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
@@ -30,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,11 +71,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult-child:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -94,7 +95,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -222,11 +223,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewAdultChildUpdateAddress() {
+export default function RenewAdultChildUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.mailingAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -96,10 +97,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/dental-insurance', params));
 }
 
-export default function RenewAdultConfirmAddress() {
+export default function RenewAdultConfirmAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -50,7 +50,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -49,11 +50,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -72,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -145,10 +146,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-address', params));
 }
 
-export default function RenewAdultConfirmEmail() {
+export default function RenewAdultConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -36,7 +36,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -35,11 +36,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -52,7 +53,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -107,10 +108,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
 }
 
-export default function RenewAdultConfirmFederalProvincialTerritorialBenefits() {
+export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [federalProvincialTerritorialBenefitChangedValue, setFederalProvincialTerrirorialBenefitChangedValue] = useState(defaultState);

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -93,10 +94,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-phone', params));
 }
 
-export default function RenewAdultConfirmMaritalStatus() {
+export default function RenewAdultConfirmMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-phone';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -69,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -123,10 +124,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-email', params));
 }
 
-export default function RenewAdultConfirmPhone() {
+export default function RenewAdultConfirmPhone({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, hasMaritalStatusChanged, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -18,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -17,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -119,7 +120,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -131,10 +132,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function RenewAdultConfirm() {
+export default function RenewAdultConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = loaderData;
 
   const cdcpLink = <InlineLink to={t('renew-adult:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLink = <InlineLink to={t('renew-adult:confirm.msca-link')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,7 +42,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adult.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -24,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,11 +42,11 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.adult.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('demographic-survey');
 
@@ -79,7 +80,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -154,13 +155,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
 }
 
-export default function RenewAdultDemographicSurveyQuestions() {
+export default function RenewAdultDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -91,10 +92,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-federal-provincial-territorial-benefits', params));
 }
 
-export default function RenewAdultAccessToDentalInsuranceQuestion() {
+export default function RenewAdultAccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('exit-application.exit-link'));
 }
 
-export default function RenewAdultExitApplication() {
+export default function RenewAdultExitApplication({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -26,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   if (!state.hasMaritalStatusChanged) {
     return redirect(getPathById('public/renew/$id/adult/confirm-marital-status', params));
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -126,11 +127,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/confirm-phone', params));
 }
 
-export default function RenewAdultMaritalStatus() {
+export default function RenewAdultMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = loaderData;
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -27,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -23,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -49,11 +50,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultState({ params, request, session });
@@ -77,7 +78,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -188,10 +189,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
 }
 
-export default function RenewAdultUpdateFederalProvincialTerritorialBenefits() {
+export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -24,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -50,7 +50,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-home-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -29,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -69,11 +70,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -93,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -198,11 +199,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewAdultUpdateAddress() {
+export default function RenewAdultUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -30,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,7 +70,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -31,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -71,7 +71,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-mailing-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
@@ -30,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,11 +71,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-adult:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -94,7 +95,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -222,11 +223,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewAdultUpdateAddress() {
+export default function RenewAdultUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.mailingAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import type { ApplicantInformationState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -28,7 +29,7 @@ import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.applicantInformation, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -164,11 +165,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/tax-filing', params));
 }
 
-export default function RenewApplicationInformation() {
+export default function RenewApplicationInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -29,7 +29,7 @@ import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:applicant-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.confirm-dental-benefits.title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState, loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.confirm-dental-benefits.title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -61,7 +62,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -121,10 +122,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/children/index', params));
 }
 
-export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits() {
+export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [federalProvincialTerritorialBenefitChangedValue, setFederalProvincialTerrirorialBenefitChangedValue] = useState(defaultState);

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/demographic-survey';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -25,7 +26,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,11 +42,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:demographic-survey.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('demographic-survey');
 
@@ -82,7 +83,7 @@ export async function loader({ context: { appContainer, session }, request, para
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -156,13 +157,12 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/children/index', params));
 }
 
-export default function RenewChildrenDemographicSurveyQuestions() {
+export default function RenewChildrenDemographicSurveyQuestions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = useLoaderData<typeof loader>();
+  const { indigenousStatuses, firstNations, disabilityStatuses, ethnicGroups, locationBornStatuses, genderStatuses, defaultState, editMode, memberName } = loaderData;
   const { IS_APPLICANT_FIRST_NATIONS_YES_OPTION, ANOTHER_ETHNIC_GROUP_OPTION } = useClientEnv();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const params = useParams();
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
@@ -26,7 +26,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,7 +42,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:demographic-survey.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState, loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -29,12 +30,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  if (!data) return [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,10 +89,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits', params));
 }
 
-export default function RenewChildChildrenDentalInsurance() {
+export default function RenewChildChildrenDentalInsurance({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -30,7 +30,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -29,7 +29,7 @@ import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title, data.meta.dcTermsTitle);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/layout.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router';
 
+import type { Route } from './+types/layout';
+
 import { transformChildChildrenRouteAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
 import type { RouteHandleData } from '~/utils/route-utils';
 
@@ -11,6 +13,6 @@ export const handle = {
  * Do-nothing parent route.
  * (placeholder for future code)
  */
-export default function Route() {
+export default function Route({ loaderData, params }: Route.ComponentProps) {
   return <Outlet />;
 }

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx
@@ -15,7 +15,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/parent-or-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -14,7 +15,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.parent-or-guardian.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadRenewSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,10 +50,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/children/index', params));
 }
 
-export default function RenewFlowParentOrGuardian() {
+export default function RenewFlowParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -24,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -51,7 +51,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.update-dental-benefits.title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState, loadRenewSingleChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -23,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -50,11 +51,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.update-dental-benefits.title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewSingleChildState({ params, request, session });
@@ -86,7 +87,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -210,10 +211,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/children/index', params));
 }
 
-export default function RenewChildUpdateFederalProvincialTerritorialBenefits() {
+export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, childName, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight, faEdit, faPlus, faRemove } from '@fortawesome/free-solid-svg-icons';
 import { randomUUID } from 'crypto';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -24,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -76,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { meta, children, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -106,11 +107,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/parent-intro', params));
 }
 
-export default function RenewChildIndex() {
+export default function RenewChildIndex({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { children, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const hasChildren = children.length > 0;

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -25,7 +25,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:children.index.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -40,11 +41,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -53,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -96,10 +97,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/review-child-information', params));
 }
 
-export default function RenewChildConfirmAddress() {
+export default function RenewChildConfirmAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -49,11 +50,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -72,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -145,10 +146,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/confirm-address', params));
 }
 
-export default function RenewAdultChildConfirmEmail() {
+export default function RenewAdultChildConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -50,7 +50,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -93,10 +94,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/confirm-phone', params));
 }
 
-export default function RenewChildConfirmMaritalStatus() {
+export default function RenewChildConfirmMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-phone';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -68,7 +69,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -122,10 +123,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/confirm-email', params));
 }
 
-export default function RenewChildConfirmPhone() {
+export default function RenewChildConfirmPhone({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, hasMaritalStatusChanged, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, hasMaritalStatusChanged, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -18,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -17,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -143,7 +144,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -155,10 +156,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function RenewAdultChildConfirm() {
+export default function RenewAdultChildConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo } = useLoaderData<typeof loader>();
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo } = loaderData;
 
   const cdcpLink = <InlineLink to={t('renew-child:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLink = <InlineLink to={t('renew-child:confirm.msca-link')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/renew/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/child/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('renew-child:exit-application.exit-link'));
 }
 
-export default function RenewChildExitApplication() {
+export default function RenewChildExitApplication({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/child/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -27,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -26,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   if (!state.hasMaritalStatusChanged) {
     return redirect(getPathById('public/renew/$id/child/confirm-marital-status', params));
@@ -63,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -126,11 +127,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/confirm-phone', params));
 }
 
-export default function RenewChildMaritalStatus() {
+export default function RenewChildMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = loaderData;
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
+++ b/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
@@ -1,13 +1,14 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/parent-intro';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -18,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,11 +35,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:parent-intro.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -47,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -62,7 +63,7 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/confirm-marital-status', params));
 }
 
-export default function RenewChildParentIntro() {
+export default function RenewChildParentIntro({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
+++ b/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
@@ -19,7 +19,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:parent-intro.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:review-adult-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-child-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState, validateChildrenStateForReview } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -26,7 +27,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,11 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   validateChildrenStateForReview({ childrenState: state.children, params });
 
@@ -97,7 +98,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { children, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -124,11 +125,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/child/review-adult-information', params));
 }
 
-export default function RenewChildReviewChildInformation() {
+export default function RenewChildReviewChildInformation({ loaderData, params }: Route.ComponentProps) {
   const { currentLanguage } = useCurrentLanguage();
-  const params = useParams();
+
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { children } = useLoaderData<typeof loader>();
+  const { children } = loaderData;
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -27,7 +27,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:review-child-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -30,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,7 +70,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-home-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -29,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -69,11 +70,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -93,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -199,11 +200,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewChildUpdateAddress() {
+export default function RenewChildUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { SyntheticEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-mailing-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
@@ -30,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,11 +71,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -94,7 +95,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -221,11 +222,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewChildUpdateAddress() {
+export default function RenewChildUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedMailingCountry, setSelectedMailingCountry] = useState(defaultState.mailingAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -31,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -71,7 +71,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-child:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/renew/$id/file-taxes.tsx
@@ -16,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:file-your-taxes.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -21,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -43,7 +43,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -20,7 +21,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -42,11 +43,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -55,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -110,10 +111,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
 }
 
-export default function RenewItaConfirmAddress() {
+export default function RenewItaConfirmAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -22,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -130,10 +131,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/confirm-address', params));
 }
 
-export default function RenewAdultChildConfirmEmail() {
+export default function RenewAdultChildConfirmEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
@@ -23,7 +23,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-email.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/confirm-phone';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -59,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -97,10 +98,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/confirm-email', params));
 }
 
-export default function RenewAdultChildConfirmPhone() {
+export default function RenewAdultChildConfirmPhone({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm-phone.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -18,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -1,7 +1,8 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -17,7 +18,7 @@ import { pageIds } from '~/page-ids';
 import { formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:confirm.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -128,7 +129,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -139,10 +140,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('confirm.exit-link'));
 }
 
-export default function RenewFlowConfirm() {
+export default function RenewFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance } = loaderData;
 
   const cdcpLink = <InlineLink to={t('renew-ita:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLink = <InlineLink to={t('renew-ita:confirm.msca-link')} className="external-link" newTabIndicator target="_blank" />;

--- a/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
@@ -25,7 +25,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -41,7 +41,7 @@ export const handle = {
   pageIdentifier: pageIds.public.renew.ita.demographicSurvey,
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -19,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -36,11 +37,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:dental-insurance.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -49,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -94,10 +95,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/federal-provincial-territorial-benefits', params));
 }
 
-export default function RenewItaAccessToDentalInsuranceQuestion() {
+export default function RenewItaAccessToDentalInsuranceQuestion({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -20,7 +20,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -37,7 +37,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:dental-insurance.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -13,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -23,11 +24,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewItaState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -36,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,10 +49,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('exit-application.exit-link'));
 }
 
-export default function RenewItaExitApplication() {
+export default function RenewItaExitApplication({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
-  const params = useParams();
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
@@ -14,7 +14,7 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -24,7 +24,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:exit-application.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -24,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -44,7 +44,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:dental-benefits.title',
 };
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import validator from 'validator';
 import { z } from 'zod';
+
+import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
 import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/apply-route-helpers';
@@ -23,7 +24,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -43,11 +44,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:dental-benefits.title',
 };
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewItaState({ params, request, session });
@@ -71,7 +72,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -164,10 +165,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/review-information', params));
 }
 
-export default function RenewItaFederalProvincialTerritorialBenefits() {
+export default function RenewItaFederalProvincialTerritorialBenefits({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { federalSocialPrograms, provincialTerritorialSocialPrograms, provinceTerritoryStates, defaultState, editMode } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [hasFederalBenefitValue, setHasFederalBenefitValue] = useState(defaultState?.hasFederalBenefits);

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -1,12 +1,13 @@
 import type { ChangeEventHandler } from 'react';
 import { useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -26,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -44,11 +45,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -59,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -122,11 +123,11 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/confirm-phone', params));
 }
 
-export default function RenewItaMaritalStatus() {
+export default function RenewItaMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, editMode, maritalStatuses } = useLoaderData<typeof loader>();
+  const { defaultState, editMode, maritalStatuses } = loaderData;
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -27,7 +27,7 @@ import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,7 +45,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:marital-status.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
@@ -10,6 +9,8 @@ import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/review-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaStateForReview } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -28,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -45,11 +46,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:review-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaStateForReview({ params, request, session });
 
   // renew state is valid then edit mode can be set to true
@@ -147,7 +148,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
@@ -178,10 +179,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/ita/confirmation', params));
 }
 
-export default function RenewItaReviewInformation() {
-  const params = useParams();
+export default function RenewItaReviewInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, demographicSurvey, payload } = useLoaderData<typeof loader>();
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefit, demographicSurvey, payload } = loaderData;
   const { HCAPTCHA_SITE_KEY } = useClientEnv();
   const hCaptchaEnabled = useFeature('hcaptcha');
   const fetcher = useFetcher<typeof action>();

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -29,7 +29,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -46,7 +46,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:review-information.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -30,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -70,7 +70,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -1,14 +1,15 @@
 import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useLoaderData, useParams } from 'react-router';
+import { data, redirect } from 'react-router';
 
 import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
+
+import type { Route } from './+types/update-home-address';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
@@ -29,7 +30,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -69,11 +70,11 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:update-address.home-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewItaState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -93,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -199,11 +200,11 @@ function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
 }
 
-export default function RenewItaUpdateAddress() {
+export default function RenewItaUpdateAddress({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, countryList, regionList, editMode } = useLoaderData<typeof loader>();
+  const { defaultState, countryList, regionList, editMode } = loaderData;
   const { CANADA_COUNTRY_ID, USA_COUNTRY_ID } = useClientEnv();
-  const params = useParams();
+
   const fetcher = useEnhancedFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const [selectedHomeCountry, setSelectedHomeCountry] = useState(defaultState.homeAddress?.country ?? CANADA_COUNTRY_ID);

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -31,7 +31,7 @@ import { useEnhancedFetcher } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -71,7 +71,7 @@ export const handle = {
   pageTitleI18nKey: 'renew-ita:update-address.mailing-address.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
+++ b/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
@@ -16,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:renewal-delegate.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
+++ b/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
@@ -1,10 +1,11 @@
 import type { FormEvent } from 'react';
 
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { redirect, useFetcher, useParams } from 'react-router';
+import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/renewal-delegate';
 
 import { TYPES } from '~/.server/constants';
 import { clearRenewState, loadRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -15,7 +16,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:renewal-delegate.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const { id } = loadRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id, meta };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,9 +52,9 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(t('renew:renewal-delegate.return-btn-link'));
 }
 
-export default function RenewalDelegate() {
+export default function RenewalDelegate({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const params = useParams();
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -18,7 +18,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -34,7 +34,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/tax-filing';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -17,7 +18,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -33,11 +34,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:tax-filing.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -46,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -75,10 +76,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/type-renewal', params));
 }
 
-export default function RenewFlowTaxFiling() {
+export default function RenewFlowTaxFiling({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, taxYear } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, taxYear } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -1,8 +1,9 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/terms-and-conditions';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -14,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -25,11 +26,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, request, params }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
   loadRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -38,7 +39,7 @@ export async function loader({ context: { appContainer, session }, request, para
   return { meta };
 }
 
-export async function action({ context: { appContainer, session }, request, params }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, request, params }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,7 +50,7 @@ export async function action({ context: { appContainer, session }, request, para
   return redirect(getPathById('public/renew/$id/applicant-information', params));
 }
 
-export default function RenewTermsAndConditions() {
+export default function RenewTermsAndConditions({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -15,7 +15,7 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -26,7 +26,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -1,9 +1,10 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, redirect, useFetcher, useLoaderData, useParams } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
+
+import type { Route } from './+types/type-renewal';
 
 import { TYPES } from '~/.server/constants';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -17,7 +18,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,11 +36,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:type-of-renewal.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, meta, defaultState: state.typeOfRenewal, hasFiledTaxes: state.clientApplication?.hasFiledTaxes };
 }
 
-export async function action({ context: { appContainer, session }, params, request }: ActionFunctionArgs) {
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -103,10 +104,10 @@ export async function action({ context: { appContainer, session }, params, reque
   return redirect(getPathById('public/renew/$id/renewal-delegate', params));
 }
 
-export default function RenewTypeOfRenewal() {
+export default function RenewTypeOfRenewal({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, hasFiledTaxes } = useLoaderData<typeof loader>();
-  const params = useParams();
+  const { defaultState, hasFiledTaxes } = loaderData;
+
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -18,7 +18,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,7 +36,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:type-of-renewal.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 
-import { redirect, useLoaderData, useNavigate, useParams } from 'react-router';
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { redirect, useNavigate } from 'react-router';
 
 import { randomUUID } from 'crypto';
+
+import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { startRenewState } from '~/.server/routes/helpers/renew-route-helpers';
@@ -11,7 +12,7 @@ import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -22,11 +23,11 @@ export const handle = {
   pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ context: { appContainer, session }, params, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -55,9 +56,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   return { id: state.id, locale, meta };
 }
 
-export default function RenewIndex() {
-  const { id } = useLoaderData<typeof loader>();
-  const params = useParams();
+export default function RenewIndex({ loaderData, params }: Route.ComponentProps) {
+  const { id } = loaderData;
+
   const navigate = useNavigate();
 
   const path = getPathById('public/renew/$id/terms-and-conditions', { ...params, id });

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -12,7 +12,7 @@ import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -23,7 +23,7 @@ export const handle = {
   pageTitleI18nKey: 'renew:terms-and-conditions.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/renew/layout.tsx
+++ b/frontend/app/routes/public/renew/layout.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, useLoaderData, useNavigate, useParams } from 'react-router';
+import { Outlet, useNavigate } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
@@ -20,17 +21,16 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
-export default function Route() {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+export default function Route({ loaderData, params }: Route.ComponentProps) {
+  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
-  const params = useParams();
 
   const path = getPathById('public/renew/index', params);
 

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -328,6 +328,11 @@ export const routes = [
             paths: { en: '/:lang/apply/:id/child/tax-filing', fr: '/:lang/demander/:id/enfant/declaration-impot' },
           },
           {
+            id: 'public/apply/$id/index',
+            file: 'routes/public/apply/$id/index.tsx',
+            paths: { en: '/:lang/apply/:id', fr: '/:lang/demander/:id' },
+          },
+          {
             id: 'public/apply/$id/terms-and-conditions',
             file: 'routes/public/apply/$id/terms-and-conditions.tsx',
             paths: { en: '/:lang/apply/:id/terms-and-conditions', fr: '/:lang/demander/:id/conditions-utilisation' },
@@ -594,6 +599,41 @@ export const routes = [
             paths: { en: '/:lang/renew/:id/child/children', fr: '/:lang/renouveller/:id/enfant/enfant' },
           },
           {
+            file: 'routes/public/renew/$id/child/children/$childId/layout.tsx',
+            children: [
+              {
+                id: 'public/renew/$id/child/children/$childId/information',
+                file: 'routes/public/renew/$id/child/children/$childId/information.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/information', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/information' },
+              },
+              {
+                id: 'public/renew/$id/child/children/$childId/parent-or-guardian',
+                file: 'routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/parent-or-guardian', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/parent-ou-tuteur' },
+              },
+              {
+                id: 'public/renew/$id/child/children/$childId/dental-insurance',
+                file: 'routes/public/renew/$id/child/children/$childId/dental-insurance.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/dental-insurance', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/assurance-dentaire' },
+              },
+              {
+                id: 'public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits',
+                file: 'routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
+              },
+              {
+                id: 'public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits',
+                file: 'routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/update-federal-provincial-territorial-benefits', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/mise-a-jour-prestations-dentaires-federales-provinciales-territoriales' },
+              },
+              {
+                id: 'public/renew/$id/child/children/$childId/demographic-survey',
+                file: 'routes/public/renew/$id/child/children/$childId/demographic-survey.tsx',
+                paths: { en: '/:lang/renew/:id/child/children/:childId/demographic-survey', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/questionnaire-demographique' },
+              },
+            ],
+          },
+          {
             id: 'public/renew/$id/child/review-child-information',
             file: 'routes/public/renew/$id/child/review-child-information.tsx',
             paths: { en: '/:lang/renew/:id/child/review-child-information', fr: '/:lang/renouveller/:id/enfant/revue-renseignements-enfant' },
@@ -613,16 +653,7 @@ export const routes = [
             file: 'routes/public/renew/$id/child/exit-application.tsx',
             paths: { en: '/:lang/renew/:id/child/exit-application', fr: '/:lang/renouveller/:id/enfant/quitter-demande' },
           },
-          {
-            id: 'public/renew/$id/child/children/$childId/information',
-            file: 'routes/public/renew/$id/child/children/$childId/information.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/information', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/information' },
-          },
-          {
-            id: 'public/renew/$id/child/children/$childId/parent-or-guardian',
-            file: 'routes/public/renew/$id/child/children/$childId/parent-or-guardian.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/parent-or-guardian', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/parent-ou-tuteur' },
-          },
+
           {
             id: 'public/renew/$id/child/parent-intro',
             file: 'routes/public/renew/$id/child/parent-intro.tsx',
@@ -653,21 +684,7 @@ export const routes = [
             file: 'routes/public/renew/$id/child/update-home-address.tsx',
             paths: { en: '/:lang/renew/:id/child/update-home-address', fr: '/:lang/renouveller/:id/enfant/mise-a-jour-adresse-domicile' },
           },
-          {
-            id: 'public/renew/$id/child/children/$childId/dental-insurance',
-            file: 'routes/public/renew/$id/child/children/$childId/dental-insurance.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/dental-insurance', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/assurance-dentaire' },
-          },
-          {
-            id: 'public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits',
-            file: 'routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/confirm-federal-provincial-territorial-benefits', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/confirmer-prestations-dentaires-federales-provinciales-territoriales' },
-          },
-          {
-            id: 'public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits',
-            file: 'routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/update-federal-provincial-territorial-benefits', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/mise-a-jour-prestations-dentaires-federales-provinciales-territoriales' },
-          },
+
           {
             id: 'public/renew/$id/child/confirm-phone',
             file: 'routes/public/renew/$id/child/confirm-phone.tsx',
@@ -678,11 +695,7 @@ export const routes = [
             file: 'routes/public/renew/$id/child/confirm-email.tsx',
             paths: { en: '/:lang/renew/:id/child/confirm-email', fr: '/:lang/renouveller/:id/enfant/confirmer-courriel' },
           },
-          {
-            id: 'public/renew/$id/child/children/$childId/demographic-survey',
-            file: 'routes/public/renew/$id/child/children/$childId/demographic-survey.tsx',
-            paths: { en: '/:lang/renew/:id/child/children/:childId/demographic-survey', fr: '/:lang/renouveller/:id/enfant/enfants/:childId/questionnaire-demographique' },
-          },
+
           {
             id: 'public/renew/$id/adult/confirmation',
             file: 'routes/public/renew/$id/adult/confirmation.tsx',

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -30,7 +30,7 @@ import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -48,7 +48,7 @@ export const handle = {
   pageTitleI18nKey: 'status:child.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -22,7 +22,7 @@ import { pageIds } from '~/page-ids';
 import { useClientEnv, useFeature } from '~/root';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,7 +38,7 @@ export const handle = {
   pageTitleI18nKey: 'status:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/status/layout.tsx
+++ b/frontend/app/routes/public/status/layout.tsx
@@ -1,5 +1,6 @@
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, useLoaderData } from 'react-router';
+import { Outlet } from 'react-router';
+
+import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
 import { getLocale } from '~/.server/utils/locale.utils';
@@ -14,14 +15,14 @@ export const handle = {
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export async function loader({ context: { appContainer, session }, request }: LoaderFunctionArgs) {
+export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
   return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
-export default function Route() {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = useLoaderData<typeof loader>();
+export default function Route({ loaderData, params }: Route.ComponentProps) {
+  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
   const apiSession = useApiSession();
 
   async function handleOnSessionEnd() {

--- a/frontend/app/routes/public/status/myself.tsx
+++ b/frontend/app/routes/public/status/myself.tsx
@@ -25,7 +25,7 @@ import { useClientEnv, useFeature } from '~/root';
 import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/application-code-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,7 +38,7 @@ export const handle = {
   pageTitleI18nKey: 'status:myself.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -19,7 +19,7 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +35,7 @@ export const handle = {
   pageTitleI18nKey: 'status:result.page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/unable-to-process-request.tsx
+++ b/frontend/app/routes/public/unable-to-process-request.tsx
@@ -7,7 +7,7 @@ import { InlineLink } from '~/components/inline-link';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -17,7 +17,7 @@ export const handle = {
   pageTitleI18nKey: 'unable-to-process-request:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
   return getTitleMetaTags(data.meta.title);
 });
 

--- a/frontend/app/routes/public/unable-to-process-request.tsx
+++ b/frontend/app/routes/public/unable-to-process-request.tsx
@@ -1,13 +1,13 @@
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-
 import { Trans, useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/unable-to-process-request';
 
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { InlineLink } from '~/components/inline-link';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
-import { mergeMeta } from '~/utils/meta-utils';
+import { mergeRouteModuleMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
@@ -17,18 +17,18 @@ export const handle = {
   pageTitleI18nKey: 'unable-to-process-request:page-title',
 } as const satisfies RouteHandleData;
 
-export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
-  return data ? getTitleMetaTags(data.meta.title) : [];
+export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
 });
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('unable-to-process-request:page-title') }) };
 
   return { meta };
 }
 
-export default function UnableToProcessRequest() {
+export default function UnableToProcessRequest({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const noWrap = <span className="whitespace-nowrap" />;

--- a/frontend/app/utils/meta-utils.ts
+++ b/frontend/app/utils/meta-utils.ts
@@ -1,56 +1,8 @@
-import type { ClientLoaderFunction, LoaderFunction, MetaDescriptor, MetaFunction } from 'react-router';
+import type { MetaDescriptor } from 'react-router';
 import type { CreateMetaArgs, MetaDescriptors } from 'react-router/route-module';
 
 /**
- * Merging helper
- *
- * {@link https://remix.run/docs/en/main/route/meta#meta-merging-helper}
- *
- * If you can't avoid the merge problem with global meta or index routes, we've created
- * a helper that you can put in your app that can override and append to parent meta easily.
- *
- * @example
- * ```typescript
- * import type { MetaFunction } from 'react-router';
- *
- * import { mergeMeta } from '~/utils/meta-utils';
- *
- * export const meta: MetaFunction<typeof loader> = mergeMeta(({ data }) => {
- *   return [
- *     { title: "My Leaf Route" },
- *   ];
- * });
- *
- * // In a parent route:
- * import type { MetaFunction } from 'react-router';
- *
- * export const meta: MetaFunction<typeof loader> = ({ data }) => {
- *   return [
- *     { title: "My Parent Route" },
- *     { name: 'description', content: "This is the parent route" },
- *   ];
- * }
- * ```
- * The resulting meta will contain both `title: 'My Leaf Route'` and `description: 'This is the parent route'`.
- */
-export function mergeMeta<Loader extends LoaderFunction | ClientLoaderFunction | unknown = unknown, ParentsLoaders extends Record<string, LoaderFunction | ClientLoaderFunction | unknown> = Record<string, unknown>>(
-  leafMetaFn: MetaFunction<Loader, ParentsLoaders>,
-): MetaFunction<Loader, ParentsLoaders> {
-  return (args) => {
-    const leafMeta = leafMetaFn(args);
-
-    return args.matches.reduceRight((acc, match) => {
-      for (const parentMeta of match.meta) {
-        addUniqueMeta(acc, parentMeta);
-      }
-
-      return acc;
-    }, leafMeta);
-  };
-}
-
-/**
- * Merging helper that works with Route Module Type Safety
+ * Merging helper that works
  *
  * If you can't avoid the merge problem with global meta or index routes, we've created
  * a helper that you can put in your app that can override and append to parent meta easily.
@@ -59,9 +11,9 @@ export function mergeMeta<Loader extends LoaderFunction | ClientLoaderFunction |
  * ```typescript
  * import type { Route } from './+types/leaf';
  *
- * import { mergeRouteModuleMeta } from '~/utils/meta-utils';
+ * import { mergeMeta } from '~/utils/meta-utils';
  *
- * export const meta: Route.MetaFunction = mergeRouteModuleMeta(({ data }) => {
+ * export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
  *   return [
  *     { title: "My Leaf Route" },
  *   ];
@@ -80,7 +32,7 @@ export function mergeMeta<Loader extends LoaderFunction | ClientLoaderFunction |
  * The resulting meta will contain both `title: 'My Leaf Route'` and `description: 'This is the parent route'`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function mergeRouteModuleMeta<TMetaArgs extends CreateMetaArgs<any>>(leafMetaFn: (args: TMetaArgs) => MetaDescriptors): (args: TMetaArgs) => MetaDescriptors {
+export function mergeMeta<TMetaArgs extends CreateMetaArgs<any>>(leafMetaFn: (args: TMetaArgs) => MetaDescriptors): (args: TMetaArgs) => MetaDescriptors {
   return (args) => {
     const leafMeta = leafMetaFn(args);
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fully integrated React Router [Route Module Type Safety](https://reactrouter.com/how-to/route-module-type-safety).

> React Router generates route-specific types to power type inference for URL params, loader data, and more. This guide will help you set it up if you didn't start with a template.

