### PR TITLE
fix(frontend): add id attribute to continue buttons for dental insurance forms

### DIFF
--- a/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
@@ -202,7 +202,7 @@ export default function ProtectedRenewChildrenDentalInsurance({ loaderData, para
           </div>
         ) : (
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Child access to private dental insurance click">
+            <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Child access to private dental insurance click">
               {t('protected-renew:children.dental-insurance.button.continue')}
             </LoadingButton>
             <ButtonLink

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -218,6 +218,7 @@ export default function ProtectedRenewAdultChildAccessToDentalInsuranceQuestion(
         ) : (
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <LoadingButton
+              id="continue-button"
               name="_action"
               value={FORM_ACTION.continue}
               variant="primary"

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -190,7 +190,7 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Child access to other dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Child access to other dental insurance click">
                 {t('children.dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -181,7 +181,7 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Access to other dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Access to other dental insurance click">
                 {t('dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -179,7 +179,7 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Access to other dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Access to other dental insurance click">
                 {t('dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -190,7 +190,7 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Child access to other dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Continue - Child access to other dental insurance click">
                 {t('children.dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -190,7 +190,7 @@ export default function RenewAdultChildChildrenDentalInsurance({ loaderData, par
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Child access to private dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Continue - Child access to private dental insurance click">
                 {t('children.dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -194,6 +194,7 @@ export default function RenewAdultChildAccessToDentalInsuranceQuestion({ loaderD
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
+                id="continue-button"
                 name="_action"
                 value={FORM_ACTION.continue}
                 variant="primary"

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -194,6 +194,7 @@ export default function RenewAdultAccessToDentalInsuranceQuestion({ loaderData, 
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
+                id="continue-button"
                 name="_action"
                 value={FORM_ACTION.continue}
                 variant="primary"

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/dental-insurance.tsx
@@ -190,7 +190,7 @@ export default function RenewChildChildrenDentalInsurance({ loaderData, params }
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Child access to private dental insurance click">
+              <LoadingButton id="continue-button" variant="primary" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Continue - Child access to private dental insurance click">
                 {t('children.dental-insurance.button.continue')}
               </LoadingButton>
               <ButtonLink

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -197,6 +197,7 @@ export default function RenewItaAccessToDentalInsuranceQuestion({ loaderData, pa
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <LoadingButton
+                id="continue-button"
                 name="_action"
                 value={FORM_ACTION.continue}
                 variant="primary"


### PR DESCRIPTION
### Description

Add missing `id` attribute on continue buttons in `dental-insurance.tsx` pages (discovered while using chrome devtools' record/playback feature).

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
