### PR TITLE
fix(gitops): fix typo in raoidc mocks

### DIFF
--- a/gitops/overlays/training/configs/frontend/config.conf
+++ b/gitops/overlays/training/configs/frontend/config.conf
@@ -37,7 +37,7 @@ AUTH_RASCL_LOGOUT_URL=https://cdcp-training.dev-dp-internal.dts-stn.com/
 # RAOIDC mock confuguration
 # replace with actual URL once RAOIDC integration is complete
 #
-AUTH_RAOIDC_BASE_URL=https://cdcp-training.dev-dp-internal.dts-stn.com/auth
+AUTH_RAOIDC_BASE_URL=https://cdcp-training.dev-dp-internal.dts-stn.com/oidc
 MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-training.dev-dp-internal.dts-stn.com/auth/callback/raoidc
 
 #


### PR DESCRIPTION
### Description

This PR fixes a misconfiguration/typo in the RAOIDC config in the training pseudoenvironment.
