### PR TITLE
filter primary applicant out of child only renewal

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import type { ServerConfig } from '~/.server/configs';
 import type { ClientApplicationBasicInfoRequestDto, ClientApplicationDto, ClientApplicationSinRequestDto } from '~/.server/domain/dtos';
 import type { ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
 import { DefaultClientApplicationDtoMapper } from '~/.server/domain/mappers';
 
 describe('DefaultClientApplicationDtoMapper', () => {
-  const mapper = new DefaultClientApplicationDtoMapper();
+  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'> = { APPLICANT_CATEGORY_CODE_INDIVIDUAL: 111111111, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: 222222222 };
+  const mapper = new DefaultClientApplicationDtoMapper(mockServerConfig);
 
   describe('mapClientApplicationEntityToClientApplicationDto', () => {
     it('should map ClientApplicationEntity to ClientApplicationDto', () => {
@@ -228,6 +230,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
           lastName: 'Doe',
           socialInsuranceNumber: '80000002',
         },
+        typeOfApplication: 'adult-child',
       };
 
       // Act

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -187,6 +187,7 @@ describe('DefaultClientApplicationService', () => {
     dentalBenefits: ['ID-123456'],
     hasFiledTaxes: true,
     isInvitationToApplyClient: false,
+    typeOfApplication: '111111111',
   };
 
   describe('findClientApplicationBySin', () => {

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -103,6 +103,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
       lastName: 'Doe',
       socialInsuranceNumber: '800011819',
     },
+    typeOfApplication: '111111111',
   };
 
   describe('mapRenewAdultChildStateToAdultChildBenefitRenewalDto', () => {

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -15,6 +15,7 @@ export type ClientApplicationDto = ReadonlyDeep<{
   isInvitationToApplyClient: boolean;
   livingIndependently?: boolean;
   partnerInformation?: ClientPartnerInformationDto;
+  typeOfApplication: string;
 }>;
 
 export type ClientApplicantInformationDto = Readonly<{

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -23,7 +23,6 @@ export interface ProtectedRenewState {
     coverageStartDate: string;
   };
   readonly clientApplication: ClientApplicationDto;
-  readonly externallyReviewed?: boolean;
   readonly previouslyReviewed?: boolean;
   readonly taxFiling?: boolean;
   readonly dentalInsurance?: boolean;
@@ -63,7 +62,6 @@ export interface ProtectedRenewState {
       readonly socialInsuranceNumber: string;
     };
     readonly isSurveyCompleted?: boolean;
-    readonly externallyReviewed?: boolean;
     readonly previouslyReviewed?: boolean;
     readonly demographicSurvey?: {
       readonly indigenousStatus?: string;


### PR DESCRIPTION
### Description
If the `clientApplication` indicates that this is a child only renewal, the primary applicant should be removed from the list of members that can be renewed in the protected renew app.  This PR cleans up unused code in `member-selection` as well.

### Related Azure Boards Work Items
[AB#5267](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5267)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`