### PR TITLE
use semantically correct headings in confirmation screens

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -221,8 +221,8 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
       <section className="space-y-8">
         <h2 className="font-lato text-3xl font-bold">{t('confirm.applicant-summary')}</h2>
         <section className="space-y-6">
-          <span className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</span>
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h3>
+          <h3 className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.full-name')}>{`${userInfo.firstName} ${userInfo.lastName}`}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dob')}>{userInfo.birthday}</DescriptionListItem>
@@ -235,7 +235,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
 
         {spouseInfo && (
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h3>
+            <h4 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h4>
             <dl className="divide-y border-y">
               <DescriptionListItem term={t('confirm.sin')}>
                 <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
@@ -247,7 +247,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
         )}
 
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.mailing')}>
               {mailingAddressInfo ? (
@@ -283,7 +283,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
         </section>
 
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.dental-private')}> {dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dental-public')}>
@@ -306,9 +306,9 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
         {/* CHILDREN DETAILS */}
         {children.map((child) => (
           <section className="space-y-6" key={child.id}>
-            <h3 className="font-lato text-2xl font-bold">{child.firstName}</h3>
+            <h4 className="font-lato text-2xl font-bold">{child.firstName}</h4>
             <section>
-              <h4 className="font-lato text-xl font-bold">{t('confirm.child-title', { childName: child.firstName })}</h4>
+              <h5 className="font-lato text-xl font-bold">{t('confirm.child-title', { childName: child.firstName })}</h5>
               <dl className="mt-6 divide-y border-y">
                 <DescriptionListItem term={t('confirm.full-name')}>{`${child.firstName} ${child.lastName}`}</DescriptionListItem>
                 <DescriptionListItem term={t('confirm.dental-private')}>{child.dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -179,8 +179,8 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
       <section className="space-y-8">
         <h2 className="font-lato text-3xl font-bold">{t('confirm.applicant-summary')}</h2>
         <section className="space-y-6">
-          <span className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</span>
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h3>
+          <h3 className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.full-name')}>{`${userInfo.firstName} ${userInfo.lastName}`}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dob')}>{userInfo.birthday}</DescriptionListItem>
@@ -205,7 +205,7 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
         )}
 
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.mailing')}>
               {mailingAddressInfo ? (
@@ -240,7 +240,7 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
           </dl>
         </section>
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.dental-private')}> {dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dental-public')}>

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -206,7 +206,7 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
         {children.map((child, index) => (
           <section className="space-y-6" key={child.id}>
             <section>
-              <h4 className="font-lato text-xl font-bold">{t('confirm.child-number', { childNumber: index + 1 })}</h4>
+              <h3 className="font-lato text-xl font-bold">{t('confirm.child-number', { childNumber: index + 1 })}</h3>
               <dl className="mt-6 divide-y border-y">
                 <DescriptionListItem term={t('confirm.full-name')}>{`${child.firstName} ${child.lastName}`}</DescriptionListItem>
                 <DescriptionListItem term={t('confirm.dental-private')}>{child.dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
@@ -230,8 +230,8 @@ export default function RenewAdultChildConfirm({ loaderData, params }: Route.Com
           </section>
         ))}
         <section className="space-y-6">
-          <span className="font-lato text-3xl font-bold">{t('confirm.parent-or-guardian-title')}</span>
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.parent-or-guardian-info')}</h3>
+          <h3 className="font-lato text-3xl font-bold">{t('confirm.parent-or-guardian-title')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.parent-or-guardian-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.full-name')}>{`${userInfo.firstName} ${userInfo.lastName}`}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dob')}>{userInfo.birthday}</DescriptionListItem>

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -190,8 +190,8 @@ export default function RenewFlowConfirm({ loaderData, params }: Route.Component
       <section className="space-y-8">
         <h2 className="font-lato text-3xl font-bold">{t('confirm.applicant-summary')}</h2>
         <section className="space-y-6">
-          <span className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</span>
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h3>
+          <h3 className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.full-name')}>{`${userInfo.firstName} ${userInfo.lastName}`}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dob')}>{userInfo.birthday}</DescriptionListItem>
@@ -204,7 +204,7 @@ export default function RenewFlowConfirm({ loaderData, params }: Route.Component
 
         {spouseInfo && (
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h3>
+            <h4 className="font-lato text-2xl font-bold">{t('confirm.spouse-info')}</h4>
             <dl className="divide-y border-y">
               <DescriptionListItem term={t('confirm.sin')}>
                 <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
@@ -216,7 +216,7 @@ export default function RenewFlowConfirm({ loaderData, params }: Route.Component
         )}
 
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.contact-info')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.phone-number')}>
               <span className="text-nowrap">{userInfo.phoneNumber}</span>
@@ -261,7 +261,7 @@ export default function RenewFlowConfirm({ loaderData, params }: Route.Component
         </section>
 
         <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h3>
+          <h4 className="font-lato text-2xl font-bold">{t('confirm.dental-insurance')}</h4>
           <dl className="divide-y border-y">
             <DescriptionListItem term={t('confirm.dental-private')}> {dentalInsurance.acessToDentalInsurance ? t('confirm.yes') : t('confirm.no')}</DescriptionListItem>
             <DescriptionListItem term={t('confirm.dental-public')}>


### PR DESCRIPTION
### Description
The ITAO reported an issue on the renew confirmation screens that were styling content in a way which isn't semantically correct.  This PR addresses that issue by changing headings to their proper `h{x}` element.

### Related Azure Boards Work Items
[AB#5279](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5279)
