### PR TITLE
fix(gitops): add redirect to renouveler URLs

### DIFF
--- a/gitops/overlays/prod/ingresses.yaml
+++ b/gitops/overlays/prod/ingresses.yaml
@@ -4,6 +4,10 @@ metadata:
   name: frontend
   labels:
     app.kubernetes.io/name: frontend
+    # TODO :: GjB :: to be removed when the URLs in the application have been fixed
+    nginx.ingress.kubernetes.io/server-snippet: |
+      rewrite ^/fr/renouveler(.*)$ /fr/renouveller$1 redirect;
+      rewrite ^/fr/protege/renouveler(.*)$ /fr/protege/renouveller$1 redirect;
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
### Description

Fix broken links in prod by redirecting:

- `/fr/renouveller` → `/fr/renouveler`
- `/fr/protege/renouveller` → `/fr/protege/renouveler`