### PR TITLE
fix(gitops): adjust resource requests and limits for fluentd and frontend deployments

### DIFF
--- a/gitops/base/fluentd-archiver/deployments.yaml
+++ b/gitops/base/fluentd-archiver/deployments.yaml
@@ -20,6 +20,13 @@ spec:
           ports:
             - name: fluentd
               containerPort: 24224
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 15m
+              memory: 256Mi
           volumeMounts:
             - name: audit-logs
               mountPath: /logs

--- a/gitops/base/frontend/deployments.yaml
+++ b/gitops/base/frontend/deployments.yaml
@@ -30,10 +30,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 512Mi
+              memory: 256Mi
             limits:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 750m
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
           volumeMounts:

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -21,13 +21,6 @@ spec:
         - name: fluentd
           image: docker.io/fluentd:v1.16-1
           args: [--config, /etc/fluentd.conf]
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-            limits:
-              cpu: 100m
-              memory: 256Mi
           volumeMounts:
             - name: audit-logs
               mountPath: /logs
@@ -61,10 +54,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 32Mi
+              memory: 16Mi
             limits:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 75m
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
           volumeMounts:


### PR DESCRIPTION
### Description

After weeks of performance testing, it has become clear that our kubernetes resource requests and limits are much higher than necessary. This PR:

- moves prod fluentd resource configs to the `base/` manifest
- adjusts fluentd resources, lowering requests and limits to align with the usage reported by Dynatrace
- adjusts frontend resources, lowering requests and limits to align with the usage reported by Dynatrace

### Additional Notes

Because this PR modifies resources in the `base/` folder, merging this PR will trigger a rolling restart of our production pods. Because of this, deployment has been scheduled for:


# **Friday, April 04 at 0600 ET**
