### PR TITLE
Refactoring all redirects in adult workflow.

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -151,10 +151,6 @@ export async function action({ context: { appContainer, session }, params, reque
         dateOfBirth: parsedDataResult.data.dateOfBirth,
         socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
       },
-      ...(parsedDataResult.data.dateOfBirthYear < 2006 && {
-        // Handle marital-status back button
-        newOrExistingMember: undefined,
-      }),
     },
   });
 
@@ -174,7 +170,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
-  return redirect(getPathById('public/apply/$id/adult/contact-information', params));
+  return redirect(getPathById('public/apply/$id/adult/marital-status', params));
 }
 
 export default function ApplyFlowApplicationInformation({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -151,6 +151,10 @@ export async function action({ context: { appContainer, session }, params, reque
         dateOfBirth: parsedDataResult.data.dateOfBirth,
         socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
       },
+      ...(parsedDataResult.data.dateOfBirthYear < 2006 && {
+        // Handle marital-status back button
+        newOrExistingMember: undefined,
+      }),
     },
   });
 

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -286,7 +286,7 @@ export default function ApplyFlowCommunicationPreferencePage({ loaderData, param
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId="public/apply/$id/adult/contact-information"
+                routeId="public/apply/$id/adult/phone-number"
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/email.tsx
@@ -81,13 +81,13 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({ params, session, state: { email: parsedDataResult.data.email } });
+  saveApplyState({ params, session, state: { email: parsedDataResult.data.email } }); // TODO: Which state 'email' do we want to use? (There are 3 different at the time of writing this.)
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
-  return redirect(getPathById('public/apply/$id/adult/verify-email', params));
+  return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
 }
 
 export default function ApplyFlowPersonalInformation({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/email.tsx
@@ -87,7 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
-  return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
+  return redirect(getPathById('public/apply/$id/adult/verify-email', params));
 }
 
 export default function ApplyFlowPersonalInformation({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -120,9 +120,9 @@ export async function action({ context: { appContainer, session }, params, reque
     saveApplyState({ params, session, state: { homeAddress } });
 
     if (state.editMode) {
-      return redirect(getPathById('public/apply/$id/adult/review-adult-information', params));
+      return redirect(getPathById('public/apply/$id/adult/review-information', params));
     }
-    return redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
+    return redirect(getPathById('public/apply/$id/adult/phone-number', params));
   }
 
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
@@ -173,7 +173,7 @@ export async function action({ context: { appContainer, session }, params, reque
   saveApplyState({ params, session, state: { homeAddress } });
 
   if (state.editMode) {
-    return redirect(getPathById('public/apply/$id/adult/review-adult-information', params));
+    return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
   return redirect(getPathById('public/apply/$id/adult/phone-number', params));
 }

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -133,7 +133,7 @@ export async function action({ context: { appContainer, session }, params, reque
       return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult/review-information', params) : getPathById('public/apply/$id/adult/home-address', params));
     }
 
-    return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult/dental-insurance', params) : getPathById('public/apply/$id/adult/home-address', params));
+    return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult/phone-number', params) : getPathById('public/apply/$id/adult/home-address', params));
   }
 
   // Validate Canadian adddress

--- a/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
-import { applicantInformationStateHasPartner, getAgeCategoryFromDateString, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { applicantInformationStateHasPartner, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -59,12 +59,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   // Handle back button redirect
   invariant(state.applicantInformation?.dateOfBirth, 'Expected applicantInformation.dateOfBirth to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
   const yearOfBirth = extractDateParts(state.applicantInformation.dateOfBirth).year;
-  const isYouthOrNewUser = ageCategory === 'youth' || Number(yearOfBirth) >= 2006;
+  const isNewUser = Number(yearOfBirth) >= 2006;
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:marital-status.page-title') }) };
-  return { isYouthOrNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -146,7 +145,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplyAdultMaritalStatus({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { isYouthOrNewUser, defaultState, editMode, maritalStatuses } = loaderData;
+  const { isNewUser, defaultState, editMode, maritalStatuses } = loaderData;
   const { MARITAL_STATUS_CODE_COMMONLAW, MARITAL_STATUS_CODE_MARRIED } = useClientEnv();
 
   const fetcher = useFetcher<typeof action>();
@@ -231,7 +230,7 @@ export default function ApplyAdultMaritalStatus({ loaderData, params }: Route.Co
               </LoadingButton>
               <ButtonLink
                 id="back-button"
-                routeId={isYouthOrNewUser ? 'public/apply/$id/adult/new-or-existing-member' : 'public/apply/$id/adult/applicant-information'}
+                routeId={isNewUser ? 'public/apply/$id/adult/new-or-existing-member' : 'public/apply/$id/adult/applicant-information'}
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -118,7 +118,6 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, { newOrExistingMember: 'input-radio-new-or-existing-member-option-0', clientNumber: 'client-number' });
   const [isNewOrExistingMember, setIsNewOrExistingMember] = useState(defaultState?.isNewOrExistingMember);
-  // const ageCategory = getAgeCategoryFromDateString(userAge);
 
   const handleNewOrExistingMemberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
     setIsNewOrExistingMember(e.target.value === NEW_OR_EXISTING_MEMBER_OPTION.yes);

--- a/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
@@ -8,6 +8,7 @@ import type { Route } from './+types/phone-number';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
+import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { phoneSchema } from '~/.server/validation/phone-schema';
@@ -50,6 +51,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,
       phoneNumberAlt: state.contactInformation?.phoneNumberAlt,
+      backToMailingAddress: state.isHomeAddressSameAsMailingAddress,
     },
     editMode: state.editMode,
   };
@@ -84,8 +86,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  // TODO: Uncomment when address routes are available
-  // saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+  saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
@@ -159,7 +160,7 @@ export default function ApplyFlowPhoneNumber({ loaderData, params }: Route.Compo
             </LoadingButton>
             <ButtonLink
               id="back-button"
-              routeId="public/apply/$id/adult/applicant-information" //TODO: refactor route id when address routes are available
+              routeId={defaultState.backToMailingAddress ? 'public/apply/$id/adult/mailing-address' : 'public/apply/$id/adult/home-address'}
               params={params}
               disabled={isSubmitting}
               startIcon={faChevronLeft}

--- a/frontend/app/routes/public/apply/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/tax-filing.tsx
@@ -99,7 +99,7 @@ export default function ApplyFlowTaxFiling({ loaderData, params }: Route.Compone
             <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Continue - Tax filing click">
               {t('apply:tax-filing.continue-btn')}
             </LoadingButton>
-            <ButtonLink id="back-button" routeId="public/apply/$id/type-application" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Tax filing click">
+            <ButtonLink id="back-button" routeId="public/apply/$id/terms-and-conditions" params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form:Back - Tax filing click">
               {t('apply:tax-filing.back-btn')}
             </ButtonLink>
           </div>


### PR DESCRIPTION
### Description
`review-information` is currently redirecting to `applicant-information`.

Its because of `Line 144` in `app/.server/routes/helpers/apply-adult-route-helpers.ts`

![image](https://github.com/user-attachments/assets/375f9efd-e0a9-426f-a5c6-c4e2cfae7210)

The state will need to be finalized for `review-information` to be properly coded.

### Related Azure Boards Work Items
[AB#5195](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5195)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Go through the apply/adult flow. Every path taken should also go back to the previous pages visited.
