### PR TITLE
AB#16578 Update benefit renewal service for protected renewal

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -126,6 +126,7 @@ export type ProtectedDentalFederalBenefitsState = Pick<NonNullable<ProtectedRene
 export type ProtectedDentalProvincialTerritorialBenefitsState = Pick<NonNullable<ProtectedRenewState['dentalBenefits']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
 export type ProtectedContactInformationState = NonNullable<ProtectedRenewState['contactInformation']>;
 export type ProtectedDemographicSurveyState = NonNullable<ProtectedRenewState['demographicSurvey']>;
+export type ProtectedConmmunicationPreferenceState = NonNullable<ProtectedRenewState['communicationPreferences']>;
 
 /**
  * Schema for validating UUID.


### PR DESCRIPTION
### Description
The renewal application behind MSCA was not updating preferredLanguage after the user changed their preferred language. This issue was due to missing logic in the benefit renewal state mapper.

This PR adds the necessary logic to ensure that if the preferred language has changed, the updated value is included in the payload.

### Related Azure Boards Work Items
AB#16578

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

- Navigate through the renewal flow in the protected route.
- On the review page, change the preferred language to a different option.
- Save the changes and submit the application.
- On the review and submit page, check the JSON payload to verify that PersonLanguage has been updated to reflect the new selection.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->