### PR TITLE
Default to the matching renewal application year's coverage end date; Renaming `coverageStartDate` to `coverageEndDate`  in renewal state and DTO

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -67,7 +67,7 @@ describe('DefaultApplicationYearService', () => {
   mockApplicationYearRepository.listApplicationYears.mockResolvedValue(mockApplicationYearResultEntity);
 
   describe('findRenewalApplicationYear', () => {
-    const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { taxYear: '2025', coverageStartDate: '2025-01-01' };
+    const mockRenewalApplicationYearResultDto: RenewalApplicationYearResultDto = { taxYear: '2025', coverageEndDate: '2025-01-01' };
     const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
     mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
     mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
@@ -79,7 +79,7 @@ describe('DefaultApplicationYearService', () => {
       const result = await service.findRenewalApplicationYear('2025-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
-        coverageStartDate: '2024-12-31',
+        coverageEndDate: '2024-12-31',
         applicationYearResultDto: {
           applicationYear: '2025',
           applicationYearId: '2025',
@@ -103,7 +103,7 @@ describe('DefaultApplicationYearService', () => {
       const result = await service.findRenewalApplicationYear('2026-01-01');
 
       expect(mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto).toHaveBeenCalledWith({
-        coverageStartDate: '2025-12-31',
+        coverageEndDate: '2025-12-31',
         applicationYearResultDto: { applicationYear: '2026', applicationYearId: '2026', taxYear: '2026', coverageStartDate: '2026-01-01', coverageEndDate: '2026-12-31', intakeStartDate: '2026-01-01', renewalStartDate: '2026-01-01' },
       });
       expect(result).toEqual(mockRenewalApplicationYearResultDto);

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -112,7 +112,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         applicationYear: {
           renewalYearId: '2024',
           taxYear: '2024',
-          coverageStartDate: '2024-01-01',
+          coverageEndDate: '2024-01-01',
         },
         children: [
           {

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -20,7 +20,7 @@ export type ApplicationYearResultDto = Readonly<{
 export type RenewalApplicationYearResultDto = Readonly<{
   renewalYearId?: string;
   taxYear: string;
-  coverageStartDate: string;
+  coverageEndDate: string;
 }>;
 
 /**

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -12,7 +12,7 @@ export interface ApplicationYearDtoMapper {
 }
 
 interface ToRenewalApplicationYearResultDtoArgs {
-  coverageStartDate: string;
+  coverageEndDate: string;
   applicationYearResultDto: ApplicationYearResultDto;
 }
 
@@ -25,10 +25,10 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
     };
   }
 
-  mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageStartDate, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
+  mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageEndDate, applicationYearResultDto }: ToRenewalApplicationYearResultDtoArgs): RenewalApplicationYearResultDto {
     return {
       taxYear: applicationYearResultDto.taxYear,
-      coverageStartDate,
+      coverageEndDate,
       renewalYearId: applicationYearResultDto.applicationYearId,
     };
   }

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -1,6 +1,5 @@
 import { inject, injectable } from 'inversify';
 import moize from 'moize';
-import invariant from 'tiny-invariant';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
@@ -150,9 +149,12 @@ export class DefaultApplicationYearService implements ApplicationYearService {
     const intakeYear = applicationYearResultDtos.find((applicationYear) => {
       return applicationYear.nextApplicationYearId === matchingRenewalApplicationYear.applicationYearId;
     });
-    invariant(intakeYear, 'Expected intakeYear to be defined');
 
-    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageEndDate: intakeYear.coverageEndDate, applicationYearResultDto: matchingRenewalApplicationYear });
+    // Use the intake year's coverage end date if found;
+    // Otherwise, use the matching renewal application year's coverage end date.
+    const coverageEndDate = intakeYear ? intakeYear.coverageEndDate : matchingRenewalApplicationYear.coverageEndDate;
+
+    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageEndDate, applicationYearResultDto: matchingRenewalApplicationYear });
 
     this.log.trace('Returning renewal application year result: [%j]', renewalApplicationYearResultDto);
     return renewalApplicationYearResultDto;

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -152,7 +152,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
     });
     invariant(intakeYear, 'Expected intakeYear to be defined');
 
-    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageStartDate: intakeYear.coverageEndDate, applicationYearResultDto: matchingRenewalApplicationYear });
+    const renewalApplicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto({ coverageEndDate: intakeYear.coverageEndDate, applicationYearResultDto: matchingRenewalApplicationYear });
 
     this.log.trace('Returning renewal application year result: [%j]', renewalApplicationYearResultDto);
     return renewalApplicationYearResultDto;

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -19,7 +19,7 @@ export interface ProtectedRenewState {
   readonly applicationYear: {
     renewalYearId: string;
     taxYear: string;
-    coverageStartDate: string;
+    coverageEndDate: string;
   };
   readonly clientApplication: ClientApplicationDto;
   readonly previouslyReviewed?: boolean;
@@ -266,7 +266,7 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
     communicationPreferences: clientApplication.communicationPreferences,
     children: clientApplication.children
       // filter out children who will be 18 or older at the start of the coverage period as they are ineligible for renewal
-      .filter((child) => getAgeFromDateString(child.information.dateOfBirth, applicationYear.coverageStartDate) < 18) //
+      .filter((child) => getAgeFromDateString(child.information.dateOfBirth, applicationYear.coverageEndDate) < 18) //
       .map((child) => {
         const childStateObj = {
           id: randomUUID(),

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -18,7 +18,7 @@ export interface RenewState {
   readonly applicationYear: {
     renewalYearId: string;
     taxYear: string;
-    coverageStartDate: string;
+    coverageEndDate: string;
   };
   readonly applicantInformation?: {
     firstName: string;

--- a/frontend/app/routes/protected/renew/index.tsx
+++ b/frontend/app/routes/protected/renew/index.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     applicationYear: {
       renewalYearId: applicationYear.renewalYearId,
       taxYear: applicationYear.taxYear,
-      coverageStartDate: applicationYear.coverageStartDate,
+      coverageEndDate: applicationYear.coverageEndDate,
     },
     clientApplication,
     id,

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -124,7 +124,7 @@ export async function action({ context: { appContainer, session }, params, reque
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
 
-      const coverageStartDate = renewState.applicationYear.coverageStartDate;
+      const coverageEndDate = renewState.applicationYear.coverageEndDate;
 
       if (!isValidDateString(dateOfBirth)) {
         ctx.addIssue({
@@ -144,10 +144,10 @@ export async function action({ context: { appContainer, session }, params, reque
           message: t('renew-adult-child:children.information.error-message.date-of-birth-is-past-valid'),
           path: ['dateOfBirth'],
         });
-      } else if (getAgeFromDateString(dateOfBirth, coverageStartDate) >= 18) {
+      } else if (getAgeFromDateString(dateOfBirth, coverageEndDate) >= 18) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('renew-adult-child:children.information.error-message.date-of-birth-ineligible', { coverageStartDate: toLocaleDateString(parseDateString(coverageStartDate), locale) }),
+          message: t('renew-adult-child:children.information.error-message.date-of-birth-ineligible', { coverageEndDate: toLocaleDateString(parseDateString(coverageEndDate), locale) }),
           path: ['dateOfBirth'],
         });
       }

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -124,7 +124,7 @@ export async function action({ context: { appContainer, session }, params, reque
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
 
-      const coverageStartDate = renewState.applicationYear.coverageStartDate;
+      const coverageEndDate = renewState.applicationYear.coverageEndDate;
 
       if (!isValidDateString(dateOfBirth)) {
         ctx.addIssue({
@@ -144,10 +144,10 @@ export async function action({ context: { appContainer, session }, params, reque
           message: t('renew-child:children.information.error-message.date-of-birth-is-past-valid'),
           path: ['dateOfBirth'],
         });
-      } else if (getAgeFromDateString(dateOfBirth, coverageStartDate) >= 18) {
+      } else if (getAgeFromDateString(dateOfBirth, coverageEndDate) >= 18) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('renew-child:children.information.error-message.date-of-birth-ineligible', { coverageStartDate: toLocaleDateString(parseDateString(coverageStartDate), locale) }),
+          message: t('renew-child:children.information.error-message.date-of-birth-ineligible', { coverageEndDate: toLocaleDateString(parseDateString(coverageEndDate), locale) }),
           path: ['dateOfBirth'],
         });
       }

--- a/frontend/app/routes/public/renew/index.tsx
+++ b/frontend/app/routes/public/renew/index.tsx
@@ -44,7 +44,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     applicationYear: {
       renewalYearId: applicationYear.renewalYearId,
       taxYear: applicationYear.taxYear,
-      coverageStartDate: applicationYear.coverageStartDate,
+      coverageEndDate: applicationYear.coverageEndDate,
     },
     id,
     session,

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -318,7 +318,7 @@
         "date-of-birth-day-required": "Date of birth must include a day",
         "date-of-birth-is-past": "Date of birth must be in the past",
         "date-of-birth-is-past-valid": "Date of birth too far in the past",
-        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageStartDate}}. They must submit an application as an adult to maintain their dental coverage.",
+        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageEndDate}}. They must submit an application as an adult to maintain their dental coverage.",
         "date-of-birth-month-required": "Date of birth must include a month",
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -59,7 +59,7 @@
         "date-of-birth-day-required": "Date of birth must include a day",
         "date-of-birth-is-past": "Date of birth must be in the past",
         "date-of-birth-is-past-valid": "Date of birth too far in the past",
-        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageStartDate}}. They must submit an application as an adult to maintain their dental coverage.",
+        "date-of-birth-ineligible": "The individual is not eligible to renew their benefits because they will be 18 as of {{coverageEndDate}}. They must submit an application as an adult to maintain their dental coverage.",
         "date-of-birth-month-required": "Date of birth must include a month",
         "date-of-birth-valid": "Day must be valid for the given month and year",
         "date-of-birth-year-number": "Year must be a number, for example 1950",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -319,7 +319,7 @@
         "date-of-birth-day-required": "La date de naissance doit inclure un jour",
         "date-of-birth-is-past": "La date de naissance doit être dans le passé",
         "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
-        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageStartDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
+        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageEndDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
         "date-of-birth-month-required": "La date de naissance doit inclure un mois",
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisis",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -59,7 +59,7 @@
         "date-of-birth-day-required": "La date de naissance doit inclure un jour",
         "date-of-birth-is-past": "La date de naissance doit être dans le passé",
         "date-of-birth-is-past-valid": "Date de naissance trop éloignée dans le passé",
-        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageStartDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
+        "date-of-birth-ineligible": "La personne n'est pas éligible au renouvellement de ses prestations car elle aura 18 ans à compter du {{coverageEndDate}}. Ils doivent soumettre une demande à l'âge adulte pour maintenir leur couverture dentaire.",
         "date-of-birth-month-required": "La date de naissance doit inclure un mois",
         "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisis",
         "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",


### PR DESCRIPTION
### Description
Before this PR, we use the "previous application year" to display that year's coverage end date in certain error messages. That "previous application year" doesn't exist when we query Interop's `retrieve application config dates` endpoint using May 1, 2025 (or after) so we fail (early).

This PR defaults to the current/matching application year coverage end date when no "previous application year" exists. See change in `application-year.service.ts`. The rest of the files in this PR are just field name changes.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/19286

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`