### PR TITLE
Removing edit mode check in confirm-fpt page

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -100,7 +100,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
-          dentalBenefits: state.editMode && parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
+          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
         };
       }),
     },

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -89,7 +89,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
-      dentalBenefits: state.editMode && parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
+      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
     },
   });
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -89,7 +89,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
-      dentalBenefits: state.editMode && parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
+      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
     },
   });
 

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -101,7 +101,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefitsChanged: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged,
-          dentalBenefits: state.editMode && parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
+          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
         };
       }),
     },


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
[AB#5271](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5271)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
- Navigate to /confirm-fpt-benefits and answer "Yes"
- Choose any FPT benefits on the /update-fpt-benefits page and hit "Continue"
- Hit "Back" (bottom button) until you reach /confirm-fpt-benefits page. Hit "Continue" since "Yes" should already be pre-selected.

(Also try from the `review-adult-information` page)
