### PR TITLE
AB#5207 Add email page for adult flow

### DIFF
--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -52,6 +52,7 @@ export type ApplyState = ReadonlyDeep<{
     preferredMethod: string;
     preferredNotificationMethod: string;
   };
+  email?: string;
   hasFederalProvincialTerritorialBenefits?: boolean;
   maritalStatus?: string;
   dateOfBirth?: string; // TODO: once all pages are re-worked, this can be removed. (We will use applicantInformation.dateOfBirth)

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -55,6 +55,7 @@ export const pageIds = {
         livingIndependently: 'CDCP-APPL-AD-0018',
         newOrExistingMember: 'CDCP-APPL-AD-0019',
         phoneNumber: 'CDCP-APPL-AD-0020',
+        email: 'CDCP-APPL-AD-0021',
       },
       adultChild: {
         applicantInformation: 'CDCP-APPL-ADCH-0006',

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -133,7 +133,11 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
-  return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
+  if (parsedDataResult.data.preferredMethod !== COMMUNICATION_METHOD_EMAIL_ID && parsedDataResult.data.preferredNotificationMethod === 'mail') {
+    return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
+  }
+
+  return redirect(getPathById('public/apply/$id/adult/email', params));
 }
 
 export default function ApplyFlowCommunicationPreferencePage({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/email.tsx
@@ -1,0 +1,163 @@
+import { data, redirect, useFetcher } from 'react-router';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import type { Route } from './+types/email';
+
+import { TYPES } from '~/.server/constants';
+import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
+import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { LoadingButton } from '~/components/loading-button';
+import { Progress } from '~/components/progress';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
+  pageIdentifier: pageIds.public.apply.adult.email,
+  pageTitleI18nKey: 'apply-adult:email.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const state = loadApplyAdultState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:email.page-title') }) };
+
+  return {
+    id: state.id,
+    meta,
+    defaultState: state.email,
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadApplyAdultState({ params, request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const emailSchema = z
+    .object({
+      email: z
+        .string({ errorMap: () => ({ message: t('apply-adult:email.error-message.email-required') }) })
+        .trim()
+        .min(1)
+        .max(64),
+    })
+    .superRefine((val, ctx) => {
+      if (!validator.isEmail(val.email)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply-adult:email.error-message.email-valid'), path: ['email'] });
+      }
+    });
+
+  const parsedDataResult = emailSchema.safeParse({
+    email: formData.get('email') ? String(formData.get('email') ?? '') : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  saveApplyState({ params, session, state: { email: parsedDataResult.data.email } });
+
+  if (state.editMode) {
+    return redirect(getPathById('public/apply/$id/adult/review-information', params));
+  }
+
+  return redirect(getPathById('public/apply/$id/adult/verify-email', params));
+}
+
+export default function ApplyFlowPersonalInformation({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = loaderData;
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, { email: 'email' });
+
+  return (
+    <>
+      <div className="my-6 sm:my-8">
+        <Progress value={55} size="lg" label={t('apply:progress.label')} />
+      </div>
+      <div className="max-w-prose">
+        <errorSummary.ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <fieldset className="mb-6">
+            <p className="mb-4">{t('apply-adult:email.provide-email')}</p>
+            <p className="mb-8">{t('apply-adult:email.verify-email')}</p>
+            <p className="mb-4 italic">{t('apply:required-label')}</p>
+            <div className="grid items-end gap-6 md:grid-cols-2">
+              <InputField
+                id="email"
+                name="email"
+                type="email"
+                inputMode="email"
+                className="w-full"
+                autoComplete="email"
+                defaultValue={defaultState}
+                errorMessage={errors?.email}
+                label={t('apply-adult:email.email-legend')}
+                maxLength={64}
+                aria-describedby="adding-email"
+                required
+              />
+            </div>
+          </fieldset>
+          {editMode ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Email click">
+                {t('apply-adult:email.save-btn')}
+              </Button>
+              <ButtonLink id="back-button" routeId="public/apply/$id/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Email click">
+                {t('apply-adult:email.cancel-btn')}
+              </ButtonLink>
+            </div>
+          ) : (
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Email click">
+                {t('apply-adult:email.continue')}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                routeId="public/apply/$id/adult/communication-preference"
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Email click"
+              >
+                {t('apply-adult:email.back')}
+              </ButtonLink>
+            </div>
+          )}
+        </fetcher.Form>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -41,6 +41,7 @@ export const routes = [
           { id: 'public/apply/$id/adult/living-independently', file: 'routes/public/apply/$id/adult/living-independently.tsx', paths: { en: '/:lang/apply/:id/adult/living-independently', fr: '/:lang/demander/:id/adulte/vivre-maniere-independante' } },
           { id: 'public/apply/$id/adult/new-or-existing-member', file: 'routes/public/apply/$id/adult/new-or-existing-member.tsx', paths: { en: '/:lang/apply/:id/adult/new-or-existing-member', fr: '/:lang/demander/:id/adulte/new-or-existing-member' } }, // TODO: Update French route
           { id: 'public/apply/$id/adult/phone-number', file: 'routes/public/apply/$id/adult/phone-number.tsx', paths: { en: '/:lang/apply/:id/adult/phone-number', fr: '/:lang/demander/:id/adulte/phone-number' } }, // TODO: Update French route
+          { id: 'public/apply/$id/adult/email', file: 'routes/public/apply/$id/adult/email.tsx', paths: { en: '/:lang/apply/:id/adult/email', fr: '/:lang/demander/:id/adulte/adresse-courriel' } },
           { id: 'public/apply/$id/adult-child/children/index', file: 'routes/public/apply/$id/adult-child/children/index.tsx', paths: { en: '/:lang/apply/:id/adult-child/children', fr: '/:lang/demander/:id/adulte-enfant/enfants' } },
           { id: 'public/apply/$id/adult/marital-status', file: 'routes/public/apply/$id/adult/marital-status.tsx', paths: { en: '/:lang/apply/:id/adult/marital-status', fr: '/:lang/demander/:id/adulte/etat-civil' } },
           {

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -89,6 +89,20 @@
       "preferred-notification-method-required": "Select preferred notification method"
     }
   },
+  "email": {
+    "page-title": "Email",
+    "provide-email": "Provide the email address you'd like the Government of Canada and/or Sun Life to use to contact you about your Canadian Dental Care Plan coverage.",
+    "verify-email": "We will need to verify your email address.",
+    "email-legend": "Email address",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "email-required": "Enter email address",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com"
+    }
+  },
   "confirm": {
     "page-title": "Application successfully submitted",
     "app-code-is": "Your application code is:",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -89,6 +89,20 @@
       "preferred-notification-method-required": "(FR) Select preferred notification method"
     }
   },
+  "email": {
+    "page-title": "Adresse courriel",
+    "provide-email": "Fournissez l'adresse courriel que vous souhaitez que le gouvernement du Canada ou la Sun Life utilise pour communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires.",
+    "verify-email": "Nous devons vérifier votre adresse courriel.",
+    "email-legend": "Adresse courriel",
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "email-required": "Entrez l'adresse courriel",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com"
+    }
+  },
   "confirm": {
     "page-title": "Demande soumise avec succès",
     "app-code-is": "Votre code de demande est\u00a0:",


### PR DESCRIPTION
### Description
Add email page for adult flow.
Update communication-preference: check user input. If both preferredMethod and preferredNotificationMethod value is `mail`, skip `email` and `verify-email` page, go to `dental-insurance` page

### Related Azure Boards Work Items
[AB#5207](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5207)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->