### PR TITLE
AB#5179 ITA flow: Hitting "Cancel" on Home/Mailing address in edit mode should redirect back to review page.

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -74,9 +74,9 @@ export interface RenewState {
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly previousAddressState?: {
-    hasAddressChanged?: boolean,
-    isHomeAddressSameAsMailingAddress?: boolean
-  }
+    hasAddressChanged?: boolean;
+    isHomeAddressSameAsMailingAddress?: boolean;
+  };
   readonly mailingAddress?: {
     address: string;
     city: string;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -73,6 +73,10 @@ export interface RenewState {
   };
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;
+  readonly previousAddressState?: {
+    hasAddressChanged?: boolean,
+    isHomeAddressSameAsMailingAddress?: boolean
+  }
   readonly mailingAddress?: {
     address: string;
     city: string;

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -111,12 +111,6 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       },
     });
-    if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No) {
-      if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.No) {
-        return redirect(getPathById('public/renew/$id/ita/update-home-address', params));
-      }
-      return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
-    }
   }
 
   if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No) {

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -97,21 +97,12 @@ export async function action({ context: { appContainer, session }, params, reque
     state: {
       hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
       isHomeAddressSameAsMailingAddress: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes : undefined,
+      previousAddressState: {
+        hasAddressChanged: state.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
+      },
     },
   });
-
-  if (state.editMode) {
-    saveRenewState({
-      params,
-      session,
-      state: {
-        previousAddressState: {
-          hasAddressChanged: state.hasAddressChanged,
-          isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
-        },
-      },
-    });
-  }
 
   if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No) {
     if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.No) {

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -37,6 +37,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 enum FormAction {
   Submit = 'submit',
+  Cancel = 'cancel',
   UseInvalidAddress = 'use-invalid-address',
   UseSelectedAddress = 'use-selected-address',
 }
@@ -107,6 +108,18 @@ export async function action({ context: { appContainer, session }, params, reque
 
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewItaState({ params, request, session });
+
+  if (formAction === FormAction.Cancel) {
+    saveRenewState({
+      params,
+      session,
+      state: {
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+      },
+    });
+    return redirect(getPathById('public/renew/$id/ita/review-information', params));
+  }
 
   const homeAddressValidator = appContainer.get(TYPES.routes.validators.HomeAddressValidatorFactory).createHomeAddressValidator(locale);
 
@@ -340,9 +353,9 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Home address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FormAction.Cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Home address click">
                 {t('renew-ita:update-address.cancel-btn')}
-              </ButtonLink>
+              </Button>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -38,6 +38,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 enum FormAction {
   Submit = 'submit',
+  Cancel = 'cancel',
   UseInvalidAddress = 'use-invalid-address',
   UseSelectedAddress = 'use-selected-address',
 }
@@ -109,6 +110,18 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadRenewItaState({ params, request, session });
   const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+
+  if (formAction === FormAction.Cancel) {
+    saveRenewState({
+      params,
+      session,
+      state: {
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+      },
+    });
+    return redirect(getPathById('public/renew/$id/ita/review-information', params));
+  }
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
@@ -370,9 +383,9 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Mailing address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FormAction.Cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Mailing address click">
                 {t('renew-ita:update-address.cancel-btn')}
-              </ButtonLink>
+              </Button>
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -163,7 +163,7 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (state.editMode) {
-      return redirect(getPathById('public/renew/$id/ita/review-information', params));
+      return redirect(isCopyMailingToHome ? getPathById('public/renew/$id/ita/review-information', params) : getPathById('public/renew/$id/ita/update-home-address', params));
     }
     return redirect(isCopyMailingToHome ? getPathById('public/renew/$id/ita/dental-insurance', params) : getPathById('public/renew/$id/ita/update-home-address', params));
   }


### PR DESCRIPTION
### Description
This PR addresses the navigation issue in the ITA flow related to the home/mailing address in edit mode.

#### Scenario
On the `confirm-address` page:

- Select **No** for the first question.

- Select **Yes** for the second question and proceed to the review page.

On the review page:

- Click the link to change either the home or mailing address. This navigates to the `confirm-address` page in edit mode.

On the `confirm-address` page in edit mode:

- Select **Yes** for the first question and proceed to the mailing address page.

On the mailing address page:

- Click the **Cancel** button without entering any information.

- The page stays but will exits edit mode, this is because the `mailing` address state is undefined while `hasAddressChanged` is true

#### Fix Implemented
To resolve this issue:

A new state, `previousAddressState`, has been introduced.
`previousAddressState` is used to roll back to the prior state of the confirm-address page if the user cancels out of edit mode.
 
#### Behavior After Fix
If a user clicks the **Cancel** button on the mailing address or home address page, any changes made on the confirm-address page during edit mode are discarded.
The user is redirected back to the review page with their previous selections (from before entering edit mode) restored.

### Related Azure Boards Work Items
AB#5179

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->