### PR TITLE
Adding `findLocalized()` methods for FPT lookup and replacing try/catch with if/else in `/protected/renew` Review routes

### DIFF
--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -204,6 +204,59 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     });
   });
 
+  describe('findLocalizedFederalGovernmentInsurancePlanById', () => {
+    it('fetches federal government insurance plan by id and locale', () => {
+      const id = '1';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+      });
+
+      const mockDto: FederalGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+      };
+
+      const mockLocalizedDto: FederalGovernmentInsurancePlanLocalizedDto = {
+        id: '1',
+        name: 'First Insurance Plan',
+      };
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+      mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+      mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto.mockReturnValueOnce(mockLocalizedDto);
+
+      const service = new DefaultFederalGovernmentInsurancePlanService(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findLocalizedFederalGovernmentInsurancePlanById(id, 'en');
+
+      expect(dto).toEqual(mockLocalizedDto);
+      expect(mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
+    });
+
+    it('fetches federal government insurance plan by id and locale and returns null if not found', () => {
+      const id = '1033';
+      const mockFederalGovernmentInsurancePlanRepository = mock<FederalGovernmentInsurancePlanRepository>();
+      mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockReturnValueOnce(null);
+
+      const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
+
+      const service = new DefaultFederalGovernmentInsurancePlanService(mockLogFactory, mockFederalGovernmentInsurancePlanDtoMapper, mockFederalGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findLocalizedFederalGovernmentInsurancePlanById(id, 'en');
+
+      expect(dto).toBeNull();
+      expect(mockFederalGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getLocalizedFederalGovernmentInsurancePlanById', () => {
     it('fetches localized federal government insurance plan by id', () => {
       const id = '1';

--- a/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
@@ -214,6 +214,62 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     });
   });
 
+  describe('findLocalizedProvincialGovernmentInsurancePlanById', () => {
+    it('fetches provincial government insurance plan by id and locale', () => {
+      const id = '1';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockReturnValueOnce({
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance",
+        _esdc_provinceterritorystateid_value: '10',
+      });
+
+      const mockDto: ProvincialGovernmentInsurancePlanDto = {
+        id: '1',
+        nameEn: 'First Insurance Plan',
+        nameFr: "Premier plan d'assurance",
+        provinceTerritoryStateId: '10',
+      };
+
+      const mockLocalizedDto: ProvincialGovernmentInsurancePlanLocalizedDto = {
+        id: '1',
+        name: 'First Insurance Plan',
+        provinceTerritoryStateId: '2',
+      };
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+      mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto.mockReturnValueOnce(mockDto);
+      mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtoToProvincialGovernmentInsurancePlanLocalizedDto.mockReturnValueOnce(mockLocalizedDto);
+
+      const service = new DefaultProvincialGovernmentInsurancePlanService(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findLocalizedProvincialGovernmentInsurancePlanById(id, 'en');
+
+      expect(dto).toEqual(mockLocalizedDto);
+      expect(mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtoToProvincialGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
+    });
+
+    it('fetches provincial government insurance plan by id and locale and returns null if not found', () => {
+      const id = '1033';
+      const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();
+      mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockReturnValueOnce(null);
+
+      const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
+
+      const service = new DefaultProvincialGovernmentInsurancePlanService(mockLogFactory, mockProvincialGovernmentInsurancePlanDtoMapper, mockProvincialGovernmentInsurancePlanRepository, mockServerConfig);
+
+      const dto = service.findLocalizedProvincialGovernmentInsurancePlanById(id, 'en');
+
+      expect(dto).toBeNull();
+      expect(mockProvincialGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getLocalizedProvincialGovernmentInsurancePlanById', () => {
     it('should return a localized provincial government insurance plan by id', () => {
       const mockProvincialGovernmentInsurancePlanRepository = mock<ProvincialGovernmentInsurancePlanRepository>();

--- a/frontend/app/.server/domain/repositories/federal-government-insurance-plan.repository.ts
+++ b/frontend/app/.server/domain/repositories/federal-government-insurance-plan.repository.ts
@@ -48,7 +48,7 @@ export class DefaultFederalGovernmentInsurancePlanRepository implements FederalG
     const federalGovernmentInsurancePlanEntity = federalGovernmentInsurancePlanEntities.find(({ esdc_governmentinsuranceplanid }) => esdc_governmentinsuranceplanid === id);
 
     if (!federalGovernmentInsurancePlanEntity) {
-      this.log.warn('Federal government insurance plan not found; id: [%s]', id);
+      this.log.info('Federal government insurance plan not found; id: [%s]', id);
       return null;
     }
 

--- a/frontend/app/.server/domain/repositories/provincial-government-insurance-plan.repository.ts
+++ b/frontend/app/.server/domain/repositories/provincial-government-insurance-plan.repository.ts
@@ -48,7 +48,7 @@ export class DefaultProvincialGovernmentInsurancePlanRepository implements Provi
     const provincialGovernmentInsurancePlanEntity = provincialGovernmentInsurancePlanEntities.find(({ esdc_governmentinsuranceplanid }) => esdc_governmentinsuranceplanid === id);
 
     if (!provincialGovernmentInsurancePlanEntity) {
-      this.log.warn('Provincial government insurance plan not found; id: [%s]', id);
+      this.log.info('Provincial government insurance plan not found; id: [%s]', id);
       return null;
     }
 

--- a/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
@@ -39,6 +39,16 @@ export interface FederalGovernmentInsurancePlanService {
   listFederalGovernmentInsurancePlans(): ReadonlyArray<FederalGovernmentInsurancePlanDto>;
 
   /**
+   * Finds a specific federal government insurance plan by its ID in the specified locale.
+   * Returns null if no matching federal government insurance plan is found for the specified locale.
+   *
+   * @param id - The ID of the federal government insurance plan to retrieve.
+   * @param locale - The desired locale (e.g., 'en' or 'fr').
+   * @returns The FederalGovernmentInsurancePlan DTO corresponding to the specified ID and locale or null if not found.
+   */
+  findLocalizedFederalGovernmentInsurancePlanById(id: string, locale: AppLocale): FederalGovernmentInsurancePlanLocalizedDto | null;
+
+  /**
    * Retrieves a specific federal government insurance plan by its ID in the specified locale.
    *
    * @param id - The ID of the federal government insurance plan to retrieve.
@@ -146,6 +156,21 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
     const sortedFederalGovernmentInsurancePlanLocalizedDtos = this.sortFederalGovernmentInsurancePlanLocalizedDtos(federalGovernmentInsurancePlanLocalizedDtos, locale);
     this.log.trace('Returning localized and sorted federal government insurance plans: [%j]', sortedFederalGovernmentInsurancePlanLocalizedDtos);
     return sortedFederalGovernmentInsurancePlanLocalizedDtos;
+  }
+
+  findLocalizedFederalGovernmentInsurancePlanById(id: string, locale: AppLocale): FederalGovernmentInsurancePlanLocalizedDto | null {
+    this.log.debug('Finding federal government insurance plan with id [%s] and locale [%s]', id, locale);
+    const federalGovernmentInsurancePlanDto = this.findFederalGovernmentInsurancePlanById(id);
+
+    if (!federalGovernmentInsurancePlanDto) {
+      this.log.trace('Federal government insurance plan with id [%s] not found. Returning null', id);
+      return null;
+    }
+
+    const federalGovernmentInsurancePlanLocalizedDto = this.federalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto(federalGovernmentInsurancePlanDto, locale);
+
+    this.log.trace('Returning federal government insurance plan: [%j]', federalGovernmentInsurancePlanLocalizedDto);
+    return federalGovernmentInsurancePlanLocalizedDto;
   }
 
   getLocalizedFederalGovernmentInsurancePlanById(id: string, locale: AppLocale): FederalGovernmentInsurancePlanLocalizedDto {

--- a/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
@@ -14,6 +14,7 @@ export interface ProvincialGovernmentInsurancePlanService {
   findProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto | null;
   getProvincialGovernmentInsurancePlanById(id: string): ProvincialGovernmentInsurancePlanDto;
   listAndSortLocalizedProvincialGovernmentInsurancePlans(locale: AppLocale): ReadonlyArray<ProvincialGovernmentInsurancePlanLocalizedDto>;
+  findLocalizedProvincialGovernmentInsurancePlanById(id: string, locale: AppLocale): ProvincialGovernmentInsurancePlanLocalizedDto | null;
   getLocalizedProvincialGovernmentInsurancePlanById(id: string, locale: AppLocale): ProvincialGovernmentInsurancePlanLocalizedDto;
 }
 
@@ -103,6 +104,20 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
     const sortedProvincialGovernmentInsurancePlanLocalizedDtos = this.sortLocalizedProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanLocalizedDtos, locale);
     this.log.trace('Returning localized and sorted provincial government insurance plans: [%j]', sortedProvincialGovernmentInsurancePlanLocalizedDtos);
     return sortedProvincialGovernmentInsurancePlanLocalizedDtos;
+  }
+
+  findLocalizedProvincialGovernmentInsurancePlanById(id: string, locale: AppLocale): ProvincialGovernmentInsurancePlanLocalizedDto | null {
+    this.log.debug('Finding provincial government insurance plan with id [%s] and locale [%s]', id, locale);
+    const provincialGovernmentInsurancePlanDto = this.findProvincialGovernmentInsurancePlanById(id);
+
+    if (!provincialGovernmentInsurancePlanDto) {
+      this.log.trace('Provincial government insurance plan with id: [%s] not found. Returning null', id);
+      return null;
+    }
+
+    const provincialGovernmentInsurancePlanLocalizedDto = this.provincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtoToProvincialGovernmentInsurancePlanLocalizedDto(provincialGovernmentInsurancePlanDto, locale);
+    this.log.trace('Returning provincial government insurance plan: [%j]', provincialGovernmentInsurancePlanDto);
+    return provincialGovernmentInsurancePlanLocalizedDto;
   }
 
   getLocalizedProvincialGovernmentInsurancePlanById(id: string, locale: AppLocale): ProvincialGovernmentInsurancePlanLocalizedDto {

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -181,14 +181,14 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits.map((id) => {
-    try {
-      const federalBenefit = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(id, locale);
-      return federalBenefit.name;
-    } catch {
-      const provincialBenefit = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(id, locale);
-      return provincialBenefit.name;
-    }
+  const clientDentalBenefits = state.clientApplication.dentalBenefits.flatMap((id) => {
+    const federalProgram = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).findLocalizedFederalGovernmentInsurancePlanById(id, locale);
+    if (federalProgram) return [federalProgram.name];
+
+    const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).findLocalizedProvincialGovernmentInsurancePlanById(id, locale);
+    if (provincialProgram) return [provincialProgram.name];
+
+    return [];
   });
 
   const dentalBenefits = state.dentalBenefits

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -76,14 +76,14 @@ export async function loader({ context: { appContainer, session }, params, reque
       ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
-    const clientDentalBenefits = immutableChild?.dentalBenefits.map((id) => {
-      try {
-        const federalBenefit = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(id, locale);
-        return federalBenefit.name;
-      } catch {
-        const provincialBenefit = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(id, locale);
-        return provincialBenefit.name;
-      }
+    const clientDentalBenefits = immutableChild?.dentalBenefits.flatMap((id) => {
+      const federalProgram = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).findLocalizedFederalGovernmentInsurancePlanById(id, locale);
+      if (federalProgram) return [federalProgram.name];
+
+      const provincialProgram = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).findLocalizedProvincialGovernmentInsurancePlanById(id, locale);
+      if (provincialProgram) return [provincialProgram.name];
+
+      return [];
     });
 
     const dentalBenefits = child.dentalBenefits


### PR DESCRIPTION
### Description
This PR continues the cleanup started in #3301 by replacing remaining `getLocalized...()` calls, which log `ERROR`s when keys are missing, with `findLocalized...()` calls that handle missing values more gracefully.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/90597cc4-15ef-4649-88c6-aeb10f5fc322)
![image](https://github.com/user-attachments/assets/d39ac068-3b0a-49dc-ad0c-d50d1d12271a)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`