### PR TITLE
AB#16984 Attest Parent or Guardian not set on Renewal Application

### DIFF
--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -409,7 +409,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
         IdentificationID: child.information.socialInsuranceNumber ?? '',
       },
       ApplicantDetail: {
-        AttestParentOrGuardianIndicator: child.information.isParent,
+        AttestParentOrGuardianIndicator: true,
         PrivateDentalInsuranceIndicator: child.dentalInsurance,
         InsurancePlan: this.toInsurancePlan(child.dentalBenefits),
       },


### PR DESCRIPTION
### Description
The `AttestParentOrGuardianIndicator` value returned false in UAT, but in DEV, the value in the payload is true. I'm not sure if this is an issue on our end. This pr sets the `AttestParentOrGuardianIndicator` set to `true`

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->