### PR TITLE
Adding result of retrieval of intake application year to apply state

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -35,6 +35,10 @@ describe('apply-adult-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
+      applicationYear: {
+        intakeYearId: '2025',
+        taxYear: '2025',
+      },
       children: [],
     } satisfies ApplyState;
 
@@ -790,6 +794,10 @@ describe('apply-adult-child-route-helpers', () => {
           maritalStatus: '1',
           socialInsuranceNumber: '000-000-001',
         },
+        applicationYear: {
+          intakeYearId: '2025',
+          taxYear: '2025',
+        },
         partnerInformation: {
           confirm: true,
           dateOfBirth: '1900-01-01',
@@ -845,6 +853,10 @@ describe('apply-adult-child-route-helpers', () => {
           lastName: 'Last Name',
           maritalStatus: '1',
           socialInsuranceNumber: '000-000-001',
+        },
+        applicationYear: {
+          intakeYearId: '2025',
+          taxYear: '2025',
         },
         children: [
           {

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -34,6 +34,10 @@ describe('apply-adult-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: true,
       lastUpdatedOn: '2000-01-01',
+      applicationYear: {
+        intakeYearId: '2025',
+        taxYear: '2025',
+      },
       children: [],
     } satisfies ApplyState;
 
@@ -428,6 +432,10 @@ describe('apply-adult-route-helpers', () => {
           lastName: 'Last Name',
           maritalStatus: '1',
           socialInsuranceNumber: '000-000-001',
+        },
+        applicationYear: {
+          intakeYearId: '2025',
+          taxYear: '2025',
         },
         communicationPreferences: {
           preferredLanguage: 'en',

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -35,6 +35,10 @@ describe('apply-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
+      applicationYear: {
+        intakeYearId: '2025',
+        taxYear: '2025',
+      },
       children: [],
     } satisfies ApplyState;
 
@@ -522,6 +526,10 @@ describe('apply-child-route-helpers', () => {
           maritalStatus: '1',
           socialInsuranceNumber: '000-000-001',
         },
+        applicationYear: {
+          intakeYearId: '2025',
+          taxYear: '2025',
+        },
         partnerInformation: {
           confirm: true,
           dateOfBirth: '1900-01-01',
@@ -554,6 +562,10 @@ describe('apply-child-route-helpers', () => {
           lastName: 'Last Name',
           maritalStatus: '1',
           socialInsuranceNumber: '000-000-001',
+        },
+        applicationYear: {
+          intakeYearId: '2025',
+          taxYear: '2025',
         },
         children: [
           {

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -124,6 +124,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
   const {
     allChildrenUnder18,
     applicantInformation,
+    applicationYear,
     communicationPreferences,
     dateOfBirth,
     dentalBenefits,
@@ -236,6 +237,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     ageCategory,
     allChildrenUnder18,
     applicantInformation,
+    applicationYear,
     children,
     communicationPreferences,
     contactInformation,

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -79,6 +79,7 @@ interface ValidateApplyAdultStateForReviewArgs {
 export function validateApplyAdultStateForReview({ params, state }: ValidateApplyAdultStateForReviewArgs) {
   const {
     applicantInformation,
+    applicationYear,
     communicationPreferences,
     dateOfBirth,
     dentalBenefits,
@@ -172,6 +173,7 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
   return {
     ageCategory,
     applicantInformation,
+    applicationYear,
     communicationPreferences,
     contactInformation,
     dateOfBirth,

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -121,7 +121,7 @@ interface ValidateStateForReviewArgs {
 }
 
 export function validateApplyChildStateForReview({ params, state }: ValidateStateForReviewArgs) {
-  const { applicantInformation, communicationPreferences, dateOfBirth, editMode, id, lastUpdatedOn, partnerInformation, contactInformation, submissionInfo, taxFiling2023, typeOfApplication } = state;
+  const { applicantInformation, applicationYear, communicationPreferences, dateOfBirth, editMode, id, lastUpdatedOn, partnerInformation, contactInformation, submissionInfo, taxFiling2023, typeOfApplication } = state;
 
   if (typeOfApplication === undefined) {
     throw redirect(getPathById('public/apply/$id/type-application', params));
@@ -174,6 +174,7 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
   return {
     ageCategory,
     applicantInformation,
+    applicationYear,
     children,
     communicationPreferences,
     contactInformation,

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -24,6 +24,10 @@ export type ApplyState = ReadonlyDeep<{
     maritalStatus: string;
     socialInsuranceNumber: string;
   };
+  applicationYear: {
+    intakeYearId: string;
+    taxYear: string;
+  };
   children: {
     id: string;
     dentalBenefits?: {
@@ -101,6 +105,7 @@ export type ApplyState = ReadonlyDeep<{
 }>;
 
 export type ApplicantInformationState = NonNullable<ApplyState['applicantInformation']>;
+export type ApplicationYearState = ApplyState['applicationYear'];
 export type ChildrenState = ApplyState['children'];
 export type ChildState = ChildrenState[number];
 export type ChildDentalBenefitsState = NonNullable<ChildState['dentalBenefits']>;
@@ -183,8 +188,8 @@ export function loadApplyState({ params, session }: LoadStateArgs) {
 interface SaveStateArgs {
   params: ApplyStateParams;
   session: Session;
-  state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn'>>;
-  remove?: keyof OmitStrict<ApplyState, 'children' | 'editMode' | 'id' | 'lastUpdatedOn'>;
+  state: Partial<OmitStrict<ApplyState, 'id' | 'lastUpdatedOn' | 'applicationYear'>>;
+  remove?: keyof OmitStrict<ApplyState, 'children' | 'editMode' | 'id' | 'lastUpdatedOn' | 'applicationYear'>;
 }
 
 /**
@@ -231,6 +236,7 @@ export function clearApplyState({ params, session }: ClearStateArgs) {
 }
 
 interface StartArgs {
+  applicationYear: ApplicationYearState;
   id: string;
   session: Session;
 }
@@ -240,7 +246,7 @@ interface StartArgs {
  * @param args - The arguments.
  * @returns The initial apply state.
  */
-export function startApplyState({ id, session }: StartArgs) {
+export function startApplyState({ applicationYear, id, session }: StartArgs) {
   const log = getLogger('apply-route-helpers.server/startApplyState');
   const parsedId = idSchema.parse(id);
 
@@ -248,6 +254,7 @@ export function startApplyState({ id, session }: StartArgs) {
     id: parsedId,
     editMode: false,
     lastUpdatedOn: new UTCDate().toISOString(),
+    applicationYear,
     children: [],
   };
 

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -6,9 +6,11 @@ import { randomUUID } from 'crypto';
 
 import type { Route } from './+types/index';
 
+import { TYPES } from '~/.server/constants';
 import { startApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
+import { getCurrentDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -30,7 +32,10 @@ export async function loader({ context: { appContainer, session }, request }: Ro
   const locale = getLocale(request);
 
   const id = randomUUID().toString();
-  const state = startApplyState({ id, session });
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
+  const applicationYear = await applicationYearService.getIntakeApplicationYear(currentDate);
+  const state = startApplyState({ id, session, applicationYear });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:index.page-title') }) };
 


### PR DESCRIPTION
### Description
Incremental PR that builds on top of #3223 to resolve issue where application year identifier is not passed to Interop when submitting a benefit application request.

Reverts #3048 with some changes, as we now require the application year identifier stored in state.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/17520

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`