### PR TITLE
fix(frontend) update edit spouse links in review-information in public apply app

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -271,7 +271,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-adult-child:review-adult-information.dob-title')}>
                   {spouseInfo.yearOfBirth}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/adult-child/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/adult-child/marital-status" params={params}>
                       {t('apply-adult-child:review-adult-information.dob-change')}
                     </InlineLink>
                   </p>
@@ -279,7 +279,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-adult-child:review-adult-information.sin-title')}>
                   {formatSin(spouseInfo.sin)}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/adult-child/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/adult-child/marital-status" params={params}>
                       {t('apply-adult-child:review-adult-information.sin-change')}
                     </InlineLink>
                   </p>

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -288,7 +288,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-adult:review-information.dob-title')}>
                   <p>{spouseInfo.yearOfBirth}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/adult/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/adult/marital-status" params={params}>
                       {t('apply-adult:review-information.dob-change')}
                     </InlineLink>
                   </div>
@@ -296,7 +296,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-adult:review-information.sin-title')}>
                   <p>{formatSin(spouseInfo.sin)}</p>
                   <div className="mt-4">
-                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/adult/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/adult/marital-status" params={params}>
                       {t('apply-adult:review-information.sin-change')}
                     </InlineLink>
                   </div>

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -256,7 +256,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-child:review-adult-information.dob-title')}>
                   {spouseInfo.yearOfBirth}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/child/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-date-of-birth" routeId="public/apply/$id/child/marital-status" params={params}>
                       {t('apply-child:review-adult-information.dob-change')}
                     </InlineLink>
                   </p>
@@ -264,7 +264,7 @@ export default function ReviewInformation({ loaderData, params }: Route.Componen
                 <DescriptionListItem term={t('apply-child:review-adult-information.sin-title')}>
                   {formatSin(spouseInfo.sin)}
                   <p className="mt-4">
-                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/child/applicant-information" params={params}>
+                    <InlineLink id="change-spouse-sin" routeId="public/apply/$id/child/marital-status" params={params}>
                       {t('apply-child:review-adult-information.sin-change')}
                     </InlineLink>
                   </p>


### PR DESCRIPTION
### Description
The edit links in the public apply app were routing to /applicant-information instead of /marital-status.  I checked the renew apps (protected and public) and they're fine.

### Related Azure Boards Work Items
AB#20158
