### PR TITLE
Adding service method to get intake application year

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearResultDto, IntakeApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
+import { ApplicationYearNotFoundException } from '~/.server/domain/exceptions/application-year-not-found.exception';
 import type { ApplicationYearDtoMapper } from '~/.server/domain/mappers';
 import type { ApplicationYearRepository } from '~/.server/domain/repositories';
 import { DefaultApplicationYearService } from '~/.server/domain/services';
@@ -14,13 +15,14 @@ describe('DefaultApplicationYearService', () => {
 
   const mockApplicationYearResultDtos: ApplicationYearResultDto[] = [
     {
-      // optional dates not set except nextApplicationYearId
+      // renewal start and end dates not set
       applicationYear: '2024',
       applicationYearId: '2024',
       taxYear: '2024',
       coverageStartDate: '2024-01-01',
       coverageEndDate: '2024-12-31',
       intakeStartDate: '2024-01-01',
+      intakeEndDate: '2024-12-31',
       nextApplicationYearId: '2025',
     },
     // all fields set
@@ -48,11 +50,6 @@ describe('DefaultApplicationYearService', () => {
     },
   ];
 
-  const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { taxYear: '2025', coverageStartDate: '2025-01-01' };
-  const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
-  mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
-  mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
-
   const mockApplicationYearResultEntity: ApplicationYearResultEntity = {
     BenefitApplicationYear: [
       {
@@ -70,6 +67,11 @@ describe('DefaultApplicationYearService', () => {
   mockApplicationYearRepository.listApplicationYears.mockResolvedValue(mockApplicationYearResultEntity);
 
   describe('findRenewalApplicationYear', () => {
+    const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { taxYear: '2025', coverageStartDate: '2025-01-01' };
+    const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
+    mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
+    mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
+
     it('should return the correct renewal application year if given date is within a renewal period', async () => {
       const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
@@ -114,6 +116,60 @@ describe('DefaultApplicationYearService', () => {
 
       const result = await service.findRenewalApplicationYear('2024-01-01');
       expect(result).toEqual(null);
+    });
+  });
+
+  describe('getIntakeApplicationYear', () => {
+    const mockIntakeApplicationYearResultDto: IntakeApplicationYearResultDto = { intakeYearId: '2025', taxYear: '2025' };
+    const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
+    mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
+    mockApplicationYearDtoMapper.mapApplicationYearResultDtoToIntakeApplicationYearResultDto.mockReturnValue(mockIntakeApplicationYearResultDto);
+
+    it('should return the correct intake application year if given date is within an intake period', async () => {
+      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
+      const result = await service.getIntakeApplicationYear('2025-01-01');
+
+      expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToIntakeApplicationYearResultDto).toHaveBeenCalledWith({
+        applicationYear: '2025',
+        applicationYearId: '2025',
+        taxYear: '2025',
+        coverageStartDate: '2025-01-01',
+        coverageEndDate: '2025-12-31',
+        intakeStartDate: '2025-01-01',
+        intakeEndDate: '2025-12-31',
+        nextApplicationYearId: '2026',
+        renewalStartDate: '2025-01-01',
+        renewalEndDate: '2025-12-31',
+      });
+      expect(result).toEqual(mockIntakeApplicationYearResultDto);
+    });
+
+    it('should return the correct intake application year when the given date is on or after the intake start date and no intake end date is provided', async () => {
+      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
+      const result = await service.getIntakeApplicationYear('2026-01-01');
+
+      expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToIntakeApplicationYearResultDto).toHaveBeenCalledWith({
+        applicationYear: '2026',
+        applicationYearId: '2026',
+        taxYear: '2026',
+        coverageStartDate: '2026-01-01',
+        coverageEndDate: '2026-12-31',
+        intakeStartDate: '2026-01-01',
+        renewalStartDate: '2026-01-01',
+      });
+      expect(result).toEqual(mockIntakeApplicationYearResultDto);
+    });
+
+    it('should throw if given date is not within any intake period', async () => {
+      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+
+      const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
+
+      await expect(async () => await service.getIntakeApplicationYear('2023-01-01')).rejects.toThrow(ApplicationYearNotFoundException);
     });
   });
 });

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -26,4 +26,7 @@ export type RenewalApplicationYearResultDto = Readonly<{
 /**
  * Represents a Data Transfer Object (DTO) for an intake application year result.
  */
-export type IntakeApplicationYearResultDto = Omit<ApplicationYearResultDto, 'applicationYear' | 'intakeStartDate' | 'intakeEndDate' | 'renewalStartDate' | 'renewalEndDate' | 'renewalYearId' | 'coverageStartDate' | 'coverageEndDate'>;
+export type IntakeApplicationYearResultDto = Readonly<{
+  intakeYearId: string;
+  taxYear: string;
+}>;

--- a/frontend/app/.server/domain/exceptions/application-year-not-found.exception.ts
+++ b/frontend/app/.server/domain/exceptions/application-year-not-found.exception.ts
@@ -1,0 +1,3 @@
+import { ResourceNotFoundException } from '~/.server/domain/exceptions/resource-not-found.exception';
+
+export class ApplicationYearNotFoundException extends ResourceNotFoundException {}

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -1,10 +1,12 @@
 import { injectable } from 'inversify';
 
-import type { ApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
+import type { ApplicationYearResultDto, IntakeApplicationYearResultDto, RenewalApplicationYearResultDto } from '~/.server/domain/dtos';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 
 export interface ApplicationYearDtoMapper {
   mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity: ApplicationYearResultEntity): ReadonlyArray<ApplicationYearResultDto>;
+
+  mapApplicationYearResultDtoToIntakeApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): IntakeApplicationYearResultDto;
 
   mapApplicationYearResultDtoToRenewalApplicationYearResultDto(toRenewalApplicationYearResultDtoArgs: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto;
 }
@@ -16,6 +18,13 @@ interface ToRenewalApplicationYearResultDtoArgs {
 
 @injectable()
 export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper {
+  mapApplicationYearResultDtoToIntakeApplicationYearResultDto(applicationYearResultDto: ApplicationYearResultDto): IntakeApplicationYearResultDto {
+    return {
+      taxYear: applicationYearResultDto.taxYear,
+      intakeYearId: applicationYearResultDto.applicationYearId,
+    };
+  }
+
   mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageStartDate, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
     return {
       taxYear: applicationYearResultDto.taxYear,


### PR DESCRIPTION
### Description
Incremental PR to resolve issue where application year identifier is not passed to Interop when submitting a benefit application request.

This PR utilizes similar logic to fetching the renewal application year except the service method throws when an intake application year cannot be found as we always expect to be within an intake period.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/17520

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`