### PR TITLE
Modifying benefit application mappers, dto, and entity to include application year id

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -2,6 +2,7 @@ import type { ReadonlyDeep } from 'type-fest';
 
 export type BenefitApplicationDto = ReadonlyDeep<{
   applicantInformation: ApplicantInformationDto;
+  applicationYearId: string;
   children: ChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;

--- a/frontend/app/.server/domain/entities/benefit-application.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-application.entity.ts
@@ -102,6 +102,11 @@ export type BenefitApplicationRequestEntity = ReadonlyDeep<{
     BenefitApplicationChannelCode: {
       ReferenceDataID: string;
     };
+    BenefitApplicationYear: {
+      BenefitApplicationYearIdentification: {
+        IdentificationID: string;
+      }[];
+    };
   };
 }>;
 

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -38,6 +38,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
 
   mapBenefitApplicationDtoToBenefitApplicationRequestEntity({
     applicantInformation,
+    applicationYearId,
     children,
     communicationPreferences,
     contactInformation,
@@ -99,6 +100,13 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
         },
         BenefitApplicationChannelCode: {
           ReferenceDataID: '775170001', // PP's static value for "Online"
+        },
+        BenefitApplicationYear: {
+          BenefitApplicationYearIdentification: [
+            {
+              IdentificationID: applicationYearId,
+            },
+          ],
         },
       },
     };

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -6,6 +6,7 @@ import type { BenefitApplicationDto } from '~/.server/domain/dtos';
 import { getAgeCategoryFromDateString } from '~/.server/routes/helpers/apply-route-helpers';
 import type {
   ApplicantInformationState,
+  ApplicationYearState,
   ChildState,
   CommunicationPreferencesState,
   ContactInformationState,
@@ -17,6 +18,7 @@ import type {
 
 export interface ApplyAdultState {
   applicantInformation: ApplicantInformationState;
+  applicationYear: ApplicationYearState;
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
   dateOfBirth: string;
@@ -30,6 +32,7 @@ export interface ApplyAdultState {
 
 export interface ApplyAdultChildState {
   applicantInformation: ApplicantInformationState;
+  applicationYear: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -44,6 +47,7 @@ export interface ApplyAdultChildState {
 
 export interface ApplyChildState {
   applicantInformation: ApplicantInformationState;
+  applicationYear: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -56,6 +60,7 @@ export interface ApplyChildState {
 
 interface ToBenefitApplicationDtoArgs {
   applicantInformation: ApplicantInformationState;
+  applicationYear: ApplicationYearState;
   children?: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -118,6 +123,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
 
   private toBenefitApplicationDto({
     applicantInformation,
+    applicationYear,
     children,
     communicationPreferences,
     dateOfBirth,
@@ -131,6 +137,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
   }: ToBenefitApplicationDtoArgs) {
     return {
       applicantInformation,
+      applicationYearId: applicationYear.intakeYearId,
       children: this.toChildren(children),
       communicationPreferences,
       contactInformation: this.toContactInformation(contactInformation),


### PR DESCRIPTION
### Description
Incremental PR that builds on top of #3224 to resolve issue where application year identifier is not passed to Interop when submitting a benefit application request.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/17520

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/198ad699-9d48-4aca-9e24-0bb3cc9a0ab9)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Run application and complete an intake application until you reach the review page. Verify that the payload includes `BenefitApplicationYearIdentification`.