### PR TITLE
fix(frontend) make suggested address the default selected radio option

### DIFF
--- a/frontend/app/components/address-validation-dialog.tsx
+++ b/frontend/app/components/address-validation-dialog.tsx
@@ -48,7 +48,7 @@ export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddres
   const enteredAddressOptionValue = 'entered-address';
   const suggestedAddressOptionValue = 'suggested-address';
   type AddressSelectionOption = typeof enteredAddressOptionValue | typeof suggestedAddressOptionValue;
-  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(enteredAddressOptionValue);
+  const [selectedAddressSuggestionOption, setSelectedAddressSuggestionOption] = useState<AddressSelectionOption>(suggestedAddressOptionValue);
 
   async function onSubmitHandler(event: SyntheticEvent<HTMLFormElement, SubmitEvent>) {
     event.preventDefault();


### PR DESCRIPTION
### Description
IIUC, in order to make the "suggested address" the default selected radio option, we only need to change the initial value in the `useState` in the `AddressValidationDialog` component 🤔 

### Related Azure Boards Work Items
[AB#5533](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5533)
