### PR TITLE
AB#5248 -- Adding marital status route for child flow

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -98,6 +98,7 @@ export const pageIds = {
         contactApplyChild: 'CDCP-APPL-CH-0018',
         newOrExistingMember: 'CDCP-APPL-CH-0019',
         phoneNumber: 'CDCP-APPL-CH-0020',
+        maritalStatus: 'CDCP-APPL-CH-0021', // TODO: Check the correct page ID.
       },
     },
     status: { index: 'CDCP-STAT-0001', myself: 'CDCP-STAT-0002', child: 'CDCP-STAT-0003', result: 'CDCP-STAT-0004' },

--- a/frontend/app/routes/public/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/child/marital-status.tsx
@@ -1,0 +1,245 @@
+import type { ChangeEventHandler } from 'react';
+import { useMemo, useState } from 'react';
+
+import { redirect, useFetcher } from 'react-router';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import type { Route } from './+types/marital-status';
+
+import { TYPES } from '~/.server/constants';
+import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-helpers';
+import { applicantInformationStateHasPartner, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputCheckbox } from '~/components/input-checkbox';
+import { InputPatternField } from '~/components/input-pattern-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { useClientEnv } from '~/root';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.child.maritalStatus,
+  pageTitleI18nKey: 'apply-child:marital-status.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const state = loadApplyChildState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:marital-status.page-title') }) };
+  return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadApplyChildState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
+    return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
+  }
+
+  // state validation schema
+  const maritalStatusSchema = z.object({
+    maritalStatus: z
+      .string({ errorMap: () => ({ message: t('apply-child:marital-status.error-message.marital-status-required') }) })
+      .trim()
+      .min(1, t('apply-child:marital-status.error-message.marital-status-required')),
+  });
+
+  const currentYear = new Date().getFullYear().toString();
+  const partnerInformationSchema = z.object({
+    confirm: z.boolean().refine((val) => val === true, t('apply-child:marital-status.error-message.confirm-required')),
+    yearOfBirth: z
+      .string()
+      .trim()
+      .min(1, t('apply-child:marital-status.error-message.date-of-birth-year-required'))
+      .refine((year) => year < currentYear, t('apply-child:marital-status.error-message.yob-is-future')),
+    socialInsuranceNumber: z
+      .string()
+      .trim()
+      .min(1, t('apply-child:marital-status.error-message.sin-required'))
+      .refine(isValidSin, t('apply-child:marital-status.error-message.sin-valid'))
+      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('apply-child:marital-status.error-message.sin-unique')),
+  }); //satisfies z.ZodType<PartnerInformationState>; TODO: Add once the state is reworked.
+
+  const maritalStatusData = {
+    maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,
+  };
+  const partnerInformationData = {
+    confirm: formData.get('confirm') === 'yes',
+    yearOfBirth: String(formData.get('yearOfBirth') ?? ''),
+    socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),
+  };
+
+  const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
+  const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
+
+  if (!parsedMaritalStatus.success || (applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success) || parsedPartnerInformation.data === undefined) {
+    return {
+      errors: {
+        ...(parsedMaritalStatus.error ? transformFlattenedError(parsedMaritalStatus.error.flatten()) : {}),
+        ...(parsedMaritalStatus.success && applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(parsedPartnerInformation.error.flatten()) : {}),
+      },
+    };
+  }
+
+  saveApplyState({
+    params,
+    session,
+    state: {
+      maritalStatus: parsedMaritalStatus.data.maritalStatus,
+      partnerInformation: {
+        confirm: parsedPartnerInformation.data.confirm,
+        dateOfBirth: parsedPartnerInformation.data.yearOfBirth,
+        firstName: '', //TODO: to remove when the state is reworked.
+        lastName: '',
+        socialInsuranceNumber: parsedPartnerInformation.data.socialInsuranceNumber,
+      },
+    },
+  });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
+  }
+
+  return redirect(getPathById('public/apply/$id/child/contact-information', params)); // TODO: Needs to be changed to /update-mailing
+}
+
+export default function ApplyChildMaritalStatus({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode, maritalStatuses } = loaderData;
+  const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  function getBackButtonRouteId() {
+    if (defaultState.newUser) {
+      return 'public/apply/$id/child/new-or-existing-member';
+    }
+
+    return 'public/apply/$id/child/applicant-information';
+  }
+
+  const [marriedOrCommonlaw, setMarriedOrCommonlaw] = useState(defaultState.maritalStatus);
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    maritalStatus: 'input-radio-marital-status-option-0',
+    socialInsuranceNumber: 'social-insurance-number',
+    yearOfBirth: 'year-of-birth',
+    confirm: 'input-checkbox-confirm',
+  });
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setMarriedOrCommonlaw(e.target.value);
+  };
+
+  const maritalStatusOptions = useMemo<InputRadiosProps['options']>(() => {
+    return maritalStatuses.map((status) => ({ defaultChecked: status.id === defaultState.maritalStatus, children: status.name, value: status.id, onChange: handleChange }));
+  }, [defaultState, maritalStatuses]);
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={39} size="lg" label={t('apply:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t('apply:required-label')}</p>
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <div className="mb-8 space-y-6">
+            <InputRadios id="marital-status" name="maritalStatus" legend={t('apply-child:marital-status.marital-status')} options={maritalStatusOptions} errorMessage={errors?.maritalStatus} required />
+
+            {(marriedOrCommonlaw === MARITAL_STATUS_CODE_COMMONLAW.toString() || marriedOrCommonlaw === MARITAL_STATUS_CODE_MARRIED.toString()) && (
+              <>
+                <h2 className="font-lato mb-6 text-2xl font-bold">{t('apply-child:marital-status.spouse-or-commonlaw')}</h2>
+                <p className="mb-4">{t('apply-child:marital-status.provide-sin')}</p>
+                <p className="mb-6">{t('apply-child:marital-status.required-information')}</p>
+                <InputPatternField
+                  id="social-insurance-number"
+                  name="socialInsuranceNumber"
+                  format={sinInputPatternFormat}
+                  label={t('marital-status.sin')}
+                  inputMode="numeric"
+                  helpMessagePrimary={t('apply-child:marital-status.help-message.sin')}
+                  helpMessagePrimaryClassName="text-black"
+                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                  errorMessage={errors?.socialInsuranceNumber}
+                  required
+                />
+                <InputPatternField id="year-of-birth" name="yearOfBirth" inputMode="numeric" format="####" defaultValue={defaultState.dateOfBirth ?? ''} label={t('apply-child:marital-status.year-of-birth')} errorMessage={errors?.yearOfBirth} required />
+                <InputCheckbox id="confirm" name="confirm" value="yes" errorMessage={errors?.confirm} defaultChecked={defaultState.confirm === true} required>
+                  {t('apply-child:marital-status.confirm-checkbox')}
+                </InputCheckbox>
+              </>
+            )}
+          </div>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Marital status click">
+                {t('apply-child:marital-status.save-btn')}
+              </Button>
+              <LoadingButton id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Marital status click">
+                {t('apply-child:marital-status.cancel-btn')}
+              </LoadingButton>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.continue}
+                variant="primary"
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Marital status click"
+              >
+                {t('apply-child:marital-status.continue-btn')}
+              </LoadingButton>
+              <ButtonLink id="back-button" routeId={getBackButtonRouteId()} params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Back - Marital status click">
+                {t('apply-child:marital-status.back-btn')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -188,6 +188,7 @@ export const routes = [
           },
           { id: 'public/apply/$id/child/applicant-information', file: 'routes/public/apply/$id/child/applicant-information.tsx', paths: { en: '/:lang/apply/:id/child/applicant-information', fr: '/:lang/demander/:id/enfant/renseignements-demandeur' } },
           { id: 'public/apply/$id/child/new-or-existing-member', file: 'routes/public/apply/$id/child/new-or-existing-member.tsx', paths: { en: '/:lang/apply/:id/child/new-or-existing-member', fr: '/:lang/demander/:id/enfant/new-or-existing-member' } }, // TODO: Update French route
+          { id: 'public/apply/$id/child/marital-status', file: 'routes/public/apply/$id/child/marital-status.tsx', paths: { en: '/:lang/apply/:id/child/marital-status', fr: '/:lang/demander/:id/enfant/etat-civil' } },
           { id: 'public/apply/$id/child/phone-number', file: 'routes/public/apply/$id/child/phone-number.tsx', paths: { en: '/:lang/apply/:id/child/phone-number', fr: '/:lang/demander/:id/enfant/phone-number' } }, // TODO: Update French route
           {
             id: 'public/apply/$id/child/communication-preference',

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -35,6 +35,32 @@
       "last-name-no-digits": "Last name must contain letters only"
     }
   },
+  "marital-status": {
+    "page-title": "Marital status",
+    "marital-status": "What is your current marital status?",
+    "spouse-or-commonlaw": "Spouse or common-law partner information",
+    "provide-sin": "Provide information on your current spouse or common-law partner as indicated on their Social Insurance Number (SIN) card or letter.",
+    "required-information": "The information is required to calculate your adjusted family net income. Your spouse or common-law partner must submit their own application for the Canadian Dental Care Plan.",
+    "back-btn": "Back",
+    "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Social Insurance Number (SIN)",
+    "year-of-birth": "Year of birth",
+    "confirm-checkbox": "I confirm that my spouse or common-law partner is aware and has agreed to share their personal information.",
+    "help-message": {
+      "sin": "Enter the 9-digit SIN"
+    },
+    "error-message": {
+      "marital-status-required": "Select marital status",
+      "confirm-required": "Consent from spouse or common-law partner is required to proceed",
+      "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-future": "Year of birth must be in the past",
+      "sin-required": "Enter 9-digit SIN, for example 123 456 789",
+      "sin-valid": "Must be a valid SIN",
+      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+    }
+  },
   "new-or-existing-member": {
     "page-title": "New or existing member",
     "previously-enrolled": "Have you ever been enrolled in the Canadian Dental Care Plan?",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -35,6 +35,32 @@
       "last-name-no-digits": "Le nom de famille doit contenir uniquement des lettres"
     }
   },
+  "marital-status": {
+    "page-title": "État civil",
+    "marital-status": "Quel est votre état civil actuel?",
+    "spouse-or-commonlaw": "Renseignements sur l'époux/épouse ou le conjoint/la conjointe de fait",
+    "provide-sin": "Fournissez les renseignements sur votre époux/épouse ou conjoint/conjointe de fait actuel/actuelle tels qu'ils figurent sur sa carte ou sa lettre de numéro d'assurance sociale (NAS).",
+    "required-information": "Ces renseignements sont nécessaires pour calculer le revenu familial net rajusté. Votre époux/épouse ou conjoint/conjointe de fait doit présenter sa propre demande au Régime canadien de soins dentaires.",
+    "back-btn": "Retour",
+    "continue-btn": "Continuer",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "sin": "Numéro d'assurance sociale (NAS)",
+    "year-of-birth": "Année de naissance",
+    "confirm-checkbox": "Je confirme que mon époux/épouse ou conjoint/conjointe de fait est au courant de la communication de ses renseignements personnels et y a consenti.",
+    "help-message": {
+      "sin": "Entrez le NAS à 9 chiffres"
+    },
+    "error-message": {
+      "marital-status-required": "Sélectionnez l'état civil",
+      "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
+      "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-future": "L'année de naissance doit être dans le passé",
+      "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
+      "sin-valid": "Le NAS doit être valide",
+      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+    }
+  },
   "new-or-existing-member": {
     "page-title": "New or existing member",
     "previously-enrolled": "Avez-vous déjà été inscrit au Régime canadien de soins dentaires?",


### PR DESCRIPTION
### Description
In an attempt to clean up some `TODO`s involving the apply state object and redirects for the apply flow, we have to add the `/child/marital-status` route, which depends on the apply state object.

Continuation of #3304.

### Related Azure Boards Work Items
[AB#5248](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5248)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/72545e2c-6f3c-421d-be36-b0917d23b151)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`