### PR TITLE
increase colour contrast on dialog close focus indicator

### DIFF
--- a/frontend/app/components/dialog.tsx
+++ b/frontend/app/components/dialog.tsx
@@ -34,7 +34,7 @@ const DialogContent = React.forwardRef<React.ComponentRef<typeof DialogPrimitive
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-gray-200 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-white data-[state=open]:text-black">
+        <DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-gray-700 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-white data-[state=open]:text-black">
           <FontAwesomeIcon icon={faXmark} className="block size-4" />
           <span className="sr-only">{t('dialog.close')}</span>
         </DialogPrimitive.Close>


### PR DESCRIPTION
### Description
The ITAO reported that the focus indicator on the close button of our Dialog component fails colour contrast tests.  This PR increases the contrast to the permissible ratio of >3:1 (foreground to background colour)

### Related Azure Boards Work Items
[AB#5279](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5279)