### PR TITLE
feat(frontend): enable auto pipelining in Redis configuration

### DIFF
--- a/frontend/app/.server/data/redis.client.ts
+++ b/frontend/app/.server/data/redis.client.ts
@@ -1,5 +1,5 @@
-import Redis from 'ioredis';
 import type { RedisOptions } from 'ioredis';
+import Redis from 'ioredis';
 
 import type { ServerConfig } from '~/.server/configs';
 import { getEnv } from '~/.server/utils/env.utils';
@@ -72,6 +72,7 @@ function getRedisConfig(serverConfig: ServerConfig): RedisOptions {
         username: REDIS_USERNAME,
         password: REDIS_PASSWORD,
         commandTimeout: REDIS_COMMAND_TIMEOUT_SECONDS * 1000,
+        enableAutoPipelining: true,
         retryStrategy,
       };
     }
@@ -85,6 +86,7 @@ function getRedisConfig(serverConfig: ServerConfig): RedisOptions {
         username: REDIS_USERNAME,
         password: REDIS_PASSWORD,
         commandTimeout: REDIS_COMMAND_TIMEOUT_SECONDS * 1000,
+        enableAutoPipelining: true,
         retryStrategy,
       };
     }


### PR DESCRIPTION
### Description

Enable [autopipelining](https://github.com/redis/ioredis#autopipelining) in the redis client in an attempt to alleviate some "command timed out" errors being thrown during performance testing.
