### PR TITLE
Preventing unintended form submission on Enter key press by setting `type='button'` to Request new verification code button

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
@@ -217,7 +217,15 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
                 required
               />
             </div>
-            <LoadingButton id="request-button" name="_action" variant="link" loading={isSubmitting} value={FORM_ACTION.request} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Request new verification code - Verify email click">
+            <LoadingButton
+              id="request-button"
+              type="button"
+              name="_action"
+              variant="link"
+              loading={isSubmitting}
+              value={FORM_ACTION.request}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Request new verification code - Verify email click"
+            >
               {t('apply-adult:verify-email.request-new-code')}
             </LoadingButton>
           </fieldset>


### PR DESCRIPTION
### Description
Hitting Enter on `/verify-email` now triggers "Continue" instead of requesting a new verification code.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`