### PR TITLE
AB#5338 -- Updating title on confirm-federal-provincial-territorial-benefits screens

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -176,7 +176,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Child access to other federal, provincial or territorial dental benefits click">
+              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Child access to other government dental benefits click">
                 {t('renew-adult-child:children.confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -184,7 +184,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/renew/$id/adult-child/review-child-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Child access to other government dental benefits click"
               >
                 {t('renew-adult-child:children.confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -196,7 +196,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Child access to other government dental benefits click"
               >
                 {t('renew-adult-child:children.confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -206,7 +206,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Child access to other government dental benefits click"
               >
                 {t('renew-adult-child:children.confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -162,7 +162,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Access to other federal, provincial or territorial dental benefits click">
+              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Save - Access to other government dental benefits click">
                 {t('renew-adult-child:confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -170,7 +170,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/renew/$id/adult-child/review-adult-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Cancel - Access to other government dental benefits click"
               >
                 {t('renew-adult-child:confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -182,7 +182,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Access to other government dental benefits click"
               >
                 {t('renew-adult-child:confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -192,7 +192,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Back - Access to other government dental benefits click"
               >
                 {t('renew-adult-child:confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -162,7 +162,7 @@ export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ 
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other federal, provincial or territorial dental benefits click">
+              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Save - Access to other government dental benefits click">
                 {t('renew-adult:confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -170,20 +170,14 @@ export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ 
                 routeId="public/renew/$id/adult/review-adult-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Cancel - Access to other government dental benefits click"
               >
                 {t('renew-adult:confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton
-                variant="primary"
-                id="continue-button"
-                loading={isSubmitting}
-                endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Access to other federal, provincial or territorial dental benefits click"
-              >
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Continue - Access to other government dental benefits click">
                 {t('renew-adult:confirm-dental-benefits.button.continue')}
               </LoadingButton>
               <ButtonLink
@@ -192,7 +186,7 @@ export default function RenewAdultConfirmFederalProvincialTerritorialBenefits({ 
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Back - Access to other government dental benefits click"
               >
                 {t('renew-adult:confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -176,7 +176,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Child access to other federal, provincial or territorial dental benefits click">
+              <Button variant="primary" id="save-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Save - Child access to other government dental benefits click">
                 {t('renew-child:children.confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -184,7 +184,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/renew/$id/child/review-child-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Cancel - Child access to other government dental benefits click"
               >
                 {t('renew-child:children.confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -196,7 +196,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Child access to other government dental benefits click"
               >
                 {t('renew-child:children.confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -206,7 +206,7 @@ export default function RenewAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Child access to other federal, provincial or territorial dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Back - Child access to other government dental benefits click"
               >
                 {t('renew-child:children.confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -152,7 +152,7 @@
     "save-btn": "Save"
   },
   "confirm-dental-benefits": {
-    "title": "Access to other federal, provincial or territorial dental benefits",
+    "title": "Access to other government dental benefits",
     "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
     "select-one": "Select one",
     "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",
@@ -389,7 +389,7 @@
       }
     },
     "confirm-dental-benefits": {
-      "title": "{{childName}}: access to other federal, provincial or territorial dental benefits",
+      "title": "{{childName}}: access to other government dental benefits",
       "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
       "select-one": "Select one",
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -201,7 +201,7 @@
     }
   },
   "confirm-dental-benefits": {
-    "title": "Access to other federal, provincial or territorial dental benefits",
+    "title": "Access to other government dental benefits",
     "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social program will not impact your eligibility for the Canadian Dental Care Plan.",
     "select-one": "Select one",
     "eligibility-criteria": "If you meet all the eligibility criteria, your coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -130,7 +130,7 @@
       }
     },
     "confirm-dental-benefits": {
-      "title": "{{childName}}: access to other federal, provincial or territorial dental benefits",
+      "title": "{{childName}}: access to other government dental benefits",
       "access-to-dental": "Access to dental coverage through a provincial, territorial or federal government social programs will not impact the child's eligibility for the Canadian Dental Care Plan.",
       "select-one": "Select one",
       "eligibility-criteria": "If the child meets all the eligibility criteria, their coverage will be coordinated between the plans to ensure there are no gaps or duplication in coverage.",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -153,7 +153,7 @@
     "save-btn": "Sauvegarder"
   },
   "confirm-dental-benefits": {
-    "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+    "title": "Accès à d'autres prestations dentaires gouvernementales",
     "access-to-dental": "L'accès à une assurance dentaire dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur votre admissibilité au Régime canadien de soins dentaires.",
     "select-one": "Sélectionnez une option",
     "eligibility-criteria": "Si vous répondez à tous les critères d'admissibilité, votre couverture sera coordonnée entre les régimes afin qu'il n'y ait pas de lacunes ou de dédoublement dans la couverture.",
@@ -391,7 +391,7 @@
       }
     },
     "confirm-dental-benefits": {
-      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires gouvernementales",
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -201,7 +201,7 @@
     }
   },
   "confirm-dental-benefits": {
-    "title": "Accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+    "title": "Accès à d'autres prestations dentaires gouvernementales",
     "access-to-dental": "L'accès à une assurance dentaire dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur votre admissibilité au Régime canadien de soins dentaires.",
     "select-one": "Sélectionnez une option",
     "eligibility-criteria": "Si vous répondez à tous les critères d'admissibilité, votre couverture sera coordonnée entre les régimes afin qu'il n'y ait pas de lacunes ou de dédoublement dans la couverture.",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -131,7 +131,7 @@
       }
     },
     "confirm-dental-benefits": {
-      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires fédérales, provinciales ou territoriales",
+      "title": "{{childName}}\u00a0: accès à d'autres prestations dentaires gouvernementales",
       "access-to-dental": "L'accès à des prestations dentaires dans le cadre d'un programme social provincial, territorial ou fédéral n'aura aucune incidence sur l'admissibilité de l'enfant au Régime canadien de soins dentaires.",
       "select-one": "Sélectionnez une option",
       "eligibility-criteria": "Si l'enfant répond à tous les critères d'admissibilité, sa couverture doit être coordonnée entre les régimes afin qu'il n'y ait pas de dédoublement ou de lacunes dans la couverture.",


### PR DESCRIPTION
### Description
This PR resolves the accessibility issue where the `<h1>` and `<title>` for two pages in a flow (`confirm-federal-provincial-territorial-benefits` and `update-federal-provincial-territorial-benefits`) are the same.

The title has been updated on the `confirm-federal-provincial-territorial-benefits` pages as suggested by designers and reflected in the Figma.

Adobe Analytics custom click attribute values have also been updated.

### Related Azure Boards Work Items
AB#5338

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/3ec12988-c944-4bad-9226-d3fa14cf742d)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`