### PR TITLE
reafactor(frontend): remove TS enums

### DIFF
--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -27,15 +27,15 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -159,12 +159,12 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<ProtectedDentalProvincialTerritorialBenefitsState>;
 
   const dentalFederalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
   };
 
   const dentalProvincialTerritorialBenefits = {
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -226,12 +226,12 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -266,7 +266,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -287,7 +287,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -305,7 +305,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -351,7 +351,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:children.update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -30,10 +30,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -127,7 +127,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+  const preferNotToAnswer = z.nativeEnum(FORM_ACTION).parse(formData.get('_action')) === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -247,7 +247,7 @@ export default function ProtectedChildrenDemographicSurveyQuestions({ loaderData
             <p>{t('protected-renew:children.demographic-survey.improve-cdcp')}</p>
             <p>{t('protected-renew:children.demographic-survey.confidential')}</p>
             <p>{t('protected-renew:children.demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Prefer not to answer - Child voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Prefer not to answer - Child voluntary demographic questions click">
               {t('protected-renew:children.demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew:all-questions-optional-label')}</p>
@@ -283,7 +283,7 @@ export default function ProtectedChildrenDemographicSurveyQuestions({ loaderData
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <LoadingButton id="save-button" variant="primary" name="_action" value={FormAction.Continue} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Child voluntary demographic questions click">
+              <LoadingButton id="save-button" variant="primary" name="_action" value={FORM_ACTION.continue} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Child voluntary demographic questions click">
                 {t('protected-renew:children.demographic-survey.save-btn')}
               </LoadingButton>
               <ButtonLink
@@ -302,7 +302,7 @@ export default function ProtectedChildrenDemographicSurveyQuestions({ loaderData
                 id="continue-button"
                 variant="primary"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 loading={isSubmitting}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Child voluntary demographic questions click"

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum ParentOrGuardianOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const PARENT_OR_GUARDIAN_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -70,7 +70,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const parentOrGuardianSchema = z.object({
-    parentOrGuardian: z.nativeEnum(ParentOrGuardianOption, {
+    parentOrGuardian: z.nativeEnum(PARENT_OR_GUARDIAN_OPTION, {
       errorMap: () => ({ message: t('protected-renew:children.parent-or-guardian.error-message.parent-or-guardian-required') }),
     }),
   });
@@ -92,7 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
         if (child.id !== state.id) return child;
         return {
           ...child,
-          isParentOrLegalGuardian: parsedDataResult.data.parentOrGuardian === ParentOrGuardianOption.Yes,
+          isParentOrLegalGuardian: parsedDataResult.data.parentOrGuardian === PARENT_OR_GUARDIAN_OPTION.yes,
         };
       }),
     },
@@ -101,7 +101,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-parent-or-guardian', { userId: idToken.sub });
 
-  if (parsedDataResult.data.parentOrGuardian === ParentOrGuardianOption.No) {
+  if (parsedDataResult.data.parentOrGuardian === PARENT_OR_GUARDIAN_OPTION.no) {
     return redirect(getPathById('protected/renew/$id/$childId/parent-or-guardian-required', params));
   }
 
@@ -129,8 +129,8 @@ export default function ProtectedRenewParentOrGuardian({ loaderData, params }: R
           name="parentOrGuardian"
           legend={t('protected-renew:children.parent-or-guardian.form-instructions', { childName })}
           options={[
-            { value: ParentOrGuardianOption.Yes, children: t('protected-renew:children.parent-or-guardian.radio-options.yes'), defaultChecked: defaultState === true },
-            { value: ParentOrGuardianOption.No, children: t('protected-renew:children.parent-or-guardian.radio-options.no'), defaultChecked: defaultState === false },
+            { value: PARENT_OR_GUARDIAN_OPTION.yes, children: t('protected-renew:children.parent-or-guardian.radio-options.yes'), defaultChecked: defaultState === true },
+            { value: PARENT_OR_GUARDIAN_OPTION.no, children: t('protected-renew:children.parent-or-guardian.radio-options.no'), defaultChecked: defaultState === false },
           ]}
           errorMessage={errors?.parentOrGuardian}
           required

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -23,15 +23,15 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatAddressLine } from '~/utils/string-utils';
 
-enum FormAction {
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddressRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const ADDRESS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -70,7 +70,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const confirmAddressSchema = z.object({
-    isHomeAddressSameAsMailingAddress: z.nativeEnum(AddressRadioOptions, { errorMap: () => ({ message: t('protected-renew:confirm-address.error-message.is-home-address-same-as-mailing-address-required') }) }),
+    isHomeAddressSameAsMailingAddress: z.nativeEnum(ADDRESS_RADIO_OPTIONS, { errorMap: () => ({ message: t('protected-renew:confirm-address.error-message.is-home-address-same-as-mailing-address-required') }) }),
   });
 
   const parsedDataResult = confirmAddressSchema.safeParse({
@@ -82,7 +82,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const homeAddress =
-    parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes
+    parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.yes
       ? state.mailingAddress
         ? state.mailingAddress
         : {
@@ -99,12 +99,12 @@ export async function action({ context: { appContainer, session }, params, reque
     request,
     session,
     state: {
-      isHomeAddressSameAsMailingAddress: parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes,
+      isHomeAddressSameAsMailingAddress: parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.yes,
       homeAddress,
     },
   });
 
-  if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.No) {
+  if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.no) {
     return redirect(getPathById('protected/renew/$id/confirm-home-address', params));
   }
 
@@ -138,8 +138,8 @@ export default function ProtectedRenewProtectedConfirmAddress({ loaderData, para
             name="isHomeAddressSameAsMailingAddress"
             legend={t('protected-renew:confirm-address.is-home-address-same-as-mailing-address')}
             options={[
-              { value: AddressRadioOptions.Yes, children: t('protected-renew:confirm-address.radio-options.yes'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === true },
-              { value: AddressRadioOptions.No, children: t('protected-renew:confirm-address.radio-options.no'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === false },
+              { value: ADDRESS_RADIO_OPTIONS.yes, children: t('protected-renew:confirm-address.radio-options.yes'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === true },
+              { value: ADDRESS_RADIO_OPTIONS.no, children: t('protected-renew:confirm-address.radio-options.no'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === false },
             ]}
             errorMessage={errors?.isHomeAddressSameAsMailingAddress}
             required
@@ -147,7 +147,7 @@ export default function ProtectedRenewProtectedConfirmAddress({ loaderData, para
         </div>
         {editMode ? (
           <div className="flex flex-wrap items-center gap-3">
-            <LoadingButton id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Confirm address click">
+            <LoadingButton id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Confirm address click">
               {t('protected-renew:confirm-address.save-btn')}
             </LoadingButton>
             <ButtonLink id="cancel-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Confirm address click">

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -22,10 +22,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -156,7 +156,7 @@ export default function ProtectedRenewConfirmEmail({ loaderData, params }: Route
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-3">
-          <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
+          <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
             {t('protected-renew:confirm-email.save-btn')}
           </Button>
           <ButtonLink id="cancel-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Email click">

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -27,21 +27,21 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -166,12 +166,12 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<ProtectedDentalProvincialTerritorialBenefitsState>;
 
   const dentalFederalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
   };
 
   const dentalProvincialTerritorialBenefits = {
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -236,12 +236,12 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -274,7 +274,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -295,7 +295,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -313,7 +313,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -359,7 +359,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
@@ -373,7 +373,7 @@ export default function ProtectedRenewConfirmFederalProvincialTerritorialBenefit
               <LoadingButton
                 id="save-button"
                 name="_action"
-                value={FormAction.Save}
+                value={FORM_ACTION.save}
                 variant="primary"
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Access to other federal, provincial or territorial dental benefits click"

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -34,13 +34,13 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Cancel = 'cancel',
-  Save = 'save',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  cancel: 'cancel',
+  save: 'save',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -107,7 +107,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
@@ -342,7 +342,7 @@ export default function ProtectedRenewConfirmHomeAddress({ loaderData, params }:
             <div className="flex flex-wrap items-center justify-end gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Home address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Home address click">
                     {t('protected-renew:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -367,7 +367,7 @@ export default function ProtectedRenewConfirmHomeAddress({ loaderData, params }:
                   id="continue-button"
                   type="submit"
                   name="_action"
-                  value={FormAction.Submit}
+                  value={FORM_ACTION.submit}
                   loading={isSubmitting}
                   endIcon={faChevronRight}
                   data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Home address click"
@@ -479,7 +479,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('protected-renew:update-address.dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -537,7 +537,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -35,11 +35,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -103,7 +103,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const addressValidationService = appContainer.get(TYPES.domain.services.AddressValidationService);
@@ -355,7 +355,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
           <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
               <DialogTrigger asChild>
-                <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Mailing address click">
+                <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Mailing address click">
                   {t('protected-renew:update-address.save-btn')}
                 </LoadingButton>
               </DialogTrigger>
@@ -462,7 +462,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('protected-renew:update-address.dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -524,7 +524,7 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -32,11 +32,11 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -228,7 +228,7 @@ export default function ProtectedRenewMaritalStatus({ loaderData, params }: Rout
         </div>
         {editMode ? (
           <div className="flex flex-wrap items-center gap-3">
-            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Marital status click">
+            <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Marital status click">
               {t('protected-renew:marital-status.save-btn')}
             </Button>
             <ButtonLink id="cancel-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Marital status click">
@@ -240,7 +240,7 @@ export default function ProtectedRenewMaritalStatus({ loaderData, params }: Rout
             <LoadingButton
               id="continue-button"
               name="_action"
-              value={FormAction.Continue}
+              value={FORM_ACTION.continue}
               variant="primary"
               loading={isSubmitting}
               endIcon={faChevronRight}

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -22,10 +22,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -152,7 +152,7 @@ export default function ProtectedRenewConfirmPhone({ loaderData, params }: Route
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Phone Number click">
+            <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Phone Number click">
               {t('protected-renew:confirm-phone.save-btn')}
             </Button>
             <ButtonLink id="cancel-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Phone Number click">

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -19,10 +19,10 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Close = 'close',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  close: 'close',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -216,7 +216,7 @@ export default function ProtectedRenewConfirm({ loaderData, params }: Route.Comp
           <CsrfTokenInput />
           <LoadingButton
             name="_action"
-            value={FormAction.Close}
+            value={FORM_ACTION.close}
             variant="primary"
             loading={isSubmitting}
             endIcon={faChevronRight}

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -30,10 +30,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+  const preferNotToAnswer = z.nativeEnum(FORM_ACTION).parse(formData.get('_action')) === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -235,7 +235,7 @@ export default function ProtectedDemographicSurveyQuestions({ loaderData, params
             <p>{t('protected-renew:demographic-survey.improve-cdcp')}</p>
             <p>{t('protected-renew:demographic-survey.confidential')}</p>
             <p>{t('protected-renew:demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Prefer not to answer - Voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Prefer not to answer - Voluntary demographic questions click">
               {t('protected-renew:demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew:all-questions-optional-label')}</p>
@@ -263,7 +263,7 @@ export default function ProtectedDemographicSurveyQuestions({ loaderData, params
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <LoadingButton id="save-button" variant="primary" name="_action" value={FormAction.Continue} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Voluntary demographic questions click">
+              <LoadingButton id="save-button" variant="primary" name="_action" value={FORM_ACTION.continue} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Voluntary demographic questions click">
                 {t('protected-renew:demographic-survey.save-btn')}
               </LoadingButton>
               <ButtonLink
@@ -281,7 +281,7 @@ export default function ProtectedDemographicSurveyQuestions({ loaderData, params
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -23,11 +23,11 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -68,8 +68,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     if (state.clientApplication.isInvitationToApplyClient) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
@@ -191,7 +191,7 @@ export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion(
         </div>
         {editMode ? (
           <div className="mt-8 flex flex-wrap items-center gap-3">
-            <Button name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Access to private dental insurance click">
+            <Button name="_action" value={FORM_ACTION.save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Access to private dental insurance click">
               {t('dental-insurance.button.save-btn')}
             </Button>
             <ButtonLink
@@ -208,7 +208,7 @@ export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion(
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <LoadingButton
               name="_action"
-              value={FormAction.Continue}
+              value={FORM_ACTION.continue}
               variant="primary"
               loading={isSubmitting}
               endIcon={faChevronRight}
@@ -216,7 +216,7 @@ export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion(
             >
               {t('dental-insurance.button.continue')}
             </LoadingButton>
-            <LoadingButton name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Access to private dental insurance click">
+            <LoadingButton name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Access to private dental insurance click">
               {t('dental-insurance.button.back')}
             </LoadingButton>
           </div>

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -27,12 +27,12 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -144,7 +144,7 @@ export default function ProtectedRenewMemberSelection({ loaderData, params }: Ro
           <LoadingButton
             id="continue-button"
             name="_action"
-            value={FormAction.Continue}
+            value={FORM_ACTION.continue}
             variant="primary"
             loading={isSubmitting}
             endIcon={faChevronRight}

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -33,10 +33,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -228,8 +228,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveProtectedRenewState({
       params,
       request,
@@ -467,7 +467,7 @@ export default function ProtectedRenewReviewAdultInformation({ loaderData, param
             variant="primary"
             id="continue-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             disabled={isSubmitting}
             loading={isSubmitting}
             endIcon={faChevronRight}
@@ -480,7 +480,7 @@ export default function ProtectedRenewReviewAdultInformation({ loaderData, param
           <LoadingButton
             id="confirm-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             variant="primary"
             disabled={isSubmitting}
             loading={isSubmitting}
@@ -489,7 +489,7 @@ export default function ProtectedRenewReviewAdultInformation({ loaderData, param
             {t('protected-renew:review-adult-information.continue-button')}
           </LoadingButton>
         )}
-        <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Review your information click">
+        <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Review your information click">
           {t('protected-renew:review-adult-information.back-button')}
         </Button>
       </fetcher.Form>

--- a/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
@@ -28,10 +28,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -102,8 +102,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewStateForReview({ params, request, session, demographicSurveyEnabled });
   const primaryApplicantStateCompleted = isPrimaryApplicantStateComplete(loadProtectedRenewState({ params, request, session }), demographicSurveyEnabled);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     if (!primaryApplicantStateCompleted || validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled).length === 0) {
       return redirect(getPathById('protected/renew/$id/review-adult-information', params));
     }
@@ -183,15 +183,15 @@ export default function ProtectedRenewReviewSubmit({ loaderData, params }: Route
             <LoadingButton
               id="submit-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="green"
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               endIcon={faChevronRight}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Submit application - Submit your renewal application click"
             >
               {t('protected-renew:review-submit.submit-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Submit your renewal application click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Submit your renewal application click">
               {t('protected-renew:review-submit.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -25,10 +25,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'gcweb'),
@@ -128,8 +128,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.review-child-information', { userId: idToken.sub });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveProtectedRenewState({
       params,
       request,
@@ -243,7 +243,7 @@ export default function ProtectedRenewReviewChildInformation({ loaderData, param
           <LoadingButton
             id="confirm-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             variant="primary"
             disabled={isSubmitting}
             loading={isSubmitting}
@@ -252,7 +252,7 @@ export default function ProtectedRenewReviewChildInformation({ loaderData, param
           >
             {t('protected-renew:review-child-information.continue-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Review child(ren) information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Review child(ren) information click">
             {t('protected-renew:review-child-information.back-button')}
           </Button>
         </div>

--- a/frontend/app/routes/protected/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/$id/tax-filing.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum TaxFilingOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const TAX_FILING_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -63,7 +63,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema = z.object({
-    taxFiling: z.nativeEnum(TaxFilingOption, {
+    taxFiling: z.nativeEnum(TAX_FILING_OPTION, {
       errorMap: () => ({ message: t('protected-renew:tax-filing.error-message.tax-filing-required') }),
     }),
   });
@@ -80,13 +80,13 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     request,
     session,
-    state: { taxFiling: parsedDataResult.data.taxFiling === TaxFilingOption.Yes },
+    state: { taxFiling: parsedDataResult.data.taxFiling === TAX_FILING_OPTION.yes },
   });
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.tax-filing', { userId: idToken.sub });
 
-  if (parsedDataResult.data.taxFiling === TaxFilingOption.No) {
+  if (parsedDataResult.data.taxFiling === TAX_FILING_OPTION.no) {
     return redirect(getPathById('protected/renew/$id/file-taxes', params));
   }
 
@@ -113,8 +113,8 @@ export default function ProtectedRenewFlowTaxFiling({ loaderData, params }: Rout
           name="taxFiling"
           legend={t('protected-renew:tax-filing.form-instructions', { taxYear })}
           options={[
-            { value: TaxFilingOption.Yes, children: t('protected-renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-            { value: TaxFilingOption.No, children: t('protected-renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+            { value: TAX_FILING_OPTION.yes, children: t('protected-renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+            { value: TAX_FILING_OPTION.no, children: t('protected-renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
           ]}
           errorMessage={errors?.taxFiling}
           required

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -30,11 +30,11 @@ import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -100,7 +100,7 @@ export async function action({ context: { appContainer, session }, request, para
   const provinceTerritoryStateService = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService);
   const locale = getLocale(request);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
@@ -323,7 +323,7 @@ export default function AddressValidationIndexRoute({ loaderData, params }: Rout
           <div className="flex flex-wrap items-center gap-3">
             <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
               <DialogTrigger asChild>
-                <LoadingButton type="submit" id="submit-button" name="_action" value={FormAction.Submit} variant="primary" loading={fetcher.isSubmitting} endIcon={faCheck}>
+                <LoadingButton type="submit" id="submit-button" name="_action" value={FORM_ACTION.submit} variant="primary" loading={fetcher.isSubmitting} endIcon={faCheck}>
                   {t('address-validation:index.submit-button')}
                 </LoadingButton>
               </DialogTrigger>
@@ -417,7 +417,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('address-validation:index.dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -470,7 +470,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('address-validation:index.dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -34,11 +34,11 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -74,9 +74,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const applyState = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
 
     if (applicantInformationStateHasPartner(state.applicantInformation) && state.partnerInformation === undefined) {
@@ -242,10 +242,10 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Applicant information click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Applicant information click">
                 {t('apply-adult-child:applicant-information.save-btn')}
               </Button>
-              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Applicant information click">
+              <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Applicant information click">
                 {t('apply-adult-child:applicant-information.cancel-btn')}
               </Button>
             </div>
@@ -254,7 +254,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -27,15 +27,15 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -134,9 +134,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -198,12 +198,12 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -236,13 +236,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -274,13 +274,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue === true && (

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -37,10 +37,10 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum YesNoOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const YES_NO_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'apply-adult-child', 'gcweb'),
@@ -172,11 +172,11 @@ export async function action({ context: { appContainer, session }, params, reque
     dateOfBirthMonth: formData.get('dateOfBirthMonth') ? Number(formData.get('dateOfBirthMonth')) : undefined,
     dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
     dateOfBirth: '',
-    isParent: formData.get('isParent') ? formData.get('isParent') === YesNoOption.Yes : undefined,
+    isParent: formData.get('isParent') ? formData.get('isParent') === YES_NO_OPTION.yes : undefined,
   });
 
   const parsedSinDataResult = childSinSchema.safeParse({
-    hasSocialInsuranceNumber: formData.get('hasSocialInsuranceNumber') ? formData.get('hasSocialInsuranceNumber') === YesNoOption.Yes : undefined,
+    hasSocialInsuranceNumber: formData.get('hasSocialInsuranceNumber') ? formData.get('hasSocialInsuranceNumber') === YES_NO_OPTION.yes : undefined,
     socialInsuranceNumber: formData.get('socialInsuranceNumber') ? String(formData.get('socialInsuranceNumber') ?? '') : undefined,
   });
 
@@ -244,13 +244,13 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
   });
 
   const handleSocialInsuranceNumberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
-    setHasSocialInsuranceNumberValue(e.target.value === YesNoOption.Yes);
+    setHasSocialInsuranceNumberValue(e.target.value === YES_NO_OPTION.yes);
   };
 
   const options: InputRadiosProps['options'] = [
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
-      value: YesNoOption.Yes,
+      value: YES_NO_OPTION.yes,
       defaultChecked: defaultState?.hasSocialInsuranceNumber === true,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
@@ -270,7 +270,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     },
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.information.sin-no" components={{ bold: <strong /> }} />,
-      value: YesNoOption.No,
+      value: YES_NO_OPTION.no,
       defaultChecked: defaultState?.hasSocialInsuranceNumber === false,
       onChange: handleSocialInsuranceNumberSelection,
     },
@@ -340,8 +340,8 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
               name="isParent"
               legend={t('apply-adult-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
-                { value: YesNoOption.No, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YES_NO_OPTION.yes, children: t('apply-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YES_NO_OPTION.no, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
             />

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -31,13 +31,13 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Add = 'add',
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-  Remove = 'remove',
-}
+const FORM_ACTION = {
+  add: 'add',
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+  remove: 'remove',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -84,16 +84,16 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadApplyAdultChildState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Add) {
+  if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();
     const children = [...getChildrenState(state), { id: childId }];
     saveApplyState({ params, session, state: { children } });
     return redirect(getPathById('public/apply/$id/adult-child/children/$childId/information', { ...params, childId }));
   }
 
-  if (formAction === FormAction.Remove) {
+  if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
     const children = [...getChildrenState(state)].filter((child) => child.id !== removeChildId);
     saveApplyState({ params, session, state: { children } });
@@ -213,7 +213,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                             <Button
                               id="remove-child"
                               name="_action"
-                              value={FormAction.Remove}
+                              value={FORM_ACTION.remove}
                               disabled={isSubmitting}
                               variant="primary"
                               size="sm"
@@ -234,7 +234,15 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
 
         <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
           <CsrfTokenInput />
-          <Button className="my-10" id="add-child" name="_action" value={FormAction.Add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Add child - Child(ren) application click">
+          <Button
+            className="my-10"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            startIcon={faPlus}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Add child - Child(ren) application click"
+          >
             {children.length === 0 ? t('apply-adult-child:children.index.add-child') : t('apply-adult-child:children.index.add-another-child')}
           </Button>
 
@@ -265,10 +273,10 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 disabled={!hasChildren || isSubmitting}
-                loading={isSubmitting && submitAction === FormAction.Continue}
+                loading={isSubmitting && submitAction === FORM_ACTION.continue}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Child(ren) application click"
               >

--- a/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/date-of-birth.tsx
@@ -29,10 +29,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum AllChildrenUnder18Option {
-  No = 'no',
-  Yes = 'yes',
-}
+const ALL_CHILDREN_UNDER18_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -77,7 +77,7 @@ export async function action({ context: { appContainer, session }, params, reque
         invalid_type_error: t('apply-adult-child:eligibility.date-of-birth.error-message.date-of-birth-day-number'),
       }),
       dateOfBirth: z.string(),
-      allChildrenUnder18: z.nativeEnum(AllChildrenUnder18Option, {
+      allChildrenUnder18: z.nativeEnum(ALL_CHILDREN_UNDER18_OPTION, {
         errorMap: () => ({ message: t('apply-adult-child:eligibility.date-of-birth.error-message.child-age-required') }),
       }),
     })
@@ -133,7 +133,7 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      allChildrenUnder18: parsedDataResult.data.allChildrenUnder18 === AllChildrenUnder18Option.Yes,
+      allChildrenUnder18: parsedDataResult.data.allChildrenUnder18 === ALL_CHILDREN_UNDER18_OPTION.yes,
       dateOfBirth: parsedDataResult.data.dateOfBirth,
       disabilityTaxCredit: ageCategory === 'adults' ? state.disabilityTaxCredit : undefined,
       livingIndependently: ageCategory === 'youth' ? state.livingIndependently : undefined,
@@ -230,8 +230,8 @@ export default function ApplyFlowDateOfBirth({ loaderData, params }: Route.Compo
                 name="allChildrenUnder18"
                 legend={t('apply-adult-child:eligibility.date-of-birth.child-age-instruction')}
                 options={[
-                  { value: AllChildrenUnder18Option.Yes, children: t('apply-adult-child:eligibility.date-of-birth.yes'), defaultChecked: defaultState.allChildrenUnder18 === true },
-                  { value: AllChildrenUnder18Option.No, children: t('apply-adult-child:eligibility.date-of-birth.no'), defaultChecked: defaultState.allChildrenUnder18 === false },
+                  { value: ALL_CHILDREN_UNDER18_OPTION.yes, children: t('apply-adult-child:eligibility.date-of-birth.yes'), defaultChecked: defaultState.allChildrenUnder18 === true },
+                  { value: ALL_CHILDREN_UNDER18_OPTION.no, children: t('apply-adult-child:eligibility.date-of-birth.no'), defaultChecked: defaultState.allChildrenUnder18 === false },
                 ]}
                 errorMessage={errors?.allChildrenUnder18}
                 required

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -26,10 +26,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum DisabilityTaxCreditOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const DISABILITY_TAX_CREDIT_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -67,7 +67,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const disabilityTaxCreditSchema = z.object({
-    disabilityTaxCredit: z.nativeEnum(DisabilityTaxCreditOption, {
+    disabilityTaxCredit: z.nativeEnum(DISABILITY_TAX_CREDIT_OPTION, {
       errorMap: () => ({ message: t('apply-adult-child:disability-tax-credit.error-message.disability-tax-credit-required') }),
     }),
   });
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.Yes } });
+  saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.yes } });
 
   invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
   const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
@@ -93,15 +93,15 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult-child/date-of-birth', params));
   }
 
-  if (parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.No && state.allChildrenUnder18) {
+  if (parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.no && state.allChildrenUnder18) {
     return redirect(getPathById('public/apply/$id/adult-child/apply-children', params));
   }
 
-  if (parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.No && !state.allChildrenUnder18) {
+  if (parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.no && !state.allChildrenUnder18) {
     return redirect(getPathById('public/apply/$id/adult-child/dob-eligibility', params));
   }
 
-  if (parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.No) {
+  if (parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.no) {
     return redirect(getPathById('public/apply/$id/adult-child/parent-or-guardian', params));
   }
 
@@ -146,8 +146,8 @@ export default function ApplyFlowDisabilityTaxCredit({ loaderData, params }: Rou
             name="disabilityTaxCredit"
             legend={t('apply-adult-child:disability-tax-credit.form-label')}
             options={[
-              { value: DisabilityTaxCreditOption.Yes, children: t('apply-adult-child:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: DisabilityTaxCreditOption.No, children: t('apply-adult-child:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === false },
+              { value: DISABILITY_TAX_CREDIT_OPTION.yes, children: t('apply-adult-child:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: DISABILITY_TAX_CREDIT_OPTION.no, children: t('apply-adult-child:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.disabilityTaxCredit}
             required

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -29,15 +29,15 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -126,9 +126,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -184,12 +184,12 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -226,13 +226,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -265,13 +265,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue === true && (

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum LivingIndependentlyOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const LIVING_INDEPENDENTLY_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -60,7 +60,7 @@ export async function action({ context: { appContainer, session }, params, reque
    * Schema for living independently.
    */
   const livingIndependentlySchema = z.object({
-    livingIndependently: z.nativeEnum(LivingIndependentlyOption, {
+    livingIndependently: z.nativeEnum(LIVING_INDEPENDENTLY_OPTION, {
       errorMap: () => ({ message: t('apply-adult-child:living-independently.error-message.living-independently-required') }),
     }),
   });
@@ -73,7 +73,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data.livingIndependently === LivingIndependentlyOption.Yes } });
+  saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes } });
 
   return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
 }
@@ -107,12 +107,12 @@ export default function ApplyFlowLivingIndependently({ loaderData, params }: Rou
             legend={t('apply-adult-child:living-independently.form-instructions')}
             options={[
               {
-                value: LivingIndependentlyOption.Yes,
+                value: LIVING_INDEPENDENTLY_OPTION.yes,
                 children: t('apply-adult-child:living-independently.radio-options.yes'),
                 defaultChecked: defaultState === true,
               },
               {
-                value: LivingIndependentlyOption.No,
+                value: LIVING_INDEPENDENTLY_OPTION.no,
                 children: t('apply-adult-child:living-independently.radio-options.no'),
                 defaultChecked: defaultState === false,
               },

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -32,10 +32,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -157,9 +157,9 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
     return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
   }
@@ -411,15 +411,15 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
             variant="primary"
             id="continue-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             disabled={isSubmitting}
-            loading={isSubmitting && submitAction === FormAction.Submit}
+            loading={isSubmitting && submitAction === FORM_ACTION.submit}
             endIcon={faChevronRight}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Review adult information click"
           >
             {t('apply-adult-child:review-adult-information.continue-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Review adult information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Review adult information click">
             {t('apply-adult-child:review-adult-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -116,8 +116,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: {} });
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
@@ -265,15 +265,15 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
             <LoadingButton
               id="confirm-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="green"
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Submit - Review child(ren) information click"
             >
               {t('apply-adult-child:review-child-information.submit-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Review child(ren) information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Exit - Review child(ren) information click">
               {t('apply-adult-child:review-child-information.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/tax-filing.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum TaxFilingOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const TAX_FILING_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult-child', 'apply', 'gcweb'),
@@ -57,7 +57,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema = z.object({
-    taxFiling2023: z.nativeEnum(TaxFilingOption, {
+    taxFiling2023: z.nativeEnum(TAX_FILING_OPTION, {
       errorMap: () => ({ message: t('apply-adult-child:eligibility.tax-filing.error-message.tax-filing-required') }),
     }),
   });
@@ -72,7 +72,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { taxFiling2023: parsedDataResult.data.taxFiling2023 === 'yes' } });
 
-  if (parsedDataResult.data.taxFiling2023 === TaxFilingOption.No) {
+  if (parsedDataResult.data.taxFiling2023 === TAX_FILING_OPTION.no) {
     return redirect(getPathById('public/apply/$id/adult-child/file-taxes', params));
   }
 
@@ -106,8 +106,8 @@ export default function ApplyFlowTaxFiling({ loaderData, params }: Route.Compone
             name="taxFiling2023"
             legend={t('apply-adult-child:eligibility.tax-filing.form-instructions')}
             options={[
-              { value: TaxFilingOption.Yes, children: t('apply-adult-child:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: TaxFilingOption.No, children: t('apply-adult-child:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+              { value: TAX_FILING_OPTION.yes, children: t('apply-adult-child:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: TAX_FILING_OPTION.no, children: t('apply-adult-child:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.taxFiling2023}
             required

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -34,11 +34,11 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -73,9 +73,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
 
     if (applicantInformationStateHasPartner(state.applicantInformation) && state.partnerInformation === undefined) {
@@ -236,10 +236,10 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Applicant information click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Applicant information click">
                 {t('apply-adult:applicant-information.save-btn')}
               </Button>
-              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Applicant information click">
+              <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Applicant information click">
                 {t('apply-adult:applicant-information.cancel-btn')}
               </Button>
             </div>
@@ -248,7 +248,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -26,10 +26,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum DisabilityTaxCreditOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const DISABILITY_TAX_CREDIT_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -67,7 +67,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const disabilityTaxCreditSchema = z.object({
-    disabilityTaxCredit: z.nativeEnum(DisabilityTaxCreditOption, {
+    disabilityTaxCredit: z.nativeEnum(DISABILITY_TAX_CREDIT_OPTION, {
       errorMap: () => ({ message: t('apply-adult:disability-tax-credit.error-message.disability-tax-credit-required') }),
     }),
   });
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.Yes } });
+  saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.yes } });
 
   invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
   const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
@@ -93,7 +93,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult/date-of-birth', params));
   }
 
-  if (parsedDataResult.data.disabilityTaxCredit === DisabilityTaxCreditOption.No) {
+  if (parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.no) {
     return redirect(getPathById('public/apply/$id/adult/dob-eligibility', params));
   }
 
@@ -129,8 +129,8 @@ export default function ApplyFlowDisabilityTaxCredit({ loaderData, params }: Rou
             name="disabilityTaxCredit"
             legend={t('apply-adult:disability-tax-credit.form-label')}
             options={[
-              { value: DisabilityTaxCreditOption.Yes, children: t('apply-adult:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: DisabilityTaxCreditOption.No, children: t('apply-adult:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === false },
+              { value: DISABILITY_TAX_CREDIT_OPTION.yes, children: t('apply-adult:disability-tax-credit.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: DISABILITY_TAX_CREDIT_OPTION.no, children: t('apply-adult:disability-tax-credit.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.disabilityTaxCredit}
             required

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -28,15 +28,15 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -125,9 +125,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -180,12 +180,12 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -221,13 +221,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -260,13 +260,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue === true && (

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum LivingIndependentlyOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const LIVING_INDEPENDENTLY_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -60,7 +60,7 @@ export async function action({ context: { appContainer, session }, params, reque
    * Schema for living independently.
    */
   const livingIndependentlySchema = z.object({
-    livingIndependently: z.nativeEnum(LivingIndependentlyOption, {
+    livingIndependently: z.nativeEnum(LIVING_INDEPENDENTLY_OPTION, {
       errorMap: () => ({ message: t('apply-adult:living-independently.error-message.living-independently-required') }),
     }),
   });
@@ -73,13 +73,13 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data.livingIndependently === LivingIndependentlyOption.Yes } });
+  saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes } });
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
-  if (parsedDataResult.data.livingIndependently === LivingIndependentlyOption.Yes) {
+  if (parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes) {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
   }
 
@@ -113,12 +113,12 @@ export default function ApplyFlowLivingIndependently({ loaderData, params }: Rou
             legend={t('apply-adult:living-independently.form-instructions')}
             options={[
               {
-                value: LivingIndependentlyOption.Yes,
+                value: LIVING_INDEPENDENTLY_OPTION.yes,
                 children: t('apply-adult:living-independently.radio-options.yes'),
                 defaultChecked: defaultState === true,
               },
               {
-                value: LivingIndependentlyOption.No,
+                value: LIVING_INDEPENDENTLY_OPTION.no,
                 children: t('apply-adult:living-independently.radio-options.no'),
                 defaultChecked: defaultState === false,
               },

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -162,8 +162,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
     return redirect(getPathById('public/apply/$id/adult/federal-provincial-territorial-benefits', params));
   }
@@ -421,15 +421,15 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
           <LoadingButton
             id="confirm-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             variant="green"
             disabled={isSubmitting}
-            loading={isSubmitting && submitAction === FormAction.Submit}
+            loading={isSubmitting && submitAction === FORM_ACTION.submit}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Submit - Review your information click"
           >
             {t('apply-adult:review-information.submit-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Exit - Review your information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Exit - Review your information click">
             {t('apply-adult:review-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/tax-filing.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum TaxFilingOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const TAX_FILING_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
@@ -57,7 +57,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema = z.object({
-    taxFiling2023: z.nativeEnum(TaxFilingOption, {
+    taxFiling2023: z.nativeEnum(TAX_FILING_OPTION, {
       errorMap: () => ({ message: t('apply-adult:eligibility.tax-filing.error-message.tax-filing-required') }),
     }),
   });
@@ -70,9 +70,9 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { taxFiling2023: parsedDataResult.data.taxFiling2023 === TaxFilingOption.Yes } });
+  saveApplyState({ params, session, state: { taxFiling2023: parsedDataResult.data.taxFiling2023 === TAX_FILING_OPTION.yes } });
 
-  if (parsedDataResult.data.taxFiling2023 === TaxFilingOption.No) {
+  if (parsedDataResult.data.taxFiling2023 === TAX_FILING_OPTION.no) {
     return redirect(getPathById('public/apply/$id/adult/file-taxes', params));
   }
 
@@ -103,8 +103,8 @@ export default function ApplyFlowTaxFiling({ loaderData, params }: Route.Compone
             name="taxFiling2023"
             legend={t('apply-adult:eligibility.tax-filing.form-instructions')}
             options={[
-              { value: TaxFilingOption.Yes, children: t('apply-adult:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: TaxFilingOption.No, children: t('apply-adult:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+              { value: TAX_FILING_OPTION.yes, children: t('apply-adult:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: TAX_FILING_OPTION.no, children: t('apply-adult:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.taxFiling2023}
             required

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -37,11 +37,11 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -161,9 +161,9 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('apply-child:applicant-information.error-message.marital-status-required')),
   }) satisfies z.ZodType<ApplicantInformationState>;
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
 
     if (applicantInformationStateHasPartner(state.applicantInformation) && state.partnerInformation === undefined) {
@@ -328,10 +328,17 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Parent or legal guardian personal information click">
+              <Button
+                id="save-button"
+                name="_action"
+                value={FORM_ACTION.save}
+                variant="primary"
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Parent or legal guardian personal information click"
+              >
                 {t('apply-child:applicant-information.save-btn')}
               </Button>
-              <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Parent or legal guardian personal information click">
+              <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Parent or legal guardian personal information click">
                 {t('apply-child:applicant-information.cancel-btn')}
               </Button>
             </div>
@@ -340,7 +347,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -27,15 +27,15 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -134,9 +134,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -198,12 +198,12 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -236,13 +236,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -275,13 +275,13 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue === true && (

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -37,10 +37,10 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum YesNoOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const YES_NO_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -172,11 +172,11 @@ export async function action({ context: { appContainer, session }, params, reque
     dateOfBirthMonth: formData.get('dateOfBirthMonth') ? Number(formData.get('dateOfBirthMonth')) : undefined,
     dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
     dateOfBirth: '',
-    isParent: formData.get('isParent') ? formData.get('isParent') === YesNoOption.Yes : undefined,
+    isParent: formData.get('isParent') ? formData.get('isParent') === YES_NO_OPTION.yes : undefined,
   });
 
   const parsedSinDataResult = childSinSchema.safeParse({
-    hasSocialInsuranceNumber: formData.get('hasSocialInsuranceNumber') ? formData.get('hasSocialInsuranceNumber') === YesNoOption.Yes : undefined,
+    hasSocialInsuranceNumber: formData.get('hasSocialInsuranceNumber') ? formData.get('hasSocialInsuranceNumber') === YES_NO_OPTION.yes : undefined,
     socialInsuranceNumber: formData.get('socialInsuranceNumber') ? String(formData.get('socialInsuranceNumber') ?? '') : undefined,
   });
 
@@ -244,13 +244,13 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
   });
 
   const handleSocialInsuranceNumberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
-    setHasSocialInsuranceNumberValue(e.target.value === YesNoOption.Yes);
+    setHasSocialInsuranceNumberValue(e.target.value === YES_NO_OPTION.yes);
   };
 
   const options: InputRadiosProps['options'] = [
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
-      value: YesNoOption.Yes,
+      value: YES_NO_OPTION.yes,
       defaultChecked: defaultState?.hasSocialInsuranceNumber === true,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
@@ -270,7 +270,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     },
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.information.sin-no" components={{ bold: <strong /> }} />,
-      value: YesNoOption.No,
+      value: YES_NO_OPTION.no,
       defaultChecked: defaultState?.hasSocialInsuranceNumber === false,
       onChange: handleSocialInsuranceNumberSelection,
     },
@@ -340,8 +340,8 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
               name="isParent"
               legend={t('apply-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
-                { value: YesNoOption.No, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YES_NO_OPTION.yes, children: t('apply-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
+                { value: YES_NO_OPTION.no, children: t('apply-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
               required

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -31,13 +31,13 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Add = 'add',
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-  Remove = 'remove',
-}
+const FORM_ACTION = {
+  add: 'add',
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+  remove: 'remove',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -85,16 +85,16 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadApplyChildState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Add) {
+  if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();
     const children = [...getChildrenState(state), { id: childId }];
     saveApplyState({ params, session, state: { children } });
     return redirect(getPathById('public/apply/$id/child/children/$childId/information', { ...params, childId }));
   }
 
-  if (formAction === FormAction.Remove) {
+  if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
     const children = [...getChildrenState(state)].filter((child) => child.id !== removeChildId);
     saveApplyState({ params, session, state: { children } });
@@ -206,7 +206,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                             <Button
                               id="remove-child"
                               name="_action"
-                              value={FormAction.Remove}
+                              value={FORM_ACTION.remove}
                               disabled={isSubmitting}
                               variant="primary"
                               size="sm"
@@ -227,7 +227,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
 
         <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
           <CsrfTokenInput />
-          <Button className="my-10" id="add-child" name="_action" value={FormAction.Add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Add child - Child(ren) application click">
+          <Button className="my-10" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Add child - Child(ren) application click">
             {children.length === 0 ? t('apply-child:children.index.add-child') : t('apply-child:children.index.add-another-child')}
           </Button>
 
@@ -258,10 +258,10 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 disabled={!hasChildren || isSubmitting}
-                loading={isSubmitting && submitAction === FormAction.Continue}
+                loading={isSubmitting && submitAction === FORM_ACTION.continue}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Child(ren) application click"
               >

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -137,8 +137,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     return redirect(getPathById('public/apply/$id/child/review-child-information', params));
   }
 
@@ -364,15 +364,15 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
             <LoadingButton
               id="confirm-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="green"
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Submit - Review adult information click"
             >
               {t('apply-child:review-adult-information.submit-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Exit - Review adult information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Exit - Review adult information click">
               {t('apply-child:review-adult-information.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -33,10 +33,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -108,8 +108,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
     return redirect(getPathById('public/apply/$id/child/communication-preference', params));
   }
@@ -245,15 +245,15 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
             variant="primary"
             id="continue-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             disabled={isSubmitting}
-            loading={isSubmitting && submitAction === FormAction.Submit}
+            loading={isSubmitting && submitAction === FORM_ACTION.submit}
             endIcon={faChevronRight}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Review child information click"
           >
             {t('apply-child:review-child-information.continue-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Exit - Review child information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Exit - Review child information click">
             {t('apply-child:review-child-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/child/tax-filing.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum TaxFilingOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const TAX_FILING_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
@@ -57,7 +57,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema = z.object({
-    taxFiling2023: z.nativeEnum(TaxFilingOption, {
+    taxFiling2023: z.nativeEnum(TAX_FILING_OPTION, {
       errorMap: () => ({ message: t('apply-child:eligibility.tax-filing.error-message.tax-filing-required') }),
     }),
   });
@@ -70,9 +70,9 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { taxFiling2023: parsedDataResult.data.taxFiling2023 === TaxFilingOption.Yes } });
+  saveApplyState({ params, session, state: { taxFiling2023: parsedDataResult.data.taxFiling2023 === TAX_FILING_OPTION.yes } });
 
-  if (parsedDataResult.data.taxFiling2023 === TaxFilingOption.No) {
+  if (parsedDataResult.data.taxFiling2023 === TAX_FILING_OPTION.no) {
     return redirect(getPathById('public/apply/$id/child/file-taxes', params));
   }
 
@@ -104,8 +104,8 @@ export default function ApplyFlowTaxFiling({ loaderData, params }: Route.Compone
             name="taxFiling2023"
             legend={t('apply-child:eligibility.tax-filing.form-instructions')}
             options={[
-              { value: TaxFilingOption.Yes, children: t('apply-child:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: TaxFilingOption.No, children: t('apply-child:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+              { value: TAX_FILING_OPTION.yes, children: t('apply-child:eligibility.tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: TAX_FILING_OPTION.no, children: t('apply-child:eligibility.tax-filing.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.taxFiling2023}
             required

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -24,12 +24,12 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum ApplicantType {
-  Adult = 'adult',
-  AdultChild = 'adult-child',
-  Child = 'child',
-  Delegate = 'delegate',
-}
+const APPLICANT_TYPE = {
+  adult: 'adult',
+  adultChild: 'adult-child',
+  child: 'child',
+  delegate: 'delegate',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply', 'gcweb'),
@@ -62,7 +62,7 @@ export async function action({ context: { appContainer, session }, params, reque
    * Schema for application delegate.
    */
   const typeOfApplicationSchema = z.object({
-    typeOfApplication: z.nativeEnum(ApplicantType, {
+    typeOfApplication: z.nativeEnum(APPLICANT_TYPE, {
       errorMap: () => ({ message: t('apply:type-of-application.error-message.type-of-application-required') }),
     }),
   });
@@ -84,15 +84,15 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  if (parsedDataResult.data.typeOfApplication === ApplicantType.Adult) {
+  if (parsedDataResult.data.typeOfApplication === APPLICANT_TYPE.adult) {
     return redirect(getPathById('public/apply/$id/adult/tax-filing', params));
   }
 
-  if (parsedDataResult.data.typeOfApplication === ApplicantType.AdultChild) {
+  if (parsedDataResult.data.typeOfApplication === APPLICANT_TYPE.adultChild) {
     return redirect(getPathById('public/apply/$id/adult-child/tax-filing', params));
   }
 
-  if (parsedDataResult.data.typeOfApplication === ApplicantType.Child) {
+  if (parsedDataResult.data.typeOfApplication === APPLICANT_TYPE.child) {
     return redirect(getPathById('public/apply/$id/child/tax-filing', params));
   }
 
@@ -151,24 +151,24 @@ export default function ApplyFlowTypeOfApplication({ loaderData, params }: Route
             legend={t('apply:type-of-application.form-instructions')}
             options={[
               {
-                value: ApplicantType.Adult,
+                value: APPLICANT_TYPE.adult,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.personal" />,
-                defaultChecked: defaultState === ApplicantType.Adult,
+                defaultChecked: defaultState === APPLICANT_TYPE.adult,
               },
               {
-                value: ApplicantType.Child,
+                value: APPLICANT_TYPE.child,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.child" />,
-                defaultChecked: defaultState === ApplicantType.Child,
+                defaultChecked: defaultState === APPLICANT_TYPE.child,
               },
               {
-                value: ApplicantType.AdultChild,
+                value: APPLICANT_TYPE.adultChild,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.personal-and-child" />,
-                defaultChecked: defaultState === ApplicantType.AdultChild,
+                defaultChecked: defaultState === APPLICANT_TYPE.adultChild,
               },
               {
-                value: ApplicantType.Delegate,
+                value: APPLICANT_TYPE.delegate,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="apply:type-of-application.radio-options.delegate" />,
-                defaultChecked: defaultState === ApplicantType.Delegate,
+                defaultChecked: defaultState === APPLICANT_TYPE.delegate,
               },
             ]}
             required

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -27,10 +27,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FederalBenefitsChangedOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const FEDERAL_BENEFITS_CHANGED_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -78,7 +78,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const dentalBenefits = {
-    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FEDERAL_BENEFITS_CHANGED_OPTION.yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -135,7 +135,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FederalBenefitsChangedOption.Yes);
+    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FEDERAL_BENEFITS_CHANGED_OPTION.yes);
   }
 
   return (
@@ -159,13 +159,13 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.confirm-dental-benefits.option-yes" />,
-                  value: FederalBenefitsChangedOption.Yes,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.yes,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === true,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.confirm-dental-benefits.option-no" />,
-                  value: FederalBenefitsChangedOption.No,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.no,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === false,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
@@ -30,10 +30,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'gcweb'),
@@ -122,7 +122,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+  const preferNotToAnswer = z.nativeEnum(FORM_ACTION).parse(formData.get('_action')) === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -238,7 +238,7 @@ export default function RenewAdultChildChildrenDemographicSurveyQuestions({ load
             <p>{t('renew-adult-child:children.demographic-survey.improve-cdcp')}</p>
             <p>{t('renew-adult-child:children.demographic-survey.confidential')}</p>
             <p>{t('renew-adult-child:children.demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Prefer not to answer - Child voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Prefer not to answer - Child voluntary demographic questions click">
               {t('renew-adult-child:children.demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew-adult-child:children.demographic-survey.optional')}</p>
@@ -274,7 +274,7 @@ export default function RenewAdultChildChildrenDemographicSurveyQuestions({ load
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Child voluntary demographic questions click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Child voluntary demographic questions click">
                 {t('renew-adult-child:children.demographic-survey.save-btn')}
               </Button>
               <ButtonLink
@@ -292,7 +292,7 @@ export default function RenewAdultChildChildrenDemographicSurveyQuestions({ load
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum YesNoOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const YES_NO_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew', 'renew-adult-child', 'gcweb'),
@@ -165,7 +165,7 @@ export async function action({ context: { appContainer, session }, params, reque
     dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
     dateOfBirth: '',
     clientNumber: String(formData.get('clientNumber') ?? ''),
-    isParent: formData.get('isParent') ? formData.get('isParent') === YesNoOption.Yes : undefined,
+    isParent: formData.get('isParent') ? formData.get('isParent') === YES_NO_OPTION.yes : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -304,8 +304,8 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               name="isParent"
               legend={t('renew-adult-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('renew-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: false, tabIndex: 0 },
-                { value: YesNoOption.No, children: t('renew-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
+                { value: YES_NO_OPTION.yes, children: t('renew-adult-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: false, tabIndex: 0 },
+                { value: YES_NO_OPTION.no, children: t('renew-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
             />

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -30,21 +30,21 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -98,8 +98,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Cancel) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       saveRenewState({
         params,
@@ -163,9 +163,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -231,12 +231,12 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -273,7 +273,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -294,7 +294,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -312,7 +312,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -358,7 +358,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:children.update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
@@ -372,7 +372,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <Button
                 id="save-button"
                 name="_action"
-                value={FormAction.Save}
+                value={FORM_ACTION.save}
                 variant="primary"
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Child access to other federal, provincial or territorial dental benefits click"
@@ -382,7 +382,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <LoadingButton
                 id="cancel-button"
                 name="_action"
-                value={FormAction.Cancel}
+                value={FORM_ACTION.cancel}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Child access to other federal, provincial or territorial dental benefits click"
               >
@@ -394,7 +394,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -30,14 +30,14 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Add = 'add',
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-  Remove = 'remove',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  add: 'add',
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+  remove: 'remove',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -86,9 +86,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     if (demographicSurveyEnabled) {
       return redirect(getPathById('public/renew/$id/adult-child/demographic-survey', params));
     }
@@ -98,14 +98,14 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
   }
 
-  if (formAction === FormAction.Add) {
+  if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();
     const children = [...getChildrenState(state), { id: childId }];
     saveRenewState({ params, session, state: { children } });
     return redirect(getPathById('public/renew/$id/adult-child/children/$childId/information', { ...params, childId }));
   }
 
-  if (formAction === FormAction.Remove) {
+  if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
     const children = [...getChildrenState(state)].filter((child) => child.id !== removeChildId);
     saveRenewState({ params, session, state: { children } });
@@ -226,7 +226,7 @@ export default function RenewFlowChildSummary({ loaderData, params }: Route.Comp
                             <Button
                               id="remove-child"
                               name="_action"
-                              value={FormAction.Remove}
+                              value={FORM_ACTION.remove}
                               disabled={isSubmitting}
                               variant="primary"
                               size="sm"
@@ -247,7 +247,7 @@ export default function RenewFlowChildSummary({ loaderData, params }: Route.Comp
 
         <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
           <CsrfTokenInput />
-          <Button className="my-10" id="add-child" name="_action" value={FormAction.Add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Renew child - Child(ren) renewal click">
+          <Button className="my-10" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Renew child - Child(ren) renewal click">
             {children.length === 0 ? t('renew-adult-child:children.index.add-child') : t('renew-adult-child:children.index.add-another-child')}
           </Button>
 
@@ -278,15 +278,15 @@ export default function RenewFlowChildSummary({ loaderData, params }: Route.Comp
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
-                loading={isSubmitting && submitAction === FormAction.Continue}
+                loading={isSubmitting && submitAction === FORM_ACTION.continue}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Child(ren) renewal click"
               >
                 {t('renew-adult-child:children.index.continue-btn')}
               </LoadingButton>
-              <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Child(ren) renewal click">
+              <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Child(ren) renewal click">
                 {t('renew-adult-child:children.index.back-btn')}
               </Button>
             </div>

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -24,16 +24,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddressRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const ADDRESS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -64,7 +64,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const confirmAddressSchema = z.object({
-    hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+    hasAddressChanged: z.nativeEnum(ADDRESS_RADIO_OPTIONS, {
       errorMap: () => ({ message: t('renew-adult-child:confirm-address.error-message.has-address-changed-required') }),
     }),
   });
@@ -81,13 +81,13 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
-      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.homeAddress,
-      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.mailingAddress,
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes,
+      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.homeAddress,
+      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.mailingAddress,
     },
   });
 
-  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes) {
+  if (parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes) {
     return redirect(getPathById('public/renew/$id/adult-child/update-mailing-address', params));
   }
 
@@ -124,8 +124,8 @@ export default function RenewAdultChildConfirmAddress({ loaderData, params }: Ro
               name="hasAddressChanged"
               legend={t('renew-adult-child:confirm-address.have-you-moved')}
               options={[
-                { value: AddressRadioOptions.Yes, children: t('renew-adult-child:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
-                { value: AddressRadioOptions.No, children: t('renew-adult-child:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
+                { value: ADDRESS_RADIO_OPTIONS.yes, children: t('renew-adult-child:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
+                { value: ADDRESS_RADIO_OPTIONS.no, children: t('renew-adult-child:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
               ]}
               helpMessagePrimary={t('renew-adult-child:confirm-address.help-message')}
               errorMessage={errors?.hasAddressChanged}
@@ -135,7 +135,7 @@ export default function RenewAdultChildConfirmAddress({ loaderData, params }: Ro
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Address click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Address click">
                 {t('renew-adult-child:confirm-address.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult-child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Address click">

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -28,21 +28,21 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdateEmailOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_EMAIL_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
-enum ShouldReceiveEmailCommunicationOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -84,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const emailSchema = z
     .object({
-      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
+      isNewOrUpdatedEmail: z.nativeEnum(ADD_OR_UPDATE_EMAIL_OPTION, {
         errorMap: () => ({ message: t('renew-adult-child:confirm-email.error-message.add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
@@ -92,7 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
       shouldReceiveEmailCommunication: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (!val.email) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.email-required'), path: ['email'] });
         }
@@ -114,7 +114,7 @@ export async function action({ context: { appContainer, session }, params, reque
         }
       }
 
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (val.shouldReceiveEmailCommunication === undefined) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
         }
@@ -122,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
-      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes : undefined,
+      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes,
+      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes : undefined,
     }));
 
   const parsedDataResult = emailSchema.safeParse({
@@ -164,7 +164,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
   const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
 
   function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
+    setIsNewOrUpdatedEmail(e.target.value === ADD_OR_UPDATE_EMAIL_OPTION.yes);
   }
 
   return (
@@ -188,7 +188,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-yes" />,
-                  value: AddOrUpdateEmailOption.Yes,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.yes,
                   defaultChecked: isNewOrUpdatedEmail === true,
                   onChange: handleNewOrUpdateEmailChanged,
                   append: isNewOrUpdatedEmail === true && (
@@ -224,7 +224,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-no" />,
-                  value: AddOrUpdateEmailOption.No,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.no,
                   defaultChecked: isNewOrUpdatedEmail === false,
                   onChange: handleNewOrUpdateEmailChanged,
                 },
@@ -242,12 +242,12 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
                 options={[
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-yes" />,
-                    value: ShouldReceiveEmailCommunicationOption.Yes,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
                   },
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-email.option-no" />,
-                    value: ShouldReceiveEmailCommunicationOption.No,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.no,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
                   },
                 ]}
@@ -258,7 +258,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
           )}
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Email click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Email click">
                 {t('renew-adult-child:confirm-email.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult-child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Email click">
@@ -270,7 +270,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -25,10 +25,10 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FederalBenefitsChangedOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const FEDERAL_BENEFITS_CHANGED_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -71,7 +71,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const dentalBenefits = {
-    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FEDERAL_BENEFITS_CHANGED_OPTION.yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -122,7 +122,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FederalBenefitsChangedOption.Yes);
+    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FEDERAL_BENEFITS_CHANGED_OPTION.yes);
   }
 
   return (
@@ -145,13 +145,13 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-dental-benefits.option-yes" />,
-                  value: FederalBenefitsChangedOption.Yes,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.yes,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === true,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-dental-benefits.option-no" />,
-                  value: FederalBenefitsChangedOption.No,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.no,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === false,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum MaritalStatusRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const MARITAL_STATUS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -121,8 +121,8 @@ export default function RenewAdultChildConfirmMaritalStatus({ loaderData, params
               name="hasMaritalStatusChanged"
               legend={t('renew-adult-child:confirm-marital-status.has-marital-status-changed')}
               options={[
-                { value: MaritalStatusRadioOptions.Yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
-                { value: MaritalStatusRadioOptions.No, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
               helpMessagePrimary={t('renew-adult-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -28,16 +28,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdatePhoneOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_PHONE_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -81,7 +81,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const phoneNumberSchema = z
     .object({
-      isNewOrUpdatedPhoneNumber: z.nativeEnum(AddOrUpdatePhoneOption, {
+      isNewOrUpdatedPhoneNumber: z.nativeEnum(ADD_OR_UPDATE_PHONE_OPTION, {
         errorMap: () => ({ message: t('renew-adult-child:confirm-phone.error-message.add-or-update-required') }),
       }),
       phoneNumber: phoneSchema({
@@ -94,7 +94,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes) {
+      if (val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes) {
         if (!val.phoneNumber) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:confirm-phone.error-message.phone-required'), path: ['phoneNumber'] });
         }
@@ -102,7 +102,7 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes,
+      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes,
     }));
 
   const parsedDataResult = phoneNumberSchema.safeParse({
@@ -141,7 +141,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
   const [isNewOrUpdatedPhoneNumber, setIsNewOrUpdatedPhoneNumber] = useState(defaultState.isNewOrUpdatedPhoneNumber);
 
   function handleNewOrUpdatePhoneNumberChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedPhoneNumber(e.target.value === AddOrUpdatePhoneOption.Yes);
+    setIsNewOrUpdatedPhoneNumber(e.target.value === ADD_OR_UPDATE_PHONE_OPTION.yes);
   }
 
   return (
@@ -165,7 +165,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-phone.option-yes" />,
-                  value: AddOrUpdatePhoneOption.Yes,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.yes,
                   defaultChecked: isNewOrUpdatedPhoneNumber === true,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                   append: isNewOrUpdatedPhoneNumber === true && (
@@ -201,7 +201,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:confirm-phone.option-no" />,
-                  value: AddOrUpdatePhoneOption.No,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.no,
                   defaultChecked: isNewOrUpdatedPhoneNumber === false,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                 },
@@ -212,7 +212,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Phone number click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Phone number click">
                 {t('renew-adult-child:confirm-phone.save-btn')}
               </Button>
               <ButtonLink
@@ -230,7 +230,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Close = 'close',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  close: 'close',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -376,7 +376,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
                 variant="primary"
                 size="sm"
                 name="_action"
-                value={FormAction.Close}
+                value={FORM_ACTION.close}
                 onClick={() => sessionStorage.removeItem('flow.state')}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Modal Close application - Your renewal for the Canadian Dental Care Plan is complete click"
               >

--- a/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/demographic-survey.tsx
@@ -30,11 +30,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'gcweb'),
@@ -88,9 +88,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewAdultChildState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));
     }
@@ -128,7 +128,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = formAction === FormAction.Save;
+  const preferNotToAnswer = formAction === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -230,7 +230,7 @@ export default function RenewAdultChildDemographicSurveyQuestions({ loaderData, 
             <p>{t('renew-adult-child:demographic-survey.improve-cdcp')}</p>
             <p>{t('renew-adult-child:demographic-survey.confidential')}</p>
             <p>{t('renew-adult-child:demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Prefer not to answer - Voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Prefer not to answer - Voluntary demographic questions click">
               {t('renew-adult-child:demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew-adult-child:demographic-survey.optional')}</p>
@@ -259,7 +259,7 @@ export default function RenewAdultChildDemographicSurveyQuestions({ loaderData, 
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Voluntary demographic questions click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Voluntary demographic questions click">
                 {t('renew-adult-child:demographic-survey.save-btn')}
               </Button>
               <ButtonLink
@@ -277,7 +277,7 @@ export default function RenewAdultChildDemographicSurveyQuestions({ loaderData, 
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
@@ -288,7 +288,7 @@ export default function RenewAdultChildDemographicSurveyQuestions({ loaderData, 
               <LoadingButton
                 id="back-button"
                 name="_action"
-                value={FormAction.Back}
+                value={FORM_ACTION.back}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Voluntary demographic questions click"

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -24,12 +24,12 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Back = 'back',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  back: 'back',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -64,8 +64,8 @@ export async function action({ context: { appContainer, session }, params, reque
     dentalInsurance: z.boolean({ errorMap: () => ({ message: t('renew-adult-child:dental-insurance.error-message.dental-insurance-required') }) }),
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     if (state.hasAddressChanged) {
       if (state.isHomeAddressSameAsMailingAddress) {
         return redirect(getPathById('public/renew/$id/adult-child/update-mailing-address', params));
@@ -170,7 +170,7 @@ export default function RenewAdultChildAccessToDentalInsuranceQuestion({ loaderD
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Access to private dental insurance click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Access to private dental insurance click">
                 {t('dental-insurance.button.save-btn')}
               </Button>
               <ButtonLink
@@ -187,7 +187,7 @@ export default function RenewAdultChildAccessToDentalInsuranceQuestion({ loaderD
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
@@ -198,7 +198,7 @@ export default function RenewAdultChildAccessToDentalInsuranceQuestion({ loaderD
               <Button
                 id="back-button"
                 name="_action"
-                value={FormAction.Back}
+                value={FORM_ACTION.back}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Access to private dental insurance click"

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -33,11 +33,11 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -201,7 +201,7 @@ export default function RenewAdultChildMaritalStatus({ loaderData, params }: Rou
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Marital status click">
                 {t('renew-adult-child:marital-status.save-btn')}
               </Button>
               <ButtonLink
@@ -219,7 +219,7 @@ export default function RenewAdultChildMaritalStatus({ loaderData, params }: Rou
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -159,8 +159,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: { editMode: false } });
     return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
   }
@@ -405,9 +405,9 @@ export default function RenewAdultChildReviewAdultInformation({ loaderData, para
               variant="primary"
               id="continue-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               endIcon={faChevronRight}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Review your information click"
             >
@@ -420,17 +420,17 @@ export default function RenewAdultChildReviewAdultInformation({ loaderData, para
               <LoadingButton
                 id="confirm-button"
                 name="_action"
-                value={FormAction.Submit}
+                value={FORM_ACTION.submit}
                 variant="green"
                 disabled={isSubmitting}
-                loading={isSubmitting && submitAction === FormAction.Submit}
+                loading={isSubmitting && submitAction === FORM_ACTION.submit}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Submit renewal application - Review your information click"
               >
                 {t('renew-adult-child:review-adult-information.submit-button')}
               </LoadingButton>
             </>
           )}
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Review your information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Review your information click">
             {t('renew-adult-child:review-adult-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -34,10 +34,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -115,8 +115,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: {} });
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
   }
@@ -259,15 +259,15 @@ export default function RenewAdultChildReviewChildInformation({ loaderData, para
             <LoadingButton
               id="confirm-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="green"
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Submit application - Review child(ren) information click"
             >
               {t('renew-adult-child:review-child-information.submit-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Review child(ren) information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Review child(ren) information click">
               {t('renew-adult-child:review-child-information.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -28,21 +28,21 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -89,8 +89,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Cancel) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       saveRenewState({
         params,
@@ -148,9 +148,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -210,12 +210,12 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -251,7 +251,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -272,7 +272,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -290,7 +290,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -336,7 +336,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult-child:update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
@@ -350,7 +350,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <Button
                 id="save-button"
                 name="_action"
-                value={FormAction.Save}
+                value={FORM_ACTION.save}
                 variant="primary"
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Access to other federal, provincial or territorial dental benefits click"
@@ -360,7 +360,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <LoadingButton
                 id="cancel-button"
                 name="_action"
-                value={FormAction.Cancel}
+                value={FORM_ACTION.cancel}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Access to other federal, provincial or territorial dental benefits click"
               >
@@ -372,7 +372,7 @@ export default function RenewAdultChildUpdateFederalProvincialTerritorialBenefit
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -35,11 +35,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -96,7 +96,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
@@ -327,7 +327,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Home address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Home address click">
                     {t('renew-adult-child:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -351,7 +351,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Home address click"
@@ -473,7 +473,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -539,7 +539,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -36,11 +36,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -107,7 +107,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewAdultChildState({ params, request, session });
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
@@ -368,7 +368,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                     id="save-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Mailing address click"
                   >
@@ -403,7 +403,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Mailing address click"
@@ -532,7 +532,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -602,7 +602,7 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -24,16 +24,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddressRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const ADDRESS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -64,7 +64,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const confirmAddressSchema = z.object({
-    hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+    hasAddressChanged: z.nativeEnum(ADDRESS_RADIO_OPTIONS, {
       errorMap: () => ({ message: t('renew-adult:confirm-address.error-message.has-address-changed-required') }),
     }),
   });
@@ -81,13 +81,13 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
-      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.homeAddress,
-      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.mailingAddress,
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes,
+      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.homeAddress,
+      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.mailingAddress,
     },
   });
 
-  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes) {
+  if (parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes) {
     return redirect(getPathById('public/renew/$id/adult/update-mailing-address', params));
   }
 
@@ -124,8 +124,8 @@ export default function RenewAdultConfirmAddress({ loaderData, params }: Route.C
               name="hasAddressChanged"
               legend={t('renew-adult:confirm-address.have-you-moved')}
               options={[
-                { value: AddressRadioOptions.Yes, children: t('renew-adult:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
-                { value: AddressRadioOptions.No, children: t('renew-adult:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
+                { value: ADDRESS_RADIO_OPTIONS.yes, children: t('renew-adult:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
+                { value: ADDRESS_RADIO_OPTIONS.no, children: t('renew-adult:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
               ]}
               helpMessagePrimary={t('renew-adult:confirm-address.help-message')}
               errorMessage={errors?.hasAddressChanged}
@@ -135,7 +135,7 @@ export default function RenewAdultConfirmAddress({ loaderData, params }: Route.C
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Address click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Address click">
                 {t('renew-adult:confirm-address.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Address click">

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -28,21 +28,21 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdateEmailOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_EMAIL_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
-enum ShouldReceiveEmailCommunicationOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -84,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const emailSchema = z
     .object({
-      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
+      isNewOrUpdatedEmail: z.nativeEnum(ADD_OR_UPDATE_EMAIL_OPTION, {
         errorMap: () => ({ message: t('renew-adult:confirm-email.error-message.add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
@@ -92,7 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
       shouldReceiveEmailCommunication: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (!val.email) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.email-required'), path: ['email'] });
         }
@@ -114,7 +114,7 @@ export async function action({ context: { appContainer, session }, params, reque
         }
       }
 
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (val.shouldReceiveEmailCommunication === undefined) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
         }
@@ -122,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
-      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes : undefined,
+      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes,
+      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes : undefined,
     }));
 
   const parsedDataResult = emailSchema.safeParse({
@@ -164,7 +164,7 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
   const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
 
   function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
+    setIsNewOrUpdatedEmail(e.target.value === ADD_OR_UPDATE_EMAIL_OPTION.yes);
   }
 
   return (
@@ -188,7 +188,7 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-yes" />,
-                  value: AddOrUpdateEmailOption.Yes,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.yes,
                   defaultChecked: isNewOrUpdatedEmail === true,
                   onChange: handleNewOrUpdateEmailChanged,
                   append: isNewOrUpdatedEmail === true && (
@@ -224,7 +224,7 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-no" />,
-                  value: AddOrUpdateEmailOption.No,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.no,
                   defaultChecked: isNewOrUpdatedEmail === false,
                   onChange: handleNewOrUpdateEmailChanged,
                 },
@@ -242,12 +242,12 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
                 options={[
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-yes" />,
-                    value: ShouldReceiveEmailCommunicationOption.Yes,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
                   },
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-email.option-no" />,
-                    value: ShouldReceiveEmailCommunicationOption.No,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.no,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
                   },
                 ]}
@@ -258,7 +258,7 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
           )}
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Email click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Email click">
                 {t('renew-adult:confirm-email.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Email click">
@@ -270,7 +270,7 @@ export default function RenewAdultConfirmEmail({ loaderData, params }: Route.Com
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -25,10 +25,10 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FederalBenefitsChangedOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const FEDERAL_BENEFITS_CHANGED_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -71,7 +71,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const dentalBenefits = {
-    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FEDERAL_BENEFITS_CHANGED_OPTION.yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -122,7 +122,7 @@ export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ 
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FederalBenefitsChangedOption.Yes);
+    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FEDERAL_BENEFITS_CHANGED_OPTION.yes);
   }
 
   return (
@@ -145,13 +145,13 @@ export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ 
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-dental-benefits.option-yes" />,
-                  value: FederalBenefitsChangedOption.Yes,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.yes,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === true,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-dental-benefits.option-no" />,
-                  value: FederalBenefitsChangedOption.No,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.no,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === false,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum MaritalStatusRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const MARITAL_STATUS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -121,8 +121,8 @@ export default function RenewAdultConfirmMaritalStatus({ loaderData, params }: R
               name="hasMaritalStatusChanged"
               legend={t('renew-adult:confirm-marital-status.has-marital-status-changed')}
               options={[
-                { value: MaritalStatusRadioOptions.Yes, children: t('renew-adult:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
-                { value: MaritalStatusRadioOptions.No, children: t('renew-adult:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-adult:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-adult:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
               helpMessagePrimary={t('renew-adult:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -28,16 +28,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdatePhoneOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_PHONE_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -81,7 +81,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const phoneNumberSchema = z
     .object({
-      isNewOrUpdatedPhoneNumber: z.nativeEnum(AddOrUpdatePhoneOption, {
+      isNewOrUpdatedPhoneNumber: z.nativeEnum(ADD_OR_UPDATE_PHONE_OPTION, {
         errorMap: () => ({ message: t('renew-adult:confirm-phone.error-message.add-or-update-required') }),
       }),
       phoneNumber: phoneSchema({
@@ -94,7 +94,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes) {
+      if (val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes) {
         if (!val.phoneNumber) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:confirm-phone.error-message.phone-required'), path: ['phoneNumber'] });
         }
@@ -102,7 +102,7 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes,
+      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes,
     }));
 
   const parsedDataResult = phoneNumberSchema.safeParse({
@@ -141,7 +141,7 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
   const [isNewOrUpdatedPhoneNumber, setIsNewOrUpdatedPhoneNumber] = useState(defaultState.isNewOrUpdatedPhoneNumber);
 
   function handleNewOrUpdatePhoneNumberChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedPhoneNumber(e.target.value === AddOrUpdatePhoneOption.Yes);
+    setIsNewOrUpdatedPhoneNumber(e.target.value === ADD_OR_UPDATE_PHONE_OPTION.yes);
   }
 
   return (
@@ -165,7 +165,7 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-phone.option-yes" />,
-                  value: AddOrUpdatePhoneOption.Yes,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.yes,
                   defaultChecked: isNewOrUpdatedPhoneNumber === true,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                   append: isNewOrUpdatedPhoneNumber === true && (
@@ -201,7 +201,7 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-phone.option-no" />,
-                  value: AddOrUpdatePhoneOption.No,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.no,
                   defaultChecked: isNewOrUpdatedPhoneNumber === false,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                 },
@@ -212,7 +212,7 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Phone Number click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Phone Number click">
                 {t('renew-adult:confirm-phone.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Phone Number click">
@@ -224,7 +224,7 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Close = 'close',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  close: 'close',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -304,7 +304,7 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
                 variant="primary"
                 size="sm"
                 name="_action"
-                value={FormAction.Close}
+                value={FORM_ACTION.close}
                 onClick={() => sessionStorage.removeItem('flow.state')}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Modal Close application - Your renewal for the Canadian Dental Care Plan is complete click"
               >

--- a/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/demographic-survey.tsx
@@ -30,11 +30,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'gcweb'),
@@ -88,9 +88,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewAdultState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       return redirect(getPathById('public/renew/$id/adult/update-federal-provincial-territorial-benefits', params));
     }
@@ -128,7 +128,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = formAction === FormAction.Save;
+  const preferNotToAnswer = formAction === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -230,7 +230,7 @@ export default function RenewAdultDemographicSurveyQuestions({ loaderData, param
             <p>{t('renew-adult:demographic-survey.improve-cdcp')}</p>
             <p>{t('renew-adult:demographic-survey.confidential')}</p>
             <p>{t('renew-adult:demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application:Prefer not to answer - Demographic survey click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application:Prefer not to answer - Demographic survey click">
               {t('renew-adult:demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew-adult:demographic-survey.optional')}</p>
@@ -259,7 +259,7 @@ export default function RenewAdultDemographicSurveyQuestions({ loaderData, param
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Voluntary demographic questions click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Voluntary demographic questions click">
                 {t('renew-adult:demographic-survey.save-btn')}
               </Button>
               <ButtonLink
@@ -277,7 +277,7 @@ export default function RenewAdultDemographicSurveyQuestions({ loaderData, param
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
@@ -285,7 +285,14 @@ export default function RenewAdultDemographicSurveyQuestions({ loaderData, param
               >
                 {t('renew-adult:demographic-survey.continue-btn')}
               </LoadingButton>
-              <LoadingButton id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Voluntary demographic questions click">
+              <LoadingButton
+                id="back-button"
+                name="_action"
+                value={FORM_ACTION.back}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Voluntary demographic questions click"
+              >
                 {t('renew-adult:demographic-survey.back-btn')}
               </LoadingButton>
             </div>

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -24,12 +24,12 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Back = 'back',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  back: 'back',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -64,8 +64,8 @@ export async function action({ context: { appContainer, session }, params, reque
     dentalInsurance: z.boolean({ errorMap: () => ({ message: t('renew-adult:dental-insurance.error-message.dental-insurance-required') }) }),
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     if (state.hasAddressChanged) {
       if (state.isHomeAddressSameAsMailingAddress) {
         return redirect(getPathById('public/renew/$id/adult/update-mailing-address', params));
@@ -170,7 +170,7 @@ export default function RenewAdultAccessToDentalInsuranceQuestion({ loaderData, 
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to private dental insurance click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to private dental insurance click">
                 {t('dental-insurance.button.save-btn')}
               </Button>
               <ButtonLink
@@ -187,7 +187,7 @@ export default function RenewAdultAccessToDentalInsuranceQuestion({ loaderData, 
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
@@ -195,7 +195,7 @@ export default function RenewAdultAccessToDentalInsuranceQuestion({ loaderData, 
               >
                 {t('dental-insurance.button.continue')}
               </LoadingButton>
-              <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to private dental insurance click">
+              <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to private dental insurance click">
                 {t('dental-insurance.button.back')}
               </Button>
             </div>

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -33,11 +33,11 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -192,7 +192,7 @@ export default function RenewAdultMaritalStatus({ loaderData, params }: Route.Co
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Marital status click">
                 {t('renew-adult:marital-status.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/adult/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Marital status click">
@@ -204,7 +204,7 @@ export default function RenewAdultMaritalStatus({ loaderData, params }: Route.Co
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -158,8 +158,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: { editMode: false } });
     return redirect(getPathById('public/renew/$id/adult/confirm-federal-provincial-territorial-benefits', params));
   }
@@ -396,15 +396,15 @@ export default function RenewAdultReviewAdultInformation({ loaderData, params }:
           <LoadingButton
             id="confirm-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             variant="green"
             disabled={isSubmitting}
-            loading={isSubmitting && submitAction === FormAction.Submit}
+            loading={isSubmitting && submitAction === FORM_ACTION.submit}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Submit renewal application - Review your information click"
           >
             {t('renew-adult:review-adult-information.submit-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Exit - Review your information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Exit - Review your information click">
             {t('renew-adult:review-adult-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -28,21 +28,21 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -89,8 +89,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Cancel) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       saveRenewState({
         params,
@@ -148,9 +148,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -210,12 +210,12 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -251,7 +251,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -272,7 +272,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -290,7 +290,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -336,7 +336,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
@@ -350,7 +350,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
               <Button
                 id="save-button"
                 name="_action"
-                value={FormAction.Save}
+                value={FORM_ACTION.save}
                 variant="primary"
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other federal, provincial or territorial dental benefits click"
@@ -360,7 +360,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
               <Button
                 id="cancel-button"
                 name="_action"
-                value={FormAction.Cancel}
+                value={FORM_ACTION.cancel}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other federal, provincial or territorial dental benefits click"
               >
@@ -372,7 +372,7 @@ export default function RenewAdultUpdateFederalProvincialTerritorialBenefits({ l
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -35,11 +35,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -96,7 +96,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
@@ -327,7 +327,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Home address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Home address click">
                     {t('renew-adult:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -351,7 +351,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Home address click"
@@ -473,7 +473,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -537,7 +537,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-adult:update-address.dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -36,11 +36,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -107,7 +107,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewAdultState({ params, request, session });
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
@@ -362,7 +362,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Mailing address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Mailing address click">
                     {t('renew-adult:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -388,7 +388,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Mailing address click"
@@ -517,7 +517,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -585,7 +585,7 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-adult:update-address.dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -26,10 +26,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FederalBenefitsChangedOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const FEDERAL_BENEFITS_CHANGED_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -79,7 +79,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const dentalBenefits = {
-    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FederalBenefitsChangedOption.Yes : undefined,
+    hasFederalProvincialTerritorialBenefitsChanged: formData.get('hasFederalProvincialTerritorialBenefitsChanged') ? formData.get('hasFederalProvincialTerritorialBenefitsChanged') === FEDERAL_BENEFITS_CHANGED_OPTION.yes : undefined,
   };
 
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
@@ -136,7 +136,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
   });
 
   function handleOnFederalProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FederalBenefitsChangedOption.Yes);
+    setFederalProvincialTerrirorialBenefitChangedValue(e.target.value === FEDERAL_BENEFITS_CHANGED_OPTION.yes);
   }
 
   return (
@@ -159,13 +159,13 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.confirm-dental-benefits.option-yes" />,
-                  value: FederalBenefitsChangedOption.Yes,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.yes,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === true,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.confirm-dental-benefits.option-no" />,
-                  value: FederalBenefitsChangedOption.No,
+                  value: FEDERAL_BENEFITS_CHANGED_OPTION.no,
                   defaultChecked: federalProvincialTerritorialBenefitChangedValue === false,
                   onChange: handleOnFederalProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/demographic-survey.tsx
@@ -31,10 +31,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+  const preferNotToAnswer = z.nativeEnum(FORM_ACTION).parse(formData.get('_action')) === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -242,7 +242,7 @@ export default function RenewChildrenDemographicSurveyQuestions({ loaderData, pa
             <p>{t('renew-child:demographic-survey.improve-cdcp')}</p>
             <p>{t('renew-child:demographic-survey.confidential')}</p>
             <p>{t('renew-child:demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Prefer not to answer - Voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Prefer not to answer - Voluntary demographic questions click">
               {t('renew-child:demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew-child:demographic-survey.optional')}</p>
@@ -271,7 +271,7 @@ export default function RenewChildrenDemographicSurveyQuestions({ loaderData, pa
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <LoadingButton id="save-button" variant="primary" name="_action" value={FormAction.Continue} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Voluntary demographic questions click">
+              <LoadingButton id="save-button" variant="primary" name="_action" value={FORM_ACTION.continue} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Voluntary demographic questions click">
                 {t('renew-child:demographic-survey.save-btn')}
               </LoadingButton>
               <ButtonLink
@@ -290,7 +290,7 @@ export default function RenewChildrenDemographicSurveyQuestions({ loaderData, pa
                 id="continue-button"
                 variant="primary"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 loading={isSubmitting}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Voluntary demographic questions click"

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum YesNoOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const YES_NO_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew', 'renew-child', 'gcweb'),
@@ -165,7 +165,7 @@ export async function action({ context: { appContainer, session }, params, reque
     dateOfBirthDay: formData.get('dateOfBirthDay') ? Number(formData.get('dateOfBirthDay')) : undefined,
     dateOfBirth: '',
     clientNumber: String(formData.get('clientNumber') ?? ''),
-    isParent: formData.get('isParent') ? formData.get('isParent') === YesNoOption.Yes : undefined,
+    isParent: formData.get('isParent') ? formData.get('isParent') === YES_NO_OPTION.yes : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -304,8 +304,8 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               name="isParent"
               legend={t('renew-child:children.information.parent-legend')}
               options={[
-                { value: YesNoOption.Yes, children: t('renew-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: false, tabIndex: 0 },
-                { value: YesNoOption.No, children: t('renew-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
+                { value: YES_NO_OPTION.yes, children: t('renew-child:children.information.radio-options.yes'), defaultChecked: defaultState?.isParent === true, readOnly: false, tabIndex: 0 },
+                { value: YES_NO_OPTION.no, children: t('renew-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
             />

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -29,21 +29,21 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -99,8 +99,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Cancel) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
     if (state.hasFederalProvincialTerritorialBenefitsChanged) {
       saveRenewState({
         params,
@@ -164,9 +164,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -232,12 +232,12 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -273,7 +273,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.update-dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -294,7 +294,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.update-dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -312,7 +312,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.update-dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasProvincialTerritorialBenefitValue === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue && (
@@ -358,7 +358,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:children.update-dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },
@@ -372,7 +372,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
               <Button
                 id="save-button"
                 name="_action"
-                value={FormAction.Save}
+                value={FORM_ACTION.save}
                 variant="primary"
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Child access to other federal, provincial or territorial dental benefits click"
@@ -382,7 +382,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
               <LoadingButton
                 id="cancel-button"
                 name="_action"
-                value={FormAction.Cancel}
+                value={FORM_ACTION.cancel}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Child access to other federal, provincial or territorial dental benefits click"
               >
@@ -394,7 +394,7 @@ export default function RenewChildUpdateFederalProvincialTerritorialBenefits({ l
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -30,14 +30,14 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Add = 'add',
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-  Remove = 'remove',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  add: 'add',
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+  remove: 'remove',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -84,20 +84,20 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewChildState({ params, request, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     return redirect(getPathById('public/renew/$id/type-renewal', params));
   }
 
-  if (formAction === FormAction.Add) {
+  if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();
     const children = [...getChildrenState(state), { id: childId }];
     saveRenewState({ params, session, state: { children } });
     return redirect(getPathById('public/renew/$id/child/children/$childId/information', { ...params, childId }));
   }
 
-  if (formAction === FormAction.Remove) {
+  if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
     const children = [...getChildrenState(state)].filter((child) => child.id !== removeChildId);
     saveRenewState({ params, session, state: { children } });
@@ -209,7 +209,7 @@ export default function RenewChildIndex({ loaderData, params }: Route.ComponentP
                             <Button
                               id="remove-child"
                               name="_action"
-                              value={FormAction.Remove}
+                              value={FORM_ACTION.remove}
                               disabled={isSubmitting}
                               variant="primary"
                               size="sm"
@@ -230,7 +230,7 @@ export default function RenewChildIndex({ loaderData, params }: Route.ComponentP
 
         <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
           <CsrfTokenInput />
-          <Button className="my-10" id="add-child" name="_action" value={FormAction.Add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Renew a child - Child(ren) renewal click">
+          <Button className="my-10" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} startIcon={faPlus} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Renew a child - Child(ren) renewal click">
             {children.length === 0 ? t('renew-child:children.index.add-child') : t('renew-child:children.index.add-another-child')}
           </Button>
 
@@ -262,15 +262,15 @@ export default function RenewChildIndex({ loaderData, params }: Route.ComponentP
                 id="continue-button"
                 name="_action"
                 disabled={!hasChildren || isSubmitting}
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
-                loading={isSubmitting && submitAction === FormAction.Continue}
+                loading={isSubmitting && submitAction === FORM_ACTION.continue}
                 endIcon={faChevronRight}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue with application - Child(ren) renewal click"
               >
                 {t('renew-child:children.index.continue-btn')}
               </LoadingButton>
-              <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Child(ren) renewal click">
+              <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Child(ren) renewal click">
                 {t('renew-child:children.index.back-btn')}
               </Button>
             </div>

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -24,16 +24,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddressRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const ADDRESS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -64,7 +64,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const confirmAddressSchema = z.object({
-    hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+    hasAddressChanged: z.nativeEnum(ADDRESS_RADIO_OPTIONS, {
       errorMap: () => ({ message: t('renew-child:confirm-address.error-message.has-address-changed-required') }),
     }),
   });
@@ -81,13 +81,13 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
-      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.homeAddress,
-      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? undefined : state.mailingAddress,
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes,
+      homeAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.homeAddress,
+      mailingAddress: state.editMode && parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? undefined : state.mailingAddress,
     },
   });
 
-  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes) {
+  if (parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes) {
     return redirect(getPathById('public/renew/$id/child/update-mailing-address', params));
   }
 
@@ -124,8 +124,8 @@ export default function RenewChildConfirmAddress({ loaderData, params }: Route.C
               name="hasAddressChanged"
               legend={t('renew-child:confirm-address.have-you-moved')}
               options={[
-                { value: AddressRadioOptions.Yes, children: t('renew-child:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
-                { value: AddressRadioOptions.No, children: t('renew-child:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
+                { value: ADDRESS_RADIO_OPTIONS.yes, children: t('renew-child:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true },
+                { value: ADDRESS_RADIO_OPTIONS.no, children: t('renew-child:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false },
               ]}
               helpMessagePrimary={t('renew-child:confirm-address.help-message')}
               errorMessage={errors?.hasAddressChanged}
@@ -135,7 +135,7 @@ export default function RenewChildConfirmAddress({ loaderData, params }: Route.C
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Address click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Address click">
                 {t('renew-child:confirm-address.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Address click">

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -28,21 +28,21 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdateEmailOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_EMAIL_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
-enum ShouldReceiveEmailCommunicationOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -84,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const emailSchema = z
     .object({
-      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
+      isNewOrUpdatedEmail: z.nativeEnum(ADD_OR_UPDATE_EMAIL_OPTION, {
         errorMap: () => ({ message: t('renew-child:confirm-email.error-message.add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
@@ -92,7 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
       shouldReceiveEmailCommunication: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (!val.email) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.email-required'), path: ['email'] });
         }
@@ -114,7 +114,7 @@ export async function action({ context: { appContainer, session }, params, reque
         }
       }
 
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (val.shouldReceiveEmailCommunication === undefined) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-email.error-message.receive-comms-required'), path: ['shouldReceiveEmailCommunication'] });
         }
@@ -122,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
-      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === ShouldReceiveEmailCommunicationOption.Yes : undefined,
+      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes,
+      shouldReceiveEmailCommunication: val.shouldReceiveEmailCommunication ? val.shouldReceiveEmailCommunication === SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes : undefined,
     }));
 
   const parsedDataResult = emailSchema.safeParse({
@@ -164,7 +164,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
   const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
 
   function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
+    setIsNewOrUpdatedEmail(e.target.value === ADD_OR_UPDATE_EMAIL_OPTION.yes);
   }
 
   return (
@@ -188,7 +188,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-yes" />,
-                  value: AddOrUpdateEmailOption.Yes,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.yes,
                   defaultChecked: isNewOrUpdatedEmail === true,
                   onChange: handleNewOrUpdateEmailChanged,
                   append: isNewOrUpdatedEmail === true && (
@@ -224,7 +224,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-no" />,
-                  value: AddOrUpdateEmailOption.No,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.no,
                   defaultChecked: isNewOrUpdatedEmail === false,
                   onChange: handleNewOrUpdateEmailChanged,
                 },
@@ -242,12 +242,12 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
                 options={[
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-yes" />,
-                    value: ShouldReceiveEmailCommunicationOption.Yes,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === true,
                   },
                   {
                     children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-email.option-no" />,
-                    value: ShouldReceiveEmailCommunicationOption.No,
+                    value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.no,
                     defaultChecked: defaultState.shouldReceiveEmailCommunication === false,
                   },
                 ]}
@@ -258,7 +258,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
           )}
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Email click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Email click">
                 {t('renew-child:confirm-email.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Email click">
@@ -270,7 +270,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum MaritalStatusRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const MARITAL_STATUS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -121,8 +121,8 @@ export default function RenewChildConfirmMaritalStatus({ loaderData, params }: R
               name="hasMaritalStatusChanged"
               legend={t('renew-child:confirm-marital-status.has-marital-status-changed')}
               options={[
-                { value: MaritalStatusRadioOptions.Yes, children: t('renew-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
-                { value: MaritalStatusRadioOptions.No, children: t('renew-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
+                { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
               helpMessagePrimary={t('renew-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -28,16 +28,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdatePhoneOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_PHONE_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const phoneNumberSchema = z
     .object({
-      isNewOrUpdatedPhoneNumber: z.nativeEnum(AddOrUpdatePhoneOption, {
+      isNewOrUpdatedPhoneNumber: z.nativeEnum(ADD_OR_UPDATE_PHONE_OPTION, {
         errorMap: () => ({ message: t('renew-child:confirm-phone.error-message.add-or-update-required') }),
       }),
       phoneNumber: phoneSchema({
@@ -93,7 +93,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes) {
+      if (val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes) {
         if (!val.phoneNumber) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:confirm-phone.error-message.phone-required'), path: ['phoneNumber'] });
         }
@@ -101,7 +101,7 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === AddOrUpdatePhoneOption.Yes,
+      isNewOrUpdatedPhoneNumber: val.isNewOrUpdatedPhoneNumber === ADD_OR_UPDATE_PHONE_OPTION.yes,
     }));
 
   const parsedDataResult = phoneNumberSchema.safeParse({
@@ -140,7 +140,7 @@ export default function RenewChildConfirmPhone({ loaderData, params }: Route.Com
   const [isNewOrUpdatedPhoneNumber, setIsNewOrUpdatedPhoneNumber] = useState(defaultState.isNewOrUpdatedPhoneNumber);
 
   function handleNewOrUpdatePhoneNumberChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedPhoneNumber(e.target.value === AddOrUpdatePhoneOption.Yes);
+    setIsNewOrUpdatedPhoneNumber(e.target.value === ADD_OR_UPDATE_PHONE_OPTION.yes);
   }
 
   return (
@@ -164,7 +164,7 @@ export default function RenewChildConfirmPhone({ loaderData, params }: Route.Com
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-phone.option-yes" />,
-                  value: AddOrUpdatePhoneOption.Yes,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.yes,
                   defaultChecked: isNewOrUpdatedPhoneNumber === true,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                   append: isNewOrUpdatedPhoneNumber === true && (
@@ -200,7 +200,7 @@ export default function RenewChildConfirmPhone({ loaderData, params }: Route.Com
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-child:confirm-phone.option-no" />,
-                  value: AddOrUpdatePhoneOption.No,
+                  value: ADD_OR_UPDATE_PHONE_OPTION.no,
                   defaultChecked: isNewOrUpdatedPhoneNumber === false,
                   onChange: handleNewOrUpdatePhoneNumberChanged,
                 },
@@ -211,7 +211,7 @@ export default function RenewChildConfirmPhone({ loaderData, params }: Route.Com
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Phone number click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Phone number click">
                 {t('renew-child:confirm-phone.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Phone number click">
@@ -223,7 +223,7 @@ export default function RenewChildConfirmPhone({ loaderData, params }: Route.Com
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Close = 'close',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  close: 'close',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -335,7 +335,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
                 variant="primary"
                 size="sm"
                 name="_action"
-                value={FormAction.Close}
+                value={FORM_ACTION.close}
                 onClick={() => sessionStorage.removeItem('flow.state')}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Modal Close application - Your renewal for the Canadian Dental Care Plan is complete click"
               >

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -33,11 +33,11 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -192,7 +192,7 @@ export default function RenewChildMaritalStatus({ loaderData, params }: Route.Co
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Marital status click">
                 {t('renew-child:marital-status.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/child/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Marital status click">
@@ -204,7 +204,7 @@ export default function RenewChildMaritalStatus({ loaderData, params }: Route.Co
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
+++ b/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
@@ -24,10 +24,10 @@ import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Back = 'back',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  back: 'back',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -54,9 +54,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Back) {
+  if (formAction === FORM_ACTION.back) {
     return redirect(getPathById('public/renew/$id/child/children/index', params));
   }
 
@@ -100,15 +100,15 @@ export default function RenewChildParentIntro({ loaderData, params }: Route.Comp
             <LoadingButton
               id="continue-button"
               name="_action"
-              value={FormAction.Continue}
+              value={FORM_ACTION.continue}
               variant="primary"
-              loading={isSubmitting && submitAction === FormAction.Continue}
+              loading={isSubmitting && submitAction === FORM_ACTION.continue}
               endIcon={faChevronRight}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Parent or legal guardian information click"
             >
               {t('renew-child:parent-intro.continue-btn')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Parent or legal guardian information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Parent or legal guardian information click">
               {t('renew-child:parent-intro.back-btn')}
             </Button>
           </div>

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -131,8 +131,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: {} });
     return redirect(getPathById('public/renew/$id/child/review-child-information', params));
   }
@@ -321,15 +321,15 @@ export default function RenewChildReviewAdultInformation({ loaderData, params }:
             <LoadingButton
               id="confirm-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="green"
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Submit renewal application - Review your information click"
             >
               {t('renew-child:review-adult-information.submit-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Review your information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Review your information click">
               {t('renew-child:review-adult-information.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-child-information.tsx
@@ -32,10 +32,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -108,8 +108,8 @@ export async function action({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: { editMode: false } });
 
     const state = loadRenewChildState({ params, request, session });
@@ -248,16 +248,16 @@ export default function RenewChildReviewChildInformation({ loaderData, params }:
             <LoadingButton
               id="confirm-button"
               name="_action"
-              value={FormAction.Submit}
+              value={FORM_ACTION.submit}
               variant="primary"
               endIcon={faChevronRight}
               disabled={isSubmitting}
-              loading={isSubmitting && submitAction === FormAction.Submit}
+              loading={isSubmitting && submitAction === FORM_ACTION.submit}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Review child(ren) information click"
             >
               {t('renew-child:review-child-information.continue-button')}
             </LoadingButton>
-            <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Review child(ren) information click">
+            <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Review child(ren) information click">
               {t('renew-child:review-child-information.back-button')}
             </Button>
           </div>

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -35,11 +35,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -96,7 +96,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
@@ -328,7 +328,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Home address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Home address click">
                     {t('renew-child:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -352,7 +352,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Home address click"
@@ -474,7 +474,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -540,7 +540,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -36,11 +36,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -107,7 +107,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewChildState({ params, request, session });
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
@@ -356,7 +356,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Mailing address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Mailing address click">
                     {t('renew-child:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -382,7 +382,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Mailing address click"
@@ -511,7 +511,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseSelectedAddress}
+            value={FORM_ACTION.useSelectedAddress}
             type="submit"
             id="dialog.corrected-address-use-selected-address-button"
             loading={fetcher.isSubmitting}
@@ -581,7 +581,7 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
           <LoadingButton
             name="_action"
-            value={FormAction.UseInvalidAddress}
+            value={FORM_ACTION.useInvalidAddress}
             type="submit"
             id="dialog.address-invalid-use-entered-address-button"
             loading={fetcher.isSubmitting}

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -26,16 +26,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddressRadioOptions {
-  No = 'no',
-  Yes = 'yes',
-}
+const ADDRESS_RADIO_OPTIONS = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -65,13 +65,13 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const confirmAddressSchema = z
     .object({
-      hasAddressChanged: z.nativeEnum(AddressRadioOptions, {
+      hasAddressChanged: z.nativeEnum(ADDRESS_RADIO_OPTIONS, {
         errorMap: () => ({ message: t('renew-ita:confirm-address.error-message.has-address-changed-required') }),
       }),
-      isHomeAddressSameAsMailingAddress: z.nativeEnum(AddressRadioOptions).or(z.literal('')).optional(),
+      isHomeAddressSameAsMailingAddress: z.nativeEnum(ADDRESS_RADIO_OPTIONS).or(z.literal('')).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.hasAddressChanged === AddressRadioOptions.No) {
+      if (val.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no) {
         if (!val.isHomeAddressSameAsMailingAddress) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:confirm-address.error-message.is-home-address-same-as-mailing-address-required'), path: ['isHomeAddressSameAsMailingAddress'] });
         }
@@ -95,8 +95,8 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
-      hasAddressChanged: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.Yes,
-      isHomeAddressSameAsMailingAddress: parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No ? parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.Yes : undefined,
+      hasAddressChanged: parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.yes,
+      isHomeAddressSameAsMailingAddress: parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no ? parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.yes : undefined,
       previousAddressState: {
         hasAddressChanged: state.hasAddressChanged,
         isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
@@ -104,8 +104,8 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  if (parsedDataResult.data.hasAddressChanged === AddressRadioOptions.No) {
-    if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === AddressRadioOptions.No) {
+  if (parsedDataResult.data.hasAddressChanged === ADDRESS_RADIO_OPTIONS.no) {
+    if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.no) {
       return redirect(getPathById('public/renew/$id/ita/update-home-address', params));
     }
     return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
@@ -129,7 +129,7 @@ export default function RenewItaConfirmAddress({ loaderData, params }: Route.Com
   const [hasAddressChangedRadioValue, setHasAddressChangeRadioValue] = useState(defaultState.hasAddressChanged);
 
   function handleHasAddressChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasAddressChangeRadioValue(e.target.value === AddressRadioOptions.Yes);
+    setHasAddressChangeRadioValue(e.target.value === ADDRESS_RADIO_OPTIONS.yes);
   }
 
   return (
@@ -148,8 +148,8 @@ export default function RenewItaConfirmAddress({ loaderData, params }: Route.Com
               name="hasAddressChanged"
               legend={t('renew-ita:confirm-address.have-you-moved')}
               options={[
-                { value: AddressRadioOptions.Yes, children: t('renew-ita:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true, onChange: handleHasAddressChanged },
-                { value: AddressRadioOptions.No, children: t('renew-ita:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false, onChange: handleHasAddressChanged },
+                { value: ADDRESS_RADIO_OPTIONS.yes, children: t('renew-ita:confirm-address.radio-options.yes'), defaultChecked: defaultState.hasAddressChanged === true, onChange: handleHasAddressChanged },
+                { value: ADDRESS_RADIO_OPTIONS.no, children: t('renew-ita:confirm-address.radio-options.no'), defaultChecked: defaultState.hasAddressChanged === false, onChange: handleHasAddressChanged },
               ]}
               helpMessagePrimary={t('renew-ita:confirm-address.help-message')}
               errorMessage={errors?.hasAddressChanged}
@@ -161,8 +161,8 @@ export default function RenewItaConfirmAddress({ loaderData, params }: Route.Com
                 name="isHomeAddressSameAsMailingAddress"
                 legend={t('renew-ita:confirm-address.is-home-address-same-as-mailing-address')}
                 options={[
-                  { value: AddressRadioOptions.Yes, children: t('renew-ita:confirm-address.radio-options.yes'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === true },
-                  { value: AddressRadioOptions.No, children: t('renew-ita:confirm-address.radio-options.no'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === false },
+                  { value: ADDRESS_RADIO_OPTIONS.yes, children: t('renew-ita:confirm-address.radio-options.yes'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === true },
+                  { value: ADDRESS_RADIO_OPTIONS.no, children: t('renew-ita:confirm-address.radio-options.no'), defaultChecked: defaultState.isHomeAddressSameAsMailingAddress === false },
                 ]}
                 errorMessage={errors?.isHomeAddressSameAsMailingAddress}
                 required
@@ -171,7 +171,7 @@ export default function RenewItaConfirmAddress({ loaderData, params }: Route.Com
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <LoadingButton id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Address click">
+              <LoadingButton id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Address click">
                 {t('renew-ita:confirm-address.save-btn')}
               </LoadingButton>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Address click">

--- a/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
@@ -28,16 +28,16 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
-enum AddOrUpdateEmailOption {
-  Yes = 'yes',
-  No = 'no',
-}
+const ADD_OR_UPDATE_EMAIL_OPTION = {
+  yes: 'yes',
+  no: 'no',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -78,14 +78,14 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const emailSchema = z
     .object({
-      isNewOrUpdatedEmail: z.nativeEnum(AddOrUpdateEmailOption, {
+      isNewOrUpdatedEmail: z.nativeEnum(ADD_OR_UPDATE_EMAIL_OPTION, {
         errorMap: () => ({ message: t('renew-ita:confirm-email.error-message.add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes) {
+      if (val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes) {
         if (!val.email) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:confirm-email.error-message.email-required'), path: ['email'] });
         }
@@ -109,7 +109,7 @@ export async function action({ context: { appContainer, session }, params, reque
     })
     .transform((val) => ({
       ...val,
-      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === AddOrUpdateEmailOption.Yes,
+      isNewOrUpdatedEmail: val.isNewOrUpdatedEmail === ADD_OR_UPDATE_EMAIL_OPTION.yes,
     }));
 
   const parsedDataResult = emailSchema.safeParse({
@@ -148,7 +148,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
   const [isNewOrUpdatedEmail, setIsNewOrUpdatedEmail] = useState(defaultState.isNewOrUpdatedEmail);
 
   function handleNewOrUpdateEmailChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setIsNewOrUpdatedEmail(e.target.value === AddOrUpdateEmailOption.Yes);
+    setIsNewOrUpdatedEmail(e.target.value === ADD_OR_UPDATE_EMAIL_OPTION.yes);
   }
 
   return (
@@ -170,7 +170,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:confirm-email.option-yes" />,
-                  value: AddOrUpdateEmailOption.Yes,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.yes,
                   defaultChecked: isNewOrUpdatedEmail === true,
                   onChange: handleNewOrUpdateEmailChanged,
                   append: isNewOrUpdatedEmail === true && (
@@ -206,7 +206,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:confirm-email.option-no" />,
-                  value: AddOrUpdateEmailOption.No,
+                  value: ADD_OR_UPDATE_EMAIL_OPTION.no,
                   defaultChecked: isNewOrUpdatedEmail === false,
                   onChange: handleNewOrUpdateEmailChanged,
                 },
@@ -217,7 +217,7 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Email click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Email click">
                 {t('renew-ita:confirm-email.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Email click">
@@ -226,7 +226,15 @@ export default function RenewAdultChildConfirmEmail({ loaderData, params }: Rout
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton id="continue-button" name="_action" value={FormAction.Continue} variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Email click">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Email click"
+              >
                 {t('renew-ita:confirm-email.continue-btn')}
               </LoadingButton>
               <ButtonLink id="back-button" routeId="public/renew/$id/ita/confirm-phone" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Email click">

--- a/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
@@ -25,11 +25,11 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -156,7 +156,7 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Phone click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Phone click">
                 {t('renew-ita:confirm-phone.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Phone click">
@@ -165,7 +165,15 @@ export default function RenewAdultChildConfirmPhone({ loaderData, params }: Rout
             </div>
           ) : (
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton id="continue-button" name="_action" value={FormAction.Continue} variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Phone click">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Phone click"
+              >
                 {t('renew-ita:confirm-phone.continue-btn')}
               </LoadingButton>
               <ButtonLink id="back-button" routeId="public/renew/$id/ita/marital-status" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Phone click">

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Close = 'close',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  close: 'close',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -324,7 +324,7 @@ export default function RenewFlowConfirm({ loaderData, params }: Route.Component
                 variant="primary"
                 size="sm"
                 name="_action"
-                value={FormAction.Close}
+                value={FORM_ACTION.close}
                 onClick={() => sessionStorage.removeItem('renew.state')}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-ITA:Modal Close application - Your renewal for the Canadian Dental Care Plan is complete click"
               >

--- a/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/demographic-survey.tsx
@@ -30,10 +30,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'gcweb'),
@@ -116,7 +116,7 @@ export async function action({ context: { appContainer, session }, params, reque
       }
     });
 
-  const preferNotToAnswer = z.nativeEnum(FormAction).parse(formData.get('_action')) === FormAction.Save;
+  const preferNotToAnswer = z.nativeEnum(FORM_ACTION).parse(formData.get('_action')) === FORM_ACTION.save;
 
   const parsedDataResult = demographicSurveySchema.safeParse({
     indigenousStatus: preferNotToAnswer ? INDIGENOUS_STATUS_PREFER_NOT_TO_ANSWER.toString() : String(formData.get('indigenousStatus') ?? ''),
@@ -219,7 +219,7 @@ export default function RenewItaDemographicSurveyQuestions({ loaderData, params 
             <p>{t('renew-ita:demographic-survey.improve-cdcp')}</p>
             <p>{t('renew-ita:demographic-survey.confidential')}</p>
             <p>{t('renew-ita:demographic-survey.impact-enrollment')}</p>
-            <Button name="_action" value={FormAction.Save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Prefer not to answer - Voluntary demographic questions click">
+            <Button name="_action" value={FORM_ACTION.save} variant="alternative" endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Prefer not to answer - Voluntary demographic questions click">
               {t('renew-ita:demographic-survey.prefer-not-to-answer-btn')}
             </Button>
             <p className="mb-4 italic">{t('renew-ita:demographic-survey.optional')}</p>
@@ -248,7 +248,7 @@ export default function RenewItaDemographicSurveyQuestions({ loaderData, params 
 
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Voluntary demographic questions click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.continue} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Voluntary demographic questions click">
                 {t('renew-ita:demographic-survey.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Voluntary demographic questions click">
@@ -260,7 +260,7 @@ export default function RenewItaDemographicSurveyQuestions({ loaderData, params 
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -24,12 +24,12 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Back = 'back',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  back: 'back',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -64,8 +64,8 @@ export async function action({ context: { appContainer, session }, params, reque
     dentalInsurance: z.boolean({ errorMap: () => ({ message: t('renew-ita:dental-insurance.error-message.dental-insurance-required') }) }),
   });
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     if (state.hasAddressChanged) {
       if (state.isHomeAddressSameAsMailingAddress) {
         return redirect(getPathById('public/renew/$id/ita/update-mailing-address', params));
@@ -173,7 +173,7 @@ export default function RenewItaAccessToDentalInsuranceQuestion({ loaderData, pa
           </div>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Access to private dental insurance click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Access to private dental insurance click">
                 {t('dental-insurance.button.save-btn')}
               </Button>
               <ButtonLink
@@ -190,7 +190,7 @@ export default function RenewItaAccessToDentalInsuranceQuestion({ loaderData, pa
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
@@ -198,7 +198,7 @@ export default function RenewItaAccessToDentalInsuranceQuestion({ loaderData, pa
               >
                 {t('dental-insurance.button.continue')}
               </LoadingButton>
-              <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Access to private dental insurance click">
+              <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Access to private dental insurance click">
                 {t('dental-insurance.button.back')}
               </Button>
             </div>

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -28,15 +28,15 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum HasFederalBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_FEDERAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
-enum HasProvincialTerritorialBenefitsOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -128,9 +128,9 @@ export async function action({ context: { appContainer, session }, params, reque
     }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
-    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HasFederalBenefitsOption.Yes : undefined,
+    hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,
     federalSocialProgram: formData.get('federalSocialProgram') ? String(formData.get('federalSocialProgram')) : undefined,
-    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HasProvincialTerritorialBenefitsOption.Yes : undefined,
+    hasProvincialTerritorialBenefits: formData.get('hasProvincialTerritorialBenefits') ? formData.get('hasProvincialTerritorialBenefits') === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes : undefined,
     provincialTerritorialSocialProgram: formData.get('provincialTerritorialSocialProgram') ? String(formData.get('provincialTerritorialSocialProgram')) : undefined,
     province: formData.get('province') ? String(formData.get('province')) : undefined,
   };
@@ -186,12 +186,12 @@ export default function RenewItaFederalProvincialTerritorialBenefits({ loaderDat
   });
 
   function handleOnHasFederalBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasFederalBenefitValue(e.target.value === HasFederalBenefitsOption.Yes);
+    setHasFederalBenefitValue(e.target.value === HAS_FEDERAL_BENEFITS_OPTION.yes);
   }
 
   function handleOnHasProvincialTerritorialBenefitChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setHasProvincialTerritorialBenefitValue(e.target.value === HasProvincialTerritorialBenefitsOption.Yes);
-    if (e.target.value !== HasProvincialTerritorialBenefitsOption.Yes) {
+    setHasProvincialTerritorialBenefitValue(e.target.value === HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes);
+    if (e.target.value !== HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes) {
       setProvinceValue(undefined);
       setProvincialTerritorialSocialProgramValue(undefined);
     }
@@ -227,7 +227,7 @@ export default function RenewItaFederalProvincialTerritorialBenefits({ loaderDat
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:dental-benefits.federal-benefits.option-yes" />,
-                  value: HasFederalBenefitsOption.Yes,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
                   defaultChecked: hasFederalBenefitValue === true,
                   onChange: handleOnHasFederalBenefitChanged,
                   append: hasFederalBenefitValue === true && (
@@ -248,7 +248,7 @@ export default function RenewItaFederalProvincialTerritorialBenefits({ loaderDat
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:dental-benefits.federal-benefits.option-no" />,
-                  value: HasFederalBenefitsOption.No,
+                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
                   defaultChecked: hasFederalBenefitValue === false,
                   onChange: handleOnHasFederalBenefitChanged,
                 },
@@ -266,7 +266,7 @@ export default function RenewItaFederalProvincialTerritorialBenefits({ loaderDat
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:dental-benefits.provincial-territorial-benefits.option-yes" />,
-                  value: HasProvincialTerritorialBenefitsOption.Yes,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                   append: hasProvincialTerritorialBenefitValue === true && (
@@ -312,7 +312,7 @@ export default function RenewItaFederalProvincialTerritorialBenefits({ loaderDat
                 },
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-ita:dental-benefits.provincial-territorial-benefits.option-no" />,
-                  value: HasProvincialTerritorialBenefitsOption.No,
+                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
                   defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
                   onChange: handleOnHasProvincialTerritorialBenefitChanged,
                 },

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -33,11 +33,11 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
-enum FormAction {
-  Continue = 'continue',
-  Cancel = 'cancel',
-  Save = 'save',
-}
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -188,7 +188,7 @@ export default function RenewItaMaritalStatus({ loaderData, params }: Route.Comp
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FormAction.Save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Marital status click">
                 {t('renew-ita:marital-status.save-btn')}
               </Button>
               <ButtonLink id="cancel-button" routeId="public/renew/$id/ita/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Marital status click">
@@ -200,7 +200,7 @@ export default function RenewItaMaritalStatus({ loaderData, params }: Route.Comp
               <LoadingButton
                 id="continue-button"
                 name="_action"
-                value={FormAction.Continue}
+                value={FORM_ACTION.continue}
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -35,10 +35,10 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-enum FormAction {
-  Back = 'back',
-  Submit = 'submit',
-}
+const FORM_ACTION = {
+  back: 'back',
+  submit: 'submit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -160,8 +160,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
-  if (formAction === FormAction.Back) {
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.back) {
     saveRenewState({ params, session, state: { editMode: false } });
     if (demographicSurveyEnabled) {
       return redirect(getPathById('public/renew/$id/ita/demographic-survey', params));
@@ -399,15 +399,15 @@ export default function RenewItaReviewInformation({ loaderData, params }: Route.
           <LoadingButton
             id="confirm-button"
             name="_action"
-            value={FormAction.Submit}
+            value={FORM_ACTION.submit}
             variant="green"
             disabled={isSubmitting}
-            loading={isSubmitting && submitAction === FormAction.Submit}
+            loading={isSubmitting && submitAction === FORM_ACTION.submit}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Submit renewal application - Review your information click"
           >
             {t('renew-ita:review-information.submit-button')}
           </LoadingButton>
-          <Button id="back-button" name="_action" value={FormAction.Back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Review your information click">
+          <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Back - Review your information click">
             {t('renew-ita:review-information.back-button')}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -35,12 +35,12 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Cancel = 'cancel',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  cancel: 'cancel',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -97,7 +97,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
 
   const clientConfig = appContainer.get(TYPES.configs.ClientConfig);
@@ -109,7 +109,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewItaState({ params, request, session });
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
       params,
       session,
@@ -342,7 +342,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Home address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Home address click">
                     {t('renew-ita:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -353,7 +353,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FormAction.Cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Home address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Home address click">
                 {t('renew-ita:update-address.cancel-btn')}
               </Button>
             </div>
@@ -366,7 +366,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Home address click"
@@ -479,7 +479,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-ita:update-address.dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -535,7 +535,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-ita:update-address.dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -36,12 +36,12 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Submit = 'submit',
-  Cancel = 'cancel',
-  UseInvalidAddress = 'use-invalid-address',
-  UseSelectedAddress = 'use-selected-address',
-}
+const FORM_ACTION = {
+  submit: 'submit',
+  cancel: 'cancel',
+  useInvalidAddress: 'use-invalid-address',
+  useSelectedAddress: 'use-selected-address',
+} as const;
 
 interface CanadianAddress {
   address: string;
@@ -108,10 +108,10 @@ export async function action({ context: { appContainer, session }, params, reque
 
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewItaState({ params, request, session });
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
       params,
       session,
@@ -370,7 +370,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
             <div className="flex flex-wrap items-center gap-3">
               <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
                 <DialogTrigger asChild>
-                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FormAction.Submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Mailing address click">
+                  <LoadingButton variant="primary" id="save-button" type="submit" name="_action" value={FORM_ACTION.submit} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Save - Mailing address click">
                     {t('renew-ita:update-address.save-btn')}
                   </LoadingButton>
                 </DialogTrigger>
@@ -383,7 +383,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FormAction.Cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Mailing address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Cancel - Mailing address click">
                 {t('renew-ita:update-address.cancel-btn')}
               </Button>
             </div>
@@ -396,7 +396,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                     id="continue-button"
                     type="submit"
                     name="_action"
-                    value={FormAction.Submit}
+                    value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Continue - Mailing address click"
@@ -516,7 +516,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-ita:update-address.dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -576,7 +576,7 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FormAction.UseInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
             {t('renew-ita:update-address.dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -23,10 +23,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum TaxFilingOption {
-  No = 'no',
-  Yes = 'yes',
-}
+const TAX_FILING_OPTION = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew', 'gcweb'),
@@ -56,7 +56,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const taxFilingSchema = z.object({
-    taxFiling: z.nativeEnum(TaxFilingOption, {
+    taxFiling: z.nativeEnum(TAX_FILING_OPTION, {
       errorMap: () => ({ message: t('renew:tax-filing.error-message.tax-filing-required') }),
     }),
   });
@@ -67,9 +67,9 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveRenewState({ params, session, state: { taxFiling: parsedDataResult.data.taxFiling === TaxFilingOption.Yes } });
+  saveRenewState({ params, session, state: { taxFiling: parsedDataResult.data.taxFiling === TAX_FILING_OPTION.yes } });
 
-  if (parsedDataResult.data.taxFiling === TaxFilingOption.No) {
+  if (parsedDataResult.data.taxFiling === TAX_FILING_OPTION.no) {
     return redirect(getPathById('public/renew/$id/file-taxes', params));
   }
 
@@ -100,8 +100,8 @@ export default function RenewFlowTaxFiling({ loaderData, params }: Route.Compone
             name="taxFiling"
             legend={t('renew:tax-filing.form-instructions', { taxYear })}
             options={[
-              { value: TaxFilingOption.Yes, children: t('renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
-              { value: TaxFilingOption.No, children: t('renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
+              { value: TAX_FILING_OPTION.yes, children: t('renew:tax-filing.radio-options.yes'), defaultChecked: defaultState === true },
+              { value: TAX_FILING_OPTION.no, children: t('renew:tax-filing.radio-options.no'), defaultChecked: defaultState === false },
             ]}
             errorMessage={errors?.taxFiling}
             required

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -23,12 +23,12 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum RenewalType {
-  Adult = 'adult',
-  AdultChild = 'adult-child',
-  Child = 'child',
-  Delegate = 'delegate',
-}
+const RENEWAL_TYPE = {
+  adult: 'adult',
+  adultChild: 'adult-child',
+  child: 'child',
+  delegate: 'delegate',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew', 'gcweb'),
@@ -61,7 +61,7 @@ export async function action({ context: { appContainer, session }, params, reque
    * Schema for application delegate.
    */
   const typeOfRenewalSchema = z.object({
-    typeOfRenewal: z.nativeEnum(RenewalType, {
+    typeOfRenewal: z.nativeEnum(RENEWAL_TYPE, {
       errorMap: () => ({ message: t('renew:type-of-renewal.error-message.type-of-renewal-required') }),
     }),
   });
@@ -83,21 +83,21 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  if (parsedDataResult.data.typeOfRenewal === RenewalType.Adult) {
+  if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.adult) {
     if (state.clientApplication?.isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
     return redirect(getPathById('public/renew/$id/adult/confirm-marital-status', params));
   }
 
-  if (parsedDataResult.data.typeOfRenewal === RenewalType.AdultChild) {
+  if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.adultChild) {
     if (state.clientApplication?.isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));
   }
 
-  if (parsedDataResult.data.typeOfRenewal === RenewalType.Child) {
+  if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.child) {
     return redirect(getPathById('public/renew/$id/child/children/index', params));
   }
 
@@ -130,24 +130,24 @@ export default function RenewTypeOfRenewal({ loaderData, params }: Route.Compone
             legend={t('renew:type-of-renewal.form-instructions')}
             options={[
               {
-                value: RenewalType.Adult,
+                value: RENEWAL_TYPE.adult,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.personal" />,
-                defaultChecked: defaultState === RenewalType.Adult,
+                defaultChecked: defaultState === RENEWAL_TYPE.adult,
               },
               {
-                value: RenewalType.AdultChild,
+                value: RENEWAL_TYPE.adultChild,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.personal-and-child" />,
-                defaultChecked: defaultState === RenewalType.AdultChild,
+                defaultChecked: defaultState === RENEWAL_TYPE.adultChild,
               },
               {
-                value: RenewalType.Child,
+                value: RENEWAL_TYPE.child,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.child" />,
-                defaultChecked: defaultState === RenewalType.Child,
+                defaultChecked: defaultState === RENEWAL_TYPE.child,
               },
               {
-                value: RenewalType.Delegate,
+                value: RENEWAL_TYPE.delegate,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="renew:type-of-renewal.radio-options.delegate" />,
-                defaultChecked: defaultState === RenewalType.Delegate,
+                defaultChecked: defaultState === RENEWAL_TYPE.delegate,
               },
             ]}
             required

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -37,10 +37,10 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { extractDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
-enum ChildHasSin {
-  No = 'no',
-  Yes = 'yes',
-}
+const CHILD_HAS_SIN = {
+  no: 'no',
+  yes: 'yes',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
@@ -148,7 +148,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedCodeResult = codeSchema.safeParse({ code: String(formData.get('code') ?? '') });
 
   const parsedChildHasSinResult = childHasSinSchema.safeParse({
-    childHasSin: formData.get('childHasSin') ? formData.get('childHasSin') === ChildHasSin.Yes : undefined,
+    childHasSin: formData.get('childHasSin') ? formData.get('childHasSin') === CHILD_HAS_SIN.yes : undefined,
   });
 
   // only validate if childHasSinSchema parsing is successful and parsed childHasSin is "true"
@@ -260,7 +260,7 @@ export default function StatusCheckerChild({ loaderData, params }: Route.Compone
   }, [fetcher.data]);
 
   function handleOnChildHasSinChanged(e: React.ChangeEvent<HTMLInputElement>) {
-    setChildHasSinState(e.target.value === ChildHasSin.Yes);
+    setChildHasSinState(e.target.value === CHILD_HAS_SIN.yes);
   }
 
   return (
@@ -287,12 +287,12 @@ export default function StatusCheckerChild({ loaderData, params }: Route.Compone
             legend={t('status:child.form.radio-legend')}
             options={[
               {
-                value: ChildHasSin.Yes,
+                value: CHILD_HAS_SIN.yes,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="status:child.form.option-yes" />,
                 onChange: handleOnChildHasSinChanged,
               },
               {
-                value: ChildHasSin.No,
+                value: CHILD_HAS_SIN.no,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="status:child.form.option-no" />,
                 onChange: handleOnChildHasSinChanged,
               },

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -27,10 +27,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum CheckFor {
-  Myself = 'Myself',
-  Child = 'Child',
-}
+const CHECK_FOR = {
+  myself: 'Myself',
+  child: 'Child',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
@@ -62,7 +62,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const formDataSchema = z.object({
-    checkFor: z.nativeEnum(CheckFor, { errorMap: () => ({ message: t('status:form.error-message.selection-required') }) }),
+    checkFor: z.nativeEnum(CHECK_FOR, { errorMap: () => ({ message: t('status:form.error-message.selection-required') }) }),
   });
 
   const parsedCheckFor = formDataSchema.safeParse({
@@ -75,7 +75,7 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  if (parsedCheckFor.data.checkFor === CheckFor.Myself) {
+  if (parsedCheckFor.data.checkFor === CHECK_FOR.myself) {
     return redirect(getPathById('public/status/myself', { ...params }));
   }
   // Child selected
@@ -182,11 +182,11 @@ export default function StatusChecker({ loaderData, params }: Route.ComponentPro
           options={[
             {
               children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.myself" />,
-              value: CheckFor.Myself,
+              value: CHECK_FOR.myself,
             },
             {
               children: <Trans ns={handle.i18nNamespaces} i18nKey="status:form.radio-text.child" />,
-              value: CheckFor.Child,
+              value: CHECK_FOR.child,
             },
           ]}
           required

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -24,10 +24,10 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-enum FormAction {
-  Cancel = 'cancel',
-  Exit = 'exit',
-}
+const FORM_ACTION = {
+  cancel: 'cancel',
+  exit: 'exit',
+} as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
@@ -74,9 +74,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const formAction = z.nativeEnum(FormAction).parse(formData.get('_action'));
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
-  if (formAction === FormAction.Cancel) {
+  if (formAction === FORM_ACTION.cancel) {
     return redirect(getPathById('public/status/index', params));
   }
 
@@ -116,12 +116,12 @@ export default function StatusCheckerResult({ loaderData, params }: Route.Compon
           <StatusNotFound />
         )}
         <div className="mt-12">
-          <Button id="cancel-button" name="_action" value={FormAction.Cancel} disabled={isSubmitting} variant="primary" endIcon={faChevronRight}>
+          <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} variant="primary" endIcon={faChevronRight}>
             {t('status:result.check-another')}
           </Button>
         </div>
         <div className="mt-6">
-          <Button id="exit-button" name="_action" value={FormAction.Exit} disabled={isSubmitting} className="mt-6">
+          <Button id="exit-button" name="_action" value={FORM_ACTION.exit} disabled={isSubmitting} className="mt-6">
             {t('status:result.exit-btn')}
           </Button>
         </div>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Similar to #3099, removing Typescript enums in preparation of next Typscript release. In TypeScript 5.8, a new flag is dropping. It's called erasableSyntaxOnly. It disables a bunch of features that I don't think should ever have been part of TypeScript. erasableSyntaxOnly marks enums, namespaces and class parameter properties as errors. These pieces of syntax are not considered erasable.

https://www.totaltypescript.com/erasable-syntax-only

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

Ts-morph script

```ts
import assert from 'node:assert';
import { Project, SyntaxKind } from 'ts-morph';

const project = new Project({
  skipAddingFilesFromTsConfig: true,
});

//project.addSourceFilesAtPaths('app/routes/protected/renew/$id/confirm-address.tsx');
project.addSourceFilesAtPaths(['app/**/*.{ts,tsx}', 'app/.server/**/*.{ts,tsx}', 'app/.client/**/*.{ts,tsx}']);

function convertEnumName(enumName: string): string {
  // Convert PascalCase to SNAKE_CASE
  return enumName
    .replace(/([A-Z])/g, '_$1')
    .toUpperCase()
    .replace(/^_/, '');
}

function convertEnumKey(key: string): string {
  // Convert PascalCase to camelCase
  return key.charAt(0).toLowerCase() + key.slice(1);
}

// Process all source files
project.getSourceFiles().forEach((sourceFile) => {
  const enumDeclarations = sourceFile.getEnums();

  if (!enumDeclarations.length) return;

  console.log(sourceFile.getFilePath());

  enumDeclarations.forEach((enumDecl) => {
    const enumName = enumDecl.getName();
    const newConstName = convertEnumName(enumName);

    // Create object literal expression
    const members = enumDecl.getMembers();
    const properties = members.map((member) => {
      const memberName = member.getName();
      const initializer = member.getInitializer();
      assert(initializer);
      const newKey = convertEnumKey(memberName);
      return `${newKey}: ${initializer.getText()}`;
    });

    // Create the new const declaration
    const newConstDeclaration = `const ${newConstName} = {
  ${properties.join(',\n  ')}
} as const;`;

    // Find all references to the enum and update them
    const enumRefs = enumDecl.findReferencesAsNodes();
    enumRefs.forEach((ref) => {
      // Skip the declaration itself
      if (ref.getSourceFile() === sourceFile && ref.getStart() === enumDecl.getStart()) {
        return;
      }

      // Handle different reference cases
      if (ref.getParent()?.isKind(SyntaxKind.PropertyAccessExpression)) {
        const propAccess = ref.getParent()?.asKind(SyntaxKind.PropertyAccessExpression);
        if (propAccess) {
          const enumMember = propAccess.getName();
          const newMemberName = convertEnumKey(enumMember);
          propAccess.replaceWithText(`${newConstName}.${newMemberName}`);
        }
      } else {
        ref.replaceWithText(newConstName);
      }
    });

    // Replace the enum declaration with the new const declaration
    enumDecl.replaceWithText(newConstDeclaration);
  });
});

// Save all changes
project.saveSync();
```