### PR TITLE
AB#5033 -- Refactor address validation dialog into reusable components

### DIFF
--- a/frontend/app/components/address-validation-dialog.tsx
+++ b/frontend/app/components/address-validation-dialog.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
+
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
+
+import { Address } from '~/components/address';
+import { Button } from '~/components/buttons';
+import { DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { useEnhancedFetcher } from '~/hooks';
+
+export interface CanadianAddress {
+  address: string;
+  city: string;
+  country: string;
+  countryId: string;
+  postalZipCode: string;
+  provinceState: string;
+  provinceStateId: string;
+}
+
+export interface AddressSuggestionResponse {
+  enteredAddress: CanadianAddress;
+  status: 'address-suggestion';
+  suggestedAddress: CanadianAddress;
+}
+
+export interface AddressInvalidResponse {
+  invalidAddress: CanadianAddress;
+  status: 'address-invalid';
+}
+
+export type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
+
+interface AddressSuggestionDialogContentProps {
+  enteredAddress: CanadianAddress;
+  suggestedAddress: CanadianAddress;
+  formAction: string;
+}
+
+export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, formAction }: AddressSuggestionDialogContentProps) {
+  const { t } = useTranslation(['common']);
+  const fetcher = useEnhancedFetcher();
+  const enteredAddressOptionValue = 'entered-address';
+  const suggestedAddressOptionValue = 'suggested-address';
+  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
+  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
+
+  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
+    formData.set('address', selectedAddressSuggestion.address);
+    formData.set('city', selectedAddressSuggestion.city);
+    formData.set('countryId', selectedAddressSuggestion.countryId);
+    formData.set('postalZipCode', selectedAddressSuggestion.postalZipCode);
+    formData.set('provinceStateId', selectedAddressSuggestion.provinceStateId);
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('common:dialog.address-suggestion.header')}</DialogTitle>
+        <DialogDescription>{t('common:dialog.address-suggestion.description')}</DialogDescription>
+      </DialogHeader>
+      <InputRadios
+        id="addressSelection"
+        name="addressSelection"
+        legend={t('common:dialog.address-suggestion.address-selection-legend')}
+        options={[
+          {
+            value: enteredAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2">
+                  <strong>{t('common:dialog.address-suggestion.entered-address-option')}</strong>
+                </p>
+                <Address address={enteredAddress} />
+              </>
+            ),
+          },
+          {
+            value: suggestedAddressOptionValue,
+            children: (
+              <>
+                <p className="mb-2">
+                  <strong>{t('common:dialog.address-suggestion.suggested-address-option')}</strong>
+                </p>
+                <Address address={suggestedAddress} />
+              </>
+            ),
+          },
+        ].map((option) => ({
+          ...option,
+          onChange: (e) => {
+            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
+          },
+          checked: option.value === selectedAddressSuggestionOption,
+        }))}
+      />
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
+            {t('common:dialog.address-suggestion.cancel-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={formAction} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('common:dialog.address-suggestion.use-selected-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+interface AddressInvalidDialogContentProps {
+  invalidAddress: CanadianAddress;
+  formAction: string;
+}
+
+export function AddressInvalidDialogContent({ formAction, invalidAddress }: AddressInvalidDialogContentProps) {
+  const { t } = useTranslation(['common']);
+  const fetcher = useEnhancedFetcher();
+
+  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    // Get the clicked button's value and append it to the FormData object
+    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
+    invariant(submitter, 'Expected submitter to be defined');
+    formData.set(submitter.name, submitter.value);
+
+    // Append selected address suggestion to form data
+    formData.set('address', invalidAddress.address);
+    formData.set('city', invalidAddress.city);
+    formData.set('countryId', invalidAddress.countryId);
+    formData.set('postalZipCode', invalidAddress.postalZipCode);
+    formData.set('provinceStateId', invalidAddress.provinceStateId);
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
+  return (
+    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t('common:dialog.address-invalid.header')}</DialogTitle>
+        <DialogDescription>{t('common:dialog.address-invalid.description')}</DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <p>
+          <strong>{t('common:dialog.address-invalid.entered-address')}</strong>
+        </p>
+        <Address address={invalidAddress} />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
+            {t('common:dialog.address-invalid.close-button')}
+          </Button>
+        </DialogClose>
+        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
+          <LoadingButton name="_action" value={formAction} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+            {t('common:dialog.address-invalid.use-entered-address-button')}
+          </LoadingButton>
+        </fetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -1,4 +1,3 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { redirect } from 'react-router';
@@ -12,12 +11,12 @@ import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button } from '~/components/buttons';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { PublicLayout } from '~/components/layouts/public-layout';
@@ -35,29 +34,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('address-validation', 'gcweb'),
@@ -118,8 +94,8 @@ export async function action({ context: { appContainer, session }, request, para
   const validatedMailingAddress = validatedResult.data;
 
   const isNotCanada = validatedMailingAddress.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToReview) {
@@ -327,8 +303,10 @@ export default function AddressValidationIndexRoute({ loaderData, params }: Rout
                   {t('address-validation:index.submit-button')}
                 </LoadingButton>
               </DialogTrigger>
-              {addressDialogContent && addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-              {addressDialogContent && addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+              {addressDialogContent && addressDialogContent.status === 'address-suggestion' && (
+                <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+              )}
+              {addressDialogContent && addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
             </Dialog>
             <Button id="reset-button" endIcon={faRefresh} onClick={onResetClickHandler}>
               {t('address-validation:index.reset-button')}
@@ -337,150 +315,5 @@ export default function AddressValidationIndexRoute({ loaderData, params }: Rout
         </fetcher.Form>
       </div>
     </PublicLayout>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('address', selectedAddressSuggestion.address);
-    formData.set('city', selectedAddressSuggestion.city);
-    formData.set('countryId', selectedAddressSuggestion.countryId);
-    formData.set('postalZipCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('provinceStateId', selectedAddressSuggestion.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>{t('address-validation:index.dialog.address-suggestion.header')}</DialogTitle>
-        <DialogDescription>{t('address-validation:index.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('address-validation:index.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('address-validation:index.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('address-validation:index.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
-            {t('address-validation:index.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('address-validation:index.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-}
-
-function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('address', invalidAddress.address);
-    formData.set('city', invalidAddress.city);
-    formData.set('countryId', invalidAddress.countryId);
-    formData.set('postalZipCode', invalidAddress.postalZipCode);
-    formData.set('provinceStateId', invalidAddress.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>{t('address-validation:index.dialog.address-invalid.header')}</DialogTitle>
-        <DialogDescription>{t('address-validation:index.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('address-validation:index.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
-            {t('address-validation:index.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('address-validation:index.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,4 +1,22 @@
 {
+  "dialog": {
+    "address-suggestion": {
+      "address-selection-legend": "Please select an address option below:",
+      "cancel-button": "Back",
+      "description": "There's a problem with the address you provided. Please select the address you want to use. If you live in an apartment or suite, make sure to include that information.",
+      "entered-address-option": "Entered address:",
+      "header": "Verify your address",
+      "suggested-address-option": "Suggested corrected address:",
+      "use-selected-address-button": "Use selected address"
+    },
+    "address-invalid": {
+      "close-button": "Back",
+      "description": "We could not verify your address. You can either update it or continue with the address you entered. If you live in an apartment or suite, make sure to include that information.",
+      "entered-address": "Entered address:",
+      "header": "Verify your address",
+      "use-entered-address-button": "Use entered address"
+    }
+  },
   "error-message": {
     "mailing": {
       "address-required": "Enter mailing address, typically number and street",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -1,4 +1,22 @@
 {
+  "dialog": {
+    "address-suggestion": {
+      "address-selection-legend": "Veuillez sélectionner une option d'adresse ci\u2011dessous\u00a0:",
+      "cancel-button": "Retour",
+      "description": "Il y a un problème avec l'adresse que vous avez fournie. Veuillez sélectionner l'adresse que vous souhaitez utiliser. Si vous vivez dans un appartement ou une chambre, n'oubliez pas de le préciser.",
+      "entered-address-option": "Adresse saisie\u00a0:",
+      "header": "Suggestion de correction d'adresse",
+      "suggested-address-option": "Adresse corrigée suggérée\u00a0:",
+      "use-selected-address-button": "Utiliser l'adresse sélectionnée"
+    },
+    "address-invalid": {
+      "close-button": "Retour",
+      "description": "Nous n'avons pas pu vérifier votre adresse. Vous pouvez soit la mettre à jour, soit continuer avec l'adresse que vous avez saisie. Si vous vivez dans un appartement ou une chambre, n'oubliez pas d'indiquer cette information.",
+      "entered-address": "Adresse saisie\u00a0:",
+      "header": "Adresse invalide",
+      "use-entered-address-button": "Utiliser l'adresse saisie"
+    }
+  },
   "error-message": {
     "mailing": {
       "address-required": "Entrez l'adresse postale, normalement le numéro et le nom de la rue",


### PR DESCRIPTION
### Description
This PR refactors the `AddressSuggestionDialogContent` and `AddressInvalidDialogContent` into reusable components and modifies the `/address-validation` route to use these components. The existing `common.json` i18n file has been leveraged for the dialog content. No additional functionality has been added to these dialogs.

### Related Azure Boards Work Items
[AB#5033](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5033)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/22543e50-a211-4589-a517-72d7b1a20b5e)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/en/address-validation` and check that the dialogs appear the same as it did before.

### Additional Notes
Renewal routes will be modified to use these components in a future PR.