### PR TITLE
Reflect home address update in request payload

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -122,7 +122,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToReview) {
-    saveProtectedRenewState({ params, request, session, state: { homeAddress } });
+    saveProtectedRenewState({ params, request, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
     if (state.editMode === false && isInvitationToApplyClient(state.clientApplication)) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
@@ -179,7 +179,7 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     request,
     session,
-    state: { homeAddress },
+    state: { homeAddress, isHomeAddressSameAsMailingAddress: false },
   });
 
   const idToken: IdToken = session.get('idToken');

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -116,8 +116,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
-    saveApplyState({ params, session, state: { homeAddress } });
+    saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
@@ -170,7 +169,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveApplyState({ params, session, state: { homeAddress } });
+  saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -118,7 +118,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
     saveApplyState({
       params,
       session,

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -116,8 +116,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
-    saveApplyState({ params, session, state: { homeAddress } });
+    saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/adult/review-information', params));
@@ -170,7 +169,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveApplyState({ params, session, state: { homeAddress } });
+  saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -118,7 +118,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
     saveApplyState({
       params,
       session,

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -116,8 +116,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
-    saveApplyState({ params, session, state: { homeAddress } });
+    saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
@@ -170,7 +169,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveApplyState({ params, session, state: { homeAddress } });
+  saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -118,7 +118,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
 
   if (canProceedToDental) {
-    // TODO: To check if we need this 'if' statement for the redirects.
     saveApplyState({
       params,
       session,

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -122,7 +122,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
-    saveRenewState({ params, session, state: { homeAddress } });
+    saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
@@ -175,7 +175,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveRenewState({ params, session, state: { homeAddress } });
+  saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
-    saveRenewState({ params, session, state: { homeAddress } });
+    saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
@@ -176,7 +176,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveRenewState({ params, session, state: { homeAddress } });
+  saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
-    saveRenewState({ params, session, state: { homeAddress } });
+    saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/renew/$id/child/review-adult-information', params));
@@ -176,7 +176,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveRenewState({ params, session, state: { homeAddress } });
+  saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isUseSelectedAddressAction = formAction === FORM_ACTION.useSelectedAddress;
   const canProceedToDental = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToDental) {
-    saveRenewState({ params, session, state: { homeAddress } });
+    saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
     if (state.editMode) {
       return redirect(getPathById('public/renew/$id/ita/review-information', params));
@@ -176,7 +176,7 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     } as const satisfies AddressSuggestionResponse;
   }
-  saveRenewState({ params, session, state: { homeAddress } });
+  saveRenewState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/ita/review-information', params));


### PR DESCRIPTION
### Description
The state mapper uses `isHomeAddressSameAsMailingAddress` to determine whether the mailing address should be copied as the home address. Previously, this value remained `true` even if the applicant edited their home address, causing the request payload to incorrectly set the mailing address as the home address.

This PR updates the logic to set `isHomeAddressSameAsMailingAddress` to `false` when the home address is edited, ensuring it no longer defaults to the mailing address.

### Related Azure Boards Work Items
[AB#5357](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5357)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Enter any apply/renew flow. Initially fill out the mailing address and indicate that the home address is the same as the mailing address. Proceed to the Review page and update the home address. On the Review page, verify that the request payload sets the `MailingSameAsHomeIndicator` field to `false` and that the home address is different from the mailing address.

### Additional Notes
Removed some unneeded `TODO`s