### PR TITLE
[gitops] Adding `ingresses-renew-maintenance.yaml` to prod for selective renewal application maintenance

### DIFF
--- a/gitops/overlays/prod/ingresses-renew-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-renew-maintenance.yaml
@@ -1,0 +1,66 @@
+# This file defines ingress resources that put the renewal application into "maintenance mode".
+#
+# To enable maintenance mode, reference this file in kustomization.yaml.
+# This will route traffic for the online application to the maintenance and OAuth proxy services,
+# while preserving access to the allowed routes.
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: srv024.service.canada.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(protected/renew|protege/renouveller|renew|renouveller)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: maintenance
+                port:
+                  name: http
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-internal
+  labels:
+    app.kubernetes.io/name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k # required for OAuth proxy
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(protected/renew|protege/renouveller|renew|renouveller)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: oauth-proxy

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -21,10 +21,12 @@ resources:
   #   2. uncomment the appropriate maintenance mode file:
   #      - for full application maintenance, uncomment ./ingresses-maintenance.yaml
   #      - for online application maintenance, uncomment ./ingresses-apply-maintenance.yaml
+  #      - for renewal application maintenance, uncomment ./ingresses-renew-maintenance.yaml
   #
   - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
+  # - ./ingresses-renew-maintenance.yaml
 patches:
   - path: ./patches/deployments-frontend.yaml
   - path: ./patches/deployments-maintenance.yaml


### PR DESCRIPTION
### Description
- Added new ingress resource to enable maintenance mode for the renewal application
- Updated `kustomization.yaml` instructions to toggle between full application maintenance and renewal maintenance modes
- In preparation for late February deployment - a separate PR will be created closer to actual deployment date to enable maintenance mode specifically for the renewal application