### PR TITLE
fix(gitops): set perf HPA parameters

### DIFF
--- a/gitops/overlays/perf/hpas.yaml
+++ b/gitops/overlays/perf/hpas.yaml
@@ -9,8 +9,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: frontend
-  minReplicas: 1
-  maxReplicas: 2
+  minReplicas: 2
+  maxReplicas: 20
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
### Description

Increase perf HPA max pods to 20 for ongoing perf tests.
