### PR TITLE
Refactor client application DTO so there's no dependency on benefit application DTO; Making `preferredMethodGovernmentOfCanada` mandatory in benefit application DTO

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -43,7 +43,7 @@ export type CommunicationPreferencesDto = ReadonlyDeep<{
   emailVerified?: boolean;
   preferredLanguage: string;
   preferredMethod: string;
-  preferredMethodGovernmentOfCanada?: string;
+  preferredMethodGovernmentOfCanada: string;
 }>;
 
 export type ContactInformationDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -1,11 +1,9 @@
 import type { ReadonlyDeep } from 'type-fest';
 
-import type { ChildDto, CommunicationPreferencesDto } from '~/.server/domain/dtos/benefit-application.dto';
-
 export type ClientApplicationDto = ReadonlyDeep<{
   applicantInformation: ClientApplicantInformationDto;
   children: ClientChildDto[];
-  communicationPreferences: CommunicationPreferencesDto;
+  communicationPreferences: ClientCommunicationPreferencesDto;
   contactInformation: ClientContactInformationDto;
   dateOfBirth: string;
   dentalBenefits: string[];
@@ -27,7 +25,9 @@ export type ClientApplicantInformationDto = Readonly<{
   clientNumber?: string;
 }>;
 
-export type ClientChildDto = Omit<ChildDto, 'information'> & {
+export type ClientChildDto = ReadonlyDeep<{
+  dentalBenefits: string[];
+  dentalInsurance: boolean;
   information: {
     firstName: string;
     lastName: string;
@@ -37,7 +37,13 @@ export type ClientChildDto = Omit<ChildDto, 'information'> & {
     clientNumber?: string;
     socialInsuranceNumber: string;
   };
-};
+}>;
+
+export type ClientCommunicationPreferencesDto = ReadonlyDeep<{
+  email?: string;
+  preferredLanguage: string;
+  preferredMethod: string;
+}>;
 
 export type ClientContactInformationDto = ReadonlyDeep<{
   copyMailingAddress: boolean;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -12,9 +12,9 @@ import type {
   ClientApplicantInformationDto,
   ClientApplicationDto,
   ClientChildDto,
+  ClientCommunicationPreferencesDto,
   ClientContactInformationDto,
   ClientPartnerInformationDto,
-  CommunicationPreferencesDto,
   ItaBenefitRenewalDto,
   ProtectedBenefitRenewalDto,
   RenewalApplicantInformationDto,
@@ -146,7 +146,7 @@ interface ToChildrenArgs {
 }
 
 interface ToCommunicationPreferencesArgs {
-  existingCommunicationPreferences: ReadonlyObjectDeep<CommunicationPreferencesDto>;
+  existingCommunicationPreferences: ReadonlyObjectDeep<ClientCommunicationPreferencesDto>;
   hasPreferredLanguageChanged?: boolean;
   renewedPreferredLanguage?: string;
   hasEmailChanged: boolean;


### PR DESCRIPTION
### Description
Similar to #3371 except for client application DTO instead of benefit renewal DTO.

Resulting changes allows `preferredMethodGovernmentOfCanada` to be mandatory since it must be set when submitting a benefit application.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`