### PR TITLE
AB#5319 -- Allowing hCaptcha config to be unset (for when feature flag is disabled)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -57,11 +57,11 @@ ENABLED_FEATURES=address-validation,doc-upload,hcaptcha,view-letters,view-letter
 # (optional; default: 0.79)
 HCAPTCHA_MAX_SCORE=0.79
 # hCaptcha secret key -- used for server-side verifification
-# (required; use the example below)
+# (optional; default: 0x0000000000000000000000000000000000000000)
 HCAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000
 # hCaptcha site key -- used to integrate hCaptcha to a webpage
-# (required; use the example below)
-HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
+# (optional; default: 20000000-ffff-ffff-ffff-000000000002)
+HCAPTCHA_SITE_KEY=20000000-ffff-ffff-ffff-000000000002
 # hCaptcha verify URL -- used to verify hCaptcha tokens
 # (optional; default: https://api.hcaptcha.com/siteverify)
 HCAPTCHA_VERIFY_URL=https://api.hcaptcha.com/siteverify

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -95,9 +95,9 @@ const serverEnv = clientEnvSchema.extend({
   AUTH_RAOIDC_METADATA_CACHE_TTL_SECONDS: z.coerce.number().default(24 * 60 * 60),
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
-  // hCaptcha settings
+  // hCaptcha settings (@see https://docs.hcaptcha.com)
   HCAPTCHA_MAX_SCORE: z.coerce.number().default(0.79),
-  HCAPTCHA_SECRET_KEY: z.string().trim().min(1),
+  HCAPTCHA_SECRET_KEY: z.string().trim().min(1).default('0x0000000000000000000000000000000000000000'),
   HCAPTCHA_VERIFY_URL: z.string().url().default('https://api.hcaptcha.com/siteverify'),
 
   // http proxy settings

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -34,8 +34,8 @@ export const clientEnvSchema = z.object({
   HEADER_LOGO_URL_EN: z.string().url().default('https://canada.ca/en'),
   HEADER_LOGO_URL_FR: z.string().url().default('https://canada.ca/fr'),
 
-  // hCaptcha settings
-  HCAPTCHA_SITE_KEY: z.string().trim().min(1),
+  // hCaptcha settings (@see https://docs.hcaptcha.com/#test-key-set-enterprise-account-safe-end-user)
+  HCAPTCHA_SITE_KEY: z.string().trim().min(1).default('20000000-ffff-ffff-ffff-000000000002'),
 
   SESSION_TIMEOUT_SECONDS: z.coerce.number().min(0).default(19 * 60),
   SESSION_TIMEOUT_PROMPT_SECONDS: z.coerce.number().min(0).default(5 * 60),


### PR DESCRIPTION
### Description
Default configs were taken from [Test Key Set: Enterprise Account (Safe End User)](https://docs.hcaptcha.com/#test-key-set-enterprise-account-safe-end-user).

### Related Azure Boards Work Items
AB#5319

### Screenshots (if applicable)

### Checklist
- [x] I have tested the changes locally