### PR TITLE
a11y expose alerts to assistive technology

### DIFF
--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -159,7 +159,7 @@ function CardLink({ routeId, title, previouslyReviewed, ...props }: CardLinkProp
   const { t } = useTranslation(handle.i18nNamespaces);
   return (
     <AppLink className="flex flex-row items-center gap-4 rounded-xl border border-slate-300 bg-slate-50 p-6 hover:shadow-md" routeId={routeId} {...props}>
-      <h2 className="font-lato text-2xl leading-8 font-semibold text-blue-600 underline">{title}</h2>
+      <h2 className="font-lato text-2xl font-semibold leading-8 text-blue-600 underline">{title}</h2>
       {previouslyReviewed && (
         <>
           <FontAwesomeIcon fixedWidth icon={faCircleCheck} className="ml-4 size-10 self-center" style={{ color: 'green' }} />
@@ -182,7 +182,7 @@ function SelectMember() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="select-member" className="mb-4">
+    <div ref={wrapperRef} id="select-member" className="mb-4" role="region" aria-live="polite">
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('protected-renew:member-selection.select-member.heading')}</h2>
         <InlineLink to="#primary-applicant" className="mb-2">

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -365,7 +365,7 @@ function ChildNotFound() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4">
+    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="polite">
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-adult-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-adult-child:children.information.child-not-found.please-review')}</p>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -359,7 +359,7 @@ function ChildNotFound() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4">
+    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="polite">
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-child:children.information.child-not-found.please-review')}</p>


### PR DESCRIPTION
### Description
Some of our alerts (content added to the DOM after server-side validation) were not being picked up by screen readers and other assistive technology.  This PR adds the recommended changes from the ITAO.

### Related Azure Boards Work Items
[AB#5279](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5279)
