### PR TITLE
Fixed renew ita address edit mode navigation

### DIFF
--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -69,7 +69,7 @@ export async function action({ context: { appContainer, session }, params, reque
       isHomeAddressSameAsMailingAddress: z.boolean().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.hasAddressChanged && val.isHomeAddressSameAsMailingAddress === undefined) {
+      if (!val.hasAddressChanged && val.isHomeAddressSameAsMailingAddress === undefined) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:confirm-address.error-message.is-home-address-same-as-mailing-address-required'), path: ['isHomeAddressSameAsMailingAddress'] });
       }
     });
@@ -87,6 +87,8 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     session,
     state: {
+      mailingAddress: parsedDataResult.data.hasAddressChanged ? state.mailingAddress : undefined,
+      homeAddress: parsedDataResult.data.isHomeAddressSameAsMailingAddress ? undefined : state.homeAddress,
       hasAddressChanged: parsedDataResult.data.hasAddressChanged,
       isHomeAddressSameAsMailingAddress: parsedDataResult.data.hasAddressChanged ? undefined : parsedDataResult.data.isHomeAddressSameAsMailingAddress,
       previousAddressState: {
@@ -104,6 +106,9 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/renew/$id/ita/update-home-address', params));
   }
 
+  if (state.editMode) {
+    return redirect(getPathById('public/renew/$id/ita/review-information', params));
+  }
   return redirect(getPathById('public/renew/$id/ita/dental-insurance', params));
 }
 


### PR DESCRIPTION
### Description
Fixed renew ita address edit mode navigation and review page "no update" display

-bug 1: redirected to review page on edit mode
-bug 2: show "no update" label on the review screen (set address state to undefined when "no" is selected)
-bug 3: cannot reproduce, form works as expected when checkbox is not selected

### Related Azure Boards Work Items
[AB#5276](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5276)