### PR TITLE
AB#5264 -- Adding GC Notify mock

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -220,7 +220,7 @@ REDIS_COMMAND_TIMEOUT_SECONDS=
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress
+ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,wsaddress
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/.server/container-modules/repositories.container-module.ts
+++ b/frontend/app/.server/container-modules/repositories.container-module.ts
@@ -30,6 +30,7 @@ import {
   MockBenefitRenewalRepository,
   MockClientApplicationRepository,
   MockLetterRepository,
+  MockNotificationRepository,
 } from '~/.server/domain/repositories';
 import type { MockName } from '~/.server/utils/env.utils';
 import { DefaultDynatraceRepository, DefaultHCaptchaRepository } from '~/.server/web/repositories';
@@ -94,7 +95,10 @@ export const repositoriesContainerModule = new ContainerModule((bind) => {
 
   bind(TYPES.domain.repositories.LetterTypeRepository).to(DefaultLetterTypeRepository);
   bind(TYPES.domain.repositories.MaritalStatusRepository).to(DefaultMaritalStatusRepository);
-  bind(TYPES.domain.repositories.NotificationRepository).to(DefaultNotificationRepository);
+
+  bind(TYPES.domain.repositories.NotificationRepository).to(DefaultNotificationRepository).when(isMockEnabled('gc-notify', false));
+  bind(TYPES.domain.repositories.NotificationRepository).to(MockNotificationRepository).when(isMockEnabled('gc-notify', true));
+
   bind(TYPES.domain.repositories.PreferredCommunicationMethodRepository).to(DefaultPreferredCommunicationMethodRepository);
   bind(TYPES.domain.repositories.PreferredLanguageRepository).to(DefaultPreferredLanguageRepository);
   bind(TYPES.domain.repositories.ProvinceTerritoryStateRepository).to(DefaultProvinceTerritoryStateRepository);

--- a/frontend/app/.server/domain/entities/notification.entity.ts
+++ b/frontend/app/.server/domain/entities/notification.entity.ts
@@ -10,7 +10,7 @@ export type EmailNotificationRequestEntity = ReadonlyDeep<{
 
 export type EmailNotificationResponseEntity = ReadonlyDeep<{
   id: string;
-  reference: string;
+  reference?: string;
   content: {
     subject: string;
     body: string;

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -20,7 +20,7 @@ function tryOrElseFalse(fn: () => void) {
   }
 }
 
-const validMockNames = ['cct', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
+const validMockNames = ['cct', 'gc-notify', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 // refiners

--- a/frontend/other/docker-compose.yml
+++ b/frontend/other/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - AUTH_RAOIDC_BASE_URL=http://localhost:3000/auth
       - AUTH_RAOIDC_CLIENT_ID=CDCP
       - AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
-      - ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress
+      - ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,wsaddress
       - GC_NOTIFY_API_KEY=00000000000000000000000000000000
       - HCAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000
       - HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       AUTH_RAOIDC_CLIENT_ID: 'CDCP',
       AUTH_RASCL_LOGOUT_URL: 'http://localhost:3000/',
       ENABLED_FEATURES: "hcaptcha,view-letters,view-letters-online-application,status,show-prototype-banner",
-      ENABLED_MOCKS: 'cct,power-platform,raoidc,status-check,wsaddress',
+      ENABLED_MOCKS: 'cct,gc-notify,power-platform,raoidc,status-check,wsaddress',
       GC_NOTIFY_API_KEY: '00000000000000000000000000000000',
       HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000',
       HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
AB#5264

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/0c48e6c1-5ca8-43f0-a200-9d1028584f19)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Add this in a route with the mock enabled:
```typescript
const notificationService = appContainer.get(TYPES.domain.services.NotificationService);
await notificationService.sendVerificationCodeEmail({ email: 'your-email@example.com', preferredLanguage: 'en', userId: 'anonymous', verificationCode: '123456' });
```
Verify that no email is actually sent.