### PR TITLE
InputRadios aria-descby with no visual help message.

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -162,6 +162,8 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
               id="is-new-or-updated-phone-number"
               name="isNewOrUpdatedPhoneNumber"
               legend={t('renew-adult:confirm-phone.add-or-update.legend')}
+              helpMessagePrimary={t('renew-adult:confirm-phone.add-phone')}
+              helpMessagePrimaryClassName="sr-only" // sr-only to not display helpMessagePrimary but enables screenreaders to read it.
               options={[
                 {
                   children: <Trans ns={handle.i18nNamespaces} i18nKey="renew-adult:confirm-phone.option-yes" />,
@@ -181,7 +183,6 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
                         errorMessage={errors?.phoneNumber}
                         label={t('renew-adult:confirm-phone.phone-number')}
                         maxLength={100}
-                        aria-describedby="adding-phone"
                       />
                       <InputPhoneField
                         id="phone-number-alt"
@@ -194,7 +195,6 @@ export default function RenewAdultConfirmPhone({ loaderData, params }: Route.Com
                         errorMessage={errors?.phoneNumberAlt}
                         label={t('renew-adult:confirm-phone.phone-number-alt')}
                         maxLength={100}
-                        aria-describedby="adding-phone"
                       />
                     </div>
                   ),


### PR DESCRIPTION
This change will be applied to other places in our app. This PR is just to get approval on how to approach this while using `confirm-phone` as the guinea pig.
### Description
Changing so that InputRadios have a `aria-describedby` when focused on without help messages being provided. 

Currently, we have it supported if `helpMessagePrimary` and/or `helpMessageSecondary` is passed. However, in the Figma, we do not want to display any of these `helpMessage`. (See screenshot below)

### Related Azure Boards Work Items
[AB#5285](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5285)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d234a1ff-1c1d-4285-9900-2cba681a26de)

### Additional Notes
There are some other options to fix this:
1.  We can ask Designers Group to see if they would want to move the `An up-to-date phone[...]` under the `Would you like[...]`, making it a `helpMessagePrimary`.
2. We can Make a change in `InputRadios` like so:
![image](https://github.com/user-attachments/assets/044d028f-b582-4e2f-8c1c-33b1ba1cee16)
Allowing external id to be passed like this:
![image](https://github.com/user-attachments/assets/8b38e2f6-3656-4fa9-a11d-e8571338dc34)

Open to suggestions!
