### PR TITLE
Refactoring state to include dateOfBirth field within applicantInformation

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -46,14 +46,8 @@ describe('apply-adult-child-route-helpers', () => {
       expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/file-taxes, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
-    it('should redirect if dateOfBirth is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: undefined } satisfies ApplyState;
-
-      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult-child/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
-    });
-
     it('should redirect if age category is "children"', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: '2022-01-01' } satisfies ApplyState;
+      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2022-01-01', socialInsuranceNumber: '000-000-001' } } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('children');
 
@@ -61,7 +55,7 @@ describe('apply-adult-child-route-helpers', () => {
     });
 
     it('should redirect if age category is "youth"', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: '2008-01-01' } satisfies ApplyState;
+      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2008-01-01', socialInsuranceNumber: '000-000-001' } } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('youth');
 
@@ -69,23 +63,15 @@ describe('apply-adult-child-route-helpers', () => {
     });
 
     it('should redirect if age category is "adult" and disabilityTaxCredit is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: '1985-01-10' } satisfies ApplyState;
+      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1985-01-10', socialInsuranceNumber: '000-000-001' } } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('adults');
 
       expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult-child/disability-tax-credit, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
-    it('should redirect if age category is "adult" and disabilityTaxCredit is false ', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: '1985-01-10', disabilityTaxCredit: false } satisfies ApplyState;
-
-      vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('adults');
-
-      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult-child/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
-    });
-
     it('should redirect if applicantInformation is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, dateOfBirth: '1900-01-01', applicantInformation: undefined } satisfies ApplyState;
+      const mockState = { ...baseState, typeOfApplication: 'adult-child', taxFiling2023: true, applicantInformation: undefined } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
 
@@ -97,9 +83,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
       } satisfies ApplyState;
@@ -115,9 +99,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -135,9 +117,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -156,9 +136,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -180,9 +158,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -204,9 +180,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -230,9 +204,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -256,9 +228,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -283,9 +253,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -310,8 +278,7 @@ describe('apply-adult-child-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult-child',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         applicationYear: { intakeYearId: '2025', taxYear: '2025' },
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
@@ -340,7 +307,7 @@ describe('apply-adult-child-route-helpers', () => {
       expect(act).toEqual({
         ageCategory: 'seniors',
 
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         applicationYear: { intakeYearId: '2025', taxYear: '2025' },
         children: [
           {
@@ -353,7 +320,6 @@ describe('apply-adult-child-route-helpers', () => {
           },
         ],
         communicationPreferences: { preferredLanguage: 'en', preferredMethod: 'email', preferredNotificationMethod: 'mail' },
-        dateOfBirth: '1900-01-01',
         maritalStatus: '1',
         hasFederalProvincialTerritorialBenefits: false,
         dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -46,14 +46,14 @@ describe('apply-adult-route-helpers', () => {
       expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/file-taxes, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
-    it('should redirect if dateOfBirth is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: undefined } satisfies ApplyState;
-
-      expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
-    });
-
     it('should redirect if age category is "children"', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: '2020-01-01' } satisfies ApplyState;
+      const mockState = {
+        ...baseState,
+        typeOfApplication: 'adult',
+        editMode: false,
+        taxFiling2023: true,
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2020-01-01', socialInsuranceNumber: '000-000-001' },
+      } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('children');
 
@@ -61,7 +61,14 @@ describe('apply-adult-route-helpers', () => {
     });
 
     it('should redirect if age category is "youth" and livingIndependently is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: '2008-01-01', livingIndependently: undefined } satisfies ApplyState;
+      const mockState = {
+        ...baseState,
+        typeOfApplication: 'adult',
+        editMode: false,
+        taxFiling2023: true,
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2008-01-01', socialInsuranceNumber: '000-000-001' },
+        livingIndependently: undefined,
+      } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('youth');
 
@@ -69,7 +76,14 @@ describe('apply-adult-route-helpers', () => {
     });
 
     it('should redirect if age category is "youth" and livingIndependently is false', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: '2008-01-01', livingIndependently: false } satisfies ApplyState;
+      const mockState = {
+        ...baseState,
+        typeOfApplication: 'adult',
+        editMode: false,
+        taxFiling2023: true,
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2008-01-01', socialInsuranceNumber: '000-000-001' },
+        livingIndependently: false,
+      } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('youth');
 
@@ -77,7 +91,14 @@ describe('apply-adult-route-helpers', () => {
     });
 
     it('should redirect if age category is "adult" and disabilityTaxCredit is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: '1985-01-10', disabilityTaxCredit: undefined } satisfies ApplyState;
+      const mockState = {
+        ...baseState,
+        typeOfApplication: 'adult',
+        editMode: false,
+        taxFiling2023: true,
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1985-01-10', socialInsuranceNumber: '000-000-001' },
+        disabilityTaxCredit: undefined,
+      } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('adults');
 
@@ -85,7 +106,7 @@ describe('apply-adult-route-helpers', () => {
     });
 
     it('should redirect if applicantInformation is undefined', () => {
-      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, dateOfBirth: '1900-01-01', applicantInformation: undefined } satisfies ApplyState;
+      const mockState = { ...baseState, typeOfApplication: 'adult', editMode: false, taxFiling2023: true, applicantInformation: undefined } satisfies ApplyState;
 
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
 
@@ -98,8 +119,7 @@ describe('apply-adult-route-helpers', () => {
         typeOfApplication: 'adult',
         editMode: false,
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '99',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
       } satisfies ApplyState;
@@ -116,8 +136,7 @@ describe('apply-adult-route-helpers', () => {
         typeOfApplication: 'adult',
         editMode: false,
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -136,8 +155,7 @@ describe('apply-adult-route-helpers', () => {
         typeOfApplication: 'adult',
         editMode: false,
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -157,8 +175,7 @@ describe('apply-adult-route-helpers', () => {
         typeOfApplication: 'adult',
         editMode: false,
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -178,8 +195,7 @@ describe('apply-adult-route-helpers', () => {
         ...baseState,
         typeOfApplication: 'adult',
         taxFiling2023: true,
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -196,10 +212,9 @@ describe('apply-adult-route-helpers', () => {
 
       expect(act).toEqual({
         ageCategory: 'seniors',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         applicationYear: { intakeYearId: '2025', taxYear: '2025' },
         communicationPreferences: { preferredLanguage: 'en', preferredMethod: 'email', preferredNotificationMethod: 'mail' },
-        dateOfBirth: '1900-01-01',
         maritalStatus: '1',
         hasFederalProvincialTerritorialBenefits: false,
         dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -118,26 +118,6 @@ describe('apply-child-route-helpers', () => {
       );
     });
 
-    it('should redirect if dateOfBirth is undefined', () => {
-      const mockState = {
-        ...baseState,
-        typeOfApplication: 'child',
-        taxFiling2023: true,
-        children: [
-          {
-            id: '1',
-            information: { dateOfBirth: '2012-02-23', firstName: 'John', hasSocialInsuranceNumber: false, isParent: true, lastName: 'Doe' },
-            dentalInsurance: true,
-            hasFederalProvincialTerritorialBenefits: false,
-            dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
-          },
-        ],
-        dateOfBirth: undefined,
-      } satisfies ApplyState;
-
-      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
-    });
-
     it('should redirect if applicantInformation is undefined', () => {
       const mockState = {
         ...baseState,
@@ -152,7 +132,6 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '1900-01-01',
         applicantInformation: undefined,
       } satisfies ApplyState;
 
@@ -173,8 +152,7 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '2022-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '2022-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
       } satisfies ApplyState;
 
@@ -198,8 +176,7 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '99',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
       } satisfies ApplyState;
@@ -225,8 +202,7 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: undefined,
@@ -253,8 +229,7 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
         contactInformation: { copyMailingAddress: true, mailingAddress: '123 rue Peuplier', mailingCity: 'City', mailingCountry: 'Country' },
@@ -282,8 +257,7 @@ describe('apply-child-route-helpers', () => {
             dentalBenefits: { hasFederalBenefits: false, hasProvincialTerritorialBenefits: false },
           },
         ],
-        dateOfBirth: '1900-01-01',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
         applicationYear: { intakeYearId: '2025', taxYear: '2025' },
         partnerInformation: { confirm: true, dateOfBirth: '1900-01-01', firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-002' },
@@ -299,7 +273,7 @@ describe('apply-child-route-helpers', () => {
 
       expect(act).toEqual({
         ageCategory: 'seniors',
-        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', socialInsuranceNumber: '000-000-001' },
+        applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         applicationYear: { intakeYearId: '2025', taxYear: '2025' },
         children: [
           {
@@ -312,7 +286,6 @@ describe('apply-child-route-helpers', () => {
           },
         ],
         communicationPreferences: { preferredLanguage: 'en', preferredMethod: 'email', preferredNotificationMethod: 'mail' },
-        dateOfBirth: '1900-01-01',
         maritalStatus: '1',
         editMode: false,
         id: '00000000-0000-0000-0000-000000000000',

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -120,7 +120,6 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     applicantInformation,
     applicationYear,
     communicationPreferences,
-    dateOfBirth,
     maritalStatus,
     hasFederalProvincialTerritorialBenefits,
     dentalBenefits,
@@ -157,11 +156,11 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/apply/$id/file-taxes', params));
   }
 
-  if (dateOfBirth === undefined) {
+  if (applicantInformation === undefined) {
     throw redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
   }
 
-  const ageCategory = getAgeCategoryFromDateString(dateOfBirth);
+  const ageCategory = getAgeCategoryFromDateString(applicantInformation.dateOfBirth);
 
   if (ageCategory === 'children') {
     throw redirect(getPathById('public/apply/$id/adult-child/parent-or-guardian', params));
@@ -173,10 +172,6 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
 
   if (ageCategory === 'adults' && disabilityTaxCredit === undefined) {
     throw redirect(getPathById('public/apply/$id/adult-child/disability-tax-credit', params));
-  }
-
-  if (applicantInformation === undefined) {
-    throw redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
   }
 
   if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
@@ -213,7 +208,6 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     children,
     communicationPreferences,
     contactInformation,
-    dateOfBirth,
     maritalStatus,
     hasFederalProvincialTerritorialBenefits,
     dentalBenefits,

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -81,7 +81,6 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     applicantInformation,
     applicationYear,
     communicationPreferences,
-    dateOfBirth,
     maritalStatus,
     hasFederalProvincialTerritorialBenefits,
     dentalBenefits,
@@ -119,11 +118,11 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     throw redirect(getPathById('public/apply/$id/file-taxes', params));
   }
 
-  if (dateOfBirth === undefined) {
+  if (applicantInformation === undefined) {
     throw redirect(getPathById('public/apply/$id/adult/applicant-information', params));
   }
 
-  const ageCategory = getAgeCategoryFromDateString(dateOfBirth);
+  const ageCategory = getAgeCategoryFromDateString(applicantInformation.dateOfBirth);
 
   if (ageCategory === 'children') {
     throw redirect(getPathById('public/apply/$id/adult/parent-or-guardian', params));
@@ -139,10 +138,6 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
 
   if (ageCategory === 'adults' && disabilityTaxCredit === undefined) {
     throw redirect(getPathById('public/apply/$id/adult/disability-tax-credit', params));
-  }
-
-  if (applicantInformation === undefined) {
-    throw redirect(getPathById('public/apply/$id/adult/applicant-information', params));
   }
 
   if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
@@ -176,7 +171,6 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     applicationYear,
     communicationPreferences,
     contactInformation,
-    dateOfBirth,
     maritalStatus,
     hasFederalProvincialTerritorialBenefits,
     dentalBenefits,

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -116,7 +116,7 @@ interface ValidateStateForReviewArgs {
 }
 
 export function validateApplyChildStateForReview({ params, state }: ValidateStateForReviewArgs) {
-  const { applicantInformation, applicationYear, communicationPreferences, dateOfBirth, maritalStatus, editMode, id, lastUpdatedOn, partnerInformation, contactInformation, submissionInfo, taxFiling2023, typeOfApplication } = state;
+  const { applicantInformation, applicationYear, communicationPreferences, maritalStatus, editMode, id, lastUpdatedOn, partnerInformation, contactInformation, submissionInfo, taxFiling2023, typeOfApplication } = state;
 
   if (typeOfApplication === undefined) {
     throw redirect(getPathById('public/apply/$id/type-application', params));
@@ -140,11 +140,11 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
 
   const children = validateChildrenStateForReview({ childrenState: state.children, params });
 
-  if (applicantInformation === undefined || dateOfBirth === undefined) {
+  if (applicantInformation === undefined) {
     throw redirect(getPathById('public/apply/$id/child/applicant-information', params));
   }
 
-  const ageCategory = getAgeCategoryFromDateString(dateOfBirth);
+  const ageCategory = getAgeCategoryFromDateString(applicantInformation.dateOfBirth);
 
   if (ageCategory === 'children') {
     throw redirect(getPathById('public/apply/$id/child/contact-apply-child', params));
@@ -166,7 +166,7 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
     throw redirect(getPathById('public/apply/$id/child/communication-preference', params));
   }
 
-  return { ageCategory, applicantInformation, applicationYear, children, communicationPreferences, contactInformation, dateOfBirth, maritalStatus, editMode, id, lastUpdatedOn, partnerInformation, submissionInfo, taxFiling2023, typeOfApplication };
+  return { ageCategory, applicantInformation, applicationYear, children, communicationPreferences, contactInformation, maritalStatus, editMode, id, lastUpdatedOn, partnerInformation, submissionInfo, taxFiling2023, typeOfApplication };
 }
 
 interface ValidateChildrenStateForReviewArgs {

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -20,6 +20,7 @@ export type ApplyState = ReadonlyDeep<{
   applicantInformation?: {
     firstName: string;
     lastName: string;
+    dateOfBirth: string;
     socialInsuranceNumber: string;
   };
   applicationYear: {
@@ -55,7 +56,6 @@ export type ApplyState = ReadonlyDeep<{
   email?: string;
   hasFederalProvincialTerritorialBenefits?: boolean;
   maritalStatus?: string;
-  dateOfBirth?: string; // TODO: once all pages are re-worked, this can be removed. (We will use applicantInformation.dateOfBirth)
   dentalBenefits?: {
     hasFederalBenefits: boolean;
     federalSocialProgram?: string;

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -21,7 +21,6 @@ export interface ApplyAdultState {
   applicationYear: ApplicationYearState;
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
-  dateOfBirth: string;
   maritalStatus?: string;
   dentalBenefits: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
@@ -37,7 +36,6 @@ export interface ApplyAdultChildState {
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
-  dateOfBirth: string;
   maritalStatus?: string;
   dentalBenefits: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
@@ -53,7 +51,6 @@ export interface ApplyChildState {
   children: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
-  dateOfBirth: string;
   maritalStatus?: string;
   disabilityTaxCredit?: boolean;
   livingIndependently?: boolean;
@@ -67,7 +64,6 @@ interface ToBenefitApplicationDtoArgs {
   children?: Required<ChildState>[];
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
-  dateOfBirth: string;
   maritalStatus?: string;
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance?: boolean;
@@ -93,7 +89,7 @@ export interface BenefitApplicationStateMapper {
 @injectable()
 export class DefaultBenefitApplicationStateMapper implements BenefitApplicationStateMapper {
   mapApplyAdultStateToBenefitApplicationDto(applyAdultState: ApplyAdultState): BenefitApplicationDto {
-    const ageCategory = getAgeCategoryFromDateString(applyAdultState.dateOfBirth);
+    const ageCategory = getAgeCategoryFromDateString(applyAdultState.applicantInformation.dateOfBirth);
     if (ageCategory === 'adults' && applyAdultState.disabilityTaxCredit === undefined) {
       throw Error('Expected disabilityTaxCredit to be defined');
     }
@@ -110,7 +106,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
   }
 
   mapApplyAdultChildStateToBenefitApplicationDto(applyAdultChildState: ApplyAdultChildState): BenefitApplicationDto {
-    const ageCategory = getAgeCategoryFromDateString(applyAdultChildState.dateOfBirth);
+    const ageCategory = getAgeCategoryFromDateString(applyAdultChildState.applicantInformation.dateOfBirth);
     if (ageCategory === 'adults' && applyAdultChildState.disabilityTaxCredit === undefined) {
       throw Error('Expected disabilityTaxCredit to be defined');
     }
@@ -135,7 +131,6 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     applicationYear,
     children,
     communicationPreferences,
-    dateOfBirth,
     maritalStatus,
     dentalBenefits,
     dentalInsurance,
@@ -154,7 +149,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       children: this.toChildren(children),
       communicationPreferences,
       contactInformation: this.toContactInformation(contactInformation),
-      dateOfBirth,
+      dateOfBirth: applicantInformation.dateOfBirth,
       maritalStatus,
       dentalBenefits: this.toDentalBenefits(dentalBenefits),
       dentalInsurance,

--- a/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/apply-yourself.tsx
@@ -47,7 +47,7 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
 
   const state = loadApplyAdultChildState({ params, request, session });
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
   saveApplyState({ params, session, state: { editMode: false, typeOfApplication: 'adult' } });
 
   return redirect(getPathById('public/apply/$id/adult/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -46,7 +46,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   // prettier-ignore
   if (state.applicantInformation === undefined ||
     state.communicationPreferences === undefined ||
-    state.dateOfBirth === undefined ||
     state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
     state.contactInformation?.homeCountry === undefined ||
@@ -77,7 +76,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
     preferredLanguage: preferredLanguage.name,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     martialStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,

--- a/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/contact-apply-child.tsx
@@ -39,8 +39,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:contact-apply-child.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children') {
     return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/disability-tax-credit.tsx
@@ -47,8 +47,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:disability-tax-credit.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'adults') {
     return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
@@ -82,8 +82,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.yes } });
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -38,8 +38,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:parent-or-guardian.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children' && ageCategory !== 'youth') {
     return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -73,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -46,7 +46,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   // prettier-ignore
   if (state.applicantInformation === undefined ||
     state.communicationPreferences === undefined ||
-    state.dateOfBirth === undefined ||
     state.dentalBenefits === undefined ||
     state.dentalInsurance === undefined ||
     state.contactInformation?.homeCountry === undefined ||
@@ -78,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
     preferredLanguage: preferredLanguage.name,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     martialStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,

--- a/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/disability-tax-credit.tsx
@@ -47,8 +47,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:disability-tax-credit.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'adults') {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
@@ -82,8 +82,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { disabilityTaxCredit: parsedDataResult.data.disabilityTaxCredit === DISABILITY_TAX_CREDIT_OPTION.yes } });
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -38,8 +38,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:parent-or-guardian.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children' && ageCategory !== 'youth') {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -76,7 +76,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -46,7 +46,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   // prettier-ignore
   if (state.applicantInformation === undefined ||
     state.communicationPreferences === undefined ||
-    state.dateOfBirth === undefined ||
     state.contactInformation?.homeCountry === undefined ||
     state.submissionInfo === undefined ||
     state.taxFiling2023 === undefined ||
@@ -69,7 +68,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
     preferredLanguage: preferredLanguage.name,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     martialStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -39,8 +39,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:contact-apply-child.page-title') }) };
 
-  invariant(state.dateOfBirth, 'Expected state.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.dateOfBirth);
+  invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
+  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children') {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -75,7 +75,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.contactInformation.phoneNumber,
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
-    birthday: toLocaleDateString(parseDateString(state.dateOfBirth), locale),
+    birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: maritalStatus,
     contactInformationEmail: state.contactInformation.email,


### PR DESCRIPTION
### Description
This PR removes lingering `TODO`s in the `/applicant-information` routes across all flows by moving the `dateOfBirth` field into the `applicantInformation` state object. This change simplifies the `/applicant-information` routes, as they will now store data in a dedicated `applicantInformation` object in state, rather than spreading it across multiple state fields.  This update aligns with the existing conventions in the application.

Sorry for the large PR as refactoring the state touches many depending files, including the state mapper to map the state to the DTO.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`