### PR TITLE
fix(gitops): reduce HPA count to 2

### DIFF
--- a/gitops/overlays/perf/hpas.yaml
+++ b/gitops/overlays/perf/hpas.yaml
@@ -9,8 +9,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: frontend
-  minReplicas: 2
-  maxReplicas: 20
+  minReplicas: 1
+  maxReplicas: 2
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
### Description

There is an issue in our perf pseudoenvironment that is causing the HPA to scale the pods up to max. I'm reducing them down to 2 until we figure out why.
