### PR TITLE
Updating Adobe Analytics custom click attribute value to be consistent with online application

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -180,7 +180,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Save - Child access to other government dental benefits click">
+              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Child access to other government dental benefits click">
                 {t('apply-adult-child:children.confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -188,7 +188,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/apply/$id/adult-child/children/review-child-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Cancel - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Child access to other government dental benefits click"
               >
                 {t('apply-adult-child:children.confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -200,7 +200,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Continue - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Child access to other government dental benefits click"
               >
                 {t('apply-adult-child:children.confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -210,7 +210,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Back - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Child access to other government dental benefits click"
               >
                 {t('apply-adult-child:children.confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -164,7 +164,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Save - Access to other government dental benefits click">
+              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Access to other government dental benefits click">
                 {t('apply-adult-child:confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -172,7 +172,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/apply/$id/adult-child/review-adult-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Cancel - Access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Access to other government dental benefits click"
               >
                 {t('apply-adult-child:confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -184,7 +184,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Continue - Access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Access to other government dental benefits click"
               >
                 {t('apply-adult-child:confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -194,7 +194,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Back - Access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Access to other government dental benefits click"
               >
                 {t('apply-adult-child:confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -316,7 +316,7 @@ export default function ApplyAdultChildHomeAddress({ loaderData, params }: Route
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Save - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Home address click"
                   >
                     {t('apply-adult-child:address.save-btn')}
                   </LoadingButton>
@@ -330,7 +330,7 @@ export default function ApplyAdultChildHomeAddress({ loaderData, params }: Route
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Cancel - Home address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Home address click">
                 {t('apply-adult-child:address.cancel-btn')}
               </Button>
             </div>
@@ -347,7 +347,7 @@ export default function ApplyAdultChildHomeAddress({ loaderData, params }: Route
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Continue - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Home address click"
                   >
                     {t('apply-adult-child:address.continue')}
                   </LoadingButton>
@@ -367,7 +367,7 @@ export default function ApplyAdultChildHomeAddress({ loaderData, params }: Route
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Back - Home address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Home address click"
               >
                 {t('apply-adult-child:address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -350,7 +350,7 @@ export default function ApplyAdultChildMailingAddress({ loaderData, params }: Ro
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Save - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Mailing address click"
                   >
                     {t('apply-adult-child:address.save-btn')}
                   </LoadingButton>
@@ -364,7 +364,7 @@ export default function ApplyAdultChildMailingAddress({ loaderData, params }: Ro
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Cancel - Mailing address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Mailing address click">
                 {t('apply-adult-child:address.cancel-btn')}
               </Button>
             </div>
@@ -381,7 +381,7 @@ export default function ApplyAdultChildMailingAddress({ loaderData, params }: Ro
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Continue - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Mailing address click"
                   >
                     {t('apply-adult-child:address.continue')}
                   </LoadingButton>
@@ -402,7 +402,7 @@ export default function ApplyAdultChildMailingAddress({ loaderData, params }: Ro
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult_Child:Back - Mailing address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Back - Mailing address click"
               >
                 {t('apply-adult-child:address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
@@ -221,10 +221,10 @@ export default function ApplyAdultChildMaritalStatus({ loaderData, params }: Rou
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Marital status click">
                 {t('apply-adult-child:marital-status.save-btn')}
               </Button>
-              <LoadingButton id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Cancel - Marital status click">
+              <LoadingButton id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Marital status click">
                 {t('apply-adult-child:marital-status.cancel-btn')}
               </LoadingButton>
             </div>
@@ -237,11 +237,11 @@ export default function ApplyAdultChildMaritalStatus({ loaderData, params }: Rou
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Continue - Marital status click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Marital status click"
               >
                 {t('apply-adult-child:marital-status.continue-btn')}
               </LoadingButton>
-              <ButtonLink id="back-button" routeId={getBackButtonRouteId()} params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Back - Marital status click">
+              <ButtonLink id="back-button" routeId={getBackButtonRouteId()} params={params} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Marital status click">
                 {t('apply-adult-child:marital-status.back-btn')}
               </ButtonLink>
             </div>

--- a/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -160,7 +160,7 @@ export default function ApplyAdultConfirmFederalProvincialTerritorialBenefits({ 
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Save - Access to other government dental benefits click">
+              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Access to other government dental benefits click">
                 {t('apply-adult:confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -168,14 +168,14 @@ export default function ApplyAdultConfirmFederalProvincialTerritorialBenefits({ 
                 routeId="public/apply/$id/adult/review-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Cancel - Access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Access to other government dental benefits click"
               >
                 {t('apply-adult:confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Continue - Access to other government dental benefits click">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Access to other government dental benefits click">
                 {t('apply-adult:confirm-dental-benefits.button.continue')}
               </LoadingButton>
               <ButtonLink
@@ -184,7 +184,7 @@ export default function ApplyAdultConfirmFederalProvincialTerritorialBenefits({ 
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Back - Access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Access to other government dental benefits click"
               >
                 {t('apply-adult:confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -316,7 +316,7 @@ export default function ApplyAdultHomeAddress({ loaderData, params }: Route.Comp
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Save - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Home address click"
                   >
                     {t('apply-adult:address.save-btn')}
                   </LoadingButton>
@@ -330,7 +330,7 @@ export default function ApplyAdultHomeAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Cancel - Home address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Home address click">
                 {t('apply-adult:address.cancel-btn')}
               </Button>
             </div>
@@ -347,7 +347,7 @@ export default function ApplyAdultHomeAddress({ loaderData, params }: Route.Comp
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Continue - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Home address click"
                   >
                     {t('apply-adult:address.continue')}
                   </LoadingButton>
@@ -367,7 +367,7 @@ export default function ApplyAdultHomeAddress({ loaderData, params }: Route.Comp
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Back - Home address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Home address click"
               >
                 {t('apply-adult:address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -350,7 +350,7 @@ export default function ApplyAdultMailingAddress({ loaderData, params }: Route.C
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Save - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Mailing address click"
                   >
                     {t('apply-adult:address.save-btn')}
                   </LoadingButton>
@@ -364,7 +364,7 @@ export default function ApplyAdultMailingAddress({ loaderData, params }: Route.C
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Cancel - Mailing address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Mailing address click">
                 {t('apply-adult:address.cancel-btn')}
               </Button>
             </div>
@@ -381,7 +381,7 @@ export default function ApplyAdultMailingAddress({ loaderData, params }: Route.C
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Continue - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Mailing address click"
                   >
                     {t('apply-adult:address.continue')}
                   </LoadingButton>
@@ -402,7 +402,7 @@ export default function ApplyAdultMailingAddress({ loaderData, params }: Route.C
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Back - Mailing address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Mailing address click"
               >
                 {t('apply-adult:address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
@@ -202,10 +202,10 @@ export default function ApplyAdultMaritalStatus({ loaderData, params }: Route.Co
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">
-              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Save - Marital status click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Marital status click">
                 {t('apply-adult:marital-status.save-btn')}
               </Button>
-              <LoadingButton id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Cancel - Marital status click">
+              <LoadingButton id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Marital status click">
                 {t('apply-adult:marital-status.cancel-btn')}
               </LoadingButton>
             </div>
@@ -218,7 +218,7 @@ export default function ApplyAdultMaritalStatus({ loaderData, params }: Route.Co
                 variant="primary"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Continue - Marital status click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Marital status click"
               >
                 {t('apply-adult:marital-status.continue-btn')}
               </LoadingButton>
@@ -228,7 +228,7 @@ export default function ApplyAdultMaritalStatus({ loaderData, params }: Route.Co
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Adult:Back - Marital status click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Marital status click"
               >
                 {t('apply-adult:marital-status.back-btn')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -180,7 +180,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Save - Child access to other government dental benefits click">
+              <Button id="save-button" variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Child access to other government dental benefits click">
                 {t('apply-child:children.confirm-dental-benefits.button.save-btn')}
               </Button>
               <ButtonLink
@@ -188,7 +188,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 routeId="public/apply/$id/child/review-child-information"
                 params={params}
                 disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Cancel - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Child access to other government dental benefits click"
               >
                 {t('apply-child:children.confirm-dental-benefits.button.cancel-btn')}
               </ButtonLink>
@@ -200,7 +200,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 id="continue-button"
                 loading={isSubmitting}
                 endIcon={faChevronRight}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Continue - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Child access to other government dental benefits click"
               >
                 {t('apply-child:children.confirm-dental-benefits.button.continue')}
               </LoadingButton>
@@ -210,7 +210,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Back - Child access to other government dental benefits click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Back - Child access to other government dental benefits click"
               >
                 {t('apply-child:children.confirm-dental-benefits.button.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -316,7 +316,7 @@ export default function ApplyChildHomeAddress({ loaderData, params }: Route.Comp
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Save - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Home address click"
                   >
                     {t('apply-child:address.save-btn')}
                   </LoadingButton>
@@ -330,7 +330,7 @@ export default function ApplyChildHomeAddress({ loaderData, params }: Route.Comp
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Cancel - Home address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Home address click">
                 {t('apply-child:address.cancel-btn')}
               </Button>
             </div>
@@ -347,7 +347,7 @@ export default function ApplyChildHomeAddress({ loaderData, params }: Route.Comp
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Continue - Home address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Home address click"
                   >
                     {t('apply-child:address.continue')}
                   </LoadingButton>
@@ -367,7 +367,7 @@ export default function ApplyChildHomeAddress({ loaderData, params }: Route.Comp
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Back - Home address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Back - Home address click"
               >
                 {t('apply-child:address.back')}
               </ButtonLink>

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -350,7 +350,7 @@ export default function ApplyChildMailingAddress({ loaderData, params }: Route.C
                     name="_action"
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Save - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Save - Mailing address click"
                   >
                     {t('apply-child:address.save-btn')}
                   </LoadingButton>
@@ -364,7 +364,7 @@ export default function ApplyChildMailingAddress({ loaderData, params }: Route.C
                   </>
                 )}
               </Dialog>
-              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Cancel - Mailing address click">
+              <Button id="cancel-button" name="_action" disabled={isSubmitting} value={FORM_ACTION.cancel} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Cancel - Mailing address click">
                 {t('apply-child:address.cancel-btn')}
               </Button>
             </div>
@@ -381,7 +381,7 @@ export default function ApplyChildMailingAddress({ loaderData, params }: Route.C
                     value={FORM_ACTION.submit}
                     loading={isSubmitting}
                     endIcon={faChevronRight}
-                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Continue - Mailing address click"
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Mailing address click"
                   >
                     {t('apply-child:address.continue')}
                   </LoadingButton>
@@ -402,7 +402,7 @@ export default function ApplyChildMailingAddress({ loaderData, params }: Route.C
                 params={params}
                 disabled={isSubmitting}
                 startIcon={faChevronLeft}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Apply Application Form-Child:Back - Mailing address click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Back - Mailing address click"
               >
                 {t('apply-child:address.back')}
               </ButtonLink>


### PR DESCRIPTION
### Description
The rest of the `/apply` flow uses `CDCP Online Application Form` rather than `CDCP Apply Application Form`. The pages impacted have been recently introduced and are not currently in production.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`