### PR TITLE
Adding unique SIN validation for renewal marital status pages

### DIFF
--- a/frontend/app/.server/resources/power-platform/client-application-ita.json
+++ b/frontend/app/.server/resources/power-platform/client-application-ita.json
@@ -61,7 +61,7 @@
         }
       ],
       "PersonSINIdentification": {
-        "IdentificationID": "999999999"
+        "IdentificationID": "800000408"
       },
       "MailingSameAsHomeIndicator": false,
       "PreferredMethodCommunicationCode": {

--- a/frontend/app/.server/resources/power-platform/client-application.json
+++ b/frontend/app/.server/resources/power-platform/client-application.json
@@ -91,7 +91,7 @@
         }
       ],
       "PersonSINIdentification": {
-        "IdentificationID": "999999999"
+        "IdentificationID": "800000408"
       },
       "MailingSameAsHomeIndicator": true,
       "PreferredMethodCommunicationCode": {
@@ -146,7 +146,7 @@
             "ReferenceDataName": "Dependant"
           },
           "PersonSINIdentification": {
-            "IdentificationID": "100000009"
+            "IdentificationID": "800000424"
           },
           "ApplicantDetail": {
             "PrivateDentalInsuranceIndicator": false,
@@ -189,7 +189,7 @@
             "ReferenceDataName": "Dependant"
           },
           "PersonSINIdentification": {
-            "IdentificationID": "100000010"
+            "IdentificationID": "800000648"
           },
           "ApplicantDetail": {
             "PrivateDentalInsuranceIndicator": false,
@@ -220,7 +220,7 @@
             "ReferenceDataName": "Spouse"
           },
           "PersonSINIdentification": {
-            "IdentificationID": "900000001"
+            "IdentificationID": "800000655"
           },
           "ApplicantDetail": {
             "ConsentToSharePersonalInformationIndicator": true

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -116,8 +116,18 @@ export async function action({ context: { appContainer, session }, params, reque
       .string()
       .trim()
       .min(1, t('protected-renew:marital-status.error-message.sin-required'))
-      .refine(isValidSin, t('protected-renew:marital-status.error-message.sin-valid'))
-      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('protected-renew:marital-status.error-message.sin-unique')),
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:marital-status.error-message.sin-valid') });
+        } else if (
+          [state.clientApplication.applicantInformation.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:marital-status.error-message.sin-unique') });
+        }
+      }),
   }) satisfies z.ZodType<PartnerInformationState>;
 
   const maritalStatusData = {

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -107,8 +107,18 @@ export async function action({ context: { appContainer, session }, params, reque
       .string()
       .trim()
       .min(1, t('renew-adult-child:marital-status.error-message.sin-required'))
-      .refine(isValidSin, t('renew-adult-child:marital-status.error-message.sin-valid'))
-      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-adult-child:marital-status.error-message.sin-unique')),
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:marital-status.error-message.sin-valid') });
+        } else if (
+          [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...(state.clientApplication?.children ? state.clientApplication.children.map((child) => child.information.socialInsuranceNumber) : [])]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult-child:marital-status.error-message.sin-unique') });
+        }
+      }),
   }) satisfies z.ZodType<PartnerInformationState>;
 
   const maritalStatusData = {

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -107,8 +107,18 @@ export async function action({ context: { appContainer, session }, params, reque
       .string()
       .trim()
       .min(1, t('renew-adult:marital-status.error-message.sin-required'))
-      .refine(isValidSin, t('renew-adult:marital-status.error-message.sin-valid'))
-      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-adult:marital-status.error-message.sin-unique')),
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:marital-status.error-message.sin-valid') });
+        } else if (
+          [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...(state.clientApplication?.children ? state.clientApplication.children.map((child) => child.information.socialInsuranceNumber) : [])]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-adult:marital-status.error-message.sin-unique') });
+        }
+      }),
   }) satisfies z.ZodType<PartnerInformationState>;
 
   const maritalStatusData = {

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -107,8 +107,18 @@ export async function action({ context: { appContainer, session }, params, reque
       .string()
       .trim()
       .min(1, t('renew-child:marital-status.error-message.sin-required'))
-      .refine(isValidSin, t('renew-child:marital-status.error-message.sin-valid'))
-      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-child:marital-status.error-message.sin-unique')),
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:marital-status.error-message.sin-valid') });
+        } else if (
+          [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...(state.clientApplication?.children ? state.clientApplication.children.map((child) => child.information.socialInsuranceNumber) : [])]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-child:marital-status.error-message.sin-unique') });
+        }
+      }),
   }) satisfies z.ZodType<PartnerInformationState>;
 
   const maritalStatusData = {

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -89,8 +89,18 @@ export async function action({ context: { appContainer, session }, params, reque
       .string()
       .trim()
       .min(1, t('renew-ita:marital-status.error-message.sin-required'))
-      .refine(isValidSin, t('renew-ita:marital-status.error-message.sin-valid'))
-      .refine((sin) => isValidSin(sin) && formatSin(sin, '') !== state.partnerInformation?.socialInsuranceNumber, t('renew-ita:marital-status.error-message.sin-unique')),
+      .superRefine((sin, ctx) => {
+        if (!isValidSin(sin)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:marital-status.error-message.sin-valid') });
+        } else if (
+          [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...(state.clientApplication?.children ? state.clientApplication.children.map((child) => child.information.socialInsuranceNumber) : [])]
+            .filter((sin) => sin !== undefined)
+            .map((sin) => formatSin(sin))
+            .includes(formatSin(sin))
+        ) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('renew-ita:marital-status.error-message.sin-unique') });
+        }
+      }),
   }) satisfies z.ZodType<PartnerInformationState>;
 
   const maritalStatusData = {

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -38,7 +38,7 @@
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "Invalid SIN. If you have confirmed that this is the correct SIN for your spouse or common-law partner and the issue continues, please call us at 1-833-537-4342."
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -38,7 +38,7 @@
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "Invalid SIN. If you have confirmed that this is the correct SIN for your spouse or common-law partner and the issue continues, please call us at 1-833-537-4342."
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -281,7 +281,7 @@
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "Invalid SIN. If you have confirmed that this is the correct SIN for your spouse or common-law partner and the issue continues, please call us at 1-833-537-4342."
     }
   },
   "confirm-address": {

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -22,7 +22,7 @@
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",
-      "sin-unique": "The Social Insurance Number (SIN) must be unique"
+      "sin-unique": "Invalid SIN. If you have confirmed that this is the correct SIN for your spouse or common-law partner and the issue continues, please call us at 1-833-537-4342."
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -38,7 +38,7 @@
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "NAS invalide. Si vous avez confirmé qu'il s'agit du bon NAS pour votre époux/épouse ou conjoint/conjointe de fait et que le problème persiste, veuillez nous appeler au 1-833-537-4342."
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -38,7 +38,7 @@
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "NAS invalide. Si vous avez confirmé qu'il s'agit du bon NAS pour votre époux/épouse ou conjoint/conjointe de fait et que le problème persiste, veuillez nous appeler au 1-833-537-4342."
     }
   },
   "confirm-phone": {

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -283,7 +283,7 @@
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "NAS invalide. Si vous avez confirmé qu'il s'agit du bon NAS pour votre époux/épouse ou conjoint/conjointe de fait et que le problème persiste, veuillez nous appeler au 1-833-537-4342."
     }
   },
   "confirm-address": {

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -22,7 +22,7 @@
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",
-      "sin-unique": "Le numéro d'assurance sociale (NAS) doit être unique"
+      "sin-unique": "NAS invalide. Si vous avez confirmé qu'il s'agit du bon NAS pour votre époux/épouse ou conjoint/conjointe de fait et que le problème persiste, veuillez nous appeler au 1-833-537-4342."
     }
   },
   "confirm-phone": {


### PR DESCRIPTION
### Description
During a renewal, if the Primary Applicant or a Dependent's SIN is entered into the Spouse/Common-Law Partner's SIN field, no validation is performed at that step. This allows the renewal applicant to proceed, but submission fails because Power Platform rejects duplicate SINs.

This PR adds validation to prevent the Primary Applicant's and Dependents' SIN from being reused in the Spouse’s SIN fields, ensuring the issue is caught earlier in the process.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/18970

### Screenshots (if applicable)
English:
![image](https://github.com/user-attachments/assets/6fe8be67-eef9-44bf-a768-95c083263047)

French:
![image](https://github.com/user-attachments/assets/5457eb8e-30da-49ba-9587-454a2f1bb187)

### Checklist
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
The use of a `<span className="whitespace-nowrap" />` is not applied around the phone number for the error messages because error messages are represented as plain strings (not React elements) in validation since they are determined on the server. Formatting (wrapping elements like `<span>`) is handled on the frontend where the UI is rendered. 