### PR TITLE
AB#5201 Add new or existing member page in apply adult flow

### DIFF
--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -89,6 +89,10 @@ export type ApplyState = ReadonlyDeep<{
     phoneNumberAlt?: string;
     email?: string;
   };
+  newOrExistingMember?: {
+    isNewOrExistingMember: boolean;
+    clientNumber?: string;
+  };
   submissionInfo?: {
     /**
      * The confirmation code associated with the application submission.

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -52,6 +52,7 @@ export const pageIds = {
         disabilityTaxCredit: 'CDCP-APPL-AD-0016',
         parentOrGuardian: 'CDCP-APPL-AD-0017',
         livingIndependently: 'CDCP-APPL-AD-0018',
+        newOrExistingMember: 'CDCP-APPL-AD-0019',
       },
       adultChild: {
         dateOfBirth: 'CDCP-APPL-ADCH-0004',

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -156,6 +156,9 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
+  if (parsedDataResult.data.dateOfBirthYear >= 2006) {
+    return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
+  }
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult/living-independently', params));
   }

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -156,14 +156,15 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
-  if (parsedDataResult.data.dateOfBirthYear >= 2006) {
-    return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
-  }
+
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult/living-independently', params));
   }
   if (ageCategory === 'children') {
     return redirect(getPathById('public/apply/$id/adult/parent-or-guardian', params));
+  }
+  if (parsedDataResult.data.dateOfBirthYear >= 2006) {
+    return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
   }
 
   if (state.editMode) {

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -80,7 +80,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes) {
-    return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
+    return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
   }
 
   return redirect(getPathById('public/apply/$id/adult/parent-or-guardian', params));

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+
+import { data, redirect, useFetcher } from 'react-router';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import type { Route } from './+types/new-or-existing-member';
+
+import { TYPES } from '~/.server/constants';
+import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputPatternField } from '~/components/input-pattern-field';
+import { InputRadios } from '~/components/input-radios';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adult.newOrExistingMember,
+  pageTitleI18nKey: 'apply-adult:new-or-existing-member.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const state = loadApplyState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:new-or-existing-member.page-title') }) };
+
+  return { id: state.id, meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const newOrExistingMemberSchema = z
+    .object({
+      newOrExistingMember: z.nativeEnum(NEW_OR_EXISTING_MEMBER_OPTION, {
+        errorMap: () => ({ message: t('apply-adult:new-or-existing-member.error-message.is-new-or-existing-member-required') }),
+      }),
+      clientNumber: z.string().trim().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes) {
+        if (!val.clientNumber) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: t('apply-adult:new-or-existing-member.error-message.client-number-required'),
+            path: ['clientNumber'],
+          });
+        } else if (!isValidClientNumberRenewal(val.clientNumber)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: t('apply-adult:new-or-existing-member.error-message.client-number-valid'),
+            path: ['clientNumber'],
+          });
+        }
+      }
+    });
+
+  const parsedDataResult = newOrExistingMemberSchema.safeParse({
+    newOrExistingMember: formData.get('newOrExistingMember'),
+    clientNumber: formData.get('clientNumber') ? String(formData.get('clientNumber') ?? '') : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveApplyState({
+    params,
+    session,
+    state: {
+      newOrExistingMember: {
+        isNewOrExistingMember: parsedDataResult.data.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes,
+        clientNumber: parsedDataResult.data.clientNumber,
+      },
+    },
+  });
+
+  return redirect(getPathById('public/apply/$id/adult/partner-information', params));
+}
+
+export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = loaderData;
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, { newOrExistingMember: 'input-radio-new-or-existing-member-option-0', clientNumber: 'client-number' });
+  const [isNewOrExistingMember, setIsNewOrExistingMember] = useState(defaultState?.isNewOrExistingMember);
+
+  const handleNewOrExistingMemberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setIsNewOrExistingMember(e.target.value === NEW_OR_EXISTING_MEMBER_OPTION.yes);
+  };
+
+  const options: InputRadiosProps['options'] = [
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:new-or-existing-member.yes" components={{ bold: <strong /> }} />,
+      value: NEW_OR_EXISTING_MEMBER_OPTION.yes,
+      defaultChecked: defaultState?.isNewOrExistingMember === true,
+      onChange: handleNewOrExistingMemberSelection,
+    },
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult:new-or-existing-member.no" components={{ bold: <strong /> }} />,
+      value: NEW_OR_EXISTING_MEMBER_OPTION.no,
+      defaultChecked: defaultState?.isNewOrExistingMember === false,
+      onChange: handleNewOrExistingMemberSelection,
+    },
+  ];
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={22} size="lg" label={t('apply:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('apply:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t('apply-adult:new-or-existing-member.previously-enrolled')} options={options} errorMessage={errors?.newOrExistingMember} required />
+          {isNewOrExistingMember && (
+            <div className="my-8">
+              <InputPatternField
+                id="client-number"
+                name="clientNumber"
+                format={renewalCodeInputPatternFormat}
+                label={t('apply-adult:new-or-existing-member.client-number-label')}
+                inputMode="numeric"
+                defaultValue={defaultState?.clientNumber ?? ''}
+                errorMessage={errors?.clientNumber}
+                helpMessagePrimary={t('apply-adult:new-or-existing-member.client-number-description')}
+                disableScreenReaderErrors
+                required={isNewOrExistingMember}
+              />
+            </div>
+          )}
+          {editMode ? (
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - New or existing member click">
+                {t('apply-adult:new-or-existing-member.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/apply/$id/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - New or existing member click">
+                {t('apply-adult:new-or-existing-member.back-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
+                {t('apply-adult:new-or-existing-member.continue-btn')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/apply/$id/adult/applicant-information"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
+              >
+                {t('apply-adult:new-or-existing-member.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -103,7 +103,8 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  return redirect(getPathById('public/apply/$id/adult/partner-information', params));
+  // TODO: should navigate to marital-status page, change the route when marital-status page is added
+  return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
 }
 
 export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -39,7 +39,7 @@ export const routes = [
           },
           { id: 'public/apply/$id/adult/parent-or-guardian', file: 'routes/public/apply/$id/adult/parent-or-guardian.tsx', paths: { en: '/:lang/apply/:id/adult/parent-or-guardian', fr: '/:lang/demander/:id/adulte/parent-ou-tuteur' } },
           { id: 'public/apply/$id/adult/living-independently', file: 'routes/public/apply/$id/adult/living-independently.tsx', paths: { en: '/:lang/apply/:id/adult/living-independently', fr: '/:lang/demander/:id/adulte/vivre-maniere-independante' } },
-          { id: 'public/apply/$id/adult/new-or-existing-member', file: 'routes/public/apply/$id/adult/new-or-existing-member.tsx', paths: { en: '/:lang/apply/:id/adult/new-or-existing-member', fr: '/:lang/demander/:id/adulte/new-or-existing-member' } },
+          { id: 'public/apply/$id/adult/new-or-existing-member', file: 'routes/public/apply/$id/adult/new-or-existing-member.tsx', paths: { en: '/:lang/apply/:id/adult/new-or-existing-member', fr: '/:lang/demander/:id/adulte/new-or-existing-member' } }, // TODO: Update French route
           { id: 'public/apply/$id/adult-child/children/index', file: 'routes/public/apply/$id/adult-child/children/index.tsx', paths: { en: '/:lang/apply/:id/adult-child/children', fr: '/:lang/demander/:id/adulte-enfant/enfants' } },
           {
             file: 'routes/public/apply/$id/adult-child/children/$childId/layout.tsx',

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -39,6 +39,7 @@ export const routes = [
           },
           { id: 'public/apply/$id/adult/parent-or-guardian', file: 'routes/public/apply/$id/adult/parent-or-guardian.tsx', paths: { en: '/:lang/apply/:id/adult/parent-or-guardian', fr: '/:lang/demander/:id/adulte/parent-ou-tuteur' } },
           { id: 'public/apply/$id/adult/living-independently', file: 'routes/public/apply/$id/adult/living-independently.tsx', paths: { en: '/:lang/apply/:id/adult/living-independently', fr: '/:lang/demander/:id/adulte/vivre-maniere-independante' } },
+          { id: 'public/apply/$id/adult/new-or-existing-member', file: 'routes/public/apply/$id/adult/new-or-existing-member.tsx', paths: { en: '/:lang/apply/:id/adult/new-or-existing-member', fr: '/:lang/demander/:id/adulte/new-or-existing-member' } },
           { id: 'public/apply/$id/adult-child/children/index', file: 'routes/public/apply/$id/adult-child/children/index.tsx', paths: { en: '/:lang/apply/:id/adult-child/children', fr: '/:lang/demander/:id/adulte-enfant/enfants' } },
           {
             file: 'routes/public/apply/$id/adult-child/children/$childId/layout.tsx',

--- a/frontend/e2e/public/apply/adult-flow/youth-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-flow/youth-category.spec.ts
@@ -44,22 +44,6 @@ test.describe('Youth category', () => {
 
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-
-    await test.step('Should navigate to living independently page', async () => {
-      await applyAdultPage.isLoaded('living-independently');
-
-      await page.getByRole('radio', { name: 'No' }).check();
-      await page.getByRole('button', { name: 'Continue' }).click();
-    });
-
-    await test.step('Should navigate to parent or guardian page', async () => {
-      await applyAdultPage.isLoaded('parent-or-guardian');
-    });
-
-    await test.step('Should return to CDCP main page', async () => {
-      await page.getByRole('button', { name: 'Return to main page' }).click();
-      await expect(page).toHaveURL('https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html');
-    });
   });
 
   test('Should complete flow as youth applicant', async ({ page }) => {
@@ -77,13 +61,6 @@ test.describe('Youth category', () => {
       await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
       await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);
 
-      await page.getByRole('button', { name: 'Continue' }).click();
-    });
-
-    await test.step('Should navigate to living independently page', async () => {
-      await applyAdultPage.isLoaded('living-independently');
-
-      await page.getByRole('radio', { name: 'Yes' }).check();
       await page.getByRole('button', { name: 'Continue' }).click();
     });
 

--- a/frontend/e2e/public/apply/adult-flow/youth-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-flow/youth-category.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { PlaywrightApplyAdultPage } from '../../../models/PlaywrightApplyAdultPage';
 import { PlaywrightApplyPage } from '../../../models/PlaywrightApplyPage';

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -416,5 +416,21 @@
     "back-btn": "Back",
     "return-btn": "Return to main page",
     "return-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "new-or-existing-member": {
+    "page-title": "New or existing member",
+    "previously-enrolled": "Have you ever been enrolled in the Canadian Dental Care Plan?",
+    "client-number-label": "Client Number",
+    "client-number-description": "You can find your 11-digit Client Number in the upper right corner of the letter from Service Canada or on your Canadian Dental Care Plan member card.",
+    "yes": "Yes",
+    "no": "No",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "save-btn": "Save",
+    "error-message": {
+      "is-new-or-existing-member-required": "Please select whether you are new or existing member of CDCP",
+      "client-number-required": "Enter 11 digit client number",
+      "client-number-valid": "Client Number must be 11 digits"
+    }
   }
 }

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -417,5 +417,21 @@
     "back-btn": "Retour",
     "return-btn": "Revenir à la page principale",
     "return-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
+  "new-or-existing-member": {
+    "page-title": "New or existing member",
+    "previously-enrolled": "Have you ever been enrolled in the Canadian Dental Care Plan?",
+    "client-number-label": "Client Number",
+    "client-number-description": "You can find your 11-digit Client Number in the upper right corner of the letter from Service Canada or on your Canadian Dental Care Plan member card.",
+    "yes": "Oui",
+    "no": "Non",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "is-new-or-existing-member-required": "(FR) Please select whether you are new or existing member of CDCP",
+      "client-number-required": "Entrez le numéro de client de 11 chiffres",
+      "client-number-valid": "Le numéro de client doit être composé de 11 chiffres"
+    }
   }
 }

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -420,9 +420,9 @@
   },
   "new-or-existing-member": {
     "page-title": "New or existing member",
-    "previously-enrolled": "Have you ever been enrolled in the Canadian Dental Care Plan?",
-    "client-number-label": "Client Number",
-    "client-number-description": "You can find your 11-digit Client Number in the upper right corner of the letter from Service Canada or on your Canadian Dental Care Plan member card.",
+    "previously-enrolled": "Avez-vous déjà été inscrit au Régime canadien de soins dentaires?",
+    "client-number-label": "Entrez votre numéro de client à 11 chiffres",
+    "client-number-description": "Vous trouverez votre numéro de client dans le coin supérieur droit de la lettre de Service Canada ou sur votre carte de membre du Régime canadien de soins dentaires.",
     "yes": "Oui",
     "no": "Non",
     "back-btn": "Retour",


### PR DESCRIPTION
### Description
User should be able to navigate to this page if their year of birth is greater or equal to 2006. Left a TODO in the action, refactor the route when the marital-status page is created

### Related Azure Boards Work Items
[AB#5201](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5201)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->