### PR TITLE
Adding health check for GC Notify

### DIFF
--- a/frontend/app/.server/container-modules/health.container-module.ts
+++ b/frontend/app/.server/container-modules/health.container-module.ts
@@ -3,7 +3,7 @@ import { ContainerModule } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import { AddressValidationHealthCheck, ApplicantHealthCheck, ApplicationStatusHealthCheck, HCaptchaHealthCheck, LetterHealthCheck, RedisHealthCheck } from '~/.server/health';
+import { AddressValidationHealthCheck, ApplicantHealthCheck, ApplicationStatusHealthCheck, HCaptchaHealthCheck, LetterHealthCheck, NotificationHealthCheck, RedisHealthCheck } from '~/.server/health';
 
 function featureEnabled(feature: ServerConfig['ENABLED_FEATURES'][number]) {
   return ({ parentContext }: interfaces.Request) => {
@@ -28,5 +28,6 @@ export const healthContainerModule = new ContainerModule((bind) => {
   bind(TYPES.health.HealthCheck).to(ApplicationStatusHealthCheck);
   bind(TYPES.health.HealthCheck).to(HCaptchaHealthCheck).when(featureEnabled('hcaptcha'));
   bind(TYPES.health.HealthCheck).to(LetterHealthCheck);
+  bind(TYPES.health.HealthCheck).to(NotificationHealthCheck);
   bind(TYPES.health.HealthCheck).to(RedisHealthCheck).when(sessionTypeIs('redis'));
 });

--- a/frontend/app/.server/domain/repositories/verification-code.repository.ts
+++ b/frontend/app/.server/domain/repositories/verification-code.repository.ts
@@ -15,6 +15,21 @@ export interface VerificationCodeRepository {
    * @returns A promise resolving to an `VerificationCodeEmailResponseEntity` containing the result of the operation.
    */
   sendVerificationCodeEmail(verificationCodeEmailRequestEntity: VerificationCodeEmailRequestEntity): Promise<VerificationCodeEmailResponseEntity>;
+
+  /**
+   * Retrieves metadata associated with the verification code repository.
+   *
+   * @returns A record where the keys and values are strings representing metadata information.
+   */
+  getMetadata(): Record<string, string>;
+
+  /**
+   * Performs a health check to ensure that the verification code repository is operational.
+   *
+   * @throws An error if the health check fails or the repository is unavailable.
+   * @returns A promise that resolves when the health check completes successfully.
+   */
+  checkHealth(): Promise<void>;
 }
 
 @injectable()
@@ -22,6 +37,7 @@ export class DefaultVerificationCodeRepository implements VerificationCodeReposi
   private readonly log: Logger;
   private readonly serverConfig: Pick<ServerConfig, 'GC_NOTIFY_API_KEY' | 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY'>;
   private readonly httpClient: HttpClient;
+  private readonly baseUrl: string;
 
   constructor(
     @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
@@ -31,12 +47,13 @@ export class DefaultVerificationCodeRepository implements VerificationCodeReposi
     this.log = logFactory.createLogger('DefaultVerificationCodeRepository');
     this.serverConfig = serverConfig;
     this.httpClient = httpClient;
+    this.baseUrl = `${this.serverConfig.INTEROP_API_BASE_URI}/notifications/email-txt-notifications/v1`;
   }
 
   async sendVerificationCodeEmail(verificationCodeEmailRequestEntity: VerificationCodeEmailRequestEntity): Promise<VerificationCodeEmailResponseEntity> {
     this.log.trace('Sending verification code email for request: [%j]', verificationCodeEmailRequestEntity);
 
-    const url = `${this.serverConfig.INTEROP_API_BASE_URI}/notifications/email-txt-notifications/v1/notifications/email`;
+    const url = `${this.baseUrl}/notifications/email`;
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.email-notifications.posts', url, {
       proxyUrl: this.serverConfig.HTTP_PROXY_URL,
       method: 'POST',
@@ -62,6 +79,38 @@ export class DefaultVerificationCodeRepository implements VerificationCodeReposi
     const verificationCodeEmailResponseEntity: VerificationCodeEmailResponseEntity = await response.json();
     this.log.trace('Returning verification code email response [%j]', verificationCodeEmailResponseEntity);
     return verificationCodeEmailResponseEntity;
+  }
+
+  getMetadata(): Record<string, string> {
+    return {
+      baseUrl: this.baseUrl,
+    };
+  }
+
+  async checkHealth(): Promise<void> {
+    this.log.trace('Checking health for verification code repository');
+
+    const url = `${this.baseUrl}/notifications`;
+    const response = await this.httpClient.instrumentedFetch('http.client.interop-api.email-notifications.gets', url, {
+      proxyUrl: this.serverConfig.HTTP_PROXY_URL,
+      method: 'GET',
+      headers: {
+        Authorization: `ApiKey-v1 ${this.serverConfig.GC_NOTIFY_API_KEY}`,
+        'Content-Type': 'application/json',
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+    });
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: `Failed to 'GET' email notifications`,
+        status: response.status,
+        statusText: response.statusText,
+        url,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to 'GET' email notifications. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
   }
 }
 
@@ -94,5 +143,15 @@ export class MockVerificationCodeRepository implements VerificationCodeRepositor
 
     this.log.trace('Returning verification code email response [%j]', verificationCodeEmailResponseEntity);
     return await Promise.resolve(verificationCodeEmailResponseEntity);
+  }
+
+  getMetadata(): Record<string, string> {
+    return {
+      mockEnabled: 'true',
+    };
+  }
+
+  async checkHealth(): Promise<void> {
+    return await Promise.resolve();
   }
 }

--- a/frontend/app/.server/health/index.ts
+++ b/frontend/app/.server/health/index.ts
@@ -3,4 +3,5 @@ export * from './applicant.health';
 export * from './application-status.health';
 export * from './hcaptcha.health';
 export * from './letter.health';
+export * from './notification.health';
 export * from './redis.health';

--- a/frontend/app/.server/health/notification.health.ts
+++ b/frontend/app/.server/health/notification.health.ts
@@ -1,0 +1,50 @@
+import type { HealthCheck } from '@dts-stn/health-checks';
+import { inject, injectable } from 'inversify';
+import moize from 'moize';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { VerificationCodeRepository } from '~/.server/domain/repositories';
+import type { LogFactory, Logger } from '~/.server/factories';
+
+@injectable()
+export class NotificationHealthCheck implements HealthCheck {
+  private readonly log: Logger;
+  private readonly serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL'>;
+  private readonly verificationCodeRepository: VerificationCodeRepository;
+  readonly name: string;
+  readonly metadata?: Record<string, string>;
+
+  constructor(
+    @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
+    @inject(TYPES.configs.ServerConfig)
+    serverConfig: Pick<ServerConfig, 'HEALTH_CACHE_TTL'>,
+    @inject(TYPES.domain.repositories.VerificationCodeRepository) verificationCodeRepository: VerificationCodeRepository,
+  ) {
+    this.log = logFactory.createLogger('NotificationHealthCheck');
+    this.serverConfig = serverConfig;
+    this.verificationCodeRepository = verificationCodeRepository;
+    this.name = 'notification';
+    this.metadata = this.verificationCodeRepository.getMetadata();
+
+    this.init();
+  }
+
+  private init(): void {
+    const healthCacheTTL = this.serverConfig.HEALTH_CACHE_TTL;
+    this.log.debug('Initializing NotificationHealthCheck with cache TTL of %d ms.', healthCacheTTL);
+
+    this.check = moize.promise(this.check, {
+      maxAge: healthCacheTTL,
+      // transformArgs is required to effectively ignore the abort signal sent from @dts-stn/health-checks when caching
+      transformArgs: () => [],
+      onCacheAdd: () => this.log.info('Cached function for NotificationHealthCheck has been initialized.'),
+    });
+
+    this.log.debug('NotificationHealthCheck initialization complete.');
+  }
+
+  async check(signal?: AbortSignal): Promise<void> {
+    await this.verificationCodeRepository.checkHealth();
+  }
+}


### PR DESCRIPTION
### Description
As per title

### Related Azure Boards Work Items
[AB#5264](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5264)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/7620a9ed-3749-4771-a5a7-0aad22ad5ed5)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Navigate to `/api/health`. The `notification` health check should be there.

### Additional Notes
Broke convention and didn't name the health check component `verificationCode` because it didn't quite make sense when we're just checking the existence of Interop's GC Notify endpoint. 