### PR TITLE
[gitops] Adding base files for custom 404 error page

### DIFF
--- a/gitops/base/error-pages/404/configs/404.html
+++ b/gitops/base/error-pages/404/configs/404.html
@@ -1,0 +1,119 @@
+<!--
+  404 page copied (and slightly modified) from: https://www.canada.ca/errors/404.html
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Not Found - Canada.ca</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+      integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4="
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="icon" type="image/x-icon"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <header>
+      <div id="wb-bnr" class="container">
+        <div class="row">
+          <div class="brand col-xs-8 col-sm-9 col-md-6">
+            <img
+              src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg"
+              alt="Government of Canada / Gouvernement du Canada"
+              crossorigin="anonymous"
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+    <main property="mainContentOfPage" resource="#wb-main" class="container">
+      <h1 id="wb-cont" class="wb-inv">Not Found</h1>
+      <div class="row mrgn-tp-lg mrgn-bttm-lg">
+        <div class="col-md-12">
+          <div class="row">
+            <section>
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">We couldn't find that Web page</h2>
+                      <p class="pagetag"><b>Error 404</b></p>
+                    </div>
+                  </div>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p>We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.</p>
+                      <ul>
+                        <li>Return to the <a href="https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html">Canadian Dental Care Plan</a> home page.</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section lang="fr">
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">Nous ne pouvons trouver cette page Web</h2>
+                      <p class="pagetag"><b>Erreur 404</b></p>
+                    </div>
+                  </div>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p>Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.</p>
+                      <ul>
+                        <li>Retournez à la page d'accueil du <a href="https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html">Régime canadien de soins dentaires</a>.</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer role="contentinfo" id="wb-info">
+      <div class="brand">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-6 visible-sm visible-xs tofpg">
+              <a href="#wb-cont">
+                <span lang="en">Top of page</span> / <span lang="fr">Haut de la page</span>
+                <span class="glyphicon glyphicon-chevron-up"></span>
+              </a>
+            </div>
+            <div class="col-xs-6 col-md-12 text-right">
+              <img
+                src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg"
+                alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
+                crossorigin="anonymous"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/gitops/base/error-pages/404/configs/config.conf
+++ b/gitops/base/error-pages/404/configs/config.conf
@@ -1,0 +1,14 @@
+server {
+  listen      80;
+  server_name localhost;
+
+  location / {
+    error_page 404 /404.html;
+    return 404;
+  }
+
+  location = /404.html {
+    root /usr/share/nginx/html;
+    internal;
+  }
+}

--- a/gitops/base/error-pages/404/deployments.yaml
+++ b/gitops/base/error-pages/404/deployments.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: error-404
+  labels:
+    app.kubernetes.io/name: error-404
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: error-404
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: error-404
+    spec:
+      containers:
+        - name: nginx
+          # Note: image tag should be pinned to a specific version in overlays
+          image: docker.io/nginx:latest
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: error-404-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: config.conf
+            - name: error-404-conf
+              mountPath: /usr/share/nginx/html/404.html
+              subPath: 404.html
+      volumes:
+        - name: error-404-conf
+          configMap:
+            name: error-404

--- a/gitops/base/error-pages/404/kustomization.yaml
+++ b/gitops/base/error-pages/404/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+resources:
+  - ./deployments.yaml
+  - ./services.yaml
+configMapGenerator:
+  - name: error-404
+    files:
+      - ./configs/404.html
+      - ./configs/config.conf

--- a/gitops/base/error-pages/404/services.yaml
+++ b/gitops/base/error-pages/404/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: error-404
+  labels:
+    app.kubernetes.io/name: error-404
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: error-404


### PR DESCRIPTION
### Description
This PR introduces the necessary base files for displaying a custom 404 error page when specific routes are not found. The `error-pages` directory is introduced to allow for easy addition of different custom error pages in the future.

A future PR will modify the production environment's configuration to display this custom 404 error page for the renewals routes for the next release.