### PR TITLE
Removing use of `disableScreenReaderErrors`; Fixing `aria-errormessage` for Year field

### DIFF
--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -39,23 +39,9 @@ export interface DatePickerFieldProps {
     year: string;
   };
   required?: boolean;
-  disableScreenReaderErrors?: boolean;
 }
 
-export const DatePickerField = ({
-  defaultValue,
-  disabled,
-  errorMessages,
-  helpMessagePrimary,
-  helpMessagePrimaryClassName,
-  helpMessageSecondary,
-  helpMessageSecondaryClassName,
-  id,
-  legend,
-  names,
-  required,
-  disableScreenReaderErrors,
-}: DatePickerFieldProps) => {
+export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, names, required }: DatePickerFieldProps) => {
   const { currentLanguage } = useCurrentLanguage();
   const { t } = useTranslation(['gcweb']);
   const [value] = useState(extractDateParts(defaultValue));
@@ -154,30 +140,30 @@ export const DatePickerField = ({
     return {
       all:
         typeof errorMessages?.all === 'string' ? (
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdAll} data-testid="date-picker-error-all">
+          <InputError id={inputErrorIdAll} data-testid="date-picker-error-all">
             {errorMessages.all}
           </InputError>
         ) : undefined,
       month:
         typeof errorMessages?.month === 'string' ? (
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdMonth} data-testid="date-picker-error-month">
+          <InputError id={inputErrorIdMonth} data-testid="date-picker-error-month">
             {errorMessages.month}
           </InputError>
         ) : undefined,
       day:
         typeof errorMessages?.day === 'string' ? (
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdDay} data-testid="date-picker-error-day">
+          <InputError id={inputErrorIdDay} data-testid="date-picker-error-day">
             {errorMessages.day}
           </InputError>
         ) : undefined,
       year:
         typeof errorMessages?.year === 'string' ? (
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorIdYear} data-testid="date-picker-error-year">
+          <InputError id={inputErrorIdYear} data-testid="date-picker-error-year">
             {errorMessages.year}
           </InputError>
         ) : undefined,
     };
-  }, [errorMessages?.all, errorMessages?.day, errorMessages?.month, errorMessages?.year, inputErrorIdAll, inputErrorIdDay, inputErrorIdMonth, inputErrorIdYear, disableScreenReaderErrors]);
+  }, [errorMessages?.all, errorMessages?.day, errorMessages?.month, errorMessages?.year, inputErrorIdAll, inputErrorIdDay, inputErrorIdMonth, inputErrorIdYear]);
 
   return (
     <div id={inputWrapperId} data-testid="date-picker-field">

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -66,9 +66,9 @@ export const DatePickerField = ({ defaultValue, disabled, errorMessages, helpMes
   const getAriaErrorMessageYear = useCallback(() => {
     const ariaDescribedby = [];
     if (errorMessages?.all) ariaDescribedby.push(inputErrorIdAll);
-    if (errorMessages?.year) ariaDescribedby.push(inputErrorIdMonth);
+    if (errorMessages?.year) ariaDescribedby.push(inputErrorIdYear);
     return ariaDescribedby.length > 0 ? ariaDescribedby.join(' ') : undefined;
-  }, [errorMessages?.all, errorMessages?.year, inputErrorIdAll, inputErrorIdMonth]);
+  }, [errorMessages?.all, errorMessages?.year, inputErrorIdAll, inputErrorIdYear]);
 
   const datePickerYear = useMemo(
     () => (

--- a/frontend/app/components/input-pattern-field.tsx
+++ b/frontend/app/components/input-pattern-field.tsx
@@ -22,25 +22,10 @@ export interface InputPatternFieldProps extends OmitStrict<React.ComponentProps<
   id: string;
   label: string;
   name: string;
-  disableScreenReaderErrors?: boolean;
 }
 
 export function InputPatternField(props: InputPatternFieldProps) {
-  const {
-    'aria-describedby': ariaDescribedby,
-    className,
-    defaultValue,
-    errorMessage,
-    helpMessagePrimary,
-    helpMessagePrimaryClassName,
-    helpMessageSecondary,
-    helpMessageSecondaryClassName,
-    id,
-    label,
-    required,
-    disableScreenReaderErrors,
-    ...restProps
-  } = props;
+  const { 'aria-describedby': ariaDescribedby, className, defaultValue, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
 
   const inputWrapperId = `input-pattern-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -63,9 +48,7 @@ export function InputPatternField(props: InputPatternFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
-            {errorMessage}
-          </InputError>
+          <InputError id={inputErrorId}>{errorMessage}</InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -19,25 +19,9 @@ export interface InputRadiosProps {
   name: string;
   required?: boolean;
   legendClassName?: string;
-  disableScreenReader?: boolean;
-  disableScreenReaderErrors?: boolean;
 }
 
-const InputRadios = ({
-  errorMessage,
-  helpMessagePrimary,
-  helpMessagePrimaryClassName,
-  helpMessageSecondary,
-  helpMessageSecondaryClassName,
-  id,
-  legend,
-  name,
-  options,
-  required,
-  legendClassName,
-  disableScreenReader,
-  disableScreenReaderErrors,
-}: InputRadiosProps) => {
+const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName }: InputRadiosProps) => {
   const inputErrorId = `input-radios-${id}-error`;
   const inputHelpMessagePrimaryId = `input-radios-${id}-help-primary`;
   const inputHelpMessageSecondaryId = `input-radios-${id}-help-secondary`;
@@ -45,7 +29,6 @@ const InputRadios = ({
   const inputWrapperId = `input-radios-${id}`;
 
   function getAriaDescribedby() {
-    if (disableScreenReader) return undefined;
     const ariaDescribedby = [];
     if (helpMessagePrimary) ariaDescribedby.push(inputHelpMessagePrimaryId);
     if (helpMessageSecondary) ariaDescribedby.push(inputHelpMessageSecondaryId);
@@ -59,9 +42,7 @@ const InputRadios = ({
       </InputLegend>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
-            {errorMessage}
-          </InputError>
+          <InputError id={inputErrorId}>{errorMessage}</InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -22,11 +22,10 @@ export interface InputSanitizeFieldProps
   id: string;
   label: string;
   name: string;
-  disableScreenReaderErrors?: boolean;
 }
 
 export function InputSanitizeField(props: InputSanitizeFieldProps) {
-  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, disableScreenReaderErrors, ...restProps } = props;
+  const { 'aria-describedby': ariaDescribedby, className, errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, label, required, ...restProps } = props;
 
   const inputWrapperId = `input-sanitize-field-${id}`;
   const inputErrorId = `${inputWrapperId}-error`;
@@ -49,9 +48,7 @@ export function InputSanitizeField(props: InputSanitizeFieldProps) {
       </InputLabel>
       {errorMessage && (
         <p className="mb-2">
-          <InputError aria-hidden={disableScreenReaderErrors} id={inputErrorId}>
-            {errorMessage}
-          </InputError>
+          <InputError id={inputErrorId}>{errorMessage}</InputError>
         </p>
       )}
       {helpMessagePrimary && (

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -249,7 +249,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -262,7 +261,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -284,7 +282,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -264,7 +264,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
-            disableScreenReaderErrors
           />
         </div>
       ),
@@ -306,7 +305,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -319,7 +317,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-adult-child:children.information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -338,18 +335,9 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
 
-            <InputRadios
-              id="has-social-insurance-number"
-              legend={t('apply-adult-child:children.information.sin-legend')}
-              name="hasSocialInsuranceNumber"
-              options={options}
-              errorMessage={errors?.hasSocialInsuranceNumber}
-              required
-              disableScreenReaderErrors
-            />
+            <InputRadios id="has-social-insurance-number" legend={t('apply-adult-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required />
 
             <InputRadios
               id="is-parent-radios"
@@ -360,7 +348,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('apply-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: !isNew, tabIndex: isNew ? 0 : -1 },
               ]}
               errorMessage={errors?.isParent}
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
@@ -195,7 +195,6 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
                 defaultValue={defaultState?.clientNumber ?? ''}
                 errorMessage={errors?.clientNumber}
                 helpMessagePrimary={t('apply-adult-child:new-or-existing-member.client-number-description')}
-                disableScreenReaderErrors
                 required={isNewOrExistingMember}
               />
             </div>

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -244,7 +244,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -257,7 +256,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 defaultValue={defaultState?.lastName ?? ''}
                 errorMessage={errors?.lastName}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -279,7 +277,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -194,7 +194,6 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
                 defaultValue={defaultState?.clientNumber ?? ''}
                 errorMessage={errors?.clientNumber}
                 helpMessagePrimary={t('apply-adult:new-or-existing-member.client-number-description')}
-                disableScreenReaderErrors
                 required={isNewOrExistingMember}
               />
             </div>

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -247,7 +247,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -260,7 +259,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.lastName}
                 aria-description={t('applicant-information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -279,7 +277,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
             <InputPatternField
               id="social-insurance-number"
@@ -292,7 +289,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               defaultValue={defaultState?.socialInsuranceNumber ?? ''}
               errorMessage={errors?.socialInsuranceNumber}
               required
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -264,7 +264,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
             defaultValue={defaultState?.socialInsuranceNumber ?? ''}
             errorMessage={errors?.socialInsuranceNumber}
             required
-            disableScreenReaderErrors
           />
         </div>
       ),
@@ -306,7 +305,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -319,7 +317,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('apply-child:children.information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -338,10 +335,9 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
 
-            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required disableScreenReaderErrors />
+            <InputRadios id="has-social-insurance-number" legend={t('apply-child:children.information.sin-legend')} name="hasSocialInsuranceNumber" options={options} errorMessage={errors?.hasSocialInsuranceNumber} required />
 
             <InputRadios
               id="is-parent-radios"
@@ -353,7 +349,6 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
               ]}
               errorMessage={errors?.isParent}
               required
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
@@ -192,7 +192,6 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
                 defaultValue={defaultState?.clientNumber ?? ''}
                 errorMessage={errors?.clientNumber}
                 helpMessagePrimary={t('apply-child:new-or-existing-member.client-number-description')}
-                disableScreenReaderErrors
                 required={isNewOrExistingMember}
               />
             </div>

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/information.tsx
@@ -267,7 +267,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -280,7 +279,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-adult-child:children.information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -299,7 +297,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -312,7 +309,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableScreenReaderErrors
             />
             <InputRadios
               id="is-parent-radios"
@@ -323,7 +319,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-adult-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -217,7 +217,6 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.firstName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -230,7 +229,6 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 errorMessage={errors?.lastName}
                 aria-description={t('renew:applicant-information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -249,7 +247,6 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -262,7 +259,6 @@ export default function RenewApplicationInformation({ loaderData, params }: Rout
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableScreenReaderErrors
             />
             <Collapsible id="no-client-number" summary={t('renew:applicant-information.no-client-number')}>
               <div className="space-y-2">

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/information.tsx
@@ -268,7 +268,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.firstName}
                 defaultValue={defaultState?.firstName ?? ''}
                 required
-                disableScreenReaderErrors
               />
               <InputSanitizeField
                 id="last-name"
@@ -281,7 +280,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 errorMessage={errors?.lastName}
                 aria-description={t('renew-child:children.information.name-instructions')}
                 required
-                disableScreenReaderErrors
               />
             </div>
             <DatePickerField
@@ -300,7 +298,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 day: errors?.dateOfBirthDay,
               }}
               required
-              disableScreenReaderErrors
             />
             <InputPatternField
               id="client-number"
@@ -313,7 +310,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
               defaultValue={defaultState?.clientNumber ?? ''}
               errorMessage={errors?.clientNumber}
               required
-              disableScreenReaderErrors
             />
             <InputRadios
               id="is-parent-radios"
@@ -324,7 +320,6 @@ export default function RenewFlowChildInformation({ loaderData, params }: Route.
                 { value: YES_NO_OPTION.no, children: t('renew-child:children.information.radio-options.no'), defaultChecked: defaultState?.isParent === false, readOnly: false, tabIndex: 0 },
               ]}
               errorMessage={errors?.isParent}
-              disableScreenReaderErrors
             />
           </div>
           {editMode ? (


### PR DESCRIPTION
### Description
`disableScreenReaderErrors` isn't needed because we always want inline field errors to be read by screen readers. 

This implementation originally stemmed from [AB#5281](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5281), where errors were being read twice. Specifically, the `ErrorSummary` component was causing the duplication. In #3222, we resolved this issue by removing the `role="alert"` attribute to prevent the errors from being read twice.

This PR also fixes an issue where the `aria-errormessage` for the Year field was incorrectly referencing the error message for the Month field.

### Related Azure Boards Work Items
[AB#5352](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5352)
[AB#5281](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5281)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`