### PR TITLE
[gitops] Enabling raoidc mock in int1

### DIFF
--- a/gitops/overlays/int1/configs/frontend/config.conf
+++ b/gitops/overlays/int1/configs/frontend/config.conf
@@ -1,11 +1,14 @@
 # LOG_LEVEL=debug
 
-AUTH_LOGOUT_REDIRECT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
-AUTH_RAOIDC_BASE_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc/v1
+AUTH_LOGOUT_REDIRECT_URL=https://cdcp-int1.dev-dp.dts-stn.com/
+AUTH_RAOIDC_BASE_URL=https://cdcp-int1.dev-dp-internal.dts-stn.com/oidc
 AUTH_RAOIDC_CLIENT_ID=CDCP
-AUTH_RASCL_LOGOUT_URL=https://srv113-i.sade.hrdc-drhc.gc.ca/ecas-seca/rascl/Support/GlobalLogout.aspx
+AUTH_RASCL_LOGOUT_URL=https://cdcp-int1.dev-dp.dts-stn.com/
 
 ENABLED_FEATURES=address-validation,doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,stub-login
+
+ENABLED_MOCKS=raoidc
+MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-int1.dev-dp.dts-stn.com/auth/callback/raoidc
 
 HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 


### PR DESCRIPTION
### Description
This PR enables the RAOIDC mock in INT1 to make testing easier by removing the need for ECAS/GCKey accounts.