### PR TITLE
Following the designers intended workflow editMode in apply/adult.

### DIFF
--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -17,6 +17,13 @@ export type ApplyState = ReadonlyDeep<{
   id: string;
   editMode: boolean;
   lastUpdatedOn: string;
+  editModeApplicantInformation?: {
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    socialInsuranceNumber: string;
+  };
+  editModeLivingIndependently?: boolean;
   applicantInformation?: {
     firstName: string;
     lastName: string;

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -141,24 +141,44 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
-  saveApplyState({
-    params,
-    session,
-    state: {
-      applicantInformation: {
-        firstName: parsedDataResult.data.firstName,
-        lastName: parsedDataResult.data.lastName,
-        dateOfBirth: parsedDataResult.data.dateOfBirth,
-        socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
-      },
-      ...(parsedDataResult.data.dateOfBirthYear < 2006 && {
-        // Handle marital-status back button
-        newOrExistingMember: undefined,
-      }),
-    },
-  });
-
   const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
+
+  if (state.editMode && (ageCategory === 'youth' || ageCategory === 'children' || parsedDataResult.data.dateOfBirthYear >= 2006)) {
+    // Temporary state save until the user is finished with editMode workflow.
+    saveApplyState({
+      params,
+      session,
+      state: {
+        editModeApplicantInformation: {
+          firstName: parsedDataResult.data.firstName,
+          lastName: parsedDataResult.data.lastName,
+          dateOfBirth: parsedDataResult.data.dateOfBirth,
+          socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
+        },
+        ...(parsedDataResult.data.dateOfBirthYear < 2006 && {
+          // Handle marital-status back button
+          newOrExistingMember: undefined,
+        }),
+      },
+    });
+  } else {
+    saveApplyState({
+      params,
+      session,
+      state: {
+        applicantInformation: {
+          firstName: parsedDataResult.data.firstName,
+          lastName: parsedDataResult.data.lastName,
+          dateOfBirth: parsedDataResult.data.dateOfBirth,
+          socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
+        },
+        ...(parsedDataResult.data.dateOfBirthYear < 2006 && {
+          // Handle marital-status back button
+          newOrExistingMember: undefined,
+        }),
+      },
+    });
+  }
 
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult/living-independently', params));

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -32,6 +32,12 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
 
+const FORM_ACTION = {
+  cancel: 'cancel',
+  save: 'save',
+  continue: 'continue',
+} as const;
+
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('apply-adult', 'apply', 'gcweb'),
   pageIdentifier: pageIds.public.apply.adult.newOrExistingMember,
@@ -61,6 +67,12 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+
+  if (formAction === FORM_ACTION.cancel) {
+    return redirect(getPathById('public/apply/$id/adult/review-information', params));
+  }
 
   const newOrExistingMemberSchema = z
     .object({
@@ -95,20 +107,32 @@ export async function action({ context: { appContainer, session }, params, reque
   if (!parsedDataResult.success) {
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  saveApplyState({
-    params,
-    session,
-    state: {
-      newOrExistingMember: {
-        isNewOrExistingMember: parsedDataResult.data.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes,
-        clientNumber: parsedDataResult.data.clientNumber,
-      },
-    },
-  });
-
   if (state.editMode) {
+    // Save editMode data to state.
+    saveApplyState({
+      params,
+      session,
+      state: {
+        applicantInformation: state.editModeApplicantInformation,
+        livingIndependently: state.editModeLivingIndependently,
+        newOrExistingMember: {
+          isNewOrExistingMember: parsedDataResult.data.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes,
+          clientNumber: parsedDataResult.data.clientNumber,
+        },
+      },
+    });
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
+  } else {
+    saveApplyState({
+      params,
+      session,
+      state: {
+        newOrExistingMember: {
+          isNewOrExistingMember: parsedDataResult.data.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes,
+          clientNumber: parsedDataResult.data.clientNumber,
+        },
+      },
+    });
   }
 
   return redirect(getPathById('public/apply/$id/adult/marital-status', params));
@@ -172,16 +196,24 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
           )}
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - New or existing member click">
+              <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - New or existing member click">
                 {t('apply-adult:new-or-existing-member.save-btn')}
               </Button>
-              <ButtonLink id="back-button" routeId="public/apply/$id/adult/review-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - New or existing member click">
-                {t('apply-adult:new-or-existing-member.back-btn')}
-              </ButtonLink>
+              <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - New or existing member click">
+                {t('apply-adult:new-or-existing-member.cancel-btn')}
+              </Button>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
+              <LoadingButton
+                variant="primary"
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.continue}
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click"
+              >
                 {t('apply-adult:new-or-existing-member.continue-btn')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -39,7 +39,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:parent-or-guardian.page-title') }) };
 
   invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
-  const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
+  const ageCategory = state.editModeApplicantInformation?.dateOfBirth ? getAgeCategoryFromDateString(state.editModeApplicantInformation.dateOfBirth) : getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children' && ageCategory !== 'youth') {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -250,7 +250,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <p>{userInfo.maritalStatus}</p>
                 <div className="mt-4">
                   <InlineLink id="change-martial-status" routeId="public/apply/$id/adult/marital-status" params={params}>
-                    {t('apply-adult:review-information.marital-change')}a
+                    {t('apply-adult:review-information.marital-change')}
                   </InlineLink>
                 </div>
               </DescriptionListItem>

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -386,6 +386,7 @@
       "living-independently-required": "Select whether or not you live independently from your parents"
     },
     "back-btn": "Back",
+    "cancel-btn": "Cancel",
     "continue-btn": "Continue",
     "save-btn": "Save"
   },
@@ -406,6 +407,7 @@
     "no": "No",
     "back-btn": "Back",
     "continue-btn": "Continue",
+    "cancel-btn": "Cancel",
     "save-btn": "Save",
     "error-message": {
       "is-new-or-existing-member-required": "Select whether you have ever been enrolled in the Canadian Dental Care Plan",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -386,6 +386,7 @@
       "living-independently-required": "Sélectionnez si vous vivez de manière indépendente de vos parents"
     },
     "back-btn": "Retour",
+    "cancel-btn": "Annuler",
     "continue-btn": "Continuer",
     "save-btn": "Enregistrer"
   },
@@ -406,6 +407,7 @@
     "no": "Non",
     "back-btn": "Retour",
     "continue-btn": "Continuer",
+    "cancel-btn": "Annuler",
     "save-btn": "Enregistrer",
     "help-message": "L'ajout d'un numéro de téléphone aide le gouvernement du Canada à vous contacter en cas de problème avec votre demande. Sinon, nous vous contacterons par la poste.",
     "error-message": {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

### Related Azure Boards Work Items
[AB#5426](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5426)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Use a date of birth that does not take the user to the "New or existing member" screen, like Jan 1, 1970.
Proceed to the Review screen and edit the date of birth to something that will redirect the user to the "New or existing member" screen, like Jan 1, 2006 and hit "Save".
On the "New or existing member" screen and hit "Back".

It should bring you back to where you came from, while staying in editMode.

(Also works with 2008 -- living-independently)