### PR TITLE
AB#5343 -- Updating unclear error message for spouse/partner consent

### DIFF
--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -595,7 +595,7 @@
       "sin": "Enter the 9-digit SIN"
     },
     "error-message": {
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-day-number": "Day must be a number",
       "date-of-birth-day-required": "Date of birth must include a day",
       "date-of-birth-is-past": "Date of birth must be in the past",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -274,7 +274,7 @@
       "sin": "Enter the 9-digit SIN"
     },
     "error-message": {
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-day-number": "Day must be a number",
       "date-of-birth-day-required": "Date of birth must include a day",
       "date-of-birth-is-past": "Date of birth must be in the past",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -357,7 +357,7 @@
       "sin": "Enter the 9-digit SIN"
     },
     "error-message": {
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-day-number": "Day must be a number",
       "date-of-birth-day-required": "Date of birth must include a day",
       "date-of-birth-is-past": "Date of birth must be in the past",

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -206,7 +206,7 @@
     },
     "error-message": {
       "marital-status-required": "Select marital status",
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -33,7 +33,7 @@
     },
     "error-message": {
       "marital-status-required": "Select marital status",
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -33,7 +33,7 @@
     },
     "error-message": {
       "marital-status-required": "Select marital status",
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -276,7 +276,7 @@
     },
     "error-message": {
       "marital-status-required": "Select marital status",
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -17,7 +17,7 @@
     },
     "error-message": {
       "marital-status-required": "Select marital status",
-      "confirm-required": "Checkbox must be selected",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -596,7 +596,7 @@
       "sin": "Entrez un NAS de 9 chiffres"
     },
     "error-message": {
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-day-number": "Le jour doit être un nombre",
       "date-of-birth-day-required": "La date de naissance doit inclure un jour",
       "date-of-birth-is-past": "La date de naissance doit être dans le passé",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -274,7 +274,7 @@
       "sin": "Entrez un NAS de 9 chiffres"
     },
     "error-message": {
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-day-number": "Le jour doit être un nombre",
       "date-of-birth-day-required": "La date de naissance doit inclure un jour",
       "date-of-birth-is-past": "La date de naissance doit être dans le passé",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -357,7 +357,7 @@
       "sin": "Entrez un NAS de 9 chiffres"
     },
     "error-message": {
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-day-number": "Le jour doit être un nombre",
       "date-of-birth-day-required": "La date de naissance doit inclure un jour",
       "date-of-birth-is-past": "La date de naissance doit être dans le passé",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -206,7 +206,7 @@
     },
     "error-message": {
       "marital-status-required": "Sélectionnez l'état civil",
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -33,7 +33,7 @@
     },
     "error-message": {
       "marital-status-required": "Sélectionnez l'état civil",
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -33,7 +33,7 @@
     },
     "error-message": {
       "marital-status-required": "Sélectionnez l'état civil",
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -278,7 +278,7 @@
     },
     "error-message": {
       "marital-status-required": "Sélectionnez l'état civil",
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -17,7 +17,7 @@
     },
     "error-message": {
       "marital-status-required": "Sélectionnez l'état civil",
-      "confirm-required": "La case à cocher doit être sélectionnée",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",


### PR DESCRIPTION
### Description
This PR addresses an accessibility suggestion where the error message for the consent checkbox is unclear. Designers have provided an updated error message and the "Field validation" excel (in SharePoint) has been updated.

### Related Azure Boards Work Items
[AB#5343](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5343)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/15efb7fc-4768-4950-a9e7-bf20d950c885)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`