### PR TITLE
handle editMode for page nav in protected/dental-insurance

### DIFF
--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -95,7 +95,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       dentalInsurance: parsedDataResult.data.dentalInsurance,
-      previouslyReviewed: state.clientApplication.isInvitationToApplyClient || demographicSurveyEnabled ? undefined : true,
+      previouslyReviewed: state.editMode === false && (state.clientApplication.isInvitationToApplyClient || demographicSurveyEnabled) ? undefined : true,
     },
   });
 


### PR DESCRIPTION
### Description
Previously, if a user clicked save while they were in `editMode`, they would be taken back to `/member-selection` because `previouslyReviewed` in state would be cleared.  This PR adds an additional conditional check so navigation can proceed back to the `review-adult-information` when the save button is clicked.

### Related Azure Boards Work Items
AB#17042

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`