### PR TITLE
Fixing incorrect/broken redirects

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-child-route-helpers.test.ts
@@ -82,7 +82,7 @@ describe('apply-adult-child-route-helpers', () => {
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
       vi.mocked(applicantInformationStateHasPartner).mockReturnValue(false);
 
-      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult-child/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyAdultChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult-child/marital-status, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if communicationPreferences is undefined', () => {

--- a/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-adult-route-helpers.test.ts
@@ -119,7 +119,7 @@ describe('apply-adult-route-helpers', () => {
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
       vi.mocked(applicantInformationStateHasPartner).mockReturnValue(false);
 
-      expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyAdultStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/adult/marital-status, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if communicationPreferences is undefined', () => {

--- a/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/apply-child-route-helpers.test.ts
@@ -210,7 +210,7 @@ describe('apply-child-route-helpers', () => {
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
       vi.mocked(applicantInformationStateHasPartner).mockReturnValue(false);
 
-      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/applicant-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/marital-status, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if contactInformation is undefined', () => {
@@ -237,7 +237,7 @@ describe('apply-child-route-helpers', () => {
       vi.mocked(getAgeCategoryFromDateString).mockReturnValueOnce('seniors');
       vi.mocked(applicantInformationStateHasPartner).mockResolvedValue(true);
 
-      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/contact-information, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
+      expect(() => validateApplyChildStateForReview({ params, state: mockState })).toThrow('MockedRedirect(MockedPath(public/apply/$id/child/phone-number, {"lang":"en","id":"00000000-0000-0000-0000-000000000000"}))');
     });
 
     it('should redirect if communicationPreferences is undefined', () => {

--- a/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-child-route-helpers.ts
@@ -177,15 +177,15 @@ export function validateApplyAdultChildStateForReview({ params, state }: Validat
   }
 
   if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/adult-child/marital-status', params));
   }
 
   if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/adult-child/marital-status', params));
   }
 
   if (contactInformation === undefined) {
-    throw redirect(getPathById('public/apply/$id/adult-child/contact-information', params)); // TODO: redirect to phone-number.tsx or email.tsx
+    throw redirect(getPathById('public/apply/$id/adult-child/phone-number', params));
   }
 
   if (communicationPreferences === undefined) {

--- a/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-adult-route-helpers.ts
@@ -146,15 +146,15 @@ export function validateApplyAdultStateForReview({ params, state }: ValidateAppl
   }
 
   if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/adult/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/adult/marital-status', params));
   }
 
   if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/adult/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/adult/marital-status', params));
   }
 
   if (contactInformation === undefined) {
-    throw redirect(getPathById('public/apply/$id/adult/contact-information', params));
+    throw redirect(getPathById('public/apply/$id/adult/phone-number', params));
   }
 
   if (communicationPreferences === undefined) {

--- a/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-child-route-helpers.ts
@@ -175,15 +175,15 @@ export function validateApplyChildStateForReview({ params, state }: ValidateStat
   }
 
   if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/child/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/child/marital-status', params));
   }
 
   if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
-    throw redirect(getPathById('public/apply/$id/child/applicant-information', params));
+    throw redirect(getPathById('public/apply/$id/child/marital-status', params));
   }
 
   if (contactInformation === undefined) {
-    throw redirect(getPathById('public/apply/$id/child/contact-information', params));
+    throw redirect(getPathById('public/apply/$id/child/phone-number', params));
   }
 
   if (communicationPreferences === undefined) {


### PR DESCRIPTION
### Description
As per title.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
We can verify the routes by making a temporary change to `route-utils.ts` and changing
```typescript
export function getPathById(id: string, params: Params = {}): string {
```
to
```typescript
export function getPathById(id: I18nRouteId, params: Params = {}): string {
```
then
```
npm run typecheck
```

This change will break dynamic path id resolution but we can still verify the static ids.
