### PR TITLE
fix(gitops): remove redis from training env

### DIFF
--- a/gitops/overlays/training/configs/frontend/config.conf
+++ b/gitops/overlays/training/configs/frontend/config.conf
@@ -19,12 +19,6 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-
 
 ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress
 
-SESSION_STORAGE_TYPE=redis
-
-REDIS_SENTINEL_NAME=myprimary
-REDIS_SENTINEL_HOST=redis-training
-REDIS_SENTINEL_PORT=26379
-
 MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-training.dev-dp-internal.dts-stn.com/auth/callback/raoidc
 
 


### PR DESCRIPTION
Per title. Training doesn't need redis since it's single-instance.