### PR TITLE
Update application year service to return coverage start date

### DIFF
--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -120,7 +120,7 @@ describe('DefaultApplicationYearService', () => {
   });
 
   describe('getIntakeApplicationYear', () => {
-    const mockIntakeApplicationYearResultDto: IntakeApplicationYearResultDto = { intakeYearId: '2025', taxYear: '2025' };
+    const mockIntakeApplicationYearResultDto: IntakeApplicationYearResultDto = { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' };
     const mockApplicationYearDtoMapper = mock<ApplicationYearDtoMapper>();
     mockApplicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos.mockReturnValue(mockApplicationYearResultDtos);
     mockApplicationYearDtoMapper.mapApplicationYearResultDtoToIntakeApplicationYearResultDto.mockReturnValue(mockIntakeApplicationYearResultDto);

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -24,7 +24,7 @@ describe('apply-adult-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
-      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
       children: [],
       termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
     } satisfies ApplyState;
@@ -271,7 +271,7 @@ describe('apply-adult-child-route-helpers', () => {
         hasFiledTaxes: true,
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
-        applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01'},
         partnerInformation: { confirm: true, yearOfBirth: '1900', socialInsuranceNumber: '000-000-002' },
         mailingAddress: {
           address: '123 Maple St',
@@ -316,7 +316,7 @@ describe('apply-adult-child-route-helpers', () => {
         ageCategory: 'seniors',
 
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
-        applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
         children: [
           {
             ageCategory: 'children',

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -271,7 +271,7 @@ describe('apply-adult-child-route-helpers', () => {
         hasFiledTaxes: true,
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
-        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01'},
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
         partnerInformation: { confirm: true, yearOfBirth: '1900', socialInsuranceNumber: '000-000-002' },
         mailingAddress: {
           address: '123 Maple St',

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -24,7 +24,7 @@ describe('apply-adult-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: true,
       lastUpdatedOn: '2000-01-01',
-      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
       children: [],
       termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
     } satisfies ApplyState;
@@ -222,7 +222,7 @@ describe('apply-adult-route-helpers', () => {
       expect(act).toEqual({
         ageCategory: 'seniors',
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
-        applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
         communicationPreferences: { preferredLanguage: 'en', preferredMethod: 'email', preferredNotificationMethod: 'mail' },
         maritalStatus: '1',
         hasFederalProvincialTerritorialBenefits: false,

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -24,7 +24,7 @@ describe('apply-child-route-helpers', () => {
       id: '00000000-0000-0000-0000-000000000000',
       editMode: false,
       lastUpdatedOn: '2000-01-01',
-      applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+      applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
       children: [],
       termsAndConditions: { acknowledgePrivacy: true, acknowledgeTerms: true, shareData: true },
     } satisfies ApplyState;
@@ -301,7 +301,7 @@ describe('apply-child-route-helpers', () => {
         ],
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
         maritalStatus: '1',
-        applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
         partnerInformation: { confirm: true, yearOfBirth: '1900', socialInsuranceNumber: '000-000-002' },
         mailingAddress: {
           address: '123 Maple St',
@@ -333,7 +333,7 @@ describe('apply-child-route-helpers', () => {
       expect(act).toEqual({
         ageCategory: 'seniors',
         applicantInformation: { firstName: 'First Name', lastName: 'Last Name', dateOfBirth: '1900-01-01', socialInsuranceNumber: '000-000-001' },
-        applicationYear: { intakeYearId: '2025', taxYear: '2025' },
+        applicationYear: { intakeYearId: '2025', taxYear: '2025', coverageStartDate: '2025-06-01' },
         children: [
           {
             ageCategory: 'children',

--- a/frontend/app/.server/domain/dtos/application-year.dto.ts
+++ b/frontend/app/.server/domain/dtos/application-year.dto.ts
@@ -29,4 +29,5 @@ export type RenewalApplicationYearResultDto = Readonly<{
 export type IntakeApplicationYearResultDto = Readonly<{
   intakeYearId: string;
   taxYear: string;
+  coverageStartDate: string;
 }>;

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -22,6 +22,7 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
     return {
       taxYear: applicationYearResultDto.taxYear,
       intakeYearId: applicationYearResultDto.applicationYearId,
+      coverageStartDate: applicationYearResultDto.coverageStartDate
     };
   }
 

--- a/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/application-year.dto.mapper.ts
@@ -22,7 +22,7 @@ export class DefaultApplicationYearDtoMapper implements ApplicationYearDtoMapper
     return {
       taxYear: applicationYearResultDto.taxYear,
       intakeYearId: applicationYearResultDto.applicationYearId,
-      coverageStartDate: applicationYearResultDto.coverageStartDate
+      coverageStartDate: applicationYearResultDto.coverageStartDate,
     };
   }
 

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -33,6 +33,7 @@ export type ApplyState = ReadonlyDeep<{
   applicationYear: {
     intakeYearId: string;
     taxYear: string;
+    coverageStartDate: string;
   };
   children: {
     id: string;
@@ -291,8 +292,8 @@ export function startApplyState({ applicationYear, id, session }: StartArgs) {
 
 export type AgeCategory = 'children' | 'youth' | 'adults' | 'seniors';
 
-export function getAgeCategoryFromDateString(date: string) {
-  const age = getAgeFromDateString(date);
+export function getAgeCategoryFromDateString(date: string, coverageStartDate?: string) {
+  const age = getAgeFromDateString(date, coverageStartDate);
   return getAgeCategoryFromAge(age);
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/cannot-apply-child';
 
 import { TYPES } from '~/.server/constants';
-import { loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
+import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -30,13 +30,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
+  const state = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.cannot-apply-child.page-title') }) };
 
   const currentDate = new Date();
-  const currentYear = currentDate.getFullYear();
+  const currentYear = state.applicationYear.coverageStartDate.split('-')[0];
   const currentMonth = currentDate.getMonth() + 1;
 
   const isBeforeJune = currentMonth < 6;

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -14,6 +14,7 @@ import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -39,13 +40,13 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.cannot-apply-child.page-title') }) };
-  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new Date(APPLICATION_YEAR_REQUEST_DATE) : new Date();
-  const coverageStartDate = new UTCDate(state.applicationYear.coverageStartDate);
-  const formattedDate = coverageStartDate.toLocaleDateString(`${locale}-CA`, { year: 'numeric', month: 'long', day: 'numeric' });
+  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? parseDateString(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
+  const coverageStartDate = parseDateString(state.applicationYear.coverageStartDate);
+  const formattedDate = toLocaleDateString(coverageStartDate, locale);
 
   const isBeforeCoverageStartDate = currentDate < coverageStartDate;
 
-  return { meta, isBeforeCoverageStartDate, currentYear: formattedDate };
+  return { meta, isBeforeCoverageStartDate, coverageStartDate: formattedDate };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -59,7 +60,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplyForYourself({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { currentYear, isBeforeCoverageStartDate } = loaderData;
+  const { coverageStartDate, isBeforeCoverageStartDate } = loaderData;
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
@@ -71,7 +72,7 @@ export default function ApplyForYourself({ loaderData, params }: Route.Component
       <div className="mb-6 space-y-4">
         {isBeforeCoverageStartDate ? (
           <>
-            <p>{t('apply-adult-child:eligibility.cannot-apply-child.before-june.ineligible-to-apply', { currentYear })}</p>
+            <p>{t('apply-adult-child:eligibility.cannot-apply-child.before-june.ineligible-to-apply', { coverageStartDate })}</p>
             <p>
               <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:eligibility.cannot-apply-child.before-june.eligibility-info" components={{ noWrap }} />
             </p>

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -1,5 +1,6 @@
 import { redirect, useFetcher } from 'react-router';
 
+import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -38,9 +39,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.cannot-apply-child.page-title') }) };
-
   const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new Date(APPLICATION_YEAR_REQUEST_DATE) : new Date();
-  const coverageStartDate = new Date(state.applicationYear.coverageStartDate);
+  const coverageStartDate = new UTCDate(state.applicationYear.coverageStartDate);
   const formattedDate = coverageStartDate.toLocaleDateString(`${locale}-CA`, { year: 'numeric', month: 'long', day: 'numeric' });
 
   const isBeforeCoverageStartDate = currentDate < coverageStartDate;

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -13,6 +13,7 @@ import { TYPES } from '~/.server/constants';
 import { loadApplyAdultChildState, loadApplyAdultSingleChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
 import type { ChildInformationState, ChildSinState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getAgeCategoryFromDateString, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { getEnv } from '~/.server/utils/env.utils';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -76,6 +77,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const applyState = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const { APPLICATION_YEAR_REQUEST_DATE } = getEnv();
 
   // Form action Continue & Save
   // state validation schema
@@ -190,7 +193,10 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate);
+  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new Date(APPLICATION_YEAR_REQUEST_DATE) : new Date();
+  const coverageStartDate = new Date(applyState.applicationYear.coverageStartDate);
+
+  const ageCategory = currentDate < coverageStartDate ? getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate) : getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
 
   saveApplyState({
     params,

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -190,7 +190,7 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
+  const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate);
 
   saveApplyState({
     params,

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -31,7 +31,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { Progress } from '~/components/progress';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
+import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -194,8 +194,8 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new UTCDate(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
-  const coverageStartDate = new UTCDate(applyState.applicationYear.coverageStartDate);
+  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? parseDateString(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
+  const coverageStartDate = parseDateString(applyState.applicationYear.coverageStartDate);
 
   const ageCategory = currentDate < coverageStartDate ? getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate) : getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { redirect, useFetcher } from 'react-router';
 
+import { UTCDate } from '@date-fns/utc';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -193,8 +194,8 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new Date(APPLICATION_YEAR_REQUEST_DATE) : new Date();
-  const coverageStartDate = new Date(applyState.applicationYear.coverageStartDate);
+  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? new UTCDate(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
+  const coverageStartDate = new UTCDate(applyState.applicationYear.coverageStartDate);
 
   const ageCategory = currentDate < coverageStartDate ? getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate) : getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
 
@@ -205,9 +206,6 @@ export async function action({ context: { appContainer, session }, params, reque
       children: applyState.children.map((child) => {
         if (child.id !== state.id) return child;
         const information = { ...parsedDataResult.data, ...parsedSinDataResult.data };
-        if (ageCategory !== 'youth' && ageCategory !== 'children') {
-          information['dateOfBirth'] = child.information?.dateOfBirth ?? '';
-        }
         return { ...child, information };
       }),
     },

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -550,7 +550,7 @@
         "eligibility-info": "If your child is a dependant adult and you are their legal delegate or Power of Attorney, you must speak to a Service Canada representative to apply on their behalf. You can contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>."
       },
       "before-june": {
-        "ineligible-to-apply": "Your child will be 18 years old before {{currentYear}}. They must submit their own application as an adult to the Canadian Dental Care Plan. They must be 18 years to apply.",
+        "ineligible-to-apply": "Your child will be 18 years old before {{coverageStartDate}}. They must submit their own application as an adult to the Canadian Dental Care Plan. They must be 18 years to apply.",
         "eligibility-info": "If your child is a dependant adult and you are their legal delegate or Power of Attorney, you must speak to a Service Canada representative to apply on their behalf. You can contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>."
       },
       "back-btn": "Back",

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -550,7 +550,7 @@
         "eligibility-info": "If your child is a dependant adult and you are their legal delegate or Power of Attorney, you must speak to a Service Canada representative to apply on their behalf. You can contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>."
       },
       "before-june": {
-        "ineligible-to-apply": "Your child will be 18 years old before June 1, {{currentYear}}. They must submit their own application as an adult to the Canadian Dental Care Plan. They must be 18 years to apply.",
+        "ineligible-to-apply": "Your child will be 18 years old before {{currentYear}}. They must submit their own application as an adult to the Canadian Dental Care Plan. They must be 18 years to apply.",
         "eligibility-info": "If your child is a dependant adult and you are their legal delegate or Power of Attorney, you must speak to a Service Canada representative to apply on their behalf. You can contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>."
       },
       "back-btn": "Back",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -550,8 +550,8 @@
         "eligibility-info": "Si votre enfant est un adulte à charge et que vous êtes son représentant légal ou son mandataire, vous devez vous adresser à un représentant de Service Canada pour présenter une demande en son nom. Vous pouvez contacter Service Canada en composant le <noWrap>1-833-537-4342</noWrap>."
       },
       "before-june": {
-        "ineligible-to-apply": "(FR) Your child will be 18 years old before June 1, {{currentYear}}. They must submit their own application as an adult to the Canadian Dental Care Plan. They must be 18 years to apply.",
-        "eligibility-info": "(FR) If your child is a dependant adult and you are their legal delegate or Power of Attorney, you must speak to a Service Canada representative to apply on their behalf. You can contact Service Canada by calling <noWrap>1-833-537-4342</noWrap>."
+        "ineligible-to-apply": "Votre enfant aura 18 ans avant le {{currentYear}}. Il doit soumettre sa propre demande en tant qu'adulte au Plan de soins dentaires canadien. Il doit avoir 18 ans pour postuler.",
+        "eligibility-info": "Si votre enfant est un adulte à charge et que vous êtes son représentant légal ou son mandataire, vous devez vous adresser à un représentant de Service Canada pour présenter une demande en son nom. Vous pouvez contacter Service Canada en composant le <noWrap>1-833-537-4342</noWrap>."
       },
       "back-btn": "Retour",
       "proceed-btn": "Continuer"

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -550,7 +550,7 @@
         "eligibility-info": "Si votre enfant est un adulte à charge et que vous êtes son représentant légal ou son mandataire, vous devez vous adresser à un représentant de Service Canada pour présenter une demande en son nom. Vous pouvez contacter Service Canada en composant le <noWrap>1-833-537-4342</noWrap>."
       },
       "before-june": {
-        "ineligible-to-apply": "Votre enfant aura 18 ans avant le {{currentYear}}. Il doit soumettre sa propre demande en tant qu'adulte au Plan de soins dentaires canadien. Il doit avoir 18 ans pour postuler.",
+        "ineligible-to-apply": "Votre enfant aura 18 ans avant le {{coverageStartDate}}. Il doit soumettre sa propre demande en tant qu'adulte au Plan de soins dentaires canadien. Il doit avoir 18 ans pour postuler.",
         "eligibility-info": "Si votre enfant est un adulte à charge et que vous êtes son représentant légal ou son mandataire, vous devez vous adresser à un représentant de Service Canada pour présenter une demande en son nom. Vous pouvez contacter Service Canada en composant le <noWrap>1-833-537-4342</noWrap>."
       },
       "back-btn": "Retour",


### PR DESCRIPTION
### Description
This PR updates the `Application Year Service` by returning the coverageStartDate (June 1 of the applicable year), which is used to determine which page to display. 
Set the `APPLICATION_YEAR_REQUEST_DATE` env to `2025-06-01` to mock the current date for testing.

This pr fixes the issue AB#19577

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->