### PR TITLE
Adding service method and configuration to create verification code with stub support

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -220,7 +220,7 @@ REDIS_COMMAND_TIMEOUT_SECONDS=
 
 # enabled MSW mocks -- comma separated list of mocks
 # (optional; default: undefined)
-ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,wsaddress
+ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,verification-code,wsaddress
 # allowed OIDC redirects -- list of allowed OIDC redirect URLs when mocking RAOIDC
 # (optional; default: http://localhost:3000/auth/callback/raoidc)
 MOCK_AUTH_ALLOWED_REDIRECTS=http://localhost:3000/auth/callback/raoidc

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -20,7 +20,7 @@ function tryOrElseFalse(fn: () => void) {
   }
 }
 
-const validMockNames = ['cct', 'gc-notify', 'power-platform', 'raoidc', 'status-check', 'wsaddress'] as const;
+const validMockNames = ['cct', 'gc-notify', 'power-platform', 'raoidc', 'status-check', 'verification-code', 'wsaddress'] as const;
 export type MockName = (typeof validMockNames)[number];
 
 // refiners

--- a/frontend/other/docker-compose.yml
+++ b/frontend/other/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - AUTH_RAOIDC_BASE_URL=http://localhost:3000/auth
       - AUTH_RAOIDC_CLIENT_ID=CDCP
       - AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
-      - ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,wsaddress
+      - ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,status-check,verification-code,wsaddress
       - GC_NOTIFY_API_KEY=00000000000000000000000000000000
       - HCAPTCHA_SECRET_KEY=0x0000000000000000000000000000000000000000
       - HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       AUTH_RAOIDC_CLIENT_ID: 'CDCP',
       AUTH_RASCL_LOGOUT_URL: 'http://localhost:3000/',
       ENABLED_FEATURES: "hcaptcha,view-letters,view-letters-online-application,status,show-prototype-banner",
-      ENABLED_MOCKS: 'cct,gc-notify,power-platform,raoidc,status-check,wsaddress',
+      ENABLED_MOCKS: 'cct,gc-notify,power-platform,raoidc,status-check,verification-code,wsaddress',
       GC_NOTIFY_API_KEY: '00000000000000000000000000000000',
       HCAPTCHA_SECRET_KEY: '0x0000000000000000000000000000000000000000',
       HCAPTCHA_SITE_KEY: '10000000-ffff-ffff-ffff-000000000001',


### PR DESCRIPTION
### Description
Implementing a new service method to generate a verification code. Also added a configuration to enable or disable the generation of stub verification codes for testing.

The stubbing is limited to the creation of the verification code. The email sending process is handled separately through the `gc-notify` feature flag and is not affected by this stub.

### Related Azure Boards Work Items
AB#5264

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Enable/disable the `verification-code` enabled mock and add this code in some route:
```typescript
const verificationCodeService = appContainer.get(TYPES.domain.services.VerificationCodeService);
const verificationCode = verificationCodeService.createVerificationCode('someUserId');
```