### PR TITLE
AB#5281 -- A11Y Fixed error message SR repetition on applicant/child information pages

### DIFF
--- a/frontend/__tests__/components/error-summary.test.tsx
+++ b/frontend/__tests__/components/error-summary.test.tsx
@@ -67,7 +67,6 @@ describe('ErrorSummary component', () => {
     ];
     render(<ErrorSummary errors={errors} id="error-summary" />);
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('gcweb:error-summary.header')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(2);
   });
@@ -75,7 +74,6 @@ describe('ErrorSummary component', () => {
   it('renders no errors when errors array is empty', () => {
     render(<ErrorSummary errors={[]} id="error-summary" />);
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('gcweb:error-summary.header')).toBeInTheDocument();
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
   });

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -39,9 +39,10 @@ export interface DatePickerFieldProps {
     year: string;
   };
   required?: boolean;
+  disableErrorSR?: boolean;
 }
 
-export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, names, required }: DatePickerFieldProps) => {
+export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, names, required, disableErrorSR }: DatePickerFieldProps) => {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(['gcweb']);
   const [value] = useState(extractDateParts(defaultValue));
@@ -140,25 +141,25 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
     return {
       all:
         typeof errorMessages?.all === 'string' ? (
-          <InputError id={inputErrorIdAll} data-testid="date-picker-error-all">
+          <InputError aria-hidden={disableErrorSR} id={inputErrorIdAll} data-testid="date-picker-error-all">
             {errorMessages.all}
           </InputError>
         ) : undefined,
       month:
         typeof errorMessages?.month === 'string' ? (
-          <InputError id={inputErrorIdMonth} data-testid="date-picker-error-month">
+          <InputError aria-hidden={disableErrorSR} id={inputErrorIdMonth} data-testid="date-picker-error-month">
             {errorMessages.month}
           </InputError>
         ) : undefined,
       day:
         typeof errorMessages?.day === 'string' ? (
-          <InputError id={inputErrorIdDay} data-testid="date-picker-error-day">
+          <InputError aria-hidden={disableErrorSR} id={inputErrorIdDay} data-testid="date-picker-error-day">
             {errorMessages.day}
           </InputError>
         ) : undefined,
       year:
         typeof errorMessages?.year === 'string' ? (
-          <InputError id={inputErrorIdYear} data-testid="date-picker-error-year">
+          <InputError aria-hidden={disableErrorSR} id={inputErrorIdYear} data-testid="date-picker-error-year">
             {errorMessages.year}
           </InputError>
         ) : undefined,

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -39,10 +39,23 @@ export interface DatePickerFieldProps {
     year: string;
   };
   required?: boolean;
-  disableErrorSR?: boolean;
+  disableScreenReaderErrors?: boolean;
 }
 
-export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, names, required, disableErrorSR }: DatePickerFieldProps) => {
+export const DatePickerField = ({
+  defaultValue,
+  disabled,
+  errorMessages,
+  helpMessagePrimary,
+  helpMessagePrimaryClassName,
+  helpMessageSecondary,
+  helpMessageSecondaryClassName,
+  id,
+  legend,
+  names,
+  required,
+  disableScreenReaderErrors,
+}: DatePickerFieldProps) => {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(['gcweb']);
   const [value] = useState(extractDateParts(defaultValue));
@@ -141,30 +154,30 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
     return {
       all:
         typeof errorMessages?.all === 'string' ? (
-          <InputError aria-hidden={disableErrorSR} id={inputErrorIdAll} data-testid="date-picker-error-all">
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdAll} data-testid="date-picker-error-all">
             {errorMessages.all}
           </InputError>
         ) : undefined,
       month:
         typeof errorMessages?.month === 'string' ? (
-          <InputError aria-hidden={disableErrorSR} id={inputErrorIdMonth} data-testid="date-picker-error-month">
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdMonth} data-testid="date-picker-error-month">
             {errorMessages.month}
           </InputError>
         ) : undefined,
       day:
         typeof errorMessages?.day === 'string' ? (
-          <InputError aria-hidden={disableErrorSR} id={inputErrorIdDay} data-testid="date-picker-error-day">
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdDay} data-testid="date-picker-error-day">
             {errorMessages.day}
           </InputError>
         ) : undefined,
       year:
         typeof errorMessages?.year === 'string' ? (
-          <InputError aria-hidden={disableErrorSR} id={inputErrorIdYear} data-testid="date-picker-error-year">
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdYear} data-testid="date-picker-error-year">
             {errorMessages.year}
           </InputError>
         ) : undefined,
     };
-  }, [errorMessages?.all, errorMessages?.day, errorMessages?.month, errorMessages?.year, inputErrorIdAll, inputErrorIdDay, inputErrorIdMonth, inputErrorIdYear]);
+  }, [errorMessages?.all, errorMessages?.day, errorMessages?.month, errorMessages?.year, inputErrorIdAll, inputErrorIdDay, inputErrorIdMonth, inputErrorIdYear, disableScreenReaderErrors]);
 
   return (
     <div id={inputWrapperId} data-testid="date-picker-field">

--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -96,7 +96,7 @@ export function ErrorSummary({ errors, id }: ErrorSummaryProps) {
   const { t } = useTranslation(['gcweb']);
 
   return (
-    <section id={id} className="my-5 border-4 border-red-600 p-4" tabIndex={-1} role="alert">
+    <section id={id} className="my-5 border-4 border-red-600 p-4" tabIndex={-1}>
       <h2 className="font-lato text-lg font-semibold">{t('gcweb:error-summary.header', { count: errors.length })}</h2>
       {errors.length > 0 && (
         <ul className="mt-1.5 list-disc space-y-2 pl-7">

--- a/frontend/app/components/input-pattern-field.tsx
+++ b/frontend/app/components/input-pattern-field.tsx
@@ -22,11 +22,25 @@ export interface InputPatternFieldProps extends OmitStrict<React.ComponentProps<
   id: string;
   label: string;
   name: string;
-  disableErrorSR?: boolean;
+  disableScreenReaderErrors?: boolean;
 }
 
 export function InputPatternField(props: InputPatternFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableErrorSR, ...restProps } = props;
+  const {
+    'aria-describedby': ariaDescribedby,
+    className,
+    defaultValue,
+    errorMessage,
+    helpMessagePrimary,
+    helpMessagePrimaryClassName,
+    helpMessageSecondary,
+    helpMessageSecondaryClassName,
+    id,
+    label,
+    required,
+    disableScreenReaderErrors,
+    ...restProps
+  } = props;
 
   const inputWrapperId = `input-pattern-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -49,7 +63,7 @@ export function InputPatternField(props: InputPatternFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
             {errorMessage}
           </InputError>
         </p>

--- a/frontend/app/components/input-pattern-field.tsx
+++ b/frontend/app/components/input-pattern-field.tsx
@@ -22,10 +22,11 @@ export interface InputPatternFieldProps extends OmitStrict<React.ComponentProps<
   id: string;
   label: string;
   name: string;
+  disableErrorSR?: boolean;
 }
 
 export function InputPatternField(props: InputPatternFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
+  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableErrorSR, ...restProps } = props;
 
   const inputWrapperId = `input-pattern-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -48,7 +49,9 @@ export function InputPatternField(props: InputPatternFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError id={inputErrorId}>{errorMessage}</InputError>
+          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+            {errorMessage}
+          </InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -19,11 +19,25 @@ export interface InputRadiosProps {
   name: string;
   required?: boolean;
   legendClassName?: string;
-  disableSR?: boolean;
-  disableErrorSR?: boolean;
+  disableScreenReader?: boolean;
+  disableScreenReaderErrors?: boolean;
 }
 
-const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName, disableSR, disableErrorSR }: InputRadiosProps) => {
+const InputRadios = ({
+  errorMessage,
+  helpMessagePrimary,
+  helpMessagePrimaryClassName,
+  helpMessageSecondary,
+  helpMessageSecondaryClassName,
+  id,
+  legend,
+  name,
+  options,
+  required,
+  legendClassName,
+  disableScreenReader,
+  disableScreenReaderErrors,
+}: InputRadiosProps) => {
   const inputErrorId = `input-radios-${id}-error`;
   const inputHelpMessagePrimaryId = `input-radios-${id}-help-primary`;
   const inputHelpMessageSecondaryId = `input-radios-${id}-help-secondary`;
@@ -31,7 +45,7 @@ const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClass
   const inputWrapperId = `input-radios-${id}`;
 
   function getAriaDescribedby() {
-    if (disableSR) return undefined;
+    if (disableScreenReader) return undefined;
     const ariaDescribedby = [];
     if (helpMessagePrimary) ariaDescribedby.push(inputHelpMessagePrimaryId);
     if (helpMessageSecondary) ariaDescribedby.push(inputHelpMessageSecondaryId);
@@ -45,7 +59,7 @@ const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClass
       </InputLegend>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
             {errorMessage}
           </InputError>
         </p>

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -20,9 +20,10 @@ export interface InputRadiosProps {
   required?: boolean;
   legendClassName?: string;
   disableSR?: boolean;
+  disableErrorSR?: boolean;
 }
 
-const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName, disableSR }: InputRadiosProps) => {
+const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName, disableSR, disableErrorSR }: InputRadiosProps) => {
   const inputErrorId = `input-radios-${id}-error`;
   const inputHelpMessagePrimaryId = `input-radios-${id}-help-primary`;
   const inputHelpMessageSecondaryId = `input-radios-${id}-help-secondary`;
@@ -44,7 +45,9 @@ const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClass
       </InputLegend>
       {errorMessage && (
         <p className="mb-2">
-          <InputError id={inputErrorId}>{errorMessage}</InputError>
+          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+            {errorMessage}
+          </InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -22,11 +22,11 @@ export interface InputSanitizeFieldProps
   id: string;
   label: string;
   name: string;
-  disableErrorSR?: boolean;
+  disableScreenReaderErrors?: boolean;
 }
 
 export function InputSanitizeField(props: InputSanitizeFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableErrorSR, ...restProps } = props;
+  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableScreenReaderErrors, ...restProps } = props;
 
   const inputWrapperId = `input-sanitize-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -49,7 +49,7 @@ export function InputSanitizeField(props: InputSanitizeFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
             {errorMessage}
           </InputError>
         </p>

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -22,10 +22,11 @@ export interface InputSanitizeFieldProps
   id: string;
   label: string;
   name: string;
+  disableErrorSR?: boolean;
 }
 
 export function InputSanitizeField(props: InputSanitizeFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
+  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableErrorSR, ...restProps } = props;
 
   const inputWrapperId = `input-sanitize-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -48,7 +49,9 @@ export function InputSanitizeField(props: InputSanitizeFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError id={inputErrorId}>{errorMessage}</InputError>
+          <InputError aria-hidden={disableErrorSR} id={inputErrorId}>
+            {errorMessage}
+          </InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -212,7 +212,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -225,7 +225,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <InputPatternField
@@ -239,9 +239,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableScreenReaderErrors />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -212,6 +212,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -224,6 +225,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <InputPatternField
@@ -237,8 +239,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
+              disableErrorSR
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -263,6 +263,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
+            disableErrorSR
           />
         </div>
       ),
@@ -301,6 +302,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -313,6 +315,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-adult-child:children.information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -331,9 +334,10 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
 
-            <InputRadios id="has-social-insurance-number" legend={t('apply-adult-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required />
+            <InputRadios id="has-social-insurance-number" legend={t('apply-adult-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableErrorSR />
 
             <InputRadios
               id="is-parent-radios"
@@ -344,6 +348,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
+              disableErrorSR
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -263,7 +263,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
-            disableErrorSR
+            disableScreenReaderErrors
           />
         </div>
       ),
@@ -302,7 +302,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -315,7 +315,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-adult-child:children.information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -334,10 +334,18 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
 
-            <InputRadios id="has-social-insurance-number" legend={t('apply-adult-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableErrorSR />
+            <InputRadios
+              id="has-social-insurance-number"
+              legend={t('apply-adult-child:children.information.sin-legend')}
+              name="hasSocialInsuranceNumber"
+              options={options}
+              errorMessage={errors?.hasSocialInsuranceNumber}
+              required
+              disableScreenReaderErrors
+            />
 
             <InputRadios
               id="is-parent-radios"
@@ -348,7 +356,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
-              disableErrorSR
+              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -206,6 +206,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -218,6 +219,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
                 required
+                disableErrorSR
               />
             </div>
             <InputPatternField
@@ -231,8 +233,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
+              disableErrorSR
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -206,7 +206,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -219,7 +219,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <InputPatternField
@@ -233,9 +233,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableScreenReaderErrors />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -281,6 +281,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -293,6 +294,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -311,6 +313,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
             <InputPatternField
               id="social-insurance-number"
@@ -323,8 +326,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
+              disableErrorSR
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -281,7 +281,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -294,7 +294,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -313,7 +313,7 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputPatternField
               id="social-insurance-number"
@@ -326,9 +326,9 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
-            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableErrorSR />
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('applicant-information.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required disableScreenReaderErrors />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -263,6 +263,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
+            disableErrorSR
           />
         </div>
       ),
@@ -301,6 +302,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -313,6 +315,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-child:children.information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -331,9 +334,10 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
 
-            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required />
+            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableErrorSR />
 
             <InputRadios
               id="is-parent-radios"
@@ -345,6 +349,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
               ]}
               errorMessage={errors?.isParent}
               required
+              disableErrorSR
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -263,7 +263,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
-            disableErrorSR
+            disableScreenReaderErrors
           />
         </div>
       ),
@@ -302,7 +302,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -315,7 +315,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-child:children.information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -334,10 +334,10 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
 
-            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableErrorSR />
+            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableScreenReaderErrors />
 
             <InputRadios
               id="is-parent-radios"
@@ -349,7 +349,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
               ]}
               errorMessage={errors?.isParent}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -260,7 +260,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -273,7 +273,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-adult-child:children.information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -292,7 +292,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -305,7 +305,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputRadios
               id="is-parent-radios"
@@ -316,7 +316,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
-              disableErrorSR
+              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -260,6 +260,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -272,6 +273,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-adult-child:children.information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -290,6 +292,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
             <InputPatternField
               id="client-number"
@@ -302,6 +305,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
+              disableErrorSR
             />
             <InputRadios
               id="is-parent-radios"
@@ -312,6 +316,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
+              disableErrorSR
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -125,7 +125,7 @@ export default function RenewAdultChildConfirmMaritalStatus({ loaderData, params
               ]}
               helpMessagePrimary={t('renew-adult-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              disableSR
+              disableScreenReader
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -125,7 +125,7 @@ export default function RenewAdultConfirmMaritalStatus({ loaderData, params }: R
               ]}
               helpMessagePrimary={t('renew-adult:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              disableSR
+              disableScreenReader
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -215,6 +215,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.firstName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -227,6 +228,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.lastName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -245,6 +247,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
             <InputPatternField
               id="client-number"
@@ -257,6 +260,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
+              disableErrorSR
             />
             <Collapsible id="no-client-number" summary={t('renew:applicant-information.no-client-number')}>
               <div className="space-y-2">

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -215,7 +215,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.firstName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -228,7 +228,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.lastName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -247,7 +247,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -260,7 +260,7 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <Collapsible id="no-client-number" summary={t('renew:applicant-information.no-client-number')}>
               <div className="space-y-2">

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -260,6 +260,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
+                disableErrorSR
               />
               <InputSanitizeField
                 id="last-name"
@@ -272,6 +273,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-child:children.information.name-instructions')}
                 required
+                disableErrorSR
               />
             </div>
             <DatePickerField
@@ -290,6 +292,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
+              disableErrorSR
             />
             <InputPatternField
               id="client-number"
@@ -302,6 +305,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
+              disableErrorSR
             />
             <InputRadios
               id="is-parent-radios"
@@ -312,6 +316,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
+              disableErrorSR
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -260,7 +260,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -273,7 +273,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-child:children.information.name-instructions')}
                 required
-                disableErrorSR
+                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -292,7 +292,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -305,7 +305,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableErrorSR
+              disableScreenReaderErrors
             />
             <InputRadios
               id="is-parent-radios"
@@ -316,7 +316,7 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
-              disableErrorSR
+              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -125,7 +125,7 @@ export default function RenewChildConfirmMaritalStatus({ loaderData, params }: R
               ]}
               helpMessagePrimary={t('renew-child:confirm-marital-status.help-message')}
               errorMessage={errors?.hasMaritalStatusChanged}
-              disableSR
+              disableScreenReader
             />
           </div>
           {editMode ? (


### PR DESCRIPTION
### Description
A11Y Fixed error message SR repetition on applicant/child information pages

Errors in the summary would be read twice + field error labels would also be read. Added in fixes so that only the error summary section is read and only once.

Alternate solution could removed the need for "disableErrorSR" attribute if the "aria-hidden" attribute was permanently applied to the fields (this would affect other pages utilizing these inputs, removing SR capabilities).

### Related Azure Boards Work Items
[AB#5281](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5281)