### PR TITLE
AB#19571 Update navigation on living independently page family flow

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -75,11 +75,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { livingIndependently: parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes } });
 
-  if (parsedDataResult.data.livingIndependently === LIVING_INDEPENDENTLY_OPTION.yes) {
-    return redirect(getPathById('public/apply/$id/adult-child/new-or-existing-member', params));
-  }
-
-  return redirect(getPathById('public/apply/$id/adult-child/parent-or-guardian', params));
+  return redirect(getPathById('public/apply/$id/adult-child/new-or-existing-member', params));
 }
 
 export default function ApplyFlowLivingIndependently({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/e2e/models/PlaywrightApplyAdultChildPage.ts
+++ b/frontend/e2e/models/PlaywrightApplyAdultChildPage.ts
@@ -28,7 +28,8 @@ export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
       | 'living-independently'
       | 'parent-or-guardian'
       | 'review-adult-information'
-      | 'review-child-information',
+      | 'review-child-information'
+      | 'new-or-existing-member',
     heading?: string | RegExp,
   ) {
     let pageInfo: { url: string | RegExp; heading: string | RegExp } | undefined = undefined;
@@ -96,6 +97,10 @@ export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
 
       case 'parent-or-guardian':
         pageInfo = { url: /\/en\/apply\/[a-f0-9-]+\/adult-child\/parent-or-guardian/, heading: 'Parent or legal guardian needs to apply' };
+        break;
+
+      case 'new-or-existing-member':
+        pageInfo = { url: /\/en\/apply\/[a-f0-9-]+\/adult-child\/new-or-existing-member/, heading: 'New or existing member' };
         break;
 
       case 'review-adult-information':

--- a/frontend/e2e/public/apply/adult-child-flow/youth-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-child-flow/youth-category.spec.ts
@@ -27,7 +27,7 @@ test.describe('Youth category', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
   });
 
-  test('Should return to CDCP main page if applicant is 16 or 17, child is not under 18', async ({ page }) => {
+  test('Should navigate to New or existing member page if applicant is 16 or 17, child is not under 18', async ({ page }) => {
     const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
@@ -43,13 +43,8 @@ test.describe('Youth category', () => {
       await page.getByRole('button', { name: 'Continue' }).click();
     });
 
-    await test.step('Should navigate to Parent or guardian page', async () => {
-      await applyAdultChildPage.isLoaded('parent-or-guardian');
-    });
-
-    await test.step('Should return to CDCP main page', async () => {
-      await page.getByRole('button', { name: 'Return to main page' }).click();
-      await expect(page).toHaveURL('https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html');
+    await test.step('Should navigate to New or existing member page', async () => {
+      await applyAdultChildPage.isLoaded('new-or-existing-member');
     });
   });
 


### PR DESCRIPTION
### Description
Both Yes and No option on `living-independently` in adult-child flow should navigate to `new-or-existing-member` page

### Related Azure Boards Work Items
AB#19571

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->