### PR TITLE
AB#5264 -- Removing direct call to GC Notify in favour of call to Interop email notification endpoint

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -53,9 +53,6 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 # (optional; default: "")
 ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey
 
-# GC Notify email notifications URL
-# (optional; default: https://api.notification.canada.ca/v2/notifications/email)
-GC_NOTIFY_EMAIL_NOTIFICATIONS_URL=https://api.notification.canada.ca/v2/notifications/email
 # GC Notify API key
 # (required; use the example below)
 GC_NOTIFY_API_KEY=00000000000000000000000000000000

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -96,7 +96,6 @@ const serverEnv = clientEnvSchema.extend({
   AUTH_RASCL_LOGOUT_URL: z.string().trim().min(1),
 
   // GC Notify settings (@see https://documentation.notification.canada.ca/en/)
-  GC_NOTIFY_EMAIL_NOTIFICATIONS_URL: z.string().url().default('https://api.notification.canada.ca/v2/notifications/email'),
   GC_NOTIFY_API_KEY: z.string().trim().min(1),
   GC_NOTIFY_ENGLISH_TEMPLATE_ID: z.string().trim().min(1).default('8b77428b-56a5-415c-9b48-ef1f10c128e7'),
   GC_NOTIFY_FRENCH_TEMPLATE_ID: z.string().trim().min(1).default('2991903c-56f9-4c4e-af2e-db3ecf04b44c'),


### PR DESCRIPTION
### Description
As per title.

### Related Azure Boards Work Items
[AB#5264](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5264)

### Checklist
- [x] I have tested the changes locally