### PR TITLE
AB#5429 -- Refactored confirm dental benefits save state 

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -107,13 +107,13 @@ describe('apply-child-route-helpers', () => {
       expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/children/$childId/dental-insurance, {"lang":"en","id":"00000000-0000-0000-0000-000000000000","childId":"1"}))');
     });
 
-    it('should redirect if a child dentalBenefits is undefined', () => {
+    it('should redirect if a child dentalBenefits is undefined and hasFederalProvincialTerritorialBenefits is true', () => {
       const mockState = {
         ...baseState,
         typeOfApplication: 'child',
         hasFiledTaxes: true,
         children: [
-          { id: '1', information: { dateOfBirth: '2012-02-23', firstName: 'John', hasSocialInsuranceNumber: false, isParent: true, lastName: 'Doe' }, dentalInsurance: true, hasFederalProvincialTerritorialBenefits: false, dentalBenefits: undefined },
+          { id: '1', information: { dateOfBirth: '2012-02-23', firstName: 'John', hasSocialInsuranceNumber: false, isParent: true, lastName: 'Doe' }, dentalInsurance: true, hasFederalProvincialTerritorialBenefits: true, dentalBenefits: undefined },
         ],
       } satisfies ApplyState;
 

--- a/frontend/__tests__/.server/routes/helpers/apply-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-route-helpers.test.ts
@@ -60,8 +60,8 @@ describe('apply-route-helpers', () => {
       },
     } as const satisfies ChildState;
 
-    it('should return true if dentalBenefits is undefined', () => {
-      expect(isNewChildState({ ...childWithAllProps, dentalBenefits: undefined })).toBe(true);
+    it('should return true if dentalBenefits is undefined and hasFederalProvincialTerritorialBenefits is true', () => {
+      expect(isNewChildState({ ...childWithAllProps, dentalBenefits: undefined, hasFederalProvincialTerritorialBenefits: true })).toBe(true);
     });
 
     it('should return true if dentalInsurance is undefined', () => {
@@ -80,10 +80,7 @@ describe('apply-route-helpers', () => {
   describe('getChildrenState', () => {
     const childWithAllProps = {
       id: '00000000-0000-0000-0000-000000000000',
-      dentalBenefits: {
-        hasFederalBenefits: false,
-        hasProvincialTerritorialBenefits: false,
-      },
+      dentalBenefits: undefined,
       dentalInsurance: false,
       information: {
         dateOfBirth: '2012-02-23',
@@ -97,6 +94,7 @@ describe('apply-route-helpers', () => {
     const childWithMissingDentalBenefits = {
       ...childWithAllProps,
       dentalBenefits: undefined,
+      hasFederalProvincialTerritorialBenefits: true,
     } as const satisfies ChildState;
 
     it('should return all children when includesNewChildState is true', () => {

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -213,16 +213,7 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     children,
     communicationPreferences,
     contactInformation,
-    dentalBenefits:
-      hasFederalProvincialTerritorialBenefits === false
-        ? {
-            hasFederalBenefits: false,
-            federalSocialProgram: undefined,
-            hasProvincialTerritorialBenefits: false,
-            provincialTerritorialSocialProgram: undefined,
-            province: undefined,
-          }
-        : dentalBenefits,
+    dentalBenefits,
     dentalInsurance,
     editMode,
     email,
@@ -288,16 +279,7 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
     return {
       ageCategory,
       id,
-      dentalBenefits:
-        hasFederalProvincialTerritorialBenefits === false
-          ? {
-              hasFederalBenefits: false,
-              federalSocialProgram: undefined,
-              hasProvincialTerritorialBenefits: false,
-              provincialTerritorialSocialProgram: undefined,
-              province: undefined,
-            }
-          : dentalBenefits,
+      dentalBenefits,
       dentalInsurance,
       information,
       hasFederalProvincialTerritorialBenefits,

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -196,9 +196,12 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     throw redirect(getPathById('public/apply/$id/adult-child/dental-insurance', params));
   }
 
-  //TODO: refactor to allow dentalBenefits to be undefined if hasFederalProvincialTerritorialBenefits is false
-  if (dentalBenefits === undefined || hasFederalProvincialTerritorialBenefits === undefined) {
+  if (hasFederalProvincialTerritorialBenefits === undefined) {
     throw redirect(getPathById('public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits', params));
+  }
+
+  if (dentalBenefits === undefined && hasFederalProvincialTerritorialBenefits === true) {
+    throw redirect(getPathById('public/apply/$id/adult-child/federal-provincial-territorial-benefits', params));
   }
 
   const children = validateChildrenStateForReview({ childrenState: state.children, params });
@@ -210,7 +213,16 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
     children,
     communicationPreferences,
     contactInformation,
-    dentalBenefits,
+    dentalBenefits:
+      hasFederalProvincialTerritorialBenefits === false
+        ? {
+            hasFederalBenefits: false,
+            federalSocialProgram: undefined,
+            hasProvincialTerritorialBenefits: false,
+            provincialTerritorialSocialProgram: undefined,
+            province: undefined,
+          }
+        : dentalBenefits,
     dentalInsurance,
     editMode,
     email,
@@ -265,11 +277,30 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
       throw redirect(getPathById('public/apply/$id/adult-child/children/$childId/dental-insurance', { ...params, childId }));
     }
 
-    //TODO: refactor to allow dentalBenefits to be undefined if hasFederalProvincialTerritorialBenefits is false
-    if (dentalBenefits === undefined || hasFederalProvincialTerritorialBenefits === undefined) {
+    if (hasFederalProvincialTerritorialBenefits === undefined) {
       throw redirect(getPathById('public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
-    return { ageCategory, id, dentalBenefits, dentalInsurance, information, hasFederalProvincialTerritorialBenefits };
+    if (dentalBenefits === undefined && hasFederalProvincialTerritorialBenefits === true) {
+      throw redirect(getPathById('public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits', { ...params, childId }));
+    }
+
+    return {
+      ageCategory,
+      id,
+      dentalBenefits:
+        hasFederalProvincialTerritorialBenefits === false
+          ? {
+              hasFederalBenefits: false,
+              federalSocialProgram: undefined,
+              hasProvincialTerritorialBenefits: false,
+              provincialTerritorialSocialProgram: undefined,
+              province: undefined,
+            }
+          : dentalBenefits,
+      dentalInsurance,
+      information,
+      hasFederalProvincialTerritorialBenefits,
+    };
   });
 }

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -165,9 +165,12 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     throw redirect(getPathById('public/apply/$id/adult/dental-insurance', params));
   }
 
-  //TODO: refactor to allow dentalBenefits to be undefined if hasFederalProvincialTerritorialBenefits is false
-  if (dentalBenefits === undefined || hasFederalProvincialTerritorialBenefits === undefined) {
+  if (hasFederalProvincialTerritorialBenefits === undefined) {
     throw redirect(getPathById('public/apply/$id/adult/confirm-federal-provincial-territorial-benefits', params));
+  }
+
+  if (dentalBenefits === undefined && hasFederalProvincialTerritorialBenefits === true) {
+    throw redirect(getPathById('public/apply/$id/adult/federal-provincial-territorial-benefits', params));
   }
 
   return {
@@ -177,7 +180,23 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     communicationPreferences,
     contactInformation,
     hasFederalProvincialTerritorialBenefits,
-    dentalBenefits,
+    /*dentalBenefits: {
+      hasFederalBenefits: hasFederalProvincialTerritorialBenefits === false ? false : dentalBenefits?.hasFederalBenefits,
+      federalSocialProgram: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.federalSocialProgram,
+      hasProvincialTerritorialBenefits: hasFederalProvincialTerritorialBenefits === false ? false : dentalBenefits?.hasProvincialTerritorialBenefits,
+      provincialTerritorialSocialProgram: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.provincialTerritorialSocialProgram,
+      province: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.province,
+    },*/
+    dentalBenefits:
+      hasFederalProvincialTerritorialBenefits === false
+        ? {
+            hasFederalBenefits: false,
+            federalSocialProgram: undefined,
+            hasProvincialTerritorialBenefits: false,
+            provincialTerritorialSocialProgram: undefined,
+            province: undefined,
+          }
+        : dentalBenefits,
     dentalInsurance,
     editMode,
     email,

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -180,23 +180,7 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
     communicationPreferences,
     contactInformation,
     hasFederalProvincialTerritorialBenefits,
-    /*dentalBenefits: {
-      hasFederalBenefits: hasFederalProvincialTerritorialBenefits === false ? false : dentalBenefits?.hasFederalBenefits,
-      federalSocialProgram: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.federalSocialProgram,
-      hasProvincialTerritorialBenefits: hasFederalProvincialTerritorialBenefits === false ? false : dentalBenefits?.hasProvincialTerritorialBenefits,
-      provincialTerritorialSocialProgram: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.provincialTerritorialSocialProgram,
-      province: hasFederalProvincialTerritorialBenefits === false ? undefined : dentalBenefits?.province,
-    },*/
-    dentalBenefits:
-      hasFederalProvincialTerritorialBenefits === false
-        ? {
-            hasFederalBenefits: false,
-            federalSocialProgram: undefined,
-            hasProvincialTerritorialBenefits: false,
-            provincialTerritorialSocialProgram: undefined,
-            province: undefined,
-          }
-        : dentalBenefits,
+    dentalBenefits,
     dentalInsurance,
     editMode,
     email,

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -248,11 +248,30 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
       throw redirect(getPathById('public/apply/$id/child/children/$childId/dental-insurance', { ...params, childId }));
     }
 
-    //TODO: refactor to allow dentalBenefits to be undefined if hasFederalProvincialTerritorialBenefits is false
-    if (dentalBenefits === undefined || hasFederalProvincialTerritorialBenefits === undefined) {
+    if (hasFederalProvincialTerritorialBenefits === undefined) {
       throw redirect(getPathById('public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits', { ...params, childId }));
     }
 
-    return { ageCategory, dentalBenefits, dentalInsurance, id, information, hasFederalProvincialTerritorialBenefits };
+    if (dentalBenefits === undefined && hasFederalProvincialTerritorialBenefits === true) {
+      throw redirect(getPathById('public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits', { ...params, childId }));
+    }
+
+    return {
+      ageCategory,
+      dentalBenefits:
+        hasFederalProvincialTerritorialBenefits === false
+          ? {
+              hasFederalBenefits: false,
+              federalSocialProgram: undefined,
+              hasProvincialTerritorialBenefits: false,
+              provincialTerritorialSocialProgram: undefined,
+              province: undefined,
+            }
+          : dentalBenefits,
+      dentalInsurance,
+      id,
+      information,
+      hasFederalProvincialTerritorialBenefits,
+    };
   });
 }

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -258,16 +258,7 @@ function validateChildrenStateForReview({ childrenState, params }: ValidateChild
 
     return {
       ageCategory,
-      dentalBenefits:
-        hasFederalProvincialTerritorialBenefits === false
-          ? {
-              hasFederalBenefits: false,
-              federalSocialProgram: undefined,
-              hasProvincialTerritorialBenefits: false,
-              provincialTerritorialSocialProgram: undefined,
-              province: undefined,
-            }
-          : dentalBenefits,
+      dentalBenefits,
       dentalInsurance,
       id,
       information,

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -305,7 +305,7 @@ export function getAgeCategoryFromAge(age: number): AgeCategory {
 }
 
 export function isNewChildState(child: ChildState) {
-  return child.dentalBenefits === undefined || child.dentalInsurance === undefined || child.information === undefined;
+  return (child.hasFederalProvincialTerritorialBenefits === true && child.dentalBenefits === undefined) || child.dentalInsurance === undefined || child.information === undefined;
 }
 
 export function getChildrenState<TState extends Pick<ApplyState, 'children'>>(state: TState, includesNewChildState: boolean = false) {

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -101,15 +101,6 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
-          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits
-            ? state.dentalBenefits
-            : {
-                hasFederalBenefits: false,
-                federalSocialProgram: undefined,
-                hasProvincialTerritorialBenefits: false,
-                provincialTerritorialSocialProgram: undefined,
-                province: undefined,
-              },
         };
       }),
     },

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -91,7 +91,6 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  //TODO: set dentalBenefits state at review instead of using default values here
   saveApplyState({
     params,
     session,
@@ -176,7 +175,7 @@ export default function ApplyAdultChildConfirmFederalProvincialTerritorialBenefi
               </Button>
               <ButtonLink
                 id="cancel-button"
-                routeId="public/apply/$id/adult-child/children/review-child-information"
+                routeId="public/apply/$id/adult-child/review-child-information"
                 params={params}
                 disabled={isSubmitting}
                 data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Child access to other government dental benefits click"

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -100,6 +100,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
+          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? child.dentalBenefits : undefined,
         };
       }),
     },

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -58,13 +58,15 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.index.page-title') }) };
 
   const children = getChildrenState(state).map((child) => {
-    const federalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
-      : undefined;
+    const federalGovernmentInsurancePlan =
+      child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.federalSocialProgram
+        ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+        : undefined;
 
-    const provincialTerritorialSocialProgram = child.dentalBenefits?.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
-      : undefined;
+    const provincialTerritorialSocialProgram =
+      child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
+        ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+        : undefined;
     return {
       ...child,
       dentalBenefits: {

--- a/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -86,6 +86,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
+      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? state.dentalBenefits : undefined,
     },
   });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -87,15 +87,6 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
-      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits
-        ? state.dentalBenefits
-        : {
-            hasFederalBenefits: false,
-            federalSocialProgram: undefined,
-            hasProvincialTerritorialBenefits: false,
-            provincialTerritorialSocialProgram: undefined,
-            province: undefined,
-          },
     },
   });
 

--- a/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -81,7 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  //TODO: set dentalBenefits state at review instead of using default values here
   saveApplyState({
     params,
     session,

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -108,21 +108,23 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const dentalInsurance = state.dentalInsurance;
 
-  const selectedFederalBenefit = state.dentalBenefits.federalSocialProgram
-    ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
-    : undefined;
-  const selectedProvincialBenefit = state.dentalBenefits.provincialTerritorialSocialProgram
-    ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
-    : undefined;
+  const selectedFederalBenefit =
+    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.federalSocialProgram
+      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
+      : undefined;
+  const selectedProvincialBenefit =
+    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.provincialTerritorialSocialProgram
+      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
+      : undefined;
 
   const dentalBenefit = {
     federalBenefit: {
-      access: state.dentalBenefits.hasFederalBenefits,
+      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalBenefit?.name,
     },
     provTerrBenefit: {
-      access: state.dentalBenefits.hasProvincialTerritorialBenefits,
-      province: state.dentalBenefits.province,
+      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasProvincialTerritorialBenefits,
+      province: state.dentalBenefits?.province,
       benefit: selectedProvincialBenefit?.name,
     },
   };

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -108,22 +108,20 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const dentalInsurance = state.dentalInsurance;
 
-  const selectedFederalBenefit =
-    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
-      : undefined;
-  const selectedProvincialBenefit =
-    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
-      : undefined;
+  const selectedFederalBenefit = state.dentalBenefits?.federalSocialProgram
+    ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
+    : undefined;
+  const selectedProvincialBenefit = state.dentalBenefits?.provincialTerritorialSocialProgram
+    ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
+    : undefined;
 
   const dentalBenefit = {
     federalBenefit: {
-      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasFederalBenefits,
+      access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalBenefit?.name,
     },
     provTerrBenefit: {
-      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasProvincialTerritorialBenefits,
+      access: state.dentalBenefits?.hasProvincialTerritorialBenefits,
       province: state.dentalBenefits?.province,
       benefit: selectedProvincialBenefit?.name,
     },

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -242,7 +242,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                         <>{t('apply-adult-child:review-child-information.no')}</>
                       )}
                       <p className="mt-4">
-                        <InlineLink id="change-dental-benefits" routeId="public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits" params={childParams}>
+                        <InlineLink id="change-dental-benefits" routeId="public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits" params={childParams}>
                           {t('apply-adult-child:review-child-information.dental-benefit-change')}
                         </InlineLink>
                       </p>

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -59,31 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     session,
     state: {
       editMode: true,
-      dentalBenefits:
-        state.hasFederalProvincialTerritorialBenefits === false
-          ? {
-              hasFederalBenefits: false,
-              federalSocialProgram: undefined,
-              hasProvincialTerritorialBenefits: false,
-              provincialTerritorialSocialProgram: undefined,
-              province: undefined,
-            }
-          : state.dentalBenefits,
-      children: state.children.map((child) => {
-        return {
-          ...child,
-          dentalBenefits:
-            child.hasFederalProvincialTerritorialBenefits === false
-              ? {
-                  hasFederalBenefits: false,
-                  federalSocialProgram: undefined,
-                  hasProvincialTerritorialBenefits: false,
-                  provincialTerritorialSocialProgram: undefined,
-                  province: undefined,
-                }
-              : child.dentalBenefits,
-        };
-      }),
     },
   });
 
@@ -104,12 +79,12 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const children = state.children.map((child) => {
     // prettier-ignore
-    const selectedFederalGovernmentInsurancePlan = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.federalSocialProgram
+    const selectedFederalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
       ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
 
     // prettier-ignore
-    const selectedProvincialBenefit = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
+    const selectedProvincialBenefit = child.dentalBenefits?.provincialTerritorialSocialProgram
       ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
@@ -123,11 +98,11 @@ export async function loader({ context: { appContainer, session }, params, reque
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
         federalBenefit: {
-          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasFederalBenefits,
+          access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectedFederalGovernmentInsurancePlan?.name,
         },
         provTerrBenefit: {
-          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasProvincialTerritorialBenefits,
+          access: child.dentalBenefits?.hasProvincialTerritorialBenefits,
           province: child.dentalBenefits?.province,
           benefit: selectedProvincialBenefit?.name,
         },

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -54,7 +54,38 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
-  saveApplyState({ params, session, state: { editMode: true } });
+  saveApplyState({
+    params,
+    session,
+    state: {
+      editMode: true,
+      dentalBenefits:
+        state.hasFederalProvincialTerritorialBenefits === false
+          ? {
+              hasFederalBenefits: false,
+              federalSocialProgram: undefined,
+              hasProvincialTerritorialBenefits: false,
+              provincialTerritorialSocialProgram: undefined,
+              province: undefined,
+            }
+          : state.dentalBenefits,
+      children: state.children.map((child) => {
+        return {
+          ...child,
+          dentalBenefits:
+            child.hasFederalProvincialTerritorialBenefits === false
+              ? {
+                  hasFederalBenefits: false,
+                  federalSocialProgram: undefined,
+                  hasProvincialTerritorialBenefits: false,
+                  provincialTerritorialSocialProgram: undefined,
+                  province: undefined,
+                }
+              : child.dentalBenefits,
+        };
+      }),
+    },
+  });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -15,7 +15,6 @@ import type { Route } from './+types/review-child-information';
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildStateForReview } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
 import { clearApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
-import type { ApplyAdultChildState } from '~/.server/routes/mappers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -67,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
   const benefitApplicationStateMapper = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper);
   const benefitApplicationDtoMapper = appContainer.get(TYPES.domain.mappers.BenefitApplicationDtoMapper);
-  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyAdultChildStateToBenefitApplicationDto(state as ApplyAdultChildState));
+  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyAdultChildStateToBenefitApplicationDto(state));
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService);
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService);
@@ -124,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const state = loadApplyAdultChildStateForReview({ params, request, session });
-  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyAdultChildStateToBenefitApplicationDto(state as ApplyAdultChildState);
+  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyAdultChildStateToBenefitApplicationDto(state);
   const confirmationCode = await appContainer.get(TYPES.domain.services.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
 

--- a/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -60,6 +60,8 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
+  const state = loadApplyAdultState({ params, request, session });
+
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
   const dentalBenefitsChangedSchema = z.object({
@@ -85,6 +87,7 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
+      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? state.dentalBenefits : undefined,
     },
   });
 

--- a/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -80,7 +80,6 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  //TODO: set dentalBenefits state at review instead of using default values here
   saveApplyState({
     params,
     session,

--- a/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -58,7 +58,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
-  const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   // NOTE: state validation schemas are independent otherwise user have to anwser
@@ -87,15 +86,6 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {
       hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
-      dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits
-        ? state.dentalBenefits
-        : {
-            hasFederalBenefits: false,
-            federalSocialProgram: undefined,
-            hasProvincialTerritorialBenefits: false,
-            provincialTerritorialSocialProgram: undefined,
-            province: undefined,
-          },
     },
   });
 

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -61,16 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     session,
     state: {
       editMode: true,
-      dentalBenefits:
-        state.hasFederalProvincialTerritorialBenefits === false
-          ? {
-              hasFederalBenefits: false,
-              federalSocialProgram: undefined,
-              hasProvincialTerritorialBenefits: false,
-              provincialTerritorialSocialProgram: undefined,
-              province: undefined,
-            }
-          : state.dentalBenefits,
     },
   });
 
@@ -125,23 +115,21 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const dentalInsurance = state.dentalInsurance;
 
-  const selectedFederalGovernmentInsurancePlan =
-    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
-      : undefined;
+  const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.federalSocialProgram
+    ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
+    : undefined;
 
-  const selectedProvincialBenefit =
-    state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
-      : undefined;
+  const selectedProvincialBenefit = state.dentalBenefits?.provincialTerritorialSocialProgram
+    ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
+    : undefined;
 
   const dentalBenefit = {
     federalBenefit: {
-      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasFederalBenefits,
+      access: state.dentalBenefits?.hasFederalBenefits,
       benefit: selectedFederalGovernmentInsurancePlan?.name,
     },
     provTerrBenefit: {
-      access: state.hasFederalProvincialTerritorialBenefits && state.dentalBenefits?.hasProvincialTerritorialBenefits,
+      access: state.dentalBenefits?.hasProvincialTerritorialBenefits,
       province: state.dentalBenefits?.province,
       benefit: selectedProvincialBenefit?.name,
     },

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -16,7 +16,6 @@ import { PREFERRED_NOTIFICATION_METHOD } from './communication-preference';
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultStateForReview } from '~/.server/routes/helpers/apply-adult-route-helpers';
 import { clearApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
-import type { ApplyAdultState } from '~/.server/routes/mappers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
@@ -137,7 +136,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.domain.mappers.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper);
-  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyAdultStateToBenefitApplicationDto(state as ApplyAdultState));
+  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyAdultStateToBenefitApplicationDto(state));
 
   return {
     id: state.id,
@@ -170,7 +169,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const state = loadApplyAdultStateForReview({ params, request, session });
-  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyAdultStateToBenefitApplicationDto(state as ApplyAdultState);
+  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyAdultStateToBenefitApplicationDto(state);
   const confirmationCode = await appContainer.get(TYPES.domain.services.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
 

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -55,8 +55,24 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultStateForReview({ params, request, session });
   invariant(state.mailingAddress?.country, `Unexpected mailing address country: ${state.mailingAddress?.country}`);
 
-  // apply state is valid then edit mode can be set to true
-  saveApplyState({ params, session, state: { editMode: true } });
+  // apply state is valid then edit mode can be set to true, also handle fpt benefits
+  saveApplyState({
+    params,
+    session,
+    state: {
+      editMode: true,
+      dentalBenefits:
+        state.hasFederalProvincialTerritorialBenefits === false
+          ? {
+              hasFederalBenefits: false,
+              federalSocialProgram: undefined,
+              hasProvincialTerritorialBenefits: false,
+              provincialTerritorialSocialProgram: undefined,
+              province: undefined,
+            }
+          : state.dentalBenefits,
+    },
+  });
 
   const { ENABLED_FEATURES, HCAPTCHA_SITE_KEY } = appContainer.get(TYPES.configs.ClientConfig);
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -91,7 +91,6 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  //TODO: set dentalBenefits state at review instead of using default values here
   saveApplyState({
     params,
     session,

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -101,15 +101,6 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
-          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits
-            ? state.dentalBenefits
-            : {
-                hasFederalBenefits: false,
-                federalSocialProgram: undefined,
-                hasProvincialTerritorialBenefits: false,
-                provincialTerritorialSocialProgram: undefined,
-                province: undefined,
-              },
         };
       }),
     },

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -100,6 +100,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return {
           ...child,
           hasFederalProvincialTerritorialBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits,
+          dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? child.dentalBenefits : undefined,
         };
       }),
     },

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -48,13 +48,15 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:children.index.page-title') }) };
 
   const children = getChildrenState(state).map((child) => {
-    const federalGovernmentInsurancePlanService = child.dentalBenefits?.federalSocialProgram
-      ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
-      : undefined;
+    const federalGovernmentInsurancePlanService =
+      child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.federalSocialProgram
+        ? appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
+        : undefined;
 
-    const provincialTerritorialSocialProgram = child.dentalBenefits?.provincialTerritorialSocialProgram
-      ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
-      : undefined;
+    const provincialTerritorialSocialProgram =
+      child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
+        ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
+        : undefined;
 
     return { ...child, dentalBenefits: { ...child.dentalBenefits, federalSocialProgram: federalGovernmentInsurancePlanService?.name, provincialTerritorialSocialProgram: provincialTerritorialSocialProgram?.name } };
   });

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -16,6 +16,7 @@ import { PREFERRED_NOTIFICATION_METHOD } from './communication-preference';
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildStateForReview } from '~/.server/routes/helpers/apply-child-route-helpers';
 import { clearApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import type { ApplyChildState } from '~/.server/routes/mappers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
@@ -113,7 +114,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.domain.mappers.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper);
-  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyChildStateToBenefitApplicationDto(state));
+  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyChildStateToBenefitApplicationDto(state as ApplyChildState));
 
   return {
     id: state.id,
@@ -142,7 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const state = loadApplyChildStateForReview({ params, request, session });
-  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyChildStateToBenefitApplicationDto(state);
+  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyChildStateToBenefitApplicationDto(state as ApplyChildState);
   const confirmationCode = await appContainer.get(TYPES.domain.services.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
 

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -16,7 +16,6 @@ import { PREFERRED_NOTIFICATION_METHOD } from './communication-preference';
 import { TYPES } from '~/.server/constants';
 import { loadApplyChildStateForReview } from '~/.server/routes/helpers/apply-child-route-helpers';
 import { clearApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
-import type { ApplyChildState } from '~/.server/routes/mappers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
@@ -114,7 +113,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const viewPayloadEnabled = ENABLED_FEATURES.includes('view-payload');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.domain.mappers.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper);
-  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyChildStateToBenefitApplicationDto(state as ApplyChildState));
+  const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyChildStateToBenefitApplicationDto(state));
 
   return {
     id: state.id,
@@ -143,7 +142,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const state = loadApplyChildStateForReview({ params, request, session });
-  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyChildStateToBenefitApplicationDto(state as ApplyChildState);
+  const benefitApplicationDto = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper).mapApplyChildStateToBenefitApplicationDto(state);
   const confirmationCode = await appContainer.get(TYPES.domain.services.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
 

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -52,7 +52,28 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
-  saveApplyState({ params, session, state: { editMode: true } });
+  saveApplyState({
+    params,
+    session,
+    state: {
+      editMode: true,
+      children: state.children.map((child) => {
+        return {
+          ...child,
+          dentalBenefits:
+            child.hasFederalProvincialTerritorialBenefits === false
+              ? {
+                  hasFederalBenefits: false,
+                  federalSocialProgram: undefined,
+                  hasProvincialTerritorialBenefits: false,
+                  provincialTerritorialSocialProgram: undefined,
+                  province: undefined,
+                }
+              : child.dentalBenefits,
+        };
+      }),
+    },
+  });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -64,12 +64,12 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const children = state.children.map((child) => {
     // prettier-ignore
-    const selectFederalGovernmentInsurancePlan = child.dentalBenefits.federalSocialProgram
+    const selectFederalGovernmentInsurancePlan = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.federalSocialProgram
       ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
 
     // prettier-ignore
-    const selectedProvincialBenefit = child.dentalBenefits.provincialTerritorialSocialProgram
+    const selectedProvincialBenefit = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
       ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
@@ -83,12 +83,12 @@ export async function loader({ context: { appContainer, session }, params, reque
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
         federalBenefit: {
-          access: child.dentalBenefits.hasFederalBenefits,
+          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasFederalBenefits,
           benefit: selectFederalGovernmentInsurancePlan?.name,
         },
         provTerrBenefit: {
-          access: child.dentalBenefits.hasProvincialTerritorialBenefits,
-          province: child.dentalBenefits.province,
+          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasProvincialTerritorialBenefits,
+          province: child.dentalBenefits?.province,
           benefit: selectedProvincialBenefit?.name,
         },
       },

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -57,21 +57,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     session,
     state: {
       editMode: true,
-      children: state.children.map((child) => {
-        return {
-          ...child,
-          dentalBenefits:
-            child.hasFederalProvincialTerritorialBenefits === false
-              ? {
-                  hasFederalBenefits: false,
-                  federalSocialProgram: undefined,
-                  hasProvincialTerritorialBenefits: false,
-                  provincialTerritorialSocialProgram: undefined,
-                  province: undefined,
-                }
-              : child.dentalBenefits,
-        };
-      }),
     },
   });
 
@@ -85,12 +70,12 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const children = state.children.map((child) => {
     // prettier-ignore
-    const selectFederalGovernmentInsurancePlan = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.federalSocialProgram
+    const selectFederalGovernmentInsurancePlan = child.dentalBenefits?.federalSocialProgram
       ? federalGovernmentInsurancePlanService.getLocalizedFederalGovernmentInsurancePlanById(child.dentalBenefits.federalSocialProgram, locale)
       : undefined;
 
     // prettier-ignore
-    const selectedProvincialBenefit = child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
+    const selectedProvincialBenefit = child.dentalBenefits?.provincialTerritorialSocialProgram
       ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
@@ -104,11 +89,11 @@ export async function loader({ context: { appContainer, session }, params, reque
       dentalInsurance: {
         acessToDentalInsurance: child.dentalInsurance,
         federalBenefit: {
-          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasFederalBenefits,
+          access: child.dentalBenefits?.hasFederalBenefits,
           benefit: selectFederalGovernmentInsurancePlan?.name,
         },
         provTerrBenefit: {
-          access: child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.hasProvincialTerritorialBenefits,
+          access: child.dentalBenefits?.hasProvincialTerritorialBenefits,
           province: child.dentalBenefits?.province,
           benefit: selectedProvincialBenefit?.name,
         },


### PR DESCRIPTION
### Description
Fixed confirm dental benefits save state

moved assignment of empty dentalBenefits object from the to the route helpers for each flow

tested on all flows and toggling the hasBenefits state page does populate/depopulate the dentalBenefits object correctly (seen in the payload at review time)

### Related Azure Boards Work Items
[AB#5429](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5429)
