### PR TITLE
Fixing redirects in edit mode on FPT routes

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -29,6 +29,12 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
+const FORM_ACTION = {
+  continue: 'continue',
+  cancel: 'cancel',
+  save: 'save',
+} as const;
+
 const HAS_FEDERAL_BENEFITS_OPTION = {
   no: 'no',
   yes: 'yes',
@@ -80,6 +86,20 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  if (formAction === FORM_ACTION.cancel) {
+    if (state.hasFederalProvincialTerritorialBenefits) {
+      saveApplyState({
+        params,
+        session,
+        state: {
+          hasFederalProvincialTerritorialBenefits: !!state.dentalBenefits,
+        },
+      });
+    }
+    return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
+  }
 
   // NOTE: state validation schemas are independent otherwise user have to anwser
   // both question first before the superRefine can be executed
@@ -322,22 +342,24 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
           </fieldset>
           {editMode ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Access to other dental benefits click">
+              <Button variant="primary" id="save-button" name="_action" value={FORM_ACTION.save} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Save - Access to other dental benefits click">
                 {t('apply-adult-child:dental-benefits.button.save-btn')}
               </Button>
-              <ButtonLink
-                id="back-button"
-                routeId="public/apply/$id/adult-child/review-adult-information"
-                params={params}
-                disabled={isSubmitting}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Access to other dental benefits click"
-              >
+              <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Cancel - Access to other dental benefits click">
                 {t('apply-adult-child:dental-benefits.button.cancel-btn')}
-              </ButtonLink>
+              </Button>
             </div>
           ) : (
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Access to other dental benefits click">
+              <LoadingButton
+                variant="primary"
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.continue}
+                loading={isSubmitting}
+                endIcon={faChevronRight}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Continue - Access to other dental benefits click"
+              >
                 {t('apply-adult-child:dental-benefits.button.continue')}
               </LoadingButton>
               <ButtonLink


### PR DESCRIPTION
### Description
Currently, when an applicant is in "edit mode" and hits "Cancel" on the `/federal-provincial-territorial-benefits` (for the primary applicant, not children), the user is redirected to the `/confirm-federal-provincial-territorial-benefits` rather than the Review page. 

For consistency with the rest of the application, hitting "Cancel" should redirect the user to the Review page with no prior changes (made on the  `/confirm-federal-provincial-territorial-benefits`) saved.

Also made changes to `id` attribute values to be unique.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes

- Logic taken from `/renew`.
- Review of the children FPT redirects will be made in a future PR.