### PR TITLE
[gitops] Deploy frontend v4.0.0 to prod

### DIFF
--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,status,status-checker-redirects,view-letters,view-letters-online-application
+ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application
 
 #
 # Session/redis configuration
@@ -35,11 +35,6 @@ HCAPTCHA_SITE_KEY=bfccd089-e822-4b2d-b443-9f94fa96821b
 # Interop API configuration
 #
 INTEROP_API_BASE_URI=https://services-api.service.gc.ca/prd/stream1
-
-#
-# CDCP back end api
-#
-CDCP_API_BASE_URI=https://api.cdcp.example.com
 
 #
 # Adobe Analytics Script URL

--- a/gitops/overlays/prod/ingresses-renew-error-404.yaml
+++ b/gitops/overlays/prod/ingresses-renew-error-404.yaml
@@ -61,6 +61,6 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: frontend
+                name: error-404
                 port:
-                  name: oauth-proxy
+                  name: http

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -25,10 +25,10 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  - ./ingresses.yaml
+  # - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
-  # - ./ingresses-renew-error-404.yaml
+  - ./ingresses-renew-error-404.yaml
 patches:
   - path: ./patches/deployments-error-404.yaml
   - path: ./patches/deployments-frontend.yaml

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:3.6.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:4.0.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
Marking as draft - v4.0.0 is scheduled to be deployed at 7:00am Eastern on Friday, February 28, 2025.

Renewal routes will be blocked with a custom 404 page and will be enabled at 5:00am Eastern on Monday, March 3, 2025 via a separate PR. The `apply-application-year` feature flag will also be enabled at that time as part of the same PR.