### PR TITLE
Fixing redirect bug in renew edit mode.

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
@@ -126,7 +126,7 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
   }
 
   if (hasAddressChanged === undefined) {
-    throw redirect(getPathById('public/renew/$id/adult-child/confirm-address', params));
+    throw redirect(getPathById('public/renew/$id/ita/confirm-address', params));
   }
 
   if (hasAddressChanged && mailingAddress === undefined) {

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -114,8 +114,8 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
-        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged ?? state.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress ?? state.isHomeAddressSameAsMailingAddress,
       },
     });
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -114,8 +114,8 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
-        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged ?? state.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress ?? state.isHomeAddressSameAsMailingAddress,
       },
     });
     return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -114,8 +114,8 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
-        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged ?? state.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress ?? state.isHomeAddressSameAsMailingAddress,
       },
     });
     return redirect(getPathById('public/renew/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -114,8 +114,8 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        hasAddressChanged: state.previousAddressState?.hasAddressChanged,
-        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress,
+        hasAddressChanged: state.previousAddressState?.hasAddressChanged ?? state.hasAddressChanged,
+        isHomeAddressSameAsMailingAddress: state.previousAddressState?.isHomeAddressSameAsMailingAddress ?? state.isHomeAddressSameAsMailingAddress,
       },
     });
     return redirect(getPathById('public/renew/$id/ita/review-information', params));


### PR DESCRIPTION
### Description
Description in bug ticket.

### Related Azure Boards Work Items
AB#17044
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/17044

### Test Instructions
    Go through the ITA flow
    Get to the Confirm page
    Click modify home address
    On the home address page, click cancel

it goes to the application type screen instead of back to the confirm page 
