### PR TITLE
Fixing styling of address suggestion/invalid dialog

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -439,7 +439,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('protected-renew:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('protected-renew:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -453,7 +453,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('protected-renew:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -462,7 +464,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('protected-renew:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -522,13 +526,13 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('protected-renew:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('protected-renew:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('protected-renew:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -419,7 +419,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('protected-renew:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('protected-renew:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -433,7 +433,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('protected-renew:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -442,7 +444,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('protected-renew:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -506,13 +510,13 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('protected-renew:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('protected-renew:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('protected-renew:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -388,7 +388,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('address-validation:index.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('address-validation:index.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -397,7 +399,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('address-validation:index.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('address-validation:index.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -460,7 +464,7 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
         <DialogDescription>{t('address-validation:index.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('address-validation:index.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -434,7 +434,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult-child:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -448,7 +448,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -457,7 +459,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -534,13 +538,13 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult-child:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult-child:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-adult-child:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -487,7 +487,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult-child:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -501,7 +501,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -510,7 +512,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -591,13 +595,13 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult-child:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult-child:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-adult-child:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -435,7 +435,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -449,7 +449,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -458,7 +460,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -535,13 +539,13 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-adult:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -477,7 +477,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -491,7 +491,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -500,7 +502,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -581,13 +585,13 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-adult:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-adult:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-adult:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -435,7 +435,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-child:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -449,7 +449,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -458,7 +460,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -535,13 +539,13 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-child:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-child:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -472,7 +472,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-child:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -486,7 +486,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -495,7 +497,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -576,13 +580,13 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-child:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-child:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -435,7 +435,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-ita:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-ita:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -449,7 +449,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -458,7 +460,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: Ad
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -518,13 +522,13 @@ function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogCon
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-ita:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-ita:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-ita:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -473,7 +473,7 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-ita:update-address.dialog.address-suggestion.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-ita:update-address.dialog.address-suggestion.description')}</DialogDescription>
@@ -487,7 +487,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: enteredAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
                 <Address address={enteredAddress} />
               </>
             ),
@@ -496,7 +498,9 @@ function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copy
             value: suggestedAddressOptionValue,
             children: (
               <>
-                <p className="mb-2 font-semibold">{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</p>
+                <p className="mb-2">
+                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
                 <Address address={suggestedAddress} />
               </>
             ),
@@ -560,13 +564,13 @@ function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: Addr
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 text-amber-700" />
+          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
           {t('renew-ita:update-address.dialog.address-invalid.header')}
         </DialogTitle>
         <DialogDescription>{t('renew-ita:update-address.dialog.address-invalid.description')}</DialogDescription>
       </DialogHeader>
       <div className="space-y-2">
-        <p className="font-semibold">
+        <p>
           <strong>{t('renew-ita:update-address.dialog.address-invalid.entered-address')}</strong>
         </p>
         <Address address={invalidAddress} />


### PR DESCRIPTION
### Description
Also adds `<strong>` to emphasized text in the address suggestion dialog, similar to #3143.

### Screenshots (if applicable)
**Before:**
![image](https://github.com/user-attachments/assets/0bc59f28-cb22-4bf9-a147-034b141d8248)

**After:**
![image](https://github.com/user-attachments/assets/2ae59d74-be86-45d6-8dac-659926584011)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
An ADO item is currently open to refactor these dialogs into a reusable component.