### PR TITLE
AB#5029 -- Updating adult renewals routes to use address validation dialog components

### DIFF
--- a/frontend/app/components/address-validation-dialog.tsx
+++ b/frontend/app/components/address-validation-dialog.tsx
@@ -39,9 +39,10 @@ interface AddressSuggestionDialogContentProps {
   enteredAddress: CanadianAddress;
   suggestedAddress: CanadianAddress;
   formAction: string;
+  syncAddresses?: boolean;
 }
 
-export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, formAction }: AddressSuggestionDialogContentProps) {
+export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, formAction, syncAddresses = false }: AddressSuggestionDialogContentProps) {
   const { t } = useTranslation(['common']);
   const fetcher = useEnhancedFetcher();
   const enteredAddressOptionValue = 'entered-address';
@@ -65,6 +66,9 @@ export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddres
     formData.set('countryId', selectedAddressSuggestion.countryId);
     formData.set('postalZipCode', selectedAddressSuggestion.postalZipCode);
     formData.set('provinceStateId', selectedAddressSuggestion.provinceStateId);
+    if (syncAddresses) {
+      formData.set('syncAddresses', 'true');
+    }
 
     await fetcher.submit(formData, { method: 'POST' });
   }
@@ -129,9 +133,10 @@ export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddres
 interface AddressInvalidDialogContentProps {
   invalidAddress: CanadianAddress;
   formAction: string;
+  syncAddresses?: boolean;
 }
 
-export function AddressInvalidDialogContent({ formAction, invalidAddress }: AddressInvalidDialogContentProps) {
+export function AddressInvalidDialogContent({ formAction, invalidAddress, syncAddresses = false }: AddressInvalidDialogContentProps) {
   const { t } = useTranslation(['common']);
   const fetcher = useEnhancedFetcher();
 
@@ -150,6 +155,9 @@ export function AddressInvalidDialogContent({ formAction, invalidAddress }: Addr
     formData.set('countryId', invalidAddress.countryId);
     formData.set('postalZipCode', invalidAddress.postalZipCode);
     formData.set('provinceStateId', invalidAddress.provinceStateId);
+    if (syncAddresses) {
+      formData.set('syncAddresses', 'true');
+    }
 
     await fetcher.submit(formData, { method: 'POST' });
   }

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,13 +13,13 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -41,29 +39,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -124,11 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddressValidator = appContainer.get(TYPES.routes.validators.HomeAddressValidatorFactory).createHomeAddressValidator(locale);
 
   const parsedDataResult = await homeAddressValidator.validateHomeAddress({
-    address: String(formData.get('homeAddress')),
-    countryId: String(formData.get('homeCountry')),
-    provinceStateId: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
-    city: String(formData.get('homeCity')),
-    postalZipCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -144,8 +119,8 @@ export async function action({ context: { appContainer, session }, params, reque
   };
 
   const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
     saveRenewState({ params, session, state: { homeAddress } });
@@ -272,69 +247,67 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
           <CsrfTokenInput />
           <fieldset className="mb-8">
             <div className="space-y-6">
-              <>
+              <InputSanitizeField
+                id="home-address"
+                name="address"
+                className="w-full"
+                label={t('renew-adult:update-address.address-field.address')}
+                helpMessagePrimary={t('renew-adult:update-address.address-field.address-note')}
+                helpMessagePrimaryClassName="text-black"
+                maxLength={100}
+                autoComplete="address-line1"
+                defaultValue={defaultState.homeAddress?.address}
+                errorMessage={errors?.address}
+                required
+              />
+              <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
-                  id="home-address"
-                  name="homeAddress"
+                  id="home-city"
+                  name="city"
                   className="w-full"
-                  label={t('renew-adult:update-address.address-field.address')}
-                  helpMessagePrimary={t('renew-adult:update-address.address-field.address-note')}
-                  helpMessagePrimaryClassName="text-black"
+                  label={t('renew-adult:update-address.address-field.city')}
                   maxLength={100}
-                  autoComplete="address-line1"
-                  defaultValue={defaultState.homeAddress?.address}
-                  errorMessage={errors?.address}
+                  autoComplete="address-level2"
+                  defaultValue={defaultState.homeAddress?.city}
+                  errorMessage={errors?.city}
                   required
                 />
-                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                  <InputSanitizeField
-                    id="home-city"
-                    name="homeCity"
-                    className="w-full"
-                    label={t('renew-adult:update-address.address-field.city')}
-                    maxLength={100}
-                    autoComplete="address-level2"
-                    defaultValue={defaultState.homeAddress?.city}
-                    errorMessage={errors?.city}
-                    required
-                  />
-                  <InputSanitizeField
-                    id="home-postal-code"
-                    name="homePostalCode"
-                    className="w-full"
-                    label={isPostalCodeRequired ? t('renew-adult:update-address.address-field.postal-code') : t('renew-adult:update-address.address-field.postal-code-optional')}
-                    maxLength={100}
-                    autoComplete="postal-code"
-                    defaultValue={defaultState.homeAddress?.postalCode ?? ''}
-                    errorMessage={errors?.postalZipCode}
-                    required={isPostalCodeRequired}
-                  />
-                </div>
-                {homeRegions.length > 0 && (
-                  <InputSelect
-                    id="home-province"
-                    name="homeProvince"
-                    className="w-full sm:w-1/2"
-                    label={t('renew-adult:update-address.address-field.province')}
-                    defaultValue={defaultState.homeAddress?.province}
-                    errorMessage={errors?.provinceStateId}
-                    options={[dummyOption, ...homeRegions]}
-                    required
-                  />
-                )}
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full"
+                  label={isPostalCodeRequired ? t('renew-adult:update-address.address-field.postal-code') : t('renew-adult:update-address.address-field.postal-code-optional')}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                />
+              </div>
+              {homeRegions.length > 0 && (
                 <InputSelect
-                  id="home-country"
-                  name="homeCountry"
+                  id="home-province"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
-                  label={t('renew-adult:update-address.address-field.country')}
-                  autoComplete="country"
-                  defaultValue={defaultState.homeAddress?.country ?? ''}
-                  errorMessage={errors?.countryId}
-                  options={countries}
-                  onChange={homeCountryChangeHandler}
+                  label={t('renew-adult:update-address.address-field.province')}
+                  defaultValue={defaultState.homeAddress?.province}
+                  errorMessage={errors?.provinceStateId}
+                  options={[dummyOption, ...homeRegions]}
                   required
                 />
-              </>
+              )}
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t('renew-adult:update-address.address-field.country')}
+                autoComplete="country"
+                defaultValue={defaultState.homeAddress?.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
             </div>
           </fieldset>
           {editMode ? (
@@ -356,8 +329,10 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -385,8 +360,10 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -405,173 +382,5 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('homeAddress', selectedAddressSuggestion.address);
-    formData.set('homeCity', selectedAddressSuggestion.city);
-    formData.set('homeCountry', selectedAddressSuggestion.countryId);
-    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-adult:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            disabled={fetcher.isSubmitting}
-            variant="alternative"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Dialog Cancel - Home address click"
-          >
-            {t('renew-adult:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Dialog Use Selected Address - Home address click"
-          >
-            {t('renew-adult:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-}
-
-function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('homeAddress', invalidAddress.address);
-    formData.set('homeCity', invalidAddress.city);
-    formData.set('homeCountry', invalidAddress.countryId);
-    formData.set('homePostalCode', invalidAddress.postalZipCode);
-    formData.set('homeProvince', invalidAddress.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-adult:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm">
-            {t('renew-adult:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-adult:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,14 +13,14 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -42,29 +40,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -108,7 +83,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewAdultState({ params, request, session });
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+  const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
@@ -124,11 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
-    address: String(formData.get('mailingAddress')),
-    countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
-    city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!validatedResult.success) {
@@ -146,8 +121,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
   const isNotCanada = validatedResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
@@ -254,7 +229,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
     postalZipCode: 'mailing-postal-code',
     provinceStateId: 'mailing-province',
     countryId: 'mailing-country',
-    copyMailingAddress: 'copy-mailing-address',
+    syncAddresses: 'sync-addresses',
   });
 
   const checkHandler = () => {
@@ -305,7 +280,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
             <div className="space-y-6">
               <InputSanitizeField
                 id="mailing-address"
-                name="mailingAddress"
+                name="address"
                 className="w-full"
                 label={t('renew-adult:update-address.address-field.address')}
                 maxLength={100}
@@ -319,7 +294,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
               <div className="grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
                   id="mailing-city"
-                  name="mailingCity"
+                  name="city"
                   className="w-full"
                   label={t('renew-adult:update-address.address-field.city')}
                   maxLength={100}
@@ -330,7 +305,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 />
                 <InputSanitizeField
                   id="mailing-postal-code"
-                  name="mailingPostalCode"
+                  name="postalZipCode"
                   className="w-full"
                   label={isPostalCodeRequired ? t('renew-adult:update-address.address-field.postal-code') : t('renew-adult:update-address.address-field.postal-code-optional')}
                   maxLength={100}
@@ -344,7 +319,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
               {mailingRegions.length > 0 && (
                 <InputSelect
                   id="mailing-province"
-                  name="mailingProvince"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
                   label={t('renew-adult:update-address.address-field.province')}
                   defaultValue={defaultState.mailingAddress?.province}
@@ -355,7 +330,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
               )}
               <InputSelect
                 id="mailing-country"
-                name="mailingCountry"
+                name="countryId"
                 className="w-full sm:w-1/2"
                 label={t('renew-adult:update-address.address-field.country')}
                 autoComplete="country"
@@ -365,7 +340,7 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 onChange={mailingCountryChangeHandler}
                 required
               />
-              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t('renew-adult:update-address.home-address.use-mailing-address')}
               </InputCheckbox>
             </div>
@@ -390,9 +365,9 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -421,9 +396,9 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -443,181 +418,5 @@ export default function RenewAdultUpdateAddress({ loaderData, params }: Route.Co
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('mailingAddress', selectedAddressSuggestion.address);
-    formData.set('mailingCity', selectedAddressSuggestion.city);
-    formData.set('mailingCountry', selectedAddressSuggestion.countryId);
-    formData.set('mailingPostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('mailingProvince', selectedAddressSuggestion.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-adult:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            variant="alternative"
-            disabled={fetcher.isSubmitting}
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Dialog Cancel - Mailing address click"
-          >
-            {t('renew-adult:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Dialog Use Selected Address - Mailing address click"
-          >
-            {t('renew-adult:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('mailingAddress', invalidAddress.address);
-    formData.set('mailingCity', invalidAddress.city);
-    formData.set('mailingCountry', invalidAddress.countryId);
-    formData.set('mailingPostalCode', invalidAddress.postalZipCode);
-    formData.set('mailingProvince', invalidAddress.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-adult:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm">
-            {t('renew-adult:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-adult:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }


### PR DESCRIPTION
### Description
As per title.

Added a `syncAddresses` property to the address validation components which is used to allow the form to use the mailing address as the home address.

### Related Azure Boards Work Items
[AB#5029](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5029)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go through the adult renewal flow and make sure everything with the address pages still works.

### Additional Notes
A future PR should allow the routes to pass in the field names to the components.
The rest of the flows will be updated to use this component in a big PR. This one is just to get approval with the current implementation direction.