### PR TITLE
Only scroll and focus on error alert if shown

### DIFF
--- a/frontend/app/components/error-alert.tsx
+++ b/frontend/app/components/error-alert.tsx
@@ -38,7 +38,7 @@ export function useErrorAlert(showErrorAlert: boolean, errorAlertId: string = 'e
   const alertRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (alertRef.current) {
+    if (alertRef.current && showErrorAlert) {
       alertRef.current.scrollIntoView({ behavior: 'smooth' });
       alertRef.current.focus();
       if (adobeAnalytics.isConfigured()) {
@@ -46,7 +46,7 @@ export function useErrorAlert(showErrorAlert: boolean, errorAlertId: string = 'e
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [alertRef.current, errorAlertId]);
+  }, [alertRef.current, errorAlertId, showErrorAlert]);
 
   const errorAlertComponent = useCallback(
     ({ children }: PropsWithChildren) => {


### PR DESCRIPTION
### Description
This PR addresses an issue where the screen reader (NVDA) would read the error alert even after the user fixed the error and submitted the form or navigated to the next page. This fix ensures that the error alert is no longer read in these scenarios.

### Related Azure Boards Work Items
[AB#5350](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5350)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`