### PR TITLE
AB#5344 default benefit application year

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -114,6 +114,9 @@ INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 # (optional; default: undefined)
 #APPLICATION_YEAR_REQUEST_DATE=2025-03-05
 
+# Default value for BenefitApplicationYear
+APPLICATION_YEAR_2024_ID=98f8ad43-4069-ee11-9ae7-000d3a09d1b8
+
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)
 OTEL_LOG_LEVEL=info

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -30,9 +30,9 @@ interface ToEmailAddressArgs {
 
 @injectable()
 export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDtoMapper {
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES'>;
+  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES' | 'APPLICATION_YEAR_2024_ID'>;
 
-  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES'>) {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES' | 'APPLICATION_YEAR_2024_ID'>) {
     this.serverConfig = serverConfig;
   }
 
@@ -120,7 +120,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
               BenefitApplicationYear: {
                 BenefitApplicationYearIdentification: [
                   {
-                    IdentificationID: '98f8ad43-4069-ee11-9ae7-000d3a09d1b8',
+                    IdentificationID: this.applicationYear2024Id(),
                   },
                 ],
               },
@@ -131,6 +131,10 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
 
   private applyApplicationYearEnabled() {
     return this.serverConfig.ENABLED_FEATURES.includes('apply-application-year');
+  }
+
+  private applicationYear2024Id() {
+    return this.serverConfig.APPLICATION_YEAR_2024_ID;
   }
 
   private toInsurancePlan(dentalBenefits: readonly string[]) {

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -97,7 +97,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
         },
         BenefitApplicationCategoryCode: {
           ReferenceDataID: this.toBenefitApplicationCategoryCode(typeOfApplication),
-          ...(this.applyApplicationYearEnabled() ? { ReferenceDataName: 'New' } : {}),
+          ReferenceDataName: 'New',
         },
         BenefitApplicationChannelCode: {
           ReferenceDataID: '775170001', // PP's static value for "Online"
@@ -116,7 +116,15 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
                 ],
               },
             }
-          : {}),
+          : {
+              BenefitApplicationYear: {
+                BenefitApplicationYearIdentification: [
+                  {
+                    IdentificationID: '98f8ad43-4069-ee11-9ae7-000d3a09d1b8',
+                  },
+                ],
+              },
+            }),
       },
     };
   }

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -51,6 +51,9 @@ const serverEnv = clientEnvSchema.extend({
   APPLICANT_CATEGORY_CODE_FAMILY: z.coerce.number().default(775170001),
   APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: z.coerce.number().default(775170002),
 
+  // application year IDs
+  APPLICATION_YEAR_2024_ID: z.string().trim().min(1).default("98f8ad43-4069-ee11-9ae7-000d3a09d1b8"),
+
   // province/territory lookup identifiers
   ALBERTA_PROVINCE_ID: z.string().trim().min(1).default("3b17d494-35b3-eb11-8236-0022486d8d5f"),
   BRITISH_COLUMBIA_PROVINCE_ID: z.string().trim().min(1).default("9c440baa-35b3-eb11-8236-0022486d8d5f"),


### PR DESCRIPTION
### Description
This pr make force the `BenefitApplicationYear` to the default value when the `apply-application-year` env is disabled. Addtionally, the `BenefitApplicationCategoryCode.ReferenceDataName` is alway `New`

New environment variable `APPLICATION_YEAR_2024_ID` is introduced to hold the id value

### Related Azure Boards Work Items
[AB#5344](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5344)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->