### PR TITLE
AB#19988 Adult living independently navigation update

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -93,7 +93,11 @@ export async function action({ context: { appContainer, session }, params, reque
     saveApplyState({ params, session, state: { livingIndependently: isLivingindependently } });
   }
 
-  return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
+  if (isLivingindependently) {
+    return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));
+  }
+
+  return redirect(getPathById('public/apply/$id/adult/parent-or-guardian', params));
 }
 
 export default function ApplyFlowLivingIndependently({ loaderData, params }: Route.ComponentProps) {


### PR DESCRIPTION
In Adult flow, select option "No" should go to parent-or-guardian

### Related Azure Boards Work Items
AB#19988

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->