### PR TITLE
AB#5342 a11y - fix screen reader issue on child's information

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import { data, redirect, useFetcher } from 'react-router';
 
@@ -357,15 +357,16 @@ function ChildNotFound() {
   const noWrap = <span className="whitespace-nowrap" />;
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollIntoView({ behavior: 'smooth' });
-      wrapperRef.current.focus();
+  const setWrapperRef = (node: HTMLDivElement | null) => {
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth' });
+      node.focus();
     }
-  }, []);
+    wrapperRef.current = node;
+  };
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
+    <div ref={setWrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-adult-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-adult-child:children.information.child-not-found.please-review')}</p>

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -365,7 +365,7 @@ function ChildNotFound() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="polite">
+    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-adult-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-adult-child:children.information.child-not-found.please-review')}</p>

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import { data, redirect, useFetcher } from 'react-router';
 
@@ -311,15 +311,16 @@ function StatusNotFound() {
   const noWrap = <span className="whitespace-nowrap" />;
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollIntoView({ behavior: 'smooth' });
-      wrapperRef.current.focus();
+  const setWrapperRef = (node: HTMLDivElement | null) => {
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth' });
+      node.focus();
     }
-  }, []);
+    wrapperRef.current = node;
+  };
 
   return (
-    <div ref={wrapperRef} id="status-not-found" className="mb-4">
+    <div ref={setWrapperRef} id="status-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew:applicant-information.status-not-found.heading')}</h2>
         <p className="mb-2">{t('renew:applicant-information.status-not-found.please-review')}</p>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import { data, redirect, useFetcher } from 'react-router';
 
@@ -351,15 +351,16 @@ function ChildNotFound() {
   const noWrap = <span className="whitespace-nowrap" />;
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollIntoView({ behavior: 'smooth' });
-      wrapperRef.current.focus();
+  const setWrapperRef = (node: HTMLDivElement | null) => {
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth' });
+      node.focus();
     }
-  }, []);
+    wrapperRef.current = node;
+  };
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
+    <div ref={setWrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-child:children.information.child-not-found.please-review')}</p>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -359,7 +359,7 @@ function ChildNotFound() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="polite">
+    <div ref={wrapperRef} id="child-not-found" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('renew-child:children.information.child-not-found.heading')}</h2>
         <p className="mb-2">{t('renew-child:children.information.child-not-found.please-review')}</p>


### PR DESCRIPTION
### Description

When a user enters a child's information that does not match the record, an alert is displayed at the top of the page. However, screen readers do not announce the content of the alert when it appears. 

This issue exists because:

The alert container was not programmatically focusable, so screen readers did not automatically shift focus to it when it appeared.

The aria-live attribute was not set to assertive, which is necessary to ensure that screen readers immediately announce the alert's content.

To resolve this issue, following changes are made:

Used a callback ref: Instead of relying on useEffect, callback ref  used to handle the scroll and focus logic. This ensures that the alert scrolls into view and receives focus every time it is rendered.

Changed `aria-live` to assertive: This ensures that screen readers interrupt any ongoing speech to announce the alert as soon as it appears.

Added `tabIndex={-1}` to the alert container: This makes the alert focusable programmatically, allowing it to receive focus when it appears. 

### Related Azure Boards Work Items
[AB#5342](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5342)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->