### PR TITLE
5332 using semantic headings

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -152,8 +152,8 @@ export default function ProtectedRenewConfirm({ loaderData, params }: Route.Comp
           <>
             <h2 className="font-lato text-3xl font-bold">{t('confirm.applicant-summary')}</h2>
             <section className="space-y-6">
-              <span className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</span>
-              <h3 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h3>
+              <h3 className="font-lato text-3xl font-bold">{t('confirm.applicant-title')}</h3>
+              <h4 className="font-lato text-2xl font-bold">{t('confirm.member-info')}</h4>
               <dl className="divide-y border-y">
                 <DescriptionListItem term={t('confirm.full-name')}>{`${primaryApplicantInfo.firstName} ${primaryApplicantInfo.lastName}`}</DescriptionListItem>
               </dl>


### PR DESCRIPTION
### Description
Use semantic heading tags in increasing order.  Aligns with pubic renew app which was approved by the ITAO.

### Related Azure Boards Work Items
[AB#5332](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5332)
