### PR TITLE
Removing underline style from non-link elements

### DIFF
--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -8,7 +8,7 @@ export type CollapsibleSummaryProps = ComponentProps<'summary'>;
 export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
   return (
     <summary className={cn('cursor-pointer marker:text-blue-900', className)} {...props}>
-      <div className="ml-4 inline-block text-blue-900 underline">{children}</div>
+      <div className="ml-4 inline-block text-blue-900">{children}</div>
     </summary>
   );
 }

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -8,7 +8,7 @@ export type CollapsibleSummaryProps = ComponentProps<'summary'>;
 export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
   return (
     <summary className={cn('cursor-pointer marker:text-blue-900', className)} {...props}>
-      <div className="ml-4 inline-block text-blue-900">{children}</div>
+      <div className="ml-4 inline-block text-blue-900 hover:underline">{children}</div>
     </summary>
   );
 }


### PR DESCRIPTION
### Related Azure Boards Work Items
[AB#5280](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5280)

### Additional Notes
This does not follow the Figma anymore.

All other `underline` instances in our app are for links.

An alternative could be to `hover:underline` instead of removing it completely? 