### PR TITLE
Increase min/max replicas and adjust CPU utilization target in perf HPAs

### DIFF
--- a/gitops/overlays/perf/hpas.yaml
+++ b/gitops/overlays/perf/hpas.yaml
@@ -9,12 +9,12 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: frontend
-  minReplicas: 2
-  maxReplicas: 20
+  minReplicas: 5
+  maxReplicas: 30
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 90
+          averageUtilization: 85


### PR DESCRIPTION
### Description

Increase max pods to 30 for an upcoming stress test.
