### PR TITLE
Adding apply-eligibility check with configurable envs.

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -53,9 +53,6 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 # (optional; default: "")
 ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey,apply-eligibility
 
-# Current date modifier used for testing
-# (optional; default: today; example: 2025-05-15 -> for May 5th, 2025)
-CURRENT_DATE=
 
 # GC Notify API key
 # (required; use the example below)
@@ -124,9 +121,9 @@ INTEROP_STATUS_CHECK_API_BASE_URI=
 # (optional; default: undefined)
 INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 
-# Config that holds the date used for the application year request. This date can be overridden for simulation or testing purposes -- ex. 2025-03-05
-# (optional; default: undefined)
-#APPLICATION_YEAR_REQUEST_DATE=2025-03-05
+# Config that holds a custom current date used for the application year request and apply eligibility. This date can be overridden for simulation or testing purposes -- ex. 2025-03-05 (yyyy-mm-dd)
+# (optional; default: undefined;)
+APPLICATION_CURRENT_DATE=
 
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)
@@ -425,3 +422,7 @@ HEALTH_AUTH_TOKEN_ISSUER=https://auth.example.com/
 # Placeholder value used as generic input when sending requests for health checks when actual data is unavailable
 # (optional; default: CDCP_HEALTH_CHECK)
 HEALTH_PLACEHOLDER_REQUEST_VALUE=CDCP_HEALTH_CHECK
+
+# https://www.canada.ca/en/services/benefits/dental/dental-care-plan/apply.html#when
+# Apply eligibility age groups
+APPLY_ELIGIBILITY_RULES='[{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]'

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -123,7 +123,7 @@ INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 
 # Config that holds a custom current date used for the application year request and apply eligibility. This date can be overridden for simulation or testing purposes -- ex. 2025-03-05 (yyyy-mm-dd)
 # (optional; default: undefined;)
-APPLICATION_CURRENT_DATE=
+# APPICATION_CURRENT_DATE=2025-03-05
 
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -53,6 +53,10 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 # (optional; default: "")
 ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey,apply-eligibility
 
+# Current date modifier used for testing
+# (optional; default: today; example: 2025-05-15 -> for May 5th, 2025)
+CURRENT_DATE=
+
 # GC Notify API key
 # (required; use the example below)
 GC_NOTIFY_API_KEY=00000000000000000000000000000000

--- a/frontend/__tests__/.server/domain/services/application-year.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/application-year.service.test.ts
@@ -73,7 +73,7 @@ describe('DefaultApplicationYearService', () => {
     mockApplicationYearDtoMapper.mapApplicationYearResultDtoToRenewalApplicationYearResultDto.mockReturnValue(mockRenewalApplicationYearResultDto);
 
     it('should return the correct renewal application year if given date is within a renewal period', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
       const result = await service.findRenewalApplicationYear('2025-01-01');
@@ -97,7 +97,7 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should return the correct renewal application year when the given date is on or after the renewal start date and no renewal end date is provided', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
       const result = await service.findRenewalApplicationYear('2026-01-01');
@@ -110,7 +110,7 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should return null if given date is not within any renewal period', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
 
@@ -126,7 +126,7 @@ describe('DefaultApplicationYearService', () => {
     mockApplicationYearDtoMapper.mapApplicationYearResultDtoToIntakeApplicationYearResultDto.mockReturnValue(mockIntakeApplicationYearResultDto);
 
     it('should return the correct intake application year if given date is within an intake period', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
       const result = await service.getIntakeApplicationYear('2025-01-01');
@@ -147,7 +147,7 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should return the correct intake application year when the given date is on or after the intake start date and no intake end date is provided', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
       const result = await service.getIntakeApplicationYear('2026-01-01');
@@ -165,7 +165,7 @@ describe('DefaultApplicationYearService', () => {
     });
 
     it('should throw if given date is not within any intake period', async () => {
-      const mockServerConfig = { APPLICATION_YEAR_REQUEST_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
+      const mockServerConfig = { APPLICATION_CURRENT_DATE: undefined, LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS: 10 };
 
       const service = new DefaultApplicationYearService(mockLogFactory, mockApplicationYearDtoMapper, mockApplicationYearRepository, mockServerConfig);
 

--- a/frontend/app/.server/domain/services/application-year.service.ts
+++ b/frontend/app/.server/domain/services/application-year.service.ts
@@ -42,13 +42,13 @@ export class DefaultApplicationYearService implements ApplicationYearService {
   private readonly log: Logger;
   private readonly applicationYearDtoMapper: ApplicationYearDtoMapper;
   private readonly applicationYearRepository: ApplicationYearRepository;
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE' | 'LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS'>;
+  private readonly serverConfig: Pick<ServerConfig, 'APPLICATION_CURRENT_DATE' | 'LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS'>;
 
   constructor(
     @inject(TYPES.factories.LogFactory) logFactory: LogFactory,
     @inject(TYPES.domain.mappers.ApplicationYearDtoMapper) applicationYearDtoMapper: ApplicationYearDtoMapper,
     @inject(TYPES.domain.repositories.ApplicationYearRepository) applicationYearRepository: ApplicationYearRepository,
-    @inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICATION_YEAR_REQUEST_DATE' | 'LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS'>,
+    @inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICATION_CURRENT_DATE' | 'LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS'>,
   ) {
     this.log = logFactory.createLogger('DefaultApplicationYearService');
     this.applicationYearDtoMapper = applicationYearDtoMapper;
@@ -90,7 +90,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
   async getIntakeApplicationYear(date: string): Promise<IntakeApplicationYearResultDto> {
     this.log.trace('Finding intake application year results with date: [%s]', date);
 
-    const applicationYearRequestDate = this.serverConfig.APPLICATION_YEAR_REQUEST_DATE ?? date;
+    const applicationYearRequestDate = this.serverConfig.APPLICATION_CURRENT_DATE ?? date;
     this.log.debug('Using application year request date [%s]', applicationYearRequestDate);
 
     const applicationYearResultDtos = await this.listApplicationYears(date);
@@ -121,7 +121,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
   async findRenewalApplicationYear(date: string): Promise<RenewalApplicationYearResultDto | null> {
     this.log.trace('Finding renewal application year results with date: [%s]', date);
 
-    const applicationYearRequestDate = this.serverConfig.APPLICATION_YEAR_REQUEST_DATE ?? date;
+    const applicationYearRequestDate = this.serverConfig.APPLICATION_CURRENT_DATE ?? date;
     this.log.debug('Using application year request date [%s]', applicationYearRequestDate);
 
     const applicationYearResultDtos = await this.listApplicationYears(date);
@@ -163,7 +163,7 @@ export class DefaultApplicationYearService implements ApplicationYearService {
   async listApplicationYears(date: string): Promise<ReadonlyArray<ApplicationYearResultDto>> {
     this.log.trace('Getting possible application years results with date: [%j]', date);
 
-    const applicationYearRequestDate = this.serverConfig.APPLICATION_YEAR_REQUEST_DATE ?? date;
+    const applicationYearRequestDate = this.serverConfig.APPLICATION_CURRENT_DATE ?? date;
     const applicationYearResultEntity = await this.applicationYearRepository.listApplicationYears(applicationYearRequestDate);
     const applicationYearResultDto = this.applicationYearDtoMapper.mapApplicationYearResultEntityToApplicationYearResultDtos(applicationYearResultEntity);
 

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -357,6 +357,6 @@ export function getEligibilityByAge(dateOfBirth: string): EligibilityResult {
     }
   }
 
-  // No eligibility group found.
-  return { eligible: false };
+  // No eligibility group found; Young and seniors are outisde the eligibility range validation.
+  return { eligible: true };
 }

--- a/frontend/app/.server/routes/helpers/apply-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/apply-route-helpers.ts
@@ -346,15 +346,14 @@ function getEligibilityRules(): EligibilityRule[] {
 }
 
 export function getEligibilityByAge(dateOfBirth: string): EligibilityResult {
-  const { CURRENT_DATE } = getEnv();
+  const { APPLICATION_CURRENT_DATE } = getEnv();
 
-  const today = CURRENT_DATE ? new Date(CURRENT_DATE) : new Date();
-  const age = getAgeFromDateString(dateOfBirth);
+  const today = APPLICATION_CURRENT_DATE ? new Date(APPLICATION_CURRENT_DATE) : new Date();
+  const age = getAgeFromDateString(dateOfBirth, APPLICATION_CURRENT_DATE);
 
   for (const { minAge, maxAge, startDate } of getEligibilityRules()) {
     if (age >= minAge && age <= maxAge) {
-      const ruleStartDate = startDate.toLowerCase() === 'now' ? today : new Date(startDate);
-      return today < ruleStartDate ? { eligible: false, startDate } : { eligible: true };
+      return today < new Date(startDate) ? { eligible: false, startDate } : { eligible: true };
     }
   }
 

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -204,6 +204,8 @@ const serverEnv = clientEnvSchema.extend({
   HEALTH_AUTH_TOKEN_AUDIENCE: z.string().default('00000000-0000-0000-0000-000000000000'), // intentional default to enforce an audience check when verifying JWTs
   HEALTH_AUTH_TOKEN_ISSUER: z.string().default('https://auth.example.com/'), // intentional default to enforce an issuer check when verifying JWTs
   HEALTH_PLACEHOLDER_REQUEST_VALUE: z.string().default('CDCP_HEALTH_CHECK'),
+  APPLY_ELIGIBILITY_RULES: z.string().default('[{"minAge":0,"maxAge":17,"startDate":"Now"},{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]'),
+  CURRENT_DATE: z.string().optional()
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -204,7 +204,7 @@ const serverEnv = clientEnvSchema.extend({
   HEALTH_AUTH_TOKEN_AUDIENCE: z.string().default('00000000-0000-0000-0000-000000000000'), // intentional default to enforce an audience check when verifying JWTs
   HEALTH_AUTH_TOKEN_ISSUER: z.string().default('https://auth.example.com/'), // intentional default to enforce an issuer check when verifying JWTs
   HEALTH_PLACEHOLDER_REQUEST_VALUE: z.string().default('CDCP_HEALTH_CHECK'),
-  APPLY_ELIGIBILITY_RULES: z.string().default('[{"minAge":0,"maxAge":17,"startDate":"Now"},{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]')
+  APPLY_ELIGIBILITY_RULES: z.string().default('[{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]')
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -85,7 +85,7 @@ const serverEnv = clientEnvSchema.extend({
   INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY: z.string().trim().transform(emptyToUndefined).optional(),
 
   // simulation/testing date settings
-  APPLICATION_YEAR_REQUEST_DATE: z.string().optional(),
+  APPLICATION_CURRENT_DATE: z.string().optional(),
 
   // auth/oidc settings
   AUTH_JWT_PRIVATE_KEY: z.string().refine(isValidPrivateKey),
@@ -204,8 +204,7 @@ const serverEnv = clientEnvSchema.extend({
   HEALTH_AUTH_TOKEN_AUDIENCE: z.string().default('00000000-0000-0000-0000-000000000000'), // intentional default to enforce an audience check when verifying JWTs
   HEALTH_AUTH_TOKEN_ISSUER: z.string().default('https://auth.example.com/'), // intentional default to enforce an issuer check when verifying JWTs
   HEALTH_PLACEHOLDER_REQUEST_VALUE: z.string().default('CDCP_HEALTH_CHECK'),
-  APPLY_ELIGIBILITY_RULES: z.string().default('[{"minAge":0,"maxAge":17,"startDate":"Now"},{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]'),
-  CURRENT_DATE: z.string().optional()
+  APPLY_ELIGIBILITY_RULES: z.string().default('[{"minAge":0,"maxAge":17,"startDate":"Now"},{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-15"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]')
 });
 
 export type ServerEnv = z.infer<typeof serverEnv>;

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -34,13 +34,13 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   loadApplyAdultSingleChildState({ params, request, session });
   const state = loadApplyAdultChildState({ params, request, session });
-  const { APPLICATION_YEAR_REQUEST_DATE } = getEnv();
+  const { APPLICATION_CURRENT_DATE } = getEnv();
   const locale = getLocale(request);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:eligibility.cannot-apply-child.page-title') }) };
-  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? parseDateString(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
+  const currentDate = APPLICATION_CURRENT_DATE ? parseDateString(APPLICATION_CURRENT_DATE) : new UTCDate();
   const coverageStartDate = parseDateString(state.applicationYear.coverageStartDate);
   const formattedDate = toLocaleDateString(coverageStartDate, locale);
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -79,7 +79,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const applyState = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const { APPLICATION_YEAR_REQUEST_DATE } = getEnv();
+  const { APPLICATION_CURRENT_DATE } = getEnv();
 
   // Form action Continue & Save
   // state validation schema
@@ -194,7 +194,7 @@ export async function action({ context: { appContainer, session }, params, reque
     };
   }
 
-  const currentDate = APPLICATION_YEAR_REQUEST_DATE ? parseDateString(APPLICATION_YEAR_REQUEST_DATE) : new UTCDate();
+  const currentDate = APPLICATION_CURRENT_DATE ? parseDateString(APPLICATION_CURRENT_DATE) : new UTCDate();
   const coverageStartDate = parseDateString(applyState.applicationYear.coverageStartDate);
 
   const ageCategory = currentDate < coverageStartDate ? getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth, applyState.applicationYear.coverageStartDate) : getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -9,7 +9,7 @@ import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
-import { getAgeCategoryFromDateString, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { getAgeCategoryFromDateString, getEligibilityByAge, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import type { ApplicantInformationState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -17,6 +17,7 @@ import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DatePickerField } from '~/components/date-picker-field';
+import { useErrorAlert } from '~/components/error-alert';
 import { useErrorSummary } from '~/components/error-summary';
 import { InputPatternField } from '~/components/input-pattern-field';
 import { InputRadios } from '~/components/input-radios';
@@ -75,6 +76,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const applyEligibilityEnabled = ENABLED_FEATURES.includes('apply-eligibility');
 
   if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
@@ -114,10 +117,24 @@ export async function action({ context: { appContainer, session }, params, reque
       dateOfBirthMonth: z.number({ required_error: t('applicant-information.error-message.date-of-birth-month-required') }),
       dateOfBirthDay: z.number({ required_error: t('applicant-information.error-message.date-of-birth-day-required'), invalid_type_error: t('applicant-information.error-message.date-of-birth-day-number') }),
       dateOfBirth: z.string(),
-      disabilityTaxCredit: z.string().optional(),
+      disabilityTaxCredit: z
+        .string()
+        .optional()
+        .refine(
+          (val) => {
+            if (applyEligibilityEnabled) {
+              // disabilityTaxCredit must not be empty
+              return val !== undefined && val !== '';
+            }
+            return true;
+          },
+          {
+            message: t('applicant-information.error-message.dtc-required'),
+            path: ['disabilityTaxCredit'],
+          },
+        ),
     })
     .superRefine((val, ctx) => {
-      // At this point the year, month and day should have been validated as positive integer
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       const dateOfBirth = `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`;
 
@@ -152,9 +169,14 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const ageCategory = getAgeCategoryFromDateString(parsedDataResult.data.dateOfBirth);
 
-  // TODO: conditionally check dtc eligibility depending on an env variable.
-  // check the yes or no to DTC
-  // Check here for the age eligibility from date-utils.ts
+  // Seniors and DTC certificate owners do no need to be eligibility checked.
+  if (ageCategory !== 'seniors' && parsedDataResult.data.disabilityTaxCredit !== DTC_OPTION.yes && applyEligibilityEnabled) {
+    const eligibilityResult = getEligibilityByAge(parsedDataResult.data.dateOfBirth);
+
+    if (!eligibilityResult.eligible) {
+      return { status: 'not-eligible', startDate: eligibilityResult.startDate } as const;
+    }
+  }
 
   if (state.editMode && (ageCategory === 'youth' || ageCategory === 'children' || parsedDataResult.data.dateOfBirthYear >= 2006)) {
     // Temporary state save until the user is finished with editMode workflow.
@@ -221,7 +243,13 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
-  const errors = fetcher.data?.errors;
+  const fetcherStatus = typeof fetcher.data === 'object' && 'status' in fetcher.data ? fetcher.data.status : undefined;
+  const fetcherEligibilityStartDate = typeof fetcher.data === 'object' && 'startDate' in fetcher.data ? fetcher.data.startDate : undefined;
+
+  const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+
+  const { ErrorAlert } = useErrorAlert(fetcherStatus === 'not-eligible');
+
   const errorSummary = useErrorSummary(errors, {
     firstName: 'first-name',
     lastName: 'last-name',
@@ -242,6 +270,11 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
         <p className="mb-4">{t('applicant-information.form-instructions-sin')}</p>
         <p className="mb-6">{t('applicant-information.form-instructions-info')}</p>
         <p className="mb-4 italic">{t('apply:required-label')}</p>
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t('apply-adult:applicant-information.error-message.alert.heading')}</h2>
+          <p className="mb-2">{t('apply-adult:applicant-information.error-message.alert.detail')}</p>
+          <p className="mb-2">{t('apply-adult:applicant-information.error-message.alert.applyDate', { startDate: fetcherEligibilityStartDate })}</p>
+        </ErrorAlert>
         <errorSummary.ErrorSummary />
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
@@ -283,18 +316,6 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
               errorMessages={{ all: errors?.dateOfBirth, year: errors?.dateOfBirthYear, month: errors?.dateOfBirthMonth, day: errors?.dateOfBirthDay }}
               required
             />
-            <InputPatternField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              format={sinInputPatternFormat}
-              label={t('applicant-information.sin')}
-              inputMode="numeric"
-              helpMessagePrimary={t('apply-adult:applicant-information.help-message.sin')}
-              helpMessagePrimaryClassName="text-black"
-              defaultValue={defaultState?.socialInsuranceNumber ?? ''}
-              errorMessage={errors?.socialInsuranceNumber}
-              required
-            />
             {applyEligibilityEnabled && (
               <InputRadios
                 id="dtc"
@@ -316,6 +337,18 @@ export default function ApplyFlowApplicationInformation({ loaderData, params }: 
                 errorMessage={errors?.disabilityTaxCredit}
               />
             )}
+            <InputPatternField
+              id="social-insurance-number"
+              name="socialInsuranceNumber"
+              format={sinInputPatternFormat}
+              label={t('applicant-information.sin')}
+              inputMode="numeric"
+              helpMessagePrimary={t('apply-adult:applicant-information.help-message.sin')}
+              helpMessagePrimaryClassName="text-black"
+              defaultValue={defaultState?.socialInsuranceNumber ?? ''}
+              errorMessage={errors?.socialInsuranceNumber}
+              required
+            />
           </div>
           {editMode ? (
             <div className="flex flex-wrap items-center gap-3">

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -16,7 +16,7 @@
     "save-btn": "Save",
     "radio-options": {
       "no": "No",
-      "yes": "yes"
+      "yes": "Yes"
     },
     "help-message": {
       "sin": "Enter the 9-digit SIN"
@@ -38,7 +38,12 @@
       "date-of-birth-valid": "Day must be valid for the given month and year",
       "date-of-birth-year-number": "Year must be a number, for example 1950",
       "date-of-birth-year-required": "Date of birth must include a year",
-      "dtc-required": "Select whether or not you have a valid disability tax credit"
+      "dtc-required": "Select whether or not you have a valid disability tax credit",
+      "alert": {
+        "heading": "You cannot apply at this time.",
+        "detail": "Based on the date of birth provided, you are not able to apply for the Canadian Dental Care Plan at this time.",
+        "applyDate": "You can apply starting {{startDate}}."
+      }
     }
   },
   "marital-status": {

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -38,7 +38,12 @@
       "date-of-birth-valid": "Le jour doit être valide pour le mois et l'année choisis",
       "date-of-birth-year-number": "L'année doit être un nombre, par exemple 1950",
       "date-of-birth-year-required": "La date de naissance doit inclure une année",
-      "dtc-required": "Sélectionnez si vous avez un crédit d'impôt d'invalidité valide"
+      "dtc-required": "Sélectionnez si vous avez un crédit d'impôt d'invalidité valide",
+      "alert": {
+        "heading": "Vous ne pouvez pas souscrire pour le moment",
+        "detail": "Compte tenu de votre date de naissance, vous ne pouvez pas souscrire au Régime canadien de soins dentaires pour le moment.",
+        "applyDate": "Vous pouvez souscrire à partir du {{startDate}}."
+      }
     }
   },
   "marital-status": {


### PR DESCRIPTION
### Description
Adding only for `adult` route.

If this is merged, I'll be adding it to `adult/child`.

I placed the eligibility logic inside our `apply-route-helpers.ts`. Let me know if we should move it elsewhere.

### Related Azure Boards Work Items
[AB#5473](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5473)
[AB#5532](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5532)
[AB#5490](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5490)
[AB#5492](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5492)
[AB#5489](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5489)
[AB#5493](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5493)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Inside `ENABLED_FEATURES` apply-eligibility must be added for this to appear.
`CURRENT_DATE` is also added to mannually change today's date for testing purposes.
