### PR TITLE
[gitops] Enable renewal routes and `apply-application-year` feature flag in prod

### DIFF
--- a/gitops/overlays/prod/configs/frontend/config.conf
+++ b/gitops/overlays/prod/configs/frontend/config.conf
@@ -8,7 +8,7 @@ OTEL_TRACES_ENDPOINT=https://dynatrace.prod-dp.admin.dts-stn.com/e/676a0299-9802
 #
 # Application feature flags configuration
 #
-ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application
+ENABLED_FEATURES=apply-application-year,hcaptcha,status,view-letters,view-letters-online-application
 
 #
 # Session/redis configuration

--- a/gitops/overlays/prod/ingresses-renew-error-404.yaml
+++ b/gitops/overlays/prod/ingresses-renew-error-404.yaml
@@ -28,7 +28,7 @@ spec:
                 name: frontend
                 port:
                   name: http
-          - path: /.+/(protected/renew|protege/renouveller|renew|renouveller)(/.+)?
+          - path: /.+/(protected/renew|protege/renouveler|renew|renouveler)(/.+)?
             pathType: ImplementationSpecific
             backend:
               service:

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -25,10 +25,10 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  # - ./ingresses.yaml
+  - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
-  - ./ingresses-renew-error-404.yaml
+  # - ./ingresses-renew-error-404.yaml
 patches:
   - path: ./patches/deployments-error-404.yaml
   - path: ./patches/deployments-frontend.yaml

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:4.0.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:4.1.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
Marking as draft - v4.1.0 is scheduled to be deployed at 5:00am Eastern on Monday, March 3, 2025.

Renewal routes and `apply-application-year` feature flag are to be enabled in prod.