### PR TITLE
AB#5431 AB#5335 -- Fixed a11y screenreading on protected member selection page

### DIFF
--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -157,9 +157,12 @@ interface CardLinkProps extends OmitStrict<AppLinkProps, 'className' | 'title'> 
 
 function CardLink({ routeId, title, previouslyReviewed, ...props }: CardLinkProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
+
   return (
     <AppLink className="flex flex-row items-center gap-4 rounded-xl border border-slate-300 bg-slate-50 p-6 hover:shadow-md focus:ring-2 focus:ring-blue-600 focus:outline-none" routeId={routeId} {...props}>
-      <span className="font-lato text-2xl leading-8 font-semibold text-blue-600 underline">{title}</span>
+      <span aria-description={t('protected-renew:member-selection.select-member-help')} className="font-lato text-2xl leading-8 font-semibold text-blue-600 underline">
+        {title}
+      </span>
       {previouslyReviewed && (
         <>
           <FontAwesomeIcon fixedWidth icon={faCircleCheck} className="ml-4 size-10 self-center" style={{ color: 'green' }} />

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -185,10 +185,10 @@ function SelectMember() {
   }, []);
 
   return (
-    <div ref={wrapperRef} id="select-member" className="mb-4" role="region" aria-live="polite">
+    <div ref={wrapperRef} id="select-member" className="mb-4">
       <ContextualAlert type="danger">
         <h2 className="mb-2 font-bold">{t('protected-renew:member-selection.select-member.heading')}</h2>
-        <InlineLink to="#primary-applicant" className="mb-2">
+        <InlineLink role="alert" aria-live="polite" to="#primary-applicant" className="mb-2">
           {t('protected-renew:member-selection.select-member.to-continue')}
         </InlineLink>
       </ContextualAlert>

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -157,7 +157,6 @@ interface CardLinkProps extends OmitStrict<AppLinkProps, 'className' | 'title'> 
 
 function CardLink({ routeId, title, previouslyReviewed, ...props }: CardLinkProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-
   return (
     <AppLink className="flex flex-row items-center gap-4 rounded-xl border border-slate-300 bg-slate-50 p-6 hover:shadow-md focus:ring-2 focus:ring-blue-600 focus:outline-none" routeId={routeId} {...props}>
       <span aria-description={t('protected-renew:member-selection.select-member-help')} className="font-lato text-2xl leading-8 font-semibold text-blue-600 underline">

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -113,7 +113,8 @@
     "select-member": {
       "heading": "Select a member",
       "to-continue": "You must select a member to continue."
-    }
+    },
+    "select-member-help": "Select member"
   },
   "dental-insurance": {
     "title": "{{memberName}}: access to private dental insurance",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -113,7 +113,8 @@
     "select-member": {
       "heading": "Sélectionner un membre",
       "to-continue": "Vous devez sélectionner un membre pour continuer."
-    }
+    },
+    "select-member-help": "Sélectionner un membre"
   },
   "dental-insurance": {
     "title": "{{memberName}}\u00a0: accès à une assurance dentaire privée",


### PR DESCRIPTION
### Description
Fixed a11y screen reading on protected member selection page
- Added description for individual member links
- Added alert for error message

### Related Azure Boards Work Items
AB#5431
[AB#5335](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5335)