### PR TITLE
AB#5278 -- Remove `apply-application-year` feature flag and `APPLICATION_YEAR_2024_ID` config

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -51,7 +51,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env-utils.server.ts for valid values
 # (optional; default: "")
-ENABLED_FEATURES=address-validation,apply-application-year,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey
+ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey
 
 # GC Notify email notifications URL
 # (optional; default: https://api.notification.canada.ca/v2/notifications/email)
@@ -126,9 +126,6 @@ INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 # Config that holds the date used for the application year request. This date can be overridden for simulation or testing purposes -- ex. 2025-03-05
 # (optional; default: undefined)
 #APPLICATION_YEAR_REQUEST_DATE=2025-03-05
-
-# Default value for BenefitApplicationYear
-APPLICATION_YEAR_2024_ID=98f8ad43-4069-ee11-9ae7-000d3a09d1b8
 
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)

--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -2,7 +2,7 @@ import type { ReadonlyDeep } from 'type-fest';
 
 export type BenefitApplicationDto = ReadonlyDeep<{
   applicantInformation: ApplicantInformationDto;
-  applicationYearId?: string;
+  applicationYearId: string;
   children: ChildDto[];
   communicationPreferences: CommunicationPreferencesDto;
   contactInformation: ContactInformationDto;

--- a/frontend/app/.server/domain/entities/benefit-application.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-application.entity.ts
@@ -98,12 +98,12 @@ export type BenefitApplicationRequestEntity = ReadonlyDeep<{
     };
     BenefitApplicationCategoryCode: {
       ReferenceDataID: string;
-      ReferenceDataName?: string;
+      ReferenceDataName: string;
     };
     BenefitApplicationChannelCode: {
       ReferenceDataID: string;
     };
-    BenefitApplicationYear?: {
+    BenefitApplicationYear: {
       BenefitApplicationYearIdentification: {
         IdentificationID: string;
       }[];

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -30,9 +30,9 @@ interface ToEmailAddressArgs {
 
 @injectable()
 export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDtoMapper {
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES' | 'APPLICATION_YEAR_2024_ID'>;
+  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>;
 
-  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENABLED_FEATURES' | 'APPLICATION_YEAR_2024_ID'>) {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>) {
     this.serverConfig = serverConfig;
   }
 
@@ -102,39 +102,15 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
         BenefitApplicationChannelCode: {
           ReferenceDataID: '775170001', // PP's static value for "Online"
         },
-        ...(this.applyApplicationYearEnabled()
-          ? {
-              BenefitApplicationYear: {
-                BenefitApplicationYearIdentification: [
-                  {
-                    IdentificationID:
-                      applicationYearId ??
-                      (() => {
-                        throw new Error("Expected applicationYearId to be defined when apply-application-year is enabled'");
-                      })(),
-                  },
-                ],
-              },
-            }
-          : {
-              BenefitApplicationYear: {
-                BenefitApplicationYearIdentification: [
-                  {
-                    IdentificationID: this.applicationYear2024Id(),
-                  },
-                ],
-              },
-            }),
+        BenefitApplicationYear: {
+          BenefitApplicationYearIdentification: [
+            {
+              IdentificationID: applicationYearId,
+            },
+          ],
+        },
       },
     };
-  }
-
-  private applyApplicationYearEnabled() {
-    return this.serverConfig.ENABLED_FEATURES.includes('apply-application-year');
-  }
-
-  private applicationYear2024Id() {
-    return this.serverConfig.APPLICATION_YEAR_2024_ID;
   }
 
   private toInsurancePlan(dentalBenefits: readonly string[]) {

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -23,7 +23,7 @@ export type ApplyState = ReadonlyDeep<{
     maritalStatus: string;
     socialInsuranceNumber: string;
   };
-  applicationYear?: {
+  applicationYear: {
     intakeYearId: string;
     taxYear: string;
   };
@@ -241,7 +241,7 @@ export function clearApplyState({ params, session }: ClearStateArgs) {
 }
 
 interface StartArgs {
-  applicationYear?: ApplicationYearState;
+  applicationYear: ApplicationYearState;
   id: string;
   session: Session;
 }

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -18,7 +18,7 @@ import type {
 
 export interface ApplyAdultState {
   applicantInformation: ApplicantInformationState;
-  applicationYear?: ApplicationYearState;
+  applicationYear: ApplicationYearState;
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
   dateOfBirth: string;
@@ -32,7 +32,7 @@ export interface ApplyAdultState {
 
 export interface ApplyAdultChildState {
   applicantInformation: ApplicantInformationState;
-  applicationYear?: ApplicationYearState;
+  applicationYear: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -47,7 +47,7 @@ export interface ApplyAdultChildState {
 
 export interface ApplyChildState {
   applicantInformation: ApplicantInformationState;
-  applicationYear?: ApplicationYearState;
+  applicationYear: ApplicationYearState;
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -60,7 +60,7 @@ export interface ApplyChildState {
 
 interface ToBenefitApplicationDtoArgs {
   applicantInformation: ApplicantInformationState;
-  applicationYear?: ApplicationYearState;
+  applicationYear: ApplicationYearState;
   children?: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
@@ -137,7 +137,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
   }: ToBenefitApplicationDtoArgs) {
     return {
       applicantInformation,
-      applicationYearId: applicationYear?.intakeYearId,
+      applicationYearId: applicationYear.intakeYearId,
       children: this.toChildren(children),
       communicationPreferences,
       contactInformation: this.toContactInformation(contactInformation),

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -51,9 +51,6 @@ const serverEnv = clientEnvSchema.extend({
   APPLICANT_CATEGORY_CODE_FAMILY: z.coerce.number().default(775170001),
   APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: z.coerce.number().default(775170002),
 
-  // application year IDs
-  APPLICATION_YEAR_2024_ID: z.string().trim().min(1).default("98f8ad43-4069-ee11-9ae7-000d3a09d1b8"),
-
   // province/territory lookup identifiers
   ALBERTA_PROVINCE_ID: z.string().trim().min(1).default("3b17d494-35b3-eb11-8236-0022486d8d5f"),
   BRITISH_COLUMBIA_PROVINCE_ID: z.string().trim().min(1).default("9c440baa-35b3-eb11-8236-0022486d8d5f"),

--- a/frontend/app/routes/public/apply/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/file-taxes.tsx
@@ -27,12 +27,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadApplyState({ params, session });
+  const { id, applicationYear } = loadApplyState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:file-your-taxes.page-title') }) };
 
-  return { id, meta, taxYear: '2024' }; // TODO change taxYear to applicationYear.taxYear as it will always be defined when we remove apply-application-year feature flag
+  return { id, meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/tax-filing.tsx
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:tax-filing.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.taxFiling2023, taxYear: '2024' }; // TODO change taxYear to state.applicationYear.taxYear as it will always be defined when we remove apply-application-year feature flag
+  return { id: state.id, meta, defaultState: state.taxFiling2023, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -7,7 +7,6 @@ import { randomUUID } from 'crypto';
 import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
-import type { IntakeApplicationYearResultDto } from '~/.server/domain/dtos';
 import { startApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { pageIds } from '~/page-ids';
@@ -33,18 +32,10 @@ export async function loader({ context: { appContainer, session }, request }: Ro
   const locale = getLocale(request);
 
   const id = randomUUID().toString();
-
-  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
-  const applyApplicationYearEnabled = ENABLED_FEATURES.includes('apply-application-year');
-
-  let applicationYear: IntakeApplicationYearResultDto | undefined;
-  if (applyApplicationYearEnabled) {
-    const currentDate = getCurrentDateString(locale);
-    const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
-    applicationYear = await applicationYearService.getIntakeApplicationYear(currentDate);
-  }
-
-  const state = startApplyState({ id, session, ...(applyApplicationYearEnabled ? { applicationYear } : {}) });
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.domain.services.ApplicationYearService);
+  const applicationYear = await applicationYearService.getIntakeApplicationYear(currentDate);
+  const state = startApplyState({ id, session, applicationYear });
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:index.page-title') }) };
 

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const validFeatureNames = ['address-validation', 'apply-application-year', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-payload', 'demographic-survey'] as const;
+const validFeatureNames = ['address-validation', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-payload', 'demographic-survey'] as const;
 
 export type FeatureName = (typeof validFeatureNames)[number];
 


### PR DESCRIPTION
### Description
This feature flag and config are no longer needed because the `/apply` flow will always be calling the application year service and passing the appropriate ID when submitting a benefit application for the next release.

### Related Azure Boards Work Items
[AB#5278](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5278)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`