### PR TITLE
[gitops] Adding custom 404 handling for prod

### DIFF
--- a/gitops/overlays/prod/ingresses-renew-error-404.yaml
+++ b/gitops/overlays/prod/ingresses-renew-error-404.yaml
@@ -29,7 +29,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: maintenance
+                name: error-404
                 port:
                   name: http
 

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ labels:
       app.kubernetes.io/environment: prod
       app.kubernetes.io/tier: prod
 resources:
+  - ../../base/error-pages/404
   - ../../base/frontend/
   - ../../base/fluentd-archiver/
   - ../../base/maintenance/
@@ -21,13 +22,15 @@ resources:
   #   2. uncomment the appropriate maintenance mode file:
   #      - for full application maintenance, uncomment ./ingresses-maintenance.yaml
   #      - for online application maintenance, uncomment ./ingresses-apply-maintenance.yaml
-  #      - for renewal application maintenance, uncomment ./ingresses-renew-maintenance.yaml
+  #
+  # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
   - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
-  # - ./ingresses-renew-maintenance.yaml
+  # - ./ingresses-renew-error-404.yaml
 patches:
+  - path: ./patches/deployments-error-404.yaml
   - path: ./patches/deployments-frontend.yaml
   - path: ./patches/deployments-maintenance.yaml
   - path: ./patches/pvcs.yaml

--- a/gitops/overlays/prod/patches/deployments-error-404.yaml
+++ b/gitops/overlays/prod/patches/deployments-error-404.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: error-404
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: error-404
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginx:1.27.0


### PR DESCRIPTION
### Description
This PR utilizes the base files introduced in #3261 (and updates to production specific ingress, deployment, and service files to the overlay) to provide a user-friendly 404 page for the renewal routes in prod.