### PR TITLE
Adding `find()` methods for FPT lookup and replacing try/catch with if/else in confirm FPT routes

### DIFF
--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -75,6 +75,51 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     });
   });
 
+  describe('findFederalGovernmentInsurancePlanById', () => {
+    it('fetches federal government insurance plan by id', () => {
+      const id = '1';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+      });
+
+      const mockDto: FederalGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+      };
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+      mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+
+      const service = new DefaultFederalGovernmentInsurancePlanService(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findFederalGovernmentInsurancePlanById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
+    });
+
+    it('fetches federal government insurance plan by id and returns null if not found', () => {
+      const id = '1033';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockReturnValueOnce(null);
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+
+      const service = new DefaultFederalGovernmentInsurancePlanService(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findFederalGovernmentInsurancePlanById(id);
+
+      expect(dto).toBeNull();
+      expect(mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getFederalGovernmentInsurancePlanById', () => {
     it('fetches federal government insurance plan by id', () => {
       const id = '1';

--- a/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
@@ -124,6 +124,53 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     });
   });
 
+  describe('findProvincialGovernmentInsurancePlanById', () => {
+    it('fetches provincial government insurance plan by id', () => {
+      const id = '1';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+        _esdc_provinceterritorystateid_value: '10',
+      });
+
+      const mockDto: ProvincialGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+        provinceTerritoryStateId: '10',
+      };
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+      mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+
+      const service = new DefaultProvincialGovernmentInsurancePlanService(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findProvincialGovernmentInsurancePlanById(id);
+
+      expect(dto).toEqual(mockDto);
+      expect(mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
+    });
+
+    it('fetches provincial government insurance plan by id and returns null if not found', () => {
+      const id = '1033';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockReturnValueOnce(null);
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+
+      const service = new DefaultProvincialGovernmentInsurancePlanService(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findProvincialGovernmentInsurancePlanById(id);
+
+      expect(dto).toBeNull();
+      expect(mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+    });
+  });
+
   describe('listAndSortLocalizedProvincialGovernmentInsurancePlans', () => {
     it('should return a list of localized provincial government insurance plans', () => {
       const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();

--- a/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
@@ -14,6 +14,15 @@ import type { LogFactory, Logger } from '~/.server/factories';
  */
 export interface FederalGovernmentInsurancePlanService {
   /**
+   * Finds a specific federal government insurance plan by its ID.
+   * Returns null if no matching federal government insurance plan is found.
+   *
+   * @param id - The ID of the federal government insurance plan to retrieve.
+   * @returns The FederalGovernmentInsurancePlan DTO corresponding to the specified ID or null if not found.
+   */
+  findFederalGovernmentInsurancePlanById(id: string): FederalGovernmentInsurancePlanDto | null;
+
+  /**
    * Retrieves a specific federal government insurance plan by its ID.
    *
    * @param id - The ID of the federal government insurance plan to retrieve.
@@ -79,6 +88,12 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
       onCacheAdd: () => this.log.info('Creating new listFederalGovernmentInsurancePlans memo'),
     });
 
+    this.findFederalGovernmentInsurancePlanById = moize(this.findFederalGovernmentInsurancePlanById, {
+      maxAge: federalGovernmentInsurancePlanCacheTTL,
+      maxSize: Infinity,
+      onCacheAdd: () => this.log.info('Creating new findFederalGovernmentInsurancePlanById memo'),
+    });
+
     this.getFederalGovernmentInsurancePlanById = moize(this.getFederalGovernmentInsurancePlanById, {
       maxAge: federalGovernmentInsurancePlanCacheTTL,
       maxSize: Infinity,
@@ -94,6 +109,20 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
     const federalGovernmentInsurancePlanDtos = this.federalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(federalGovernmentInsurancePlanEntities);
     this.log.trace('Returning federal government insurance plans: [%j]', federalGovernmentInsurancePlanDtos);
     return federalGovernmentInsurancePlanDtos;
+  }
+
+  findFederalGovernmentInsurancePlanById(id: string): FederalGovernmentInsurancePlanDto | null {
+    this.log.debug('Finding federal government insurance plan with id: [%s]', id);
+    const federalGovernmentInsurancePlanEntity = this.federalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById(id);
+
+    if (!federalGovernmentInsurancePlanEntity) {
+      this.log.trace('Federal government insurance plan with id: [%s] not found. Returning null', id);
+      return null;
+    }
+
+    const federalGovernmentInsurancePlanDto = this.federalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto(federalGovernmentInsurancePlanEntity);
+    this.log.trace('Returning federal government insurance plan: [%j]', federalGovernmentInsurancePlanDto);
+    return federalGovernmentInsurancePlanDto;
   }
 
   getFederalGovernmentInsurancePlanById(id: string): FederalGovernmentInsurancePlanDto {

--- a/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
@@ -11,6 +11,7 @@ import type { LogFactory, Logger } from '~/.server/factories';
 
 export interface ProvincialGovernmentInsurancePlanService {
   listProvincialGovernmentInsurancePlans(): ReadonlyArray<ProvincialGovernmentInsurancePlanDto>;
+  findProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto | null;
   getProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto;
   listAndSortLocalizedProvincialGovernmentInsurancePlans(locale: AppLocale): ReadonlyArray<ProvincialGovernmentInsurancePlanLocalizedDto>;
   getLocalizedProvincialGovernmentInsurancePlanById(id: string, locale: AppLocale): ProvincialGovernmentInsurancePlanLocalizedDto;
@@ -47,6 +48,12 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
       onCacheAdd: () => this.log.info('Creating new listProvincialGovernmentInsurancePlans memo'),
     });
 
+    this.findProvincialGovernmentInsurancePlanById = moize(this.findProvincialGovernmentInsurancePlanById, {
+      maxAge: provincialGovernmentInsurancePlanCacheTTL,
+      maxSize: Infinity,
+      onCacheAdd: () => this.log.info('Creating new findProvincialGovernmentInsurancePlanById memo'),
+    });
+
     this.getProvincialGovernmentInsurancePlanById = moize(this.getProvincialGovernmentInsurancePlanById, {
       maxAge: provincialGovernmentInsurancePlanCacheTTL,
       maxSize: Infinity,
@@ -62,6 +69,20 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
     const provincialGovernmentInsurancePlanDtos = this.provincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanEntities);
     this.log.trace('Returning provincial government insurance plans: [%j]', provincialGovernmentInsurancePlanDtos);
     return provincialGovernmentInsurancePlanDtos;
+  }
+
+  findProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto | null {
+    this.log.debug('Finding provincial government insurance plan with id: [%s]', id);
+    const provincialGovernmentInsurancePlanEntity = this.provincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById(id);
+
+    if (!provincialGovernmentInsurancePlanEntity) {
+      this.log.trace('Provincial government insurance plan with id: [%s] not found. Returning null', id);
+      return null;
+    }
+
+    const provincialGovernmentInsurancePlanDto = this.provincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto(provincialGovernmentInsurancePlanEntity);
+    this.log.trace('Returning provincial government insurance plan: [%j]', provincialGovernmentInsurancePlanDto);
+    return provincialGovernmentInsurancePlanDto;
   }
 
   getProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto {

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -71,23 +71,27 @@ export async function loader({ context: { appContainer, session }, params, reque
   };
 
   const immutableChild = renewState.clientApplication.children.find((c) => c.information.socialInsuranceNumber === state.information?.socialInsuranceNumber);
-  const clientDentalBenefits = immutableChild?.dentalBenefits.reduce((acc, id) => {
-    try {
-      appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getFederalGovernmentInsurancePlanById(id);
+  const clientDentalBenefits = immutableChild?.dentalBenefits.reduce((benefits, id) => {
+    const federalProgram = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).findFederalGovernmentInsurancePlanById(id);
+    if (federalProgram) {
       return {
-        ...acc,
+        ...benefits,
         hasFederalBenefits: true,
         federalSocialProgram: id,
       };
-    } catch {
-      const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getProvincialGovernmentInsurancePlanById(id);
+    }
+
+    const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).findProvincialGovernmentInsurancePlanById(id);
+    if (provincialProgram) {
       return {
-        ...acc,
+        ...benefits,
         hasProvincialTerritorialBenefits: true,
         provincialTerritorialSocialProgram: id,
         province: provincialProgram.provinceTerritoryStateId,
       };
     }
+
+    return benefits;
   }, {}) as ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
 
   const dentalBenefits = state.dentalBenefits ?? clientDentalBenefits;

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -73,23 +73,27 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-dental-benefits.title') }) };
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits.reduce((acc, id) => {
-    try {
-      appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getFederalGovernmentInsurancePlanById(id);
+  const clientDentalBenefits = state.clientApplication.dentalBenefits.reduce((benefits, id) => {
+    const federalProgram = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).findFederalGovernmentInsurancePlanById(id);
+    if (federalProgram) {
       return {
-        ...acc,
+        ...benefits,
         hasFederalBenefits: true,
         federalSocialProgram: id,
       };
-    } catch {
-      const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getProvincialGovernmentInsurancePlanById(id);
+    }
+
+    const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).findProvincialGovernmentInsurancePlanById(id);
+    if (provincialProgram) {
       return {
-        ...acc,
+        ...benefits,
         hasProvincialTerritorialBenefits: true,
         provincialTerritorialSocialProgram: id,
         province: provincialProgram.provinceTerritoryStateId,
       };
     }
+
+    return benefits;
   }, {}) as ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
 
   const dentalBenefits = state.clientApplication.isInvitationToApplyClient ? state.dentalBenefits : clientDentalBenefits;


### PR DESCRIPTION
### Description
This PR updates the reducer in the confirm FPT routes in the protected space to use if/else instead of try/catch by switching to new `findFederalGovernmentInsurancePlanById()` and `findProvincialGovernmentInsurancePlanById()` methods, which return `null` instead of throwing.

This stems from `ERROR` being logged when no federal or provincial program was found for an ID, but this is expected behaviour and not an actual error.

### Screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/e131a3a2-9268-4202-ba09-6583b437d97b)

After:
![image](https://github.com/user-attachments/assets/45f33706-6878-4303-af08-76ff85b2a15c)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
When running the app locally with mocks enabled, modify `app/.server/resources/power-platform/client-application.json` to not have any federal benefits (ie. remove `InsurancePlanIdentification` with value `1788f1db-25c5-ee11-9079-000d3a09d640`). 

Navigate to `/en/protected/renew` and edit your FPT benefits. You should not see any `ERROR` logged.
