### PR TITLE
Validating applicant category codes to be strings

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -6,7 +6,7 @@ import type { ClientApplicationEntity, ClientApplicationSinRequestEntity } from 
 import { DefaultClientApplicationDtoMapper } from '~/.server/domain/mappers';
 
 describe('DefaultClientApplicationDtoMapper', () => {
-  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'> = { APPLICANT_CATEGORY_CODE_INDIVIDUAL: 111111111, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: 222222222 };
+  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'> = { APPLICANT_CATEGORY_CODE_INDIVIDUAL: '111111111', APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: '222222222' };
   const mapper = new DefaultClientApplicationDtoMapper(mockServerConfig);
 
   describe('mapClientApplicationEntityToClientApplicationDto', () => {

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -293,9 +293,9 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
 
   private toBenefitApplicationCategoryCode(typeOfApplication: TypeOfApplicationDto) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_FAMILY, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
-    if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL.toString();
-    if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY.toString();
-    return APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY.toString();
+    if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL;
+    if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY;
+    return APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY;
   }
 
   mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity: BenefitApplicationResponseEntity): string {

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -432,8 +432,8 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
 
   private toBenefitApplicationCategoryCode(typeOfApplication: RenewalTypeOfApplicationDto) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_FAMILY, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
-    if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL.toString();
-    if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY.toString();
-    return APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY.toString();
+    if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL;
+    if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY;
+    return APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY;
   }
 }

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -184,8 +184,8 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
   private toBenefitApplicationCategoryCode(typeOfApplication: string) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
-    if (typeOfApplication === APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY.toString()) return 'child';
-    if (typeOfApplication === APPLICANT_CATEGORY_CODE_INDIVIDUAL.toString()) return 'adult';
+    if (typeOfApplication === APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY) return 'child';
+    if (typeOfApplication === APPLICANT_CATEGORY_CODE_INDIVIDUAL) return 'adult';
     return 'adult-child';
   }
 }

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -48,9 +48,9 @@ const serverEnv = clientEnvSchema.extend({
   NODE_ENV: z.enum(['production', 'development', 'test']),
 
   // applicant category codes
-  APPLICANT_CATEGORY_CODE_INDIVIDUAL: z.coerce.number().default(775170000),
-  APPLICANT_CATEGORY_CODE_FAMILY: z.coerce.number().default(775170001),
-  APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: z.coerce.number().default(775170002),
+  APPLICANT_CATEGORY_CODE_INDIVIDUAL: z.string().trim().min(1).default("775170000"),
+  APPLICANT_CATEGORY_CODE_FAMILY: z.string().trim().min(1).default("775170001"),
+  APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: z.string().trim().min(1).default("775170002"),
 
   // province/territory lookup identifiers
   ALBERTA_PROVINCE_ID: z.string().trim().min(1).default("3b17d494-35b3-eb11-8236-0022486d8d5f"),


### PR DESCRIPTION
### Description
There is no need for these applicant category codes to be numbers when we use them as strings via `toString()`.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c54d408d-8b8e-4c25-9f76-be6bb367448a)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`