### PR TITLE
Storing Terms and Conditions input to state and mapping to updated DTO

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -20,7 +20,14 @@ describe('apply-adult-child-route-helpers', () => {
   describe('validateApplyAdultChildStateForReview', () => {
     const params = { lang: 'en', id: '00000000-0000-0000-0000-000000000000' };
 
-    const baseState = { id: '00000000-0000-0000-0000-000000000000', editMode: false, lastUpdatedOn: '2000-01-01', applicationYear: { intakeYearId: '2025', taxYear: '2025' }, children: [] } satisfies ApplyState;
+    const baseState = {
+      id: '00000000-0000-0000-0000-000000000000',
+      editMode: false,
+      lastUpdatedOn: '2000-01-01',
+      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      children: [],
+      termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
+    } satisfies ApplyState;
 
     it('should redirect if typeOfApplication is undefined', () => {
       const mockState = { ...baseState, typeOfApplication: undefined };
@@ -358,6 +365,7 @@ describe('apply-adult-child-route-helpers', () => {
         },
         submissionInfo: undefined,
         taxFiling2023: true,
+        termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
         typeOfApplication: 'adult-child',
       });
     });

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -20,7 +20,14 @@ describe('apply-adult-route-helpers', () => {
   describe('validateApplyAdultStateForReview', () => {
     const params = { lang: 'en', id: '00000000-0000-0000-0000-000000000000' };
 
-    const baseState = { id: '00000000-0000-0000-0000-000000000000', editMode: true, lastUpdatedOn: '2000-01-01', applicationYear: { intakeYearId: '2025', taxYear: '2025' }, children: [] } satisfies ApplyState;
+    const baseState = {
+      id: '00000000-0000-0000-0000-000000000000',
+      editMode: true,
+      lastUpdatedOn: '2000-01-01',
+      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      children: [],
+      termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
+    } satisfies ApplyState;
 
     it('should redirect if typeOfApplication is undefined', () => {
       const mockState = { ...baseState, typeOfApplication: undefined };
@@ -246,6 +253,7 @@ describe('apply-adult-route-helpers', () => {
         },
         submissionInfo: undefined,
         taxFiling2023: true,
+        termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
         typeOfApplication: 'adult',
       });
     });

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -20,7 +20,14 @@ describe('apply-child-route-helpers', () => {
   describe('validateApplyChildStateForReview', () => {
     const params = { lang: 'en', id: '00000000-0000-0000-0000-000000000000' };
 
-    const baseState = { id: '00000000-0000-0000-0000-000000000000', editMode: false, lastUpdatedOn: '2000-01-01', applicationYear: { intakeYearId: '2025', taxYear: '2025' }, children: [] } satisfies ApplyState;
+    const baseState = {
+      id: '00000000-0000-0000-0000-000000000000',
+      editMode: false,
+      lastUpdatedOn: '2000-01-01',
+      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      children: [],
+      termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
+    } satisfies ApplyState;
 
     it('should redirect if typeOfApplication is undefined', () => {
       const mockState = { ...baseState, typeOfApplication: undefined };
@@ -363,6 +370,7 @@ describe('apply-child-route-helpers', () => {
         },
         submissionInfo: undefined,
         taxFiling2023: true,
+        termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
         typeOfApplication: 'child',
       });
     });

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -256,6 +256,11 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         dentalInsurance: true,
         partnerInformation: undefined,
         typeOfApplication: 'adult-child',
+        termsAndConditions: {
+          acknowledgeTerms: true,
+          acknowledgePrivacy: true,
+          shareData: true,
+        },
         userId: 'anonymous',
       };
 

--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -11,6 +11,7 @@ export type BenefitApplicationDto = ReadonlyDeep<{
   dentalInsurance?: boolean;
   livingIndependently?: boolean;
   partnerInformation?: PartnerInformationDto;
+  termsAndConditions: TermsAndConditionsDto;
   typeOfApplication: TypeOfApplicationDto;
 
   /** A unique identifier for the user making the request - used for auditing */
@@ -59,6 +60,12 @@ export type ContactInformationDto = ReadonlyDeep<{
   phoneNumber?: string;
   phoneNumberAlt?: string;
   email?: string;
+}>;
+
+export type TermsAndConditionsDto = ReadonlyDeep<{
+  acknowledgeTerms: boolean;
+  acknowledgePrivacy: boolean;
+  shareData: boolean;
 }>;
 
 export type PartnerInformationDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -47,6 +47,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     dentalInsurance,
     livingIndependently,
     partnerInformation,
+    termsAndConditions, // TODO map terms and conditions when Interop provides field structure
     typeOfApplication,
   }: BenefitApplicationDto): BenefitApplicationRequestEntity {
     return {

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -20,6 +20,7 @@ import type {
   RenewalApplicantInformationDto,
   RenewalChildDto,
   RenewalPartnerInformationDto,
+  TermsAndConditionsDto,
   TypeOfApplicationDto,
 } from '~/.server/domain/dtos';
 import type { BenefitRenewalRequestEntity } from '~/.server/domain/entities';
@@ -47,6 +48,7 @@ interface ToBenefitRenewalRequestEntityArgs {
   disabilityTaxCredit?: boolean;
   livingIndependently?: boolean;
   partnerInformation?: RenewalPartnerInformationDto;
+  termsAndConditions: TermsAndConditionsDto;
   typeOfApplication: TypeOfApplicationDto;
 }
 
@@ -114,6 +116,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     disabilityTaxCredit,
     livingIndependently,
     partnerInformation,
+    termsAndConditions, // TODO map terms and conditions when Interop provides field structure
     typeOfApplication,
   }: ToBenefitRenewalRequestEntityArgs): BenefitRenewalRequestEntity {
     return {

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -136,8 +136,13 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     contactInformation,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
   } = state;
+
+  if (termsAndConditions === undefined) {
+    throw redirect(getPathById('public/apply/$id/terms-and-conditions', params));
+  }
 
   if (typeOfApplication === undefined) {
     throw redirect(getPathById('public/apply/$id/type-application', params));
@@ -222,6 +227,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     homeAddress,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
   };
 }

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -97,8 +97,13 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     contactInformation,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
   } = state;
+
+  if (termsAndConditions === undefined) {
+    throw redirect(getPathById('public/apply/$id/terms-and-conditions', params));
+  }
 
   if (typeOfApplication === undefined) {
     throw redirect(getPathById('public/apply/$id/type-application', params));
@@ -184,6 +189,7 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     homeAddress,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
   };
 }

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -131,9 +131,14 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
     contactInformation,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
     newOrExistingMember,
   } = state;
+
+  if (termsAndConditions === undefined) {
+    throw redirect(getPathById('public/apply/$id/terms-and-conditions', params));
+  }
 
   if (typeOfApplication === undefined) {
     throw redirect(getPathById('public/apply/$id/type-application', params));
@@ -200,6 +205,7 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
     homeAddress,
     submissionInfo,
     taxFiling2023,
+    termsAndConditions,
     typeOfApplication,
     newOrExistingMember,
   };

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -109,6 +109,11 @@ export type ApplyState = ReadonlyDeep<{
     submittedOn: string;
   };
   taxFiling2023?: boolean;
+  termsAndConditions?: {
+    acknowledgeTerms: boolean;
+    acknowledgePrivacy: boolean;
+    shareData: boolean;
+  };
   typeOfApplication?: 'adult' | 'adult-child' | 'child' | 'delegate';
 }>;
 
@@ -127,6 +132,7 @@ export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<ApplySta
 export type PartnerInformationState = NonNullable<ApplyState['partnerInformation']>;
 export type ContactInformationState = NonNullable<ApplyState['contactInformation']>;
 export type SubmissionInfoState = NonNullable<ApplyState['submissionInfo']>;
+export type TermsAndConditionsState = NonNullable<ApplyState['termsAndConditions']>;
 export type TypeOfApplicationState = NonNullable<ApplyState['typeOfApplication']>;
 export type HomeAddressState = NonNullable<ApplyState['homeAddress']>;
 export type MailingAddressState = NonNullable<ApplyState['mailingAddress']>;

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -15,6 +15,7 @@ import type {
   HomeAddressState,
   MailingAddressState,
   PartnerInformationState,
+  TermsAndConditionsState,
   TypeOfApplicationState,
 } from '~/.server/routes/helpers/apply-route-helpers';
 
@@ -32,6 +33,7 @@ export interface ApplyAdultState {
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   partnerInformation?: PartnerInformationState;
+  termsAndConditions: TermsAndConditionsState;
   typeOfApplication: Extract<TypeOfApplicationState, 'adult'>;
 }
 
@@ -50,6 +52,7 @@ export interface ApplyAdultChildState {
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
   partnerInformation?: PartnerInformationState;
+  termsAndConditions: TermsAndConditionsState;
   typeOfApplication: Extract<TypeOfApplicationState, 'adult-child'>;
 }
 
@@ -66,6 +69,7 @@ export interface ApplyChildState {
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
   partnerInformation?: PartnerInformationState;
+  termsAndConditions: TermsAndConditionsState;
   typeOfApplication: Extract<TypeOfApplicationState, 'child'>;
 }
 
@@ -84,6 +88,7 @@ interface ToBenefitApplicationDtoArgs {
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   partnerInformation?: PartnerInformationState;
+  termsAndConditions: TermsAndConditionsState;
   typeOfApplication: Extract<TypeOfApplicationState, 'adult' | 'adult-child' | 'child'>;
 }
 
@@ -164,6 +169,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     mailingAddress,
     isHomeAddressSameAsMailingAddress,
     contactInformation,
+    termsAndConditions,
     typeOfApplication,
   }: ToBenefitApplicationDtoArgs) {
     return {
@@ -181,6 +187,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       dentalInsurance,
       livingIndependently,
       partnerInformation,
+      termsAndConditions,
       typeOfApplication,
       userId: 'anonymous',
     };

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -269,6 +269,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
+      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'adult',
       userId: 'anonymous',
     };
@@ -346,6 +347,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
+      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: children.length === 0 ? 'adult' : 'adult-child',
       userId: 'anonymous',
     };
@@ -405,6 +407,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: true,
         renewedPartnerInformation: partnerInformation,
       }),
+      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'adult',
       userId: 'anonymous',
     };
@@ -468,6 +471,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
+      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'child',
       userId: 'anonymous',
     };
@@ -537,6 +541,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedPartnerInformation: partnerInformation,
       }),
       userId,
+      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: applicantStateCompleted === false && children.length > 0 ? 'child' : children.length === 0 ? 'adult' : 'adult-child',
     };
   }
@@ -749,5 +754,13 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
 
   private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs) {
     return hasMaritalStatusChanged ? renewedPartnerInformation : existingPartnerInformation;
+  }
+
+  private toTermsAndConditions() {
+    return {
+      acknowledgeTerms: true,
+      acknowledgePrivacy: true,
+      shareData: true,
+    };
   }
 }

--- a/frontend/public/locales/en/apply.json
+++ b/frontend/public/locales/en/apply.json
@@ -98,9 +98,9 @@
       "share-data": "I consent to the sharing of data",
       "do-not-consent": "I have <strong>not read</strong> the Terms and Conditions and Privacy Notice Statement and <strong>do not consent</strong> to the sharing of my information for the purposes of CDCP",
       "error-message": {
-        "acknowledge-terms-required": "Terms and Conditions checkbox must be selected",
-        "acknowledge-privacy-required": "Privacy Notice Statement checkbox must be selected",
-        "share-data-required": "Sharing of data checkbox must be selected"
+        "acknowledge-terms-required": "You must read the Terms and Conditions to proceed",
+        "acknowledge-privacy-required": "You must read the Privacy Notice Statement to proceed",
+        "share-data-required": "You must consent to the sharing of your data to proceed"
       }
     },
     "dialog": {

--- a/frontend/public/locales/fr/apply.json
+++ b/frontend/public/locales/fr/apply.json
@@ -98,9 +98,9 @@
       "share-data": "Je consens à l'échange des données",
       "do-not-consent": "Je <strong>ne consens pas</strong> à la divulgation de mes renseignements dans le cadre du RCSD",
       "error-message": {
-        "acknowledge-terms-required": "(FR) Terms and Conditions checkbox must be selected",
-        "acknowledge-privacy-required": "(FR) Privacy Notice Statement checkbox must be selected",
-        "share-data-required": "(FR) Sharing of data checkbox must be selected"
+        "acknowledge-terms-required": "Vous devez lire les modalités d'utilisation avant de poursuivre",
+        "acknowledge-privacy-required": "Vous devez lire l'énoncé de confidentialité avant de poursuivre",
+        "share-data-required": "Vous devez consentir à la communication de vos renseignements avant de poursuivre"
       }
     },
     "dialog": {


### PR DESCRIPTION
### Description
The DTO mapper has been updated with a `TODO` which will be resolved once Interop provides the structure in their benefit application submission payload. 

For Renewals, we will not be adding user input on its Terms and Conditions page, but rather defaulting the three fields to `true` as per requirements. Sorry for the larger PR as the DTO for renewals depends on the DTO for intakes.

Also updated the i18n files based on the Field Validation excel for Terms and Conditions page.

### Related Azure Boards Work Items
[AB#5258](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5258)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`