### PR TITLE
AB#5029 -- Updating renewals routes to use address validation dialog components

### DIFF
--- a/frontend/app/components/address-validation-dialog.tsx
+++ b/frontend/app/components/address-validation-dialog.tsx
@@ -116,12 +116,22 @@ export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddres
       />
       <DialogFooter>
         <DialogClose asChild>
-          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm">
+          <Button id="dialog.corrected-address-close-button" disabled={fetcher.isSubmitting} variant="default" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Dialog Back - Address Suggestion click">
             {t('common:dialog.address-suggestion.cancel-button')}
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={formAction} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton
+            name="_action"
+            value={formAction}
+            type="submit"
+            id="dialog.corrected-address-use-selected-address-button"
+            loading={fetcher.isSubmitting}
+            endIcon={faCheck}
+            variant="primary"
+            size="sm"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Dialog Use Selected Address - Address Suggestion click"
+          >
             {t('common:dialog.address-suggestion.use-selected-address-button')}
           </LoadingButton>
         </fetcher.Form>
@@ -176,12 +186,22 @@ export function AddressInvalidDialogContent({ formAction, invalidAddress, syncAd
       </div>
       <DialogFooter>
         <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" variant="default" size="sm">
+          <Button id="dialog.address-invalid-close-button" variant="default" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Dialog Back - Address Invalid click">
             {t('common:dialog.address-invalid.close-button')}
           </Button>
         </DialogClose>
         <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={formAction} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
+          <LoadingButton
+            name="_action"
+            value={formAction}
+            type="submit"
+            id="dialog.address-invalid-use-entered-address-button"
+            loading={fetcher.isSubmitting}
+            endIcon={faCheck}
+            variant="primary"
+            size="sm"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Dialog Use entered address - Address Invalid click"
+          >
             {t('common:dialog.address-invalid.use-entered-address-button')}
           </LoadingButton>
         </fetcher.Form>

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -1,10 +1,7 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,14 +12,14 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
-import { Address } from '~/components/address';
-import { Button, ButtonLink } from '~/components/buttons';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
+import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -40,29 +37,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -115,15 +89,15 @@ export async function action({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
-  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+  const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
-    address: String(formData.get('mailingAddress')),
-    countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
-    city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!validatedResult.success) {
@@ -141,8 +115,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
   const isNotCanada = validatedResult.data.countryId !== CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToReview) {
@@ -247,7 +221,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
     postalZipCode: 'mailing-postal-code',
     provinceStateId: 'mailing-province',
     countryId: 'mailing-country',
-    copyMailingAddress: 'copy-mailing-address',
+    syncAddresses: 'sync-addresses',
   });
   const checkHandler = () => {
     setCopyAddressChecked((curState) => !curState);
@@ -288,7 +262,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
         <div className="space-y-6">
           <InputSanitizeField
             id="mailing-address"
-            name="mailingAddress"
+            name="address"
             className="w-full"
             label={t('protected-renew:update-address.address-field.mailing-address')}
             maxLength={100}
@@ -302,7 +276,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
           <div className="grid items-end gap-6 md:grid-cols-2">
             <InputSanitizeField
               id="mailing-city"
-              name="mailingCity"
+              name="city"
               className="w-full"
               label={t('protected-renew:update-address.address-field.city')}
               maxLength={100}
@@ -313,7 +287,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
             />
             <InputSanitizeField
               id="mailing-postal-code"
-              name="mailingPostalCode"
+              name="postalZipCode"
               className="w-full"
               label={mailingPostalCodeRequired ? t('protected-renew:update-address.address-field.postal-code') : t('protected-renew:update-address.address-field.postal-code-optional')}
               maxLength={100}
@@ -326,7 +300,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
           {mailingRegions.length > 0 && (
             <InputSelect
               id="mailing-province"
-              name="mailingProvince"
+              name="provinceStateId"
               className="w-full sm:w-1/2"
               label={t('protected-renew:update-address.address-field.province')}
               defaultValue={defaultState.province}
@@ -337,7 +311,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
           )}
           <InputSelect
             id="mailing-country"
-            name="mailingCountry"
+            name="countryId"
             className="w-full sm:w-1/2"
             label={t('protected-renew:update-address.address-field.country')}
             autoComplete="country"
@@ -347,7 +321,7 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
             onChange={mailingCountryChangeHandler}
             required
           />
-          <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+          <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
             {t('protected-renew:update-address.home-address.use-mailing-address')}
           </InputCheckbox>
         </div>
@@ -371,9 +345,9 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
               {!fetcher.isSubmitting && addressDialogContent && (
                 <>
                   {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                   )}
-                  {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                  {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                 </>
               )}
             </Dialog>
@@ -384,174 +358,5 @@ export default function ProtectedRenewConfirmMailingAddress({ loaderData, params
         </div>
       </fetcher.Form>
     </div>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('mailingAddress', selectedAddressSuggestion.address);
-    formData.set('mailingCity', selectedAddressSuggestion.city);
-    formData.set('mailingCountry', selectedAddressSuggestion.countryId);
-    formData.set('mailingPostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('mailingProvince', selectedAddressSuggestion.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('protected-renew:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('protected-renew:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('protected-renew:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('protected-renew:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.corrected-address-close-button" startIcon={faChevronLeft} disabled={fetcher.isSubmitting} variant="alternative" size="sm">
-            {t('protected-renew:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('protected-renew:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('mailingAddress', invalidAddress.address);
-    formData.set('mailingCity', invalidAddress.city);
-    formData.set('mailingCountry', invalidAddress.countryId);
-    formData.set('mailingPostalCode', invalidAddress.postalZipCode);
-    formData.set('mailingProvince', invalidAddress.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('protected-renew:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('protected-renew:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('protected-renew:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Dialog Close - Mailing address click">
-            {t('protected-renew:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useInvalidAddress}
-            type="submit"
-            id="dialog.address-invalid-use-entered-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Dialog Use Selected Address - Mailing address click"
-          >
-            {t('protected-renew:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,13 +13,13 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -41,29 +39,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -124,11 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddressValidator = appContainer.get(TYPES.routes.validators.HomeAddressValidatorFactory).createHomeAddressValidator(locale);
 
   const parsedDataResult = await homeAddressValidator.validateHomeAddress({
-    address: String(formData.get('homeAddress')),
-    countryId: String(formData.get('homeCountry')),
-    provinceStateId: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
-    city: String(formData.get('homeCity')),
-    postalZipCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -143,8 +118,8 @@ export async function action({ context: { appContainer, session }, params, reque
     province: parsedDataResult.data.provinceStateId,
   };
   const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
     saveRenewState({ params, session, state: { homeAddress } });
@@ -271,69 +246,67 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
           <CsrfTokenInput />
           <fieldset className="mb-8">
             <div className="space-y-6">
-              <>
+              <InputSanitizeField
+                id="home-address"
+                name="address"
+                className="w-full"
+                label={t('renew-adult-child:update-address.address-field.address')}
+                helpMessagePrimary={t('renew-adult-child:update-address.address-field.address-note')}
+                helpMessagePrimaryClassName="text-black"
+                maxLength={100}
+                autoComplete="address-line1"
+                defaultValue={defaultState.homeAddress?.address}
+                errorMessage={errors?.address}
+                required
+              />
+              <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
-                  id="home-address"
-                  name="homeAddress"
+                  id="home-city"
+                  name="city"
                   className="w-full"
-                  label={t('renew-adult-child:update-address.address-field.address')}
-                  helpMessagePrimary={t('renew-adult-child:update-address.address-field.address-note')}
-                  helpMessagePrimaryClassName="text-black"
+                  label={t('renew-adult-child:update-address.address-field.city')}
                   maxLength={100}
-                  autoComplete="address-line1"
-                  defaultValue={defaultState.homeAddress?.address}
-                  errorMessage={errors?.address}
+                  autoComplete="address-level2"
+                  defaultValue={defaultState.homeAddress?.city}
+                  errorMessage={errors?.city}
                   required
                 />
-                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                  <InputSanitizeField
-                    id="home-city"
-                    name="homeCity"
-                    className="w-full"
-                    label={t('renew-adult-child:update-address.address-field.city')}
-                    maxLength={100}
-                    autoComplete="address-level2"
-                    defaultValue={defaultState.homeAddress?.city}
-                    errorMessage={errors?.city}
-                    required
-                  />
-                  <InputSanitizeField
-                    id="home-postal-code"
-                    name="homePostalCode"
-                    className="w-full"
-                    label={isPostalCodeRequired ? t('renew-adult-child:update-address.address-field.postal-code') : t('renew-adult-child:update-address.address-field.postal-code-optional')}
-                    maxLength={100}
-                    autoComplete="postal-code"
-                    defaultValue={defaultState.homeAddress?.postalCode ?? ''}
-                    errorMessage={errors?.postalZipCode}
-                    required={isPostalCodeRequired}
-                  />
-                </div>
-                {homeRegions.length > 0 && (
-                  <InputSelect
-                    id="home-province"
-                    name="homeProvince"
-                    className="w-full sm:w-1/2"
-                    label={t('renew-adult-child:update-address.address-field.province')}
-                    defaultValue={defaultState.homeAddress?.province}
-                    errorMessage={errors?.provinceStateId}
-                    options={[dummyOption, ...homeRegions]}
-                    required
-                  />
-                )}
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full"
+                  label={isPostalCodeRequired ? t('renew-adult-child:update-address.address-field.postal-code') : t('renew-adult-child:update-address.address-field.postal-code-optional')}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                />
+              </div>
+              {homeRegions.length > 0 && (
                 <InputSelect
-                  id="home-country"
-                  name="homeCountry"
+                  id="home-province"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
-                  label={t('renew-adult-child:update-address.address-field.country')}
-                  autoComplete="country"
-                  defaultValue={defaultState.homeAddress?.country ?? ''}
-                  errorMessage={errors?.countryId}
-                  options={countries}
-                  onChange={homeCountryChangeHandler}
+                  label={t('renew-adult-child:update-address.address-field.province')}
+                  defaultValue={defaultState.homeAddress?.province}
+                  errorMessage={errors?.provinceStateId}
+                  options={[dummyOption, ...homeRegions]}
                   required
                 />
-              </>
+              )}
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t('renew-adult-child:update-address.address-field.country')}
+                autoComplete="country"
+                defaultValue={defaultState.homeAddress?.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
             </div>
           </fieldset>
           {editMode ? (
@@ -355,8 +328,10 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -384,8 +359,10 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -404,183 +381,5 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('homeAddress', selectedAddressSuggestion.address);
-    formData.set('homeCity', selectedAddressSuggestion.city);
-    formData.set('homeCountry', selectedAddressSuggestion.countryId);
-    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult-child:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-adult-child:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            disabled={fetcher.isSubmitting}
-            variant="alternative"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Back - Home address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Use Selected Address - Home address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-}
-
-function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('homeAddress', invalidAddress.address);
-    formData.set('homeCity', invalidAddress.city);
-    formData.set('homeCountry', invalidAddress.countryId);
-    formData.set('homePostalCode', invalidAddress.postalZipCode);
-    formData.set('homeProvince', invalidAddress.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult-child:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult-child:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-adult-child:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Back - Home address click">
-            {t('renew-adult-child:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useInvalidAddress}
-            type="submit"
-            id="dialog.address-invalid-use-entered-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Use Entered Address - Home address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,14 +13,14 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -42,29 +40,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult-child', 'renew', 'gcweb'),
@@ -109,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewAdultChildState({ params, request, session });
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+  const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
@@ -125,11 +100,11 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const parsedDataResult = await mailingAddressValidator.validateMailingAddress({
-    address: String(formData.get('mailingAddress')),
-    countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
-    city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -147,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
   const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
@@ -255,7 +230,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
     postalZipCode: 'mailing-postal-code',
     provinceStateId: 'mailing-province',
     countryId: 'mailing-country',
-    copyMailingAddress: 'copy-mailing-address',
+    syncAddresses: 'sync-addresses',
   });
 
   const checkHandler = () => {
@@ -307,7 +282,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
             <div className="space-y-6">
               <InputSanitizeField
                 id="mailing-address"
-                name="mailingAddress"
+                name="address"
                 className="w-full"
                 label={t('renew-adult-child:update-address.address-field.address')}
                 maxLength={100}
@@ -321,7 +296,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
               <div className="grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
                   id="mailing-city"
-                  name="mailingCity"
+                  name="city"
                   className="w-full"
                   label={t('renew-adult-child:update-address.address-field.city')}
                   maxLength={100}
@@ -332,7 +307,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 />
                 <InputSanitizeField
                   id="mailing-postal-code"
-                  name="mailingPostalCode"
+                  name="postalZipCode"
                   className="w-full"
                   label={isPostalCodeRequired ? t('renew-adult-child:update-address.address-field.postal-code') : t('renew-adult-child:update-address.address-field.postal-code-optional')}
                   maxLength={100}
@@ -346,7 +321,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
               {mailingRegions.length > 0 && (
                 <InputSelect
                   id="mailing-province"
-                  name="mailingProvince"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
                   label={t('renew-adult-child:update-address.address-field.province')}
                   defaultValue={defaultState.mailingAddress?.province}
@@ -357,7 +332,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
               )}
               <InputSelect
                 id="mailing-country"
-                name="mailingCountry"
+                name="countryId"
                 className="w-full sm:w-1/2"
                 label={t('renew-adult-child:update-address.address-field.country')}
                 autoComplete="country"
@@ -367,7 +342,7 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 onChange={mailingCountryChangeHandler}
                 required
               />
-              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t('renew-adult-child:update-address.home-address.use-mailing-address')}
               </InputCheckbox>
             </div>
@@ -392,9 +367,9 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -423,9 +398,9 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -445,191 +420,5 @@ export default function RenewAdultChildUpdateAddress({ loaderData, params }: Rou
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('mailingAddress', selectedAddressSuggestion.address);
-    formData.set('mailingCity', selectedAddressSuggestion.city);
-    formData.set('mailingCountry', selectedAddressSuggestion.countryId);
-    formData.set('mailingPostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('mailingProvince', selectedAddressSuggestion.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult-child:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-adult-child:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-adult-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            disabled={fetcher.isSubmitting}
-            variant="alternative"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Back - Mailing address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Use Selected Address - Mailing address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('mailingAddress', invalidAddress.address);
-    formData.set('mailingCity', invalidAddress.city);
-    formData.set('mailingCountry', invalidAddress.countryId);
-    formData.set('mailingPostalCode', invalidAddress.postalZipCode);
-    formData.set('mailingProvince', invalidAddress.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-adult-child:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-adult-child:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-adult-child:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Back - Mailing address click">
-            {t('renew-adult-child:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useInvalidAddress}
-            type="submit"
-            id="dialog.address-invalid-use-entered-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Dialog Use Entered Address - Mailing address click"
-          >
-            {t('renew-adult-child:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,13 +13,13 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -41,29 +39,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -124,11 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddressValidator = appContainer.get(TYPES.routes.validators.HomeAddressValidatorFactory).createHomeAddressValidator(locale);
 
   const parsedDataResult = await homeAddressValidator.validateHomeAddress({
-    address: String(formData.get('homeAddress')),
-    countryId: String(formData.get('homeCountry')),
-    provinceStateId: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
-    city: String(formData.get('homeCity')),
-    postalZipCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -144,8 +119,8 @@ export async function action({ context: { appContainer, session }, params, reque
   };
 
   const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
     saveRenewState({ params, session, state: { homeAddress } });
@@ -272,69 +247,67 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
           <CsrfTokenInput />
           <fieldset className="mb-8">
             <div className="space-y-6">
-              <>
+              <InputSanitizeField
+                id="home-address"
+                name="address"
+                className="w-full"
+                label={t('renew-child:update-address.address-field.address')}
+                helpMessagePrimary={t('renew-child:update-address.address-field.address-note')}
+                helpMessagePrimaryClassName="text-black"
+                maxLength={100}
+                autoComplete="address-line1"
+                defaultValue={defaultState.homeAddress?.address}
+                errorMessage={errors?.address}
+                required
+              />
+              <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
-                  id="home-address"
-                  name="homeAddress"
+                  id="home-city"
+                  name="city"
                   className="w-full"
-                  label={t('renew-child:update-address.address-field.address')}
-                  helpMessagePrimary={t('renew-child:update-address.address-field.address-note')}
-                  helpMessagePrimaryClassName="text-black"
+                  label={t('renew-child:update-address.address-field.city')}
                   maxLength={100}
-                  autoComplete="address-line1"
-                  defaultValue={defaultState.homeAddress?.address}
-                  errorMessage={errors?.address}
+                  autoComplete="address-level2"
+                  defaultValue={defaultState.homeAddress?.city}
+                  errorMessage={errors?.city}
                   required
                 />
-                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                  <InputSanitizeField
-                    id="home-city"
-                    name="homeCity"
-                    className="w-full"
-                    label={t('renew-child:update-address.address-field.city')}
-                    maxLength={100}
-                    autoComplete="address-level2"
-                    defaultValue={defaultState.homeAddress?.city}
-                    errorMessage={errors?.city}
-                    required
-                  />
-                  <InputSanitizeField
-                    id="home-postal-code"
-                    name="homePostalCode"
-                    className="w-full"
-                    label={isPostalCodeRequired ? t('renew-child:update-address.address-field.postal-code') : t('renew-child:update-address.address-field.postal-code-optional')}
-                    maxLength={100}
-                    autoComplete="postal-code"
-                    defaultValue={defaultState.homeAddress?.postalCode ?? ''}
-                    errorMessage={errors?.postalZipCode}
-                    required={isPostalCodeRequired}
-                  />
-                </div>
-                {homeRegions.length > 0 && (
-                  <InputSelect
-                    id="home-province"
-                    name="homeProvince"
-                    className="w-full sm:w-1/2"
-                    label={t('renew-child:update-address.address-field.province')}
-                    defaultValue={defaultState.homeAddress?.province}
-                    errorMessage={errors?.provinceStateId}
-                    options={[dummyOption, ...homeRegions]}
-                    required
-                  />
-                )}
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full"
+                  label={isPostalCodeRequired ? t('renew-child:update-address.address-field.postal-code') : t('renew-child:update-address.address-field.postal-code-optional')}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                />
+              </div>
+              {homeRegions.length > 0 && (
                 <InputSelect
-                  id="home-country"
-                  name="homeCountry"
+                  id="home-province"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
-                  label={t('renew-child:update-address.address-field.country')}
-                  autoComplete="country"
-                  defaultValue={defaultState.homeAddress?.country ?? ''}
-                  errorMessage={errors?.countryId}
-                  options={countries}
-                  onChange={homeCountryChangeHandler}
+                  label={t('renew-child:update-address.address-field.province')}
+                  defaultValue={defaultState.homeAddress?.province}
+                  errorMessage={errors?.provinceStateId}
+                  options={[dummyOption, ...homeRegions]}
                   required
                 />
-              </>
+              )}
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t('renew-child:update-address.address-field.country')}
+                autoComplete="country"
+                defaultValue={defaultState.homeAddress?.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
             </div>
           </fieldset>
           {editMode ? (
@@ -356,8 +329,10 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -385,8 +360,10 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -405,183 +382,5 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('homeAddress', selectedAddressSuggestion.address);
-    formData.set('homeCity', selectedAddressSuggestion.city);
-    formData.set('homeCountry', selectedAddressSuggestion.countryId);
-    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-child:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-child:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            disabled={fetcher.isSubmitting}
-            variant="alternative"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Back - Home address click"
-          >
-            {t('renew-child:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Use Selected Address - Home address click"
-          >
-            {t('renew-child:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-}
-
-function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('homeAddress', invalidAddress.address);
-    formData.set('homeCity', invalidAddress.city);
-    formData.set('homeCountry', invalidAddress.countryId);
-    formData.set('homePostalCode', invalidAddress.postalZipCode);
-    formData.set('homeProvince', invalidAddress.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-child:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-child:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Back - Home address click">
-            {t('renew-child:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useInvalidAddress}
-            type="submit"
-            id="dialog.address-invalid-use-entered-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Use Entered Address - Home address click"
-          >
-            {t('renew-child:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { SyntheticEvent } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,14 +13,14 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -42,29 +40,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-child', 'renew', 'gcweb'),
@@ -109,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewChildState({ params, request, session });
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+  const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
@@ -125,11 +100,11 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
-    address: String(formData.get('mailingAddress')),
-    countryId: String(formData.get('mailingCountry')),
-    provinceStateId: formData.get('mailingProvince') ? String(formData.get('mailingProvince')) : undefined,
-    city: String(formData.get('mailingCity')),
-    postalZipCode: formData.get('mailingPostalCode') ? String(formData.get('mailingPostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!validatedResult.success) {
@@ -147,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
   const isNotCanada = validatedResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToReviewChild = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToReviewChild) {
@@ -254,7 +229,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
     postalZipCode: 'mailing-postal-code',
     provinceStateId: 'mailing-province',
     countryId: 'mailing-country',
-    copyMailingAddress: 'copy-mailing-address',
+    syncAddresses: 'sync-addresses',
   });
   const checkHandler = () => {
     setCopyAddressChecked((curState) => !curState);
@@ -301,7 +276,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
             <div className="space-y-6">
               <InputSanitizeField
                 id="mailing-address"
-                name="mailingAddress"
+                name="address"
                 className="w-full"
                 label={t('renew-child:update-address.address-field.address')}
                 maxLength={100}
@@ -315,7 +290,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
               <div className="grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
                   id="mailing-city"
-                  name="mailingCity"
+                  name="city"
                   className="w-full"
                   label={t('renew-child:update-address.address-field.city')}
                   maxLength={100}
@@ -326,7 +301,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 />
                 <InputSanitizeField
                   id="mailing-postal-code"
-                  name="mailingPostalCode"
+                  name="postalZipCode"
                   className="w-full"
                   label={isPostalCodeRequired ? t('renew-child:update-address.address-field.postal-code') : t('renew-child:update-address.address-field.postal-code-optional')}
                   maxLength={100}
@@ -339,7 +314,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
               {mailingRegions.length > 0 && (
                 <InputSelect
                   id="mailing-province"
-                  name="mailingProvince"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
                   label={t('renew-child:update-address.address-field.province')}
                   defaultValue={defaultState.mailingAddress?.province}
@@ -350,7 +325,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
               )}
               <InputSelect
                 id="mailing-country"
-                name="mailingCountry"
+                name="countryId"
                 className="w-full sm:w-1/2"
                 label={t('renew-child:update-address.address-field.country')}
                 autoComplete="country"
@@ -360,7 +335,7 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 onChange={mailingCountryChangeHandler}
                 required
               />
-              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t('renew-child:update-address.home-address.use-mailing-address')}
               </InputCheckbox>
             </div>
@@ -385,9 +360,9 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -416,9 +391,9 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -438,191 +413,5 @@ export default function RenewChildUpdateAddress({ loaderData, params }: Route.Co
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('mailingAddress', selectedAddressSuggestion.address);
-    formData.set('mailingCity', selectedAddressSuggestion.city);
-    formData.set('mailingCountry', selectedAddressSuggestion.countryId);
-    formData.set('mailingPostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('mailingProvince', selectedAddressSuggestion.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-child:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-child:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-child:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-child:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-child:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button
-            id="dialog.corrected-address-close-button"
-            startIcon={faChevronLeft}
-            disabled={fetcher.isSubmitting}
-            variant="alternative"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Back - Mailing address click"
-          >
-            {t('renew-child:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useSelectedAddress}
-            type="submit"
-            id="dialog.corrected-address-use-selected-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Use Selected Address - Mailing address click"
-          >
-            {t('renew-child:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('mailingAddress', invalidAddress.address);
-    formData.set('mailingCity', invalidAddress.city);
-    formData.set('mailingCountry', invalidAddress.countryId);
-    formData.set('mailingPostalCode', invalidAddress.postalZipCode);
-    formData.set('mailingProvince', invalidAddress.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-child:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-child:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-child:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Back - Mailing address click">
-            {t('renew-child:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton
-            name="_action"
-            value={FORM_ACTION.useInvalidAddress}
-            type="submit"
-            id="dialog.address-invalid-use-entered-address-button"
-            loading={fetcher.isSubmitting}
-            endIcon={faCheck}
-            variant="primary"
-            size="sm"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Dialog Use Entered Address - Mailing address click"
-          >
-            {t('renew-child:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -1,10 +1,8 @@
-import type { SyntheticEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,13 +13,13 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -41,29 +39,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -124,11 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddressValidator = appContainer.get(TYPES.routes.validators.HomeAddressValidatorFactory).createHomeAddressValidator(locale);
 
   const parsedDataResult = await homeAddressValidator.validateHomeAddress({
-    address: String(formData.get('homeAddress')),
-    countryId: String(formData.get('homeCountry')),
-    provinceStateId: formData.get('homeProvince') ? String(formData.get('homeProvince')) : undefined,
-    city: String(formData.get('homeCity')),
-    postalZipCode: formData.get('homePostalCode') ? String(formData.get('homePostalCode')) : undefined,
+    address: String(formData.get('address')),
+    countryId: String(formData.get('countryId')),
+    provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
+    city: String(formData.get('city')),
+    postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
   if (!parsedDataResult.success) {
@@ -144,8 +119,8 @@ export async function action({ context: { appContainer, session }, params, reque
   };
 
   const isNotCanada = parsedDataResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
     saveRenewState({ params, session, state: { homeAddress } });
@@ -272,69 +247,67 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
           <CsrfTokenInput />
           <fieldset className="mb-8">
             <div className="space-y-6">
-              <>
+              <InputSanitizeField
+                id="home-address"
+                name="address"
+                className="w-full"
+                label={t('renew-ita:update-address.address-field.address')}
+                helpMessagePrimary={t('renew-ita:update-address.address-field.address-note')}
+                helpMessagePrimaryClassName="text-black"
+                maxLength={100}
+                autoComplete="address-line1"
+                defaultValue={defaultState.homeAddress?.address}
+                errorMessage={errors?.address}
+                required
+              />
+              <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
-                  id="home-address"
-                  name="homeAddress"
+                  id="home-city"
+                  name="city"
                   className="w-full"
-                  label={t('renew-ita:update-address.address-field.address')}
-                  helpMessagePrimary={t('renew-ita:update-address.address-field.address-note')}
-                  helpMessagePrimaryClassName="text-black"
+                  label={t('renew-ita:update-address.address-field.city')}
                   maxLength={100}
-                  autoComplete="address-line1"
-                  defaultValue={defaultState.homeAddress?.address}
-                  errorMessage={errors?.address}
+                  autoComplete="address-level2"
+                  defaultValue={defaultState.homeAddress?.city}
+                  errorMessage={errors?.city}
                   required
                 />
-                <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-                  <InputSanitizeField
-                    id="home-city"
-                    name="homeCity"
-                    className="w-full"
-                    label={t('renew-ita:update-address.address-field.city')}
-                    maxLength={100}
-                    autoComplete="address-level2"
-                    defaultValue={defaultState.homeAddress?.city}
-                    errorMessage={errors?.city}
-                    required
-                  />
-                  <InputSanitizeField
-                    id="home-postal-code"
-                    name="homePostalCode"
-                    className="w-full"
-                    label={isPostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
-                    maxLength={100}
-                    autoComplete="postal-code"
-                    defaultValue={defaultState.homeAddress?.postalCode ?? ''}
-                    errorMessage={errors?.postalZipCode}
-                    required={isPostalCodeRequired}
-                  />
-                </div>
-                {homeRegions.length > 0 && (
-                  <InputSelect
-                    id="home-province"
-                    name="homeProvince"
-                    className="w-full sm:w-1/2"
-                    label={t('renew-ita:update-address.address-field.province')}
-                    defaultValue={defaultState.homeAddress?.province}
-                    errorMessage={errors?.provinceStateId}
-                    options={[dummyOption, ...homeRegions]}
-                    required
-                  />
-                )}
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full"
+                  label={isPostalCodeRequired ? t('renew-ita:update-address.address-field.postal-code') : t('renew-ita:update-address.address-field.postal-code-optional')}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.homeAddress?.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                />
+              </div>
+              {homeRegions.length > 0 && (
                 <InputSelect
-                  id="home-country"
-                  name="homeCountry"
+                  id="home-province"
+                  name="provinceStateId"
                   className="w-full sm:w-1/2"
-                  label={t('renew-ita:update-address.address-field.country')}
-                  autoComplete="country"
-                  defaultValue={defaultState.homeAddress?.country ?? ''}
-                  errorMessage={errors?.countryId}
-                  options={countries}
-                  onChange={homeCountryChangeHandler}
+                  label={t('renew-ita:update-address.address-field.province')}
+                  defaultValue={defaultState.homeAddress?.province}
+                  errorMessage={errors?.provinceStateId}
+                  options={[dummyOption, ...homeRegions]}
                   required
                 />
-              </>
+              )}
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t('renew-ita:update-address.address-field.country')}
+                autoComplete="country"
+                defaultValue={defaultState.homeAddress?.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
             </div>
           </fieldset>
           {editMode ? (
@@ -356,8 +329,10 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -385,8 +360,10 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                 </DialogTrigger>
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
-                    {addressDialogContent.status === 'address-suggestion' && <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} />}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} />}
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -405,156 +382,5 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('homeAddress', selectedAddressSuggestion.address);
-    formData.set('homeCity', selectedAddressSuggestion.city);
-    formData.set('homeCountry', selectedAddressSuggestion.countryId);
-    formData.set('homePostalCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('homeProvince', selectedAddressSuggestion.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-ita:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-ita:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-ita:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.corrected-address-close-button" startIcon={faChevronLeft} disabled={fetcher.isSubmitting} variant="alternative" size="sm">
-            {t('renew-ita:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-ita:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-}
-
-function AddressInvalidDialogContent({ invalidAddress }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('homeAddress', invalidAddress.address);
-    formData.set('homeCity', invalidAddress.city);
-    formData.set('homeCountry', invalidAddress.countryId);
-    formData.set('homePostalCode', invalidAddress.postalZipCode);
-    formData.set('homeProvince', invalidAddress.provinceStateId);
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-ita:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-ita:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-ita:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm">
-            {t('renew-ita:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-ita:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { SyntheticEvent } from 'react';
 
 import { data, redirect } from 'react-router';
 
-import { faCheck, faChevronLeft, faChevronRight, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
 import { z } from 'zod';
@@ -15,14 +13,14 @@ import { TYPES } from '~/.server/constants';
 import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
-import { Address } from '~/components/address';
+import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '~/components/dialog';
+import { Dialog, DialogTrigger } from '~/components/dialog';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import type { InputOptionProps } from '~/components/input-option';
-import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
 import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
@@ -42,29 +40,6 @@ const FORM_ACTION = {
   useInvalidAddress: 'use-invalid-address',
   useSelectedAddress: 'use-selected-address',
 } as const;
-
-interface CanadianAddress {
-  address: string;
-  city: string;
-  country: string;
-  countryId: string;
-  postalZipCode: string;
-  provinceState: string;
-  provinceStateId: string;
-}
-
-interface AddressSuggestionResponse {
-  enteredAddress: CanadianAddress;
-  status: 'address-suggestion';
-  suggestedAddress: CanadianAddress;
-}
-
-interface AddressInvalidResponse {
-  invalidAddress: CanadianAddress;
-  status: 'address-invalid';
-}
-
-type AddressResponse = AddressSuggestionResponse | AddressInvalidResponse;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-ita', 'renew', 'gcweb'),
@@ -109,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadRenewItaState({ params, request, session });
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-  const isCopyMailingToHome = formData.get('copyMailingAddress') === 'copy';
+  const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
     saveRenewState({
@@ -125,10 +100,10 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const mailingAddressValidator = appContainer.get(TYPES.routes.validators.MailingAddressValidatorFactory).createMailingAddressValidator(locale);
   const validatedResult = await mailingAddressValidator.validateMailingAddress({
-    address: String(formData.get('mailingAddress')),
+    address: String(formData.get('address')),
     countryId: String(formData.get('countryId')),
     provinceStateId: formData.get('provinceStateId') ? String(formData.get('provinceStateId')) : undefined,
-    city: String(formData.get('mailingCity')),
+    city: String(formData.get('city')),
     postalZipCode: formData.get('postalZipCode') ? String(formData.get('postalZipCode')) : undefined,
   });
 
@@ -147,8 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const homeAddress = isCopyMailingToHome ? { ...mailingAddress } : undefined;
 
   const isNotCanada = validatedResult.data.countryId !== clientConfig.CANADA_COUNTRY_ID;
-  const isUseInvalidAddressAction = formAction === 'use-invalid-address';
-  const isUseSelectedAddressAction = formAction === 'use-selected-address';
+  const isUseInvalidAddressAction = formAction === FORM_ACTION.useInvalidAddress;
+  const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
@@ -254,7 +229,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
     postalZipCode: 'mailing-postal-code',
     provinceStateId: 'mailing-province',
     countryId: 'mailing-country',
-    copyMailingAddress: 'copy-mailing-address',
+    syncAddresses: 'sync-addresses',
   });
   const checkHandler = () => {
     setCopyAddressChecked((curState) => !curState);
@@ -302,7 +277,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
             <div className="space-y-6">
               <InputSanitizeField
                 id="mailing-address"
-                name="mailingAddress"
+                name="address"
                 className="w-full"
                 label={t('renew-ita:update-address.address-field.address')}
                 maxLength={100}
@@ -316,7 +291,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
               <div className="grid items-end gap-6 md:grid-cols-2">
                 <InputSanitizeField
                   id="mailing-city"
-                  name="mailingCity"
+                  name="city"
                   className="w-full"
                   label={t('renew-ita:update-address.address-field.city')}
                   maxLength={100}
@@ -361,7 +336,7 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                 onChange={mailingCountryChangeHandler}
                 required
               />
-              <InputCheckbox id="copyMailingAddress" name="copyMailingAddress" value="copy" checked={copyAddressChecked} onChange={checkHandler}>
+              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t('renew-ita:update-address.home-address.use-mailing-address')}
               </InputCheckbox>
             </div>
@@ -386,9 +361,9 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -417,9 +392,9 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
                 {!fetcher.isSubmitting && addressDialogContent && (
                   <>
                     {addressDialogContent.status === 'address-suggestion' && (
-                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} copyAddressToHome={copyAddressChecked} />
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
                     )}
-                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} copyAddressToHome={copyAddressChecked} />}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />}
                   </>
                 )}
               </Dialog>
@@ -439,164 +414,5 @@ export default function RenewItaUpdateAddress({ loaderData, params }: Route.Comp
         </fetcher.Form>
       </div>
     </>
-  );
-}
-
-interface AddressSuggestionDialogContentProps {
-  enteredAddress: CanadianAddress;
-  suggestedAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressSuggestionDialogContent({ enteredAddress, suggestedAddress, copyAddressToHome }: AddressSuggestionDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-  const enteredAddressOptionValue = 'entered-address';
-  const suggestedAddressOptionValue = 'suggested-address';
-  type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    const selectedAddressSuggestion = selectedAddressSuggestionOption === enteredAddressOptionValue ? enteredAddress : suggestedAddress;
-    formData.set('mailingAddress', selectedAddressSuggestion.address);
-    formData.set('mailingCity', selectedAddressSuggestion.city);
-    formData.set('countryId', selectedAddressSuggestion.countryId);
-    formData.set('postalZipCode', selectedAddressSuggestion.postalZipCode);
-    formData.set('provinceStateId', selectedAddressSuggestion.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-ita:update-address.dialog.address-suggestion.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-ita:update-address.dialog.address-suggestion.description')}</DialogDescription>
-      </DialogHeader>
-      <InputRadios
-        id="addressSelection"
-        name="addressSelection"
-        legend={t('renew-ita:update-address.dialog.address-suggestion.address-selection-legend')}
-        options={[
-          {
-            value: enteredAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.entered-address-option')}</strong>
-                </p>
-                <Address address={enteredAddress} />
-              </>
-            ),
-          },
-          {
-            value: suggestedAddressOptionValue,
-            children: (
-              <>
-                <p className="mb-2">
-                  <strong>{t('renew-ita:update-address.dialog.address-suggestion.suggested-address-option')}</strong>
-                </p>
-                <Address address={suggestedAddress} />
-              </>
-            ),
-          },
-        ].map((option) => ({
-          ...option,
-          onChange: (e) => {
-            setSelectedAddressSuggestionOption(e.target.value as AddressSelectionOption);
-          },
-          checked: option.value === selectedAddressSuggestionOption,
-        }))}
-      />
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.corrected-address-close-button" startIcon={faChevronLeft} disabled={fetcher.isSubmitting} variant="alternative" size="sm">
-            {t('renew-ita:update-address.dialog.address-suggestion.cancel-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useSelectedAddress} type="submit" id="dialog.corrected-address-use-selected-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-ita:update-address.dialog.address-suggestion.use-selected-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
-
-interface AddressInvalidDialogContentProps {
-  invalidAddress: CanadianAddress;
-  copyAddressToHome: boolean;
-}
-
-function AddressInvalidDialogContent({ invalidAddress, copyAddressToHome }: AddressInvalidDialogContentProps) {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const fetcher = useEnhancedFetcher();
-
-  async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-
-    // Get the clicked button's value and append it to the FormData object
-    const submitter = event.nativeEvent.submitter as HTMLButtonElement | null;
-    invariant(submitter, 'Expected submitter to be defined');
-    formData.set(submitter.name, submitter.value);
-
-    // Append selected address suggestion to form data
-    formData.set('mailingAddress', invalidAddress.address);
-    formData.set('mailingCity', invalidAddress.city);
-    formData.set('countryId', invalidAddress.countryId);
-    formData.set('postalZipCode', invalidAddress.postalZipCode);
-    formData.set('provinceStateId', invalidAddress.provinceStateId);
-    if (copyAddressToHome) {
-      formData.set('copyMailingAddress', 'copy');
-    }
-
-    await fetcher.submit(formData, { method: 'POST' });
-  }
-
-  return (
-    <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>
-          <FontAwesomeIcon icon={faTriangleExclamation} className="me-2 inline-block text-amber-700" />
-          {t('renew-ita:update-address.dialog.address-invalid.header')}
-        </DialogTitle>
-        <DialogDescription>{t('renew-ita:update-address.dialog.address-invalid.description')}</DialogDescription>
-      </DialogHeader>
-      <div className="space-y-2">
-        <p>
-          <strong>{t('renew-ita:update-address.dialog.address-invalid.entered-address')}</strong>
-        </p>
-        <Address address={invalidAddress} />
-      </div>
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button id="dialog.address-invalid-close-button" startIcon={faChevronLeft} variant="alternative" size="sm">
-            {t('renew-ita:update-address.dialog.address-invalid.close-button')}
-          </Button>
-        </DialogClose>
-        <fetcher.Form method="post" noValidate onSubmit={onSubmitHandler}>
-          <LoadingButton name="_action" value={FORM_ACTION.useInvalidAddress} type="submit" id="dialog.address-invalid-use-entered-address-button" loading={fetcher.isSubmitting} endIcon={faCheck} variant="primary" size="sm">
-            {t('renew-ita:update-address.dialog.address-invalid.use-entered-address-button')}
-          </LoadingButton>
-        </fetcher.Form>
-      </DialogFooter>
-    </DialogContent>
   );
 }


### PR DESCRIPTION
### Description
Continuation of #3286 except for all renewal routes.

### Related Azure Boards Work Items
[AB#5029](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5029)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go through the any renewal flow and make sure everything with the address pages still works.

### Additional Notes
Found a bug when hammering the renewal pages and will open an ADO for it - it is unrelated to the address dialog refactoring but rather the state mapping.