### PR TITLE
Adding one breadcrumb to protected renew

### DIFF
--- a/frontend/app/routes/protected/renew/layout.tsx
+++ b/frontend/app/routes/protected/renew/layout.tsx
@@ -16,6 +16,7 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 
 export const handle = {
+  breadcrumbs: [{ labelI18nKey: 'protected-renew:index.page-title' }],
   i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -1,6 +1,6 @@
 {
   "index": {
-    "page-title": "Renew"
+    "page-title": "Canadian Dental Care Plan Renewal"
   },
   "terms-and-conditions": {
     "page-title": "Terms and conditions of use and privacy notice statement",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -1,6 +1,6 @@
 {
   "index": {
-    "page-title": "Renew"
+    "page-title": "Renouvellement du Régime canadien de soins dentaires"
   },
   "terms-and-conditions": {
     "page-title": "Conditions d'utilisation et déclaration de confidentialité",


### PR DESCRIPTION
### Related Azure Boards Work Items
[AB#5293](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5293)

Currently only adding 1 breadcrumb item (Matching our Figma). Will need to speak with the designers and see where we are going with breadcrumbs.