### PR TITLE
Refactor benefit renewal DTO so there's no dependency on benefit application DTO

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -256,11 +256,6 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         dentalInsurance: true,
         partnerInformation: undefined,
         typeOfApplication: 'adult-child',
-        termsAndConditions: {
-          acknowledgeTerms: true,
-          acknowledgePrivacy: true,
-          shareData: true,
-        },
         userId: 'anonymous',
       };
 

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -1,11 +1,11 @@
-import type { ApplicantInformationDto, BenefitApplicationDto, ChildDto } from '~/.server/domain/dtos/benefit-application.dto';
+import type { ReadonlyDeep } from 'type-fest';
 
 export type AdultBenefitRenewalDto = BenefitRenewalDto &
-  Readonly<{
+  ReadonlyDeep<{
     changeIndicators: AdultChangeIndicators;
   }>;
 
-export type AdultChangeIndicators = Readonly<{
+export type AdultChangeIndicators = ReadonlyDeep<{
   hasAddressChanged: boolean;
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
@@ -13,11 +13,11 @@ export type AdultChangeIndicators = Readonly<{
 }>;
 
 export type AdultChildBenefitRenewalDto = BenefitRenewalDto &
-  Readonly<{
+  ReadonlyDeep<{
     changeIndicators: AdultChildChangeIndicators;
   }>;
 
-export type AdultChildChangeIndicators = Readonly<{
+export type AdultChildChangeIndicators = ReadonlyDeep<{
   hasAddressChanged: boolean;
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
@@ -25,20 +25,20 @@ export type AdultChildChangeIndicators = Readonly<{
 }>;
 
 export type ItaBenefitRenewalDto = BenefitRenewalDto &
-  Readonly<{
+  ReadonlyDeep<{
     changeIndicators: ItaChangeIndicators;
   }>;
 
-export type ItaChangeIndicators = Readonly<{
+export type ItaChangeIndicators = ReadonlyDeep<{
   hasAddressChanged: boolean;
 }>;
 
 export type ChildBenefitRenewalDto = BenefitRenewalDto &
-  Readonly<{
+  ReadonlyDeep<{
     changeIndicators: ChildChangeIndicators;
   }>;
 
-export type ChildChangeIndicators = Readonly<{
+export type ChildChangeIndicators = ReadonlyDeep<{
   hasAddressChanged: boolean;
   hasEmailChanged: boolean;
   hasMaritalStatusChanged: boolean;
@@ -47,35 +47,81 @@ export type ChildChangeIndicators = Readonly<{
 
 export type ProtectedBenefitRenewalDto = BenefitRenewalDto;
 
-export type BenefitRenewalDto = Omit<BenefitApplicationDto, 'applicantInformation' | 'children' | 'partnerInformation'> &
-  Readonly<{
-    applicantInformation: RenewalApplicantInformationDto;
-    applicationYearId: string;
-    children: RenewalChildDto[];
-    demographicSurvey?: DemographicSurveyDto;
-    partnerInformation?: RenewalPartnerInformationDto;
-  }>;
+export type BenefitRenewalDto = ReadonlyDeep<{
+  applicantInformation: RenewalApplicantInformationDto;
+  applicationYearId: string;
+  children: RenewalChildDto[];
+  communicationPreferences: RenewalCommunicationPreferencesDto;
+  contactInformation: RenewalContactInformationDto;
+  dateOfBirth: string;
+  dentalBenefits: string[];
+  dentalInsurance?: boolean;
+  demographicSurvey?: DemographicSurveyDto;
+  partnerInformation?: RenewalPartnerInformationDto;
+  typeOfApplication: RenewalTypeOfApplicationDto;
 
-export type RenewalApplicantInformationDto = ApplicantInformationDto &
-  Readonly<{
-    clientId: string;
-    clientNumber: string;
-  }>;
+  /** A unique identifier for the user making the request - used for auditing */
+  userId: string;
+}>;
 
-export type RenewalChildDto = ChildDto &
-  Readonly<{
-    clientId: string;
-    clientNumber: string;
-    demographicSurvey?: DemographicSurveyDto;
-  }>;
+export type RenewalApplicantInformationDto = ReadonlyDeep<{
+  clientId: string;
+  clientNumber: string;
+  firstName: string;
+  lastName: string;
+  maritalStatus: string;
+  socialInsuranceNumber: string;
+}>;
 
-export type RenewalPartnerInformationDto = Readonly<{
+export type RenewalChildDto = ReadonlyDeep<{
+  clientId: string;
+  clientNumber: string;
+  dentalBenefits: string[];
+  dentalInsurance: boolean;
+  demographicSurvey?: DemographicSurveyDto;
+  information: {
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    isParent: boolean;
+    socialInsuranceNumber?: string;
+  };
+}>;
+
+export type RenewalCommunicationPreferencesDto = ReadonlyDeep<{
+  email?: string;
+  preferredLanguage: string;
+  preferredMethod: string;
+}>;
+
+export type RenewalContactInformationDto = ReadonlyDeep<{
+  copyMailingAddress: boolean;
+  homeAddress: string;
+  homeApartment?: string;
+  homeCity: string;
+  homeCountry: string;
+  homePostalCode?: string;
+  homeProvince?: string;
+  mailingAddress: string;
+  mailingApartment?: string;
+  mailingCity: string;
+  mailingCountry: string;
+  mailingPostalCode?: string;
+  mailingProvince?: string;
+  phoneNumber?: string;
+  phoneNumberAlt?: string;
+  email?: string;
+}>;
+
+export type RenewalPartnerInformationDto = ReadonlyDeep<{
   confirm: boolean;
   yearOfBirth: string;
   socialInsuranceNumber: string;
 }>;
 
-export type DemographicSurveyDto = Readonly<{
+export type RenewalTypeOfApplicationDto = 'adult' | 'adult-child' | 'child';
+
+export type DemographicSurveyDto = ReadonlyDeep<{
   indigenousStatus?: string;
   firstNations?: string;
   disabilityStatus?: string;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -11,17 +11,16 @@ import type {
   AdultChildChangeIndicators,
   ChildBenefitRenewalDto,
   ChildChangeIndicators,
-  CommunicationPreferencesDto,
-  ContactInformationDto,
   DemographicSurveyDto,
   ItaBenefitRenewalDto,
   ItaChangeIndicators,
   ProtectedBenefitRenewalDto,
   RenewalApplicantInformationDto,
   RenewalChildDto,
+  RenewalCommunicationPreferencesDto,
+  RenewalContactInformationDto,
   RenewalPartnerInformationDto,
-  TermsAndConditionsDto,
-  TypeOfApplicationDto,
+  RenewalTypeOfApplicationDto,
 } from '~/.server/domain/dtos';
 import type { BenefitRenewalRequestEntity } from '~/.server/domain/entities';
 import { parseDateString } from '~/utils/date-utils';
@@ -39,8 +38,8 @@ interface ToBenefitRenewalRequestEntityArgs {
   applicationYearId: string;
   changeIndicators?: AdultChangeIndicators | AdultChildChangeIndicators | ItaChangeIndicators | ChildChangeIndicators;
   children: readonly RenewalChildDto[];
-  communicationPreferences: CommunicationPreferencesDto;
-  contactInformation: ContactInformationDto;
+  communicationPreferences: RenewalCommunicationPreferencesDto;
+  contactInformation: RenewalContactInformationDto;
   dateOfBirth: string;
   demographicSurvey?: DemographicSurveyDto;
   dentalBenefits: readonly string[];
@@ -48,8 +47,7 @@ interface ToBenefitRenewalRequestEntityArgs {
   disabilityTaxCredit?: boolean;
   livingIndependently?: boolean;
   partnerInformation?: RenewalPartnerInformationDto;
-  termsAndConditions: TermsAndConditionsDto;
-  typeOfApplication: TypeOfApplicationDto;
+  typeOfApplication: RenewalTypeOfApplicationDto;
 }
 
 interface ToAddressArgs {
@@ -116,7 +114,6 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     disabilityTaxCredit,
     livingIndependently,
     partnerInformation,
-    termsAndConditions, // TODO map terms and conditions when Interop provides field structure
     typeOfApplication,
   }: ToBenefitRenewalRequestEntityArgs): BenefitRenewalRequestEntity {
     return {
@@ -126,9 +123,9 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
             PrivateDentalInsuranceIndicator: dentalInsurance,
             DisabilityTaxCreditIndicator: disabilityTaxCredit,
             LivingIndependentlyIndicator: livingIndependently,
-            PrivacyStatementIndicator: termsAndConditions.acknowledgePrivacy,
-            TermsAndConditionsIndicator: termsAndConditions.acknowledgeTerms,
-            SharingConsentIndicator: termsAndConditions.shareData,
+            PrivacyStatementIndicator: true,
+            TermsAndConditionsIndicator: true,
+            SharingConsentIndicator: true,
             InsurancePlan: this.toInsurancePlan(dentalBenefits),
             ...this.toChangeIndicators(changeIndicators),
           },
@@ -281,7 +278,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     };
   }
 
-  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: ContactInformationDto) {
+  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: RenewalContactInformationDto) {
     return this.toAddress({
       address: mailingAddress,
       apartment: mailingApartment,
@@ -293,7 +290,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     });
   }
 
-  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: ContactInformationDto) {
+  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: RenewalContactInformationDto) {
     return this.toAddress({
       address: homeAddress,
       apartment: homeApartment,
@@ -345,7 +342,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     return emailAddress;
   }
 
-  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: ContactInformationDto) {
+  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: RenewalContactInformationDto) {
     const telephoneNumber = [];
 
     if (phoneNumber && !validator.isEmpty(phoneNumber)) {
@@ -433,7 +430,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     }));
   }
 
-  private toBenefitApplicationCategoryCode(typeOfApplication: TypeOfApplicationDto) {
+  private toBenefitApplicationCategoryCode(typeOfApplication: RenewalTypeOfApplicationDto) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_FAMILY, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
     if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL.toString();
     if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY.toString();

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -18,6 +18,10 @@ import type {
   ItaBenefitRenewalDto,
   ProtectedBenefitRenewalDto,
   RenewalApplicantInformationDto,
+  RenewalChildDto,
+  RenewalCommunicationPreferencesDto,
+  RenewalContactInformationDto,
+  RenewalPartnerInformationDto,
 } from '~/.server/domain/dtos';
 import type { FederalGovernmentInsurancePlanService, ProvincialGovernmentInsurancePlanService } from '~/.server/domain/services';
 import type {
@@ -269,7 +273,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
-      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'adult',
       userId: 'anonymous',
     };
@@ -347,7 +350,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
-      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: children.length === 0 ? 'adult' : 'adult-child',
       userId: 'anonymous',
     };
@@ -407,7 +409,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: true,
         renewedPartnerInformation: partnerInformation,
       }),
-      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'adult',
       userId: 'anonymous',
     };
@@ -471,7 +472,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged,
         renewedPartnerInformation: partnerInformation,
       }),
-      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: 'child',
       userId: 'anonymous',
     };
@@ -541,7 +541,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedPartnerInformation: partnerInformation,
       }),
       userId,
-      termsAndConditions: this.toTermsAndConditions(),
       typeOfApplication: applicantStateCompleted === false && children.length > 0 ? 'child' : children.length === 0 ? 'adult' : 'adult-child',
     };
   }
@@ -564,7 +563,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs) {
+  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs): RenewalChildDto[] {
     return renewedChildren.map((renewedChild) => {
       const existingChild = existingChildren.find((existingChild) => existingChild.information.clientNumber === renewedChild.information?.clientNumber);
       invariant(existingChild, 'Expected existingChild to be defined');
@@ -599,7 +598,16 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     });
   }
 
-  private toContactInformation({ existingContactInformation, hasAddressChanged, hasEmailChanged, hasPhoneChanged, isHomeAddressSameAsMailingAddress, renewedContactInformation, renewedHomeAddress, renewedMailingAddress }: ToContactInformationArgs) {
+  private toContactInformation({
+    existingContactInformation,
+    hasAddressChanged,
+    hasEmailChanged,
+    hasPhoneChanged,
+    isHomeAddressSameAsMailingAddress,
+    renewedContactInformation,
+    renewedHomeAddress,
+    renewedMailingAddress,
+  }: ToContactInformationArgs): RenewalContactInformationDto {
     return {
       ...(hasAddressChanged
         ? {
@@ -725,7 +733,14 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         };
   }
 
-  private toCommunicationPreferences({ existingCommunicationPreferences, hasEmailChanged, renewedEmail, renewedReceiveEmailCommunication, hasPreferredLanguageChanged, renewedPreferredLanguage }: ToCommunicationPreferencesArgs) {
+  private toCommunicationPreferences({
+    existingCommunicationPreferences,
+    hasEmailChanged,
+    renewedEmail,
+    renewedReceiveEmailCommunication,
+    hasPreferredLanguageChanged,
+    renewedPreferredLanguage,
+  }: ToCommunicationPreferencesArgs): RenewalCommunicationPreferencesDto {
     if (!hasEmailChanged && !hasPreferredLanguageChanged) return existingCommunicationPreferences;
 
     return {
@@ -735,7 +750,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toDentalBenefits({ existingDentalBenefits, hasFederalProvincialTerritorialBenefitsChanged, renewedDentalBenefits }: ToDentalBenefitsArgs) {
+  private toDentalBenefits({ existingDentalBenefits, hasFederalProvincialTerritorialBenefitsChanged, renewedDentalBenefits }: ToDentalBenefitsArgs): readonly string[] {
     if (!hasFederalProvincialTerritorialBenefitsChanged) return existingDentalBenefits;
     if (!renewedDentalBenefits) return [];
 
@@ -752,15 +767,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return dentalBenefits;
   }
 
-  private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs) {
+  private toPartnerInformation({ existingPartnerInformation, hasMaritalStatusChanged, renewedPartnerInformation }: ToPartnerInformationArgs): RenewalPartnerInformationDto | undefined {
     return hasMaritalStatusChanged ? renewedPartnerInformation : existingPartnerInformation;
-  }
-
-  private toTermsAndConditions() {
-    return {
-      acknowledgeTerms: true,
-      acknowledgePrivacy: true,
-      shareData: true,
-    };
   }
 }


### PR DESCRIPTION
### Description
Implementing #3364 was more difficult than expected because some benefit renewal DTOs depend on benefit application DTOs, even though they serve distinct requirements and should be independent.

This PR separates the two DTO sets, eliminating their dependency on each other. As a result, adding a mandatory field to the benefit application DTO will no longer risk breaking the renewal DTOs.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
- The terms and conditions fields are defaulted in the benefit renewal DTO mapper, which makes sense because the renewal flow does not store these values in the state object. Previously, we defaulted this value in the renewal DTO (that depended on the benefit application DTO).
- `preferredMethodGovernmentOfCanada` can be made mandatory (in a future PR) in benefit application DTO without impacting the renewal DTO.