### PR TITLE
fix(frontend): fix broken envar parsing in opentelemetry

### DIFF
--- a/frontend/app/.server/express-server/opentelemetry.server.ts
+++ b/frontend/app/.server/express-server/opentelemetry.server.ts
@@ -88,8 +88,8 @@ function getTraceExporter(): SpanExporter {
  * Will return undefined if the string can't be transformed.
  */
 function toNumber(str?: string): number | undefined {
-  const num = parseInt(str ?? '');
-  return isNaN(num) ? undefined : num;
+  const num = Number.parseInt(str ?? '');
+  return Number.isNaN(num) ? undefined : num;
 }
 
 log.info('Initializing instrumentation');


### PR DESCRIPTION
### Description

During perf testing, it was discovered that OpenTelemetry's metrics exporter was melting our CPU by constantly spamming Dynatrace with metrics. This PR is an attempt to fix that.

The core issue (*I think*) is that when `OTEL_METRICS_EXPORT_INTERVAL_MILLIS` is undefined, `Number(..)` resolves to `NaN`, which causes OpenTelemetry to constantly send metrics without waiting.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

I didn't lint and test. I will push another commit if my build fails.