### PR TITLE
Removing `ApplicationYearRequestDto`

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { ApplicationYearRequestDto, ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 import type { ApplicationYearDtoMapper } from '~/.server/domain/mappers';
 import type { ApplicationYearRepository } from '~/.server/domain/repositories';
-import type { AuditService } from '~/.server/domain/services';
 import { DefaultApplicationYearService } from '~/.server/domain/services';
 import type { LogFactory, Logger } from '~/.server/factories';
 
@@ -72,13 +71,10 @@ describe('DefaultApplicationYearService', () => {
 
   describe('findRenewalApplicationYear', () => {
     it('should return the correct renewal application year if given date is within a renewal period', async () => {
-      const mockAuditService = mock<AuditService>();
       const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
-      const mockApplicationYearRequestDto: ApplicationYearRequestDto = { date: '2025-01-01', userId: 'userId' };
-
-      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
+      const result = await service.findRenewalApplicationYear('2025-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
         intakeYearId: '2024',
@@ -99,13 +95,10 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should return the correct renewal application year when the given date is on or after the renewal start date and no renewal end date is provided', async () => {
-      const mockAuditService = mock<AuditService>();
       const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
-      const mockApplicationYearRequestDto: ApplicationYearRequestDto = { date: '2026-01-01', userId: 'userId' };
-
-      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
+      const result = await service.findRenewalApplicationYear('2026-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
         intakeYearId: '2025',
@@ -115,13 +108,11 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should return null if given date is not within any renewal period', async () => {
-      const mockAuditService = mock<AuditService>();
       const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
-      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockAuditService, mockServerConfig);
-      const mockApplicationYearRequestDto: ApplicationYearRequestDto = { date: '2024-01-01', userId: 'userId' };
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
 
-      const result = await service.findRenewalApplicationYear(mockApplicationYearRequestDto);
+      const result = await service.findRenewalApplicationYear('2024-01-01');
       expect(result).toEqual(null);
     });
   });

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -1,15 +1,4 @@
 /**
- * Represents a Data Transfer Object (DTO) for an application year request.
- */
-export type ApplicationYearRequestDto = Readonly<{
-  /** The date sent to get the application year(s) in ISO 8601 format (e.g., "2024-12-25"). */
-  date: string;
-
-  /** A unique identifier for the user making the request - used for auditing */
-  userId: string;
-}>;
-
-/**
  * Represents a Data Transfer Object (DTO) for an application year result.
  */
 export type ApplicationYearResultDto = Readonly<{

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -41,7 +41,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
-  const applicationYear = await applicationYearService.findRenewalApplicationYear({ date: currentDate, userId: userInfoToken.sub });
+  const applicationYear = await applicationYearService.findRenewalApplicationYear(currentDate);
   invariant(applicationYear?.renewalYearId, 'Expected applicationYear.renewalYearId to be defined'); // TODO this should redirect to the protected apply flow when introduced
 
   const clientApplicationService = appContainer.get(TYPES.domain.services.ClientApplicationService);

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -35,7 +35,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const currentDate = getCurrentDateString(locale);
   const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
-  const applicationYear = await applicationYearService.findRenewalApplicationYear({ date: currentDate, userId: 'anonymous' });
+  const applicationYear = await applicationYearService.findRenewalApplicationYear(currentDate);
   if (!applicationYear?.renewalYearId) {
     throw redirect(getPathById('public/apply/index', params));
   }


### PR DESCRIPTION
### Description
- `ApplicationYearRequestDto` has been removed as it is no longer needed.
- Previously, it included a `userId` field for auditing, but since application year lookups don't require user-specific tracking, the entire DTO was unnecessary.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`