### PR TITLE
Adding `apply-application-year` feature flag to control application year service call and submission behaviour

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -51,7 +51,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env-utils.server.ts for valid values
 # (optional; default: "")
-ENABLED_FEATURES=address-validation,doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,stub-login,demographic-survey
+ENABLED_FEATURES=address-validation,apply-application-year,doc-upload,hcaptcha,view-letters,view-letters-online-application,view-messages,status,view-payload,stub-login,demographic-survey
 
 # hCaptcha maximum allowed score denoting malicious activity
 # (optional; default: 0.79)

--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -2,7 +2,7 @@ import type { ReadonlyDeep } from 'type-fest';
 
 export type BenefitApplicationDto = ReadonlyDeep<{
   applicantInformation: ApplicantInformationDto;
-  applicationYearId: string;
+  applicationYearId?: string;
   children: ChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;

--- a/frontend/app/.server/domain/entities/benefit-application.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-application.entity.ts
@@ -98,12 +98,12 @@ export type BenefitApplicationRequestEntity = ReadonlyDeep<{
     };
     BenefitApplicationCategoryCode: {
       ReferenceDataID: string;
-      ReferenceDataName: string;
+      ReferenceDataName?: string;
     };
     BenefitApplicationChannelCode: {
       ReferenceDataID: string;
     };
-    BenefitApplicationYear: {
+    BenefitApplicationYear?: {
       BenefitApplicationYearIdentification: {
         IdentificationID: string;
       }[];

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -30,9 +30,9 @@ interface ToEmailAddressArgs {
 
 @injectable()
 export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDtoMapper {
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>;
+  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES'>;
 
-  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>) {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES'>) {
     this.serverConfig = serverConfig;
   }
 
@@ -97,20 +97,32 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
         },
         BenefitApplicationCategoryCode: {
           ReferenceDataID: this.toBenefitApplicationCategoryCode(typeOfApplication),
-          ReferenceDataName: 'New',
+          ...(this.applyApplicationYearEnabled() ? { ReferenceDataName: 'New' } : {}),
         },
         BenefitApplicationChannelCode: {
           ReferenceDataID: '775170001', // PP's static value for "Online"
         },
-        BenefitApplicationYear: {
-          BenefitApplicationYearIdentification: [
-            {
-              IdentificationID: applicationYearId,
-            },
-          ],
-        },
+        ...(this.applyApplicationYearEnabled()
+          ? {
+              BenefitApplicationYear: {
+                BenefitApplicationYearIdentification: [
+                  {
+                    IdentificationID:
+                      applicationYearId ??
+                      (() => {
+                        throw new Error("Expected applicationYearId to be defined when apply-application-year is enabled'");
+                      })(),
+                  },
+                ],
+              },
+            }
+          : {}),
       },
     };
+  }
+
+  private applyApplicationYearEnabled() {
+    return this.serverConfig.ENABLED_FEATURES.includes('apply-application-year');
   }
 
   private toInsurancePlan(dentalBenefits: readonly string[]) {

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -24,7 +24,7 @@ export type ApplyState = ReadonlyDeep<{
     maritalStatus: string;
     socialInsuranceNumber: string;
   };
-  applicationYear: {
+  applicationYear?: {
     intakeYearId: string;
     taxYear: string;
   };
@@ -236,7 +236,7 @@ export function clearApplyState({ params, session }: ClearStateArgs) {
 }
 
 interface StartArgs {
-  applicationYear: ApplicationYearState;
+  applicationYear?: ApplicationYearState;
   id: string;
   session: Session;
 }

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -18,7 +18,7 @@ import type {
 
 export interface ApplyAdultState {
   applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
+  applicationYear?: ApplicationYearState;
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
   dateOfBirth: string;
@@ -32,7 +32,7 @@ export interface ApplyAdultState {
 
 export interface ApplyAdultChildState {
   applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
+  applicationYear?: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -47,7 +47,7 @@ export interface ApplyAdultChildState {
 
 export interface ApplyChildState {
   applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
+  applicationYear?: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -60,7 +60,7 @@ export interface ApplyChildState {
 
 interface ToBenefitApplicationDtoArgs {
   applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
+  applicationYear?: ApplicationYearState;
   children?: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -137,7 +137,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
   }: ToBenefitApplicationDtoArgs) {
     return {
       applicantInformation,
-      applicationYearId: applicationYear.intakeYearId,
+      applicationYearId: applicationYear?.intakeYearId,
       children: this.toChildren(children),
       communicationPreferences,
       contactInformation: this.toContactInformation(contactInformation),

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -1,6 +1,19 @@
 import { z } from 'zod';
 
-const validFeatureNames = ['address-validation', 'doc-upload', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-messages', 'view-payload', 'demographic-survey'] as const;
+const validFeatureNames = [
+  'address-validation',
+  'apply-application-year',
+  'doc-upload',
+  'hcaptcha',
+  'show-prototype-banner',
+  'stub-login',
+  'status',
+  'view-letters',
+  'view-letters-online-application',
+  'view-messages',
+  'view-payload',
+  'demographic-survey',
+] as const;
 
 export type FeatureName = (typeof validFeatureNames)[number];
 


### PR DESCRIPTION
### Description
When the `apply-application-year` feature flag is disabled, the `/apply` flow will not make a call to the application year service, nor will the `BenefitApplicationYear` and `BenefitApplicationCategoryCode.ReferenceDataName` fields be submitted in the payload to Interop.

This feature flag is required because DTS will be releasing Renewals within their blanket approval window (morning of Feb 28), while Interop's release, which includes the application year API, will be released at a later date (evening of Mar 2). During that time, the `/apply` flow must still work.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`