### PR TITLE
fix navigation issue for ita clients in /protected/confirm-home-address

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -148,10 +148,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToReview) {
     saveProtectedRenewState({ params, request, session, state: { homeAddress } });
-    if (state.clientApplication.isInvitationToApplyClient) {
+    if (state.editMode === false && state.clientApplication.isInvitationToApplyClient) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
-
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 
@@ -210,6 +209,10 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-home-address', { userId: idToken.sub });
+
+  if (state.editMode === false && state.clientApplication.isInvitationToApplyClient) {
+    return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
+  }
 
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }


### PR DESCRIPTION
### Description
Previously, if an ITA client were to fill out a Canadian address, use the recommended suggestion from the address validator, click continue, click back on `/confirm-email`, then click continue again on `/confirm-home-address`, they'd be navigated to `/review-adult-information`, which subsequently navigates them to `/member-selection`.

This is difficult to test locally because the address validator always returns a recommended suggestion, which forces the conditional check for `canProceedToReview` in the action.  If the address is already valid (because the user clicked back from the next screen, the address dialog will never render because the validator has already determined it's a valid address (which is turn causes `canProceedToReview` to be `false`.  This in turn skips the conditional to navigate to `/confirm-email` and instead straight to `/review-adult-information`, where the state validator determines there's incomplete state and subsequently redirects to `/member-selection`.

### Related Azure Boards Work Items
#AB17034
