### PR TITLE
fix(frontend): increase `maxListeners` for `dailyRotateFileTransport` to prevent memory leak warnings

### DIFF
--- a/frontend/app/.server/utils/logging.utils.ts
+++ b/frontend/app/.server/utils/logging.utils.ts
@@ -96,15 +96,21 @@ export const getLogger = (category: string): Logger => {
       }),
     ),
     transports: [consoleTransport],
-  });
+  }) as Logger;
 
   //
   // Audit logs are persisted to disk to ensure that we
   // can retain a history record of important system events
   //
   if (env.auditLogEnabled) {
+    // each time a new logger is created, an `error`, `drain`, `close`, and `finish` event listener is added to `dailyRotateFileTransport`
+    // this will eventually lead to a "MaxListenersExceededWarning: Possible EventEmitter memory leak detected" wearning being emitted by nodejs
+    // to fix this, whenever a new logger is added, increase the maxListeners by 4
+    dailyRotateFileTransport.setMaxListeners(dailyRotateFileTransport.getMaxListeners() + 4);
+    logger.trace('dailyRotateFileTransport.maxListeners increased to %s', dailyRotateFileTransport.getMaxListeners());
+
     logger.add(dailyRotateFileTransport);
   }
 
-  return logger as Logger;
+  return logger;
 };


### PR DESCRIPTION
### Description

Each time a new Winston logger is created, an `error`, `drain`, `close`, and `finish` event listener is added to the application's `dailyRotateFileTransport` transport. This eventually leads to a "MaxListenersExceededWarning: Possible EventEmitter memory leak detected" warning being emitted by nodejs.

To fix this, whenever a new logger is added, increase the `dailyRotateFileTransport.maxListeners` by 4.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Run the application and confirm there are no "MaxListenersExceededWarning: Possible EventEmitter memory leak detected" warnings.
