### PR TITLE
Add additional check for undefined marital status to proceed to ITA flow

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -423,3 +423,7 @@ export function validateProtectedChildrenStateForReview(childrenState: Protected
       };
     });
 }
+
+export function isInvitationToApplyClient(clientApplication: ProtectedClientApplicationState) {
+  return clientApplication.isInvitationToApplyClient || clientApplication.applicantInformation.maritalStatus === undefined;
+}

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { Route } from './+types/confirm-address';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+  if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
     throw new Response('Not Found', { status: 404 });
   }
 

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import type { Route } from './+types/confirm-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import type { ProtectedDentalFederalBenefitsState, ProtectedDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, request, session });
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+  if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
     throw new Response('Not Found', { status: 404 });
   }
 
@@ -92,7 +92,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     }
   }, {}) as ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
 
-  const dentalBenefits = state.clientApplication.isInvitationToApplyClient ? state.dentalBenefits : clientDentalBenefits;
+  const dentalBenefits = isInvitationToApplyClient(state.clientApplication) ? state.dentalBenefits : clientDentalBenefits;
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import type { Route } from './+types/confirm-home-address';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Address } from '~/components/address';
@@ -81,7 +81,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, request, session });
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+  if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
     throw new Response('Not Found', { status: 404 });
   }
 
@@ -148,7 +148,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToReview) {
     saveProtectedRenewState({ params, request, session, state: { homeAddress } });
-    if (state.editMode === false && state.clientApplication.isInvitationToApplyClient) {
+    if (state.editMode === false && isInvitationToApplyClient(state.clientApplication)) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
@@ -210,7 +210,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-home-address', { userId: idToken.sub });
 
-  if (state.editMode === false && state.clientApplication.isInvitationToApplyClient) {
+  if (state.editMode === false && isInvitationToApplyClient(state.clientApplication)) {
     return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
   }
 

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import type { Route } from './+types/confirm-marital-status';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, renewStateHasPartner, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, renewStateHasPartner, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import type { PartnerInformationState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const state = loadProtectedRenewState({ params, request, session });
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+  if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
     throw new Response('Not Found', { status: 404 });
   }
 
@@ -77,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     defaultState: {
-      maritalStatus: state.maritalStatus ?? (state.clientApplication.isInvitationToApplyClient ? undefined : state.clientApplication.applicantInformation.maritalStatus),
+      maritalStatus: state.maritalStatus ?? (isInvitationToApplyClient(state.clientApplication) ? undefined : state.clientApplication.applicantInformation.maritalStatus),
       partnerInformation,
     },
     maritalStatuses,

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -73,7 +73,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
-    if (state.clientApplication.isInvitationToApplyClient) {
+    if (isInvitationToApplyClient(state.clientApplication)) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
     return redirect(getPathById('protected/renew/$id/member-selection', params));
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       dentalInsurance: parsedDataResult.data.dentalInsurance,
-      previouslyReviewed: state.editMode === false && (state.clientApplication.isInvitationToApplyClient || demographicSurveyEnabled) ? undefined : true,
+      previouslyReviewed: state.editMode === false && (isInvitationToApplyClient(state.clientApplication) || demographicSurveyEnabled) ? undefined : true,
     },
   });
 
@@ -109,7 +109,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 
-  if (state.clientApplication.isInvitationToApplyClient) {
+  if (isInvitationToApplyClient(state.clientApplication)) {
     return redirect(getPathById('protected/renew/$id/confirm-federal-provincial-territorial-benefits', params));
   }
 

--- a/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import type { Route } from './+types/confirm-email';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isInvitationToApplyClient, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button } from '~/components/buttons';
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  if (!state.clientApplication.isInvitationToApplyClient && !state.editMode) {
+  if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
     throw new Response('Not Found', { status: 404 });
   }
 

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/member-selection';
 
 import { TYPES } from '~/.server/constants';
-import { isChildrenStateComplete, isPrimaryApplicantStateComplete, loadProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { isChildrenStateComplete, isInvitationToApplyClient, isPrimaryApplicantStateComplete, loadProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import type { AppLinkProps } from '~/components/app-link';
@@ -62,7 +62,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       : [{ id: state.id, applicantName: `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}`, previouslyReviewed: state.previouslyReviewed, typeOfApplicant: 'primary' }]
   ).concat(state.children.map((child) => ({ id: child.id, applicantName: `${child.information?.firstName} ${child.information?.lastName}`, previouslyReviewed: child.previouslyReviewed, typeOfApplicant: 'child' })));
 
-  return { meta, members, isItaCandidate: state.clientApplication.isInvitationToApplyClient };
+  return { meta, members, isItaCandidate: isInvitationToApplyClient(state.clientApplication) };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -10,6 +10,7 @@ import type { Route } from './+types/review-adult-information';
 import { TYPES } from '~/.server/constants';
 import {
   clearProtectedRenewState,
+  isInvitationToApplyClient,
   isPrimaryApplicantStateComplete,
   loadProtectedRenewState,
   loadProtectedRenewStateForReview,
@@ -117,7 +118,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     communicationPreference: communicationPreference.name,
     preferredLanguage: preferredLanguage,
     clientApplicationEmail: state.clientApplication.communicationPreferences.email,
-    isItaClient: state.clientApplication.isInvitationToApplyClient,
+    isItaClient: isInvitationToApplyClient(state.clientApplication),
   };
 
   const hasPartner = renewStateHasPartner(state.maritalStatus ?? state.clientApplication.applicantInformation.maritalStatus);

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -2,6 +2,7 @@ import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
+import invariant from 'tiny-invariant';
 import { z } from 'zod';
 
 import type { Route } from './+types/type-renewal';
@@ -83,15 +84,18 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
+  invariant(state.clientApplication, 'Expected state.clientApplication to be defined');
+  const isInvitationToApplyClient = state.clientApplication.isInvitationToApplyClient || state.clientApplication.applicantInformation.maritalStatus === undefined;
+
   if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.adult) {
-    if (state.clientApplication?.isInvitationToApplyClient) {
+    if (isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
     return redirect(getPathById('public/renew/$id/adult/confirm-marital-status', params));
   }
 
   if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.adultChild) {
-    if (state.clientApplication?.isInvitationToApplyClient) {
+    if (isInvitationToApplyClient) {
       return redirect(getPathById('public/renew/$id/ita/marital-status', params));
     }
     return redirect(getPathById('public/renew/$id/adult-child/confirm-marital-status', params));


### PR DESCRIPTION
### Description
Applicants are receiving an error when renewing without an existing marital status, causing the call to Interop/Power Platform to fail. This PR adds an additional marital status check so that applicants without a marital status on file would proceed to the ITA flow.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/19068

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Assuming mocks are enabled, change the `client-application.json` so that the client has no marital status. Proceed through the public/protected renewal flows. You should enter the ITA flow.