### PR TITLE
AB#5297 -- Updating application year dto and mapper to remove `intakeYearId` and modify mapping target for coverage start date (for children validation)

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -48,7 +48,7 @@ describe('DefaultApplicationYearService', () => {
     },
   ];
 
-  const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { intakeYearId: '2024', taxYear: '2025', coverageStartDate: '2025-01-01' };
+  const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { taxYear: '2025', coverageStartDate: '2025-01-01' };
   const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
   mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
   mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
@@ -77,7 +77,7 @@ describe('DefaultApplicationYearService', () => {
       const result = await service.findRenewalApplicationYear('2025-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
-        intakeYearId: '2024',
+        coverageStartDate: '2024-12-31',
         applicationYearResultDto: {
           applicationYear: '2025',
           applicationYearId: '2025',
@@ -101,7 +101,7 @@ describe('DefaultApplicationYearService', () => {
       const result = await service.findRenewalApplicationYear('2026-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
-        intakeYearId: '2025',
+        coverageStartDate: '2025-12-31',
         applicationYearResultDto: { applicationYear: '2026', applicationYearId: '2026', taxYear: '2026', coverageStartDate: '2026-01-01', coverageEndDate: '2026-12-31', intakeStartDate: '2026-01-01', renewalStartDate: '2026-01-01' },
       });
       expect(result).toEqual(mockRenewalApplicationYearResultDto);

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -110,7 +110,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
     it('should map a valid RenewAdultChildState to AdultChildBenefitRenewalDto with information changed', () => {
       const renewAdultChildState: RenewAdultChildState = {
         applicationYear: {
-          intakeYearId: '2024',
           renewalYearId: '2024',
           taxYear: '2024',
           coverageStartDate: '2024-01-01',

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -18,7 +18,6 @@ export type ApplicationYearResultDto = Readonly<{
  * Represents a Data Transfer Object (DTO) for a renewal application year result.
  */
 export type RenewalApplicationYearResultDto = Readonly<{
-  intakeYearId: string;
   renewalYearId?: string;
   taxYear: string;
   coverageStartDate: string;

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -10,17 +10,16 @@ export interface ApplicationYearDtoMapper {
 }
 
 interface ToRenewalApplicationYearResultDtoArgs {
-  intakeYearId: string;
+  coverageStartDate: string;
   applicationYearResultDto: ApplicationYearResultDto;
 }
 
 @injectable()
 export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper {
-  mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ intakeYearId, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageStartDate, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
     return {
-      intakeYearId: intakeYearId,
       taxYear: applicationYearResultDto.taxYear,
-      coverageStartDate: applicationYearResultDto.coverageStartDate,
+      coverageStartDate,
       renewalYearId: applicationYearResultDto.applicationYearId,
     };
   }

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -103,7 +103,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
     });
     invariant(intakeYear, 'Expected intakeYear to be defined');
 
-    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ intakeYearId: intakeYear.applicationYearId, applicationYearResultDto: matchingRenewalApplicationYear });
+    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageStartDate: intakeYear.coverageEndDate, applicationYearResultDto: matchingRenewalApplicationYear });
 
     this.log.trace('Returning renewal application year result: [%j]', renewalApplicationYearResultDto);
     return renewalApplicationYearResultDto;

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -17,7 +17,6 @@ export interface ProtectedRenewState {
   readonly id: string;
   readonly editMode: boolean;
   readonly applicationYear: {
-    intakeYearId: string;
     renewalYearId: string;
     taxYear: string;
     coverageStartDate: string;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -16,7 +16,6 @@ export interface RenewState {
   readonly editMode: boolean;
   lastUpdatedOn: string;
   readonly applicationYear: {
-    intakeYearId: string;
     renewalYearId: string;
     taxYear: string;
     coverageStartDate: string;

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   invariant(applicationYear?.renewalYearId, 'Expected applicationYear.renewalYearId to be defined'); // TODO this should redirect to the protected apply flow when introduced
 
   const clientApplicationService = appContainer.get(TYPES.domain.services.ClientApplicationService);
-  const clientApplication = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.intakeYearId, userId: userInfoToken.sub });
+  const clientApplication = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.renewalYearId, userId: userInfoToken.sub });
   if (!clientApplication) {
     throw redirect(getPathById('protected/data-unavailable', params));
   }
@@ -53,7 +53,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const id = randomUUID().toString();
   const state = startProtectedRenewState({
     applicationYear: {
-      intakeYearId: applicationYear.intakeYearId,
       renewalYearId: applicationYear.renewalYearId,
       taxYear: applicationYear.taxYear,
       coverageStartDate: applicationYear.coverageStartDate,

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -144,7 +144,7 @@ export async function action({ context: { appContainer, session }, params, reque
     lastName: parsedDataResult.data.lastName,
     dateOfBirth: parsedDataResult.data.dateOfBirth,
     clientNumber: parsedDataResult.data.clientNumber,
-    applicationYearId: state.applicationYear.intakeYearId,
+    applicationYearId: state.applicationYear.renewalYearId,
     userId: 'anonymous',
   });
 

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -42,7 +42,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const state = startRenewState({
     applicationYear: {
-      intakeYearId: applicationYear.intakeYearId,
       renewalYearId: applicationYear.renewalYearId,
       taxYear: applicationYear.taxYear,
       coverageStartDate: applicationYear.coverageStartDate,


### PR DESCRIPTION
### Description
`intakeYearId` is no longer needed. It was previously passed to the `findClientApplicationBySin(..)` and `findClientApplicationByBasicInfo(..)` methods, but as per the ADO, `renewalYearId` is used instead.

As per the ADO, the DTO's `coverageStartDate`, which is used for validating the children's date of birth for renewal, is now mapped to the `intakeYear.coverageEndDate` field.

Tax year date is already mapped correctly - no changed is needed.

### Related Azure Boards Work Items
[AB#5297](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5297)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`