### PR TITLE
AB#5284 -- Fix renew marital status a11y (redundant content for screen reader)

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -123,9 +123,7 @@ export default function RenewAdultChildConfirmMaritalStatus({ loaderData, params
                 { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-adult-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
                 { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-adult-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
-              helpMessagePrimary={t('renew-adult-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              required
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -123,9 +123,7 @@ export default function RenewAdultConfirmMaritalStatus({ loaderData, params }: R
                 { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-adult:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
                 { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-adult:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
-              helpMessagePrimary={t('renew-adult:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              required
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -123,9 +123,7 @@ export default function RenewChildConfirmMaritalStatus({ loaderData, params }: R
                 { value: MARITAL_STATUS_RADIO_OPTIONS.yes, children: t('renew-child:confirm-marital-status.radio-options.yes'), defaultChecked: defaultState === true },
                 { value: MARITAL_STATUS_RADIO_OPTIONS.no, children: t('renew-child:confirm-marital-status.radio-options.no'), defaultChecked: defaultState === false },
               ]}
-              helpMessagePrimary={t('renew-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              required
             />
           </div>
           {editMode ? (

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -2,7 +2,6 @@
   "confirm-marital-status": {
     "page-title": "Marital status",
     "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
-    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Back",
     "continue-btn": "Continue",
     "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -2,7 +2,6 @@
   "confirm-marital-status": {
     "page-title": "Marital status",
     "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
-    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Back",
     "continue-btn": "Continue",
     "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -244,7 +244,6 @@
   "confirm-marital-status": {
     "page-title": "Marital status",
     "has-marital-status-changed": "Has your marital status or spouse changed since you applied for the Canadian Dental Care Plan?",
-    "help-message": "The marital status we have on file can also be found on the renewal letter you received from Service Canada.",
     "back-btn": "Back",
     "continue-btn": "Continue",
     "cancel-btn": "Cancel",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -2,7 +2,6 @@
   "confirm-marital-status": {
     "page-title": "État civil",
     "has-marital-status-changed": "Votre état civil ou votre conjoint a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
-    "help-message": "L'état civil que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
     "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -2,7 +2,6 @@
   "confirm-marital-status": {
     "page-title": "État civil",
     "has-marital-status-changed": "Votre état civil ou votre conjoint a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
-    "help-message": "L'état civil que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
     "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -246,7 +246,6 @@
   "confirm-marital-status": {
     "page-title": "État civil",
     "has-marital-status-changed": "Votre état civil ou votre conjoint a-t-il changé depuis que vous avez présenté une demande au Régime canadien de soins dentaires?",
-    "help-message": "L'état civil que nous avons au dossier se trouve également sur la lettre de renouvellement que vous avez reçue de Service Canada.",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
     "cancel-btn": "Annuler",


### PR DESCRIPTION
### Description
Fix renew marital status a11y (redundant content for screen reader)

-removed required SR from radio buttons
-removed help message SR from radio buttons

### Related Azure Boards Work Items
[AB#5284](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5284)