### PR TITLE
Adding `ErrorAlert` component and `useErrorAlert` hook

### DIFF
--- a/frontend/app/components/error-alert.tsx
+++ b/frontend/app/components/error-alert.tsx
@@ -1,0 +1,69 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { forwardRef, useCallback, useEffect, useRef } from 'react';
+
+import type { AlertType } from '~/components/contextual-alert';
+import { ContextualAlert } from '~/components/contextual-alert';
+import * as adobeAnalytics from '~/utils/adobe-analytics.client';
+
+export interface ErrorAlertProps {
+  /* Content to be displayed inside the alert */
+  children: ReactNode;
+
+  /* ID for the alert (defaults to 'error-alert') */
+  id: string;
+
+  /* Type of alert (eg. 'info', 'warning'; defaults to 'danger') */
+  type?: AlertType;
+}
+
+/**
+ * ForwardRef component to display the ErrorAlert with ContextualAlert
+ */
+export const ErrorAlert = forwardRef<HTMLDivElement, ErrorAlertProps>(({ children, id, type = 'danger' }, ref) => {
+  return (
+    <section ref={ref} id={id} className="mb-4" tabIndex={-1}>
+      <ContextualAlert type={type}>{children}</ContextualAlert>
+    </section>
+  );
+});
+ErrorAlert.displayName = 'ErrorAlert';
+
+/**
+ * Custom hook for managing the error alert and its focus/scroll behavior
+ *
+ * @param showErrorAlert Determines if the error alert should be shown. If true, the error alert component will be rendered.
+ * @param errorAlertId The optional ID to be assigned to the error alert component used to focus and scroll to the alert (defaults to 'error-alert').
+ */
+export function useErrorAlert(showErrorAlert: boolean, errorAlertId: string = 'error-alert') {
+  const alertRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (alertRef.current) {
+      alertRef.current.scrollIntoView({ behavior: 'smooth' });
+      alertRef.current.focus();
+      if (adobeAnalytics.isConfigured()) {
+        adobeAnalytics.pushValidationErrorEvent([errorAlertId]);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [alertRef.current, errorAlertId]);
+
+  const errorAlertComponent = useCallback(
+    ({ children }: PropsWithChildren) => {
+      return (
+        showErrorAlert && (
+          <ErrorAlert id={errorAlertId} ref={alertRef}>
+            {children}
+          </ErrorAlert>
+        )
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [alertRef.current, errorAlertId, showErrorAlert],
+  );
+
+  return {
+    errorAlertId,
+    ErrorAlert: errorAlertComponent,
+  };
+}

--- a/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { data, redirect, useFetcher } from 'react-router';
 
@@ -14,9 +14,9 @@ import { saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
-import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
+import { useErrorAlert } from '~/components/error-alert';
 import { useErrorSummary } from '~/components/error-summary';
 import { InlineLink } from '~/components/inline-link';
 import { InputField } from '~/components/input-field';
@@ -179,6 +179,7 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
   const fetcherStatus = typeof fetcher.data === 'object' && 'status' in fetcher.data ? fetcher.data.status : undefined;
   const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
   const errorSummary = useErrorSummary(errors, { verificationCode: 'verification-code' });
+  const { ErrorAlert } = useErrorAlert(fetcherStatus === 'verification-code-mismatch');
 
   const communicationLink = <InlineLink routeId="public/apply/$id/adult/communication-preference" params={params} />;
 
@@ -194,7 +195,10 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
         <Progress value={76} size="lg" label={t('apply:progress.label')} />
       </div>
       <div className="max-w-prose">
-        {fetcherStatus === 'verification-code-mismatch' && <VerificationCodeAlert />}
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t('apply-adult:verify-email.verification-code-alert.heading')}</h2>
+          <p className="mb-2">{t('apply-adult:verify-email.verification-code-alert.detail')}</p>
+        </ErrorAlert>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
@@ -283,27 +287,5 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
         </Dialog>
       </div>
     </>
-  );
-}
-
-function VerificationCodeAlert() {
-  const { t } = useTranslation(handle.i18nNamespaces);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const setWrapperRef = (node: HTMLDivElement | null) => {
-    if (node) {
-      node.scrollIntoView({ behavior: 'smooth' });
-      node.focus();
-    }
-    wrapperRef.current = node;
-  };
-
-  return (
-    <div ref={setWrapperRef} id="verification-code-alert" className="mb-4" role="region" aria-live="assertive" tabIndex={-1}>
-      <ContextualAlert type="danger">
-        <h2 className="mb-2 font-bold">{t('apply-adult:verify-email.verification-code-alert.heading')}</h2>
-        <p className="mb-2">{t('apply-adult:verify-email.verification-code-alert.detail')}</p>
-      </ContextualAlert>
-    </div>
   );
 }


### PR DESCRIPTION
### Description
This PR introduces a reusable component and hook for rendering error as alerts.

Prior to this PR, various routes were using the same (copy and pasted) component that repeated the alert message multiple times when using a screen-reader, which was flagged as an accessibility issue. This PR addresses this be removing the use of `aria-live` and `region` attributes after testing with NVDA and Orca.

This PR also adds the use of this component/hook in the adult flow's `/verify-email` route.

### Related Azure Boards Work Items
[AB#5350](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5350)

### Screenshots (if applicable)
Before (from Dev instance - error alert read multiple times):
![image](https://github.com/user-attachments/assets/1cd12024-8a83-407e-9b70-b293cee78920)

After (error alert read once):
![image](https://github.com/user-attachments/assets/96f9b3a0-679d-49b7-b282-da67e8a2410b)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Component will be applied to the rest of the routes in a future PR.