### PR TITLE
fix back navigation on child edit in public renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -272,7 +272,7 @@ export function renewStateHasPartner(maritalStatus: string) {
 }
 
 export function isNewChildState(child: ChildState) {
-  return child.dentalInsurance === undefined || child.information === undefined;
+  return child.dentalInsurance === undefined || child.information === undefined || child.hasFederalProvincialTerritorialBenefitsChanged === undefined;
 }
 
 export function getChildrenState<TState extends Pick<RenewState, 'children'>>(state: TState, includesNewChildState: boolean = false) {

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('renew-adult-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
 
-  return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
+  return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, isNew: state.isNew, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -91,7 +91,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewAdultChildChildrenDentalInsurance({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = loaderData;
+  const { defaultState, childName, editMode, isNew } = loaderData;
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -187,7 +187,7 @@ export default function RenewAdultChildChildrenDentalInsurance({ loaderData, par
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/adult-child/children/$childId/information"
+                routeId={isNew ? 'public/renew/$id/adult-child/children/$childId/information' : 'public/renew/$id/adult-child/children/index'}
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -53,6 +53,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewAdultSingleChildState({ params, request, session });
 
+  if (!state.isNew) {
+    return redirect(getPathById('public/renew/$id/adult-child/children/$childId/dental-insurance', params));
+  }
+
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const childName = t('renew-adult-child:children.child-number', { childNumber: state.childNumber });

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('renew-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
 
-  return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
+  return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, isNew: state.isNew, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -91,7 +91,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function RenewChildChildrenDentalInsurance({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState, childName, editMode } = loaderData;
+  const { defaultState, childName, editMode, isNew } = loaderData;
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -187,7 +187,7 @@ export default function RenewChildChildrenDentalInsurance({ loaderData, params }
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/renew/$id/child/children/$childId/information"
+                routeId={isNew ? 'public/renew/$id/child/children/$childId/information' : 'public/renew/$id/child/children/index'}
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -53,6 +53,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const state = loadRenewSingleChildState({ params, request, session });
 
+  if (!state.isNew) {
+    return redirect(getPathById('public/renew/$id/child/children/$childId/dental-insurance', params));
+  }
+
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const childName = t('renew-child:children.child-number', { childNumber: state.childNumber });


### PR DESCRIPTION
### Description
user should return to /children/index upon hitting the back button if they're 'editing' the child.

### Related Azure Boards Work Items
[AB#5267](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5267)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally