### PR TITLE
fix(frontend): update JWK import algorithm to `RSA-OAEP-256`

### DIFF
--- a/frontend/app/.server/utils/raoidc.utils.ts
+++ b/frontend/app/.server/utils/raoidc.utils.ts
@@ -363,7 +363,7 @@ async function createClientAssertion(issuer: string, client: ClientMetadata) {
 async function decryptJwe(jwe: string, privateKey: CryptoKey) {
   const { kty, ...restOfJwk } = await subtle.exportKey('jwk', privateKey);
   invariant(kty, 'Expected JWK to have a key type');
-  const key = await importJWK({ ...restOfJwk, kty }, 'RSA-OAEP');
+  const key = await importJWK({ ...restOfJwk, kty }, 'RSA-OAEP-256');
   const decryptResult = await compactDecrypt(jwe, key, { keyManagementAlgorithms: ['RSA-OAEP-256'] });
   return decryptResult.plaintext.toString();
 }
@@ -487,12 +487,12 @@ function validateServerMetadata(serverMetadata: ServerMetadata) {
 /**
  * Verify a JWT by checking it against a collection of JWKs.
  */
-async function verifyJwt<Payload = JWTPayload>(jwt: string, jwks: JWKSet, alg = 'RSA-OAEP') {
+async function verifyJwt<Payload = JWTPayload>(jwt: string, jwks: JWKSet) {
   const log = getLogger('raoidc-utils.server/verifyJwt');
   for (const key of jwks.keys) {
     const { kty, ...restOfKey } = key;
     invariant(kty, 'Expected JWK to have a key type');
-    const keyLike = await importJWK({ ...restOfKey, kty }, alg);
+    const keyLike = await importJWK({ ...restOfKey, kty }, 'RSA-OAEP-256');
 
     try {
       return await jwtVerify<Payload>(jwt, keyLike);


### PR DESCRIPTION
### Description

Jose v6.x requires that the algorithm contain the hash size in the name when importing a JWK.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

Log in via RAOIDC and verify nothing fails.
