### PR TITLE
feat(frontend): Logging modules

### DIFF
--- a/frontend/app/.server/logging/index.ts
+++ b/frontend/app/.server/logging/index.ts
@@ -1,0 +1,3 @@
+export * from './log-levels';
+export type * from './logger';
+export * from './logger-factory';

--- a/frontend/app/.server/logging/log-levels.ts
+++ b/frontend/app/.server/logging/log-levels.ts
@@ -1,0 +1,33 @@
+/**
+ * Available log levels in order of increasing verbosity.
+ * Each level includes messages from all levels above it, meaning:
+ * - 'audit' includes 'error', 'warn', 'info', 'debug', and 'trace'
+ * - 'error' includes 'warn', 'info', 'debug', and 'trace'
+ * - 'warn' includes 'info', 'debug', and 'trace', etc.
+ */
+export const logLevels = [
+  'audit', // Critical system events requiring persistence
+  'error', // Runtime errors that may require immediate attention
+  'warn', // Warnings, potential issues that don't stop execution
+  'info', // General operational information about system status
+  'debug', // Detailed information useful during development and debugging
+  'trace', // Highly detailed tracing information, potentially performance-impacting
+] as const;
+
+/**
+ * Type representing the tuple of available log levels.
+ * This type is useful for ensuring type safety when working with the log level array.
+ */
+export type LogLevels = typeof logLevels;
+
+/**
+ * Type representing a valid log level string.
+ * This type is a union of all possible log levels.
+ */
+export type LogLevel = LogLevels[number];
+
+/**
+ * Maximum length of log level names, used for padding log output for alignment.
+ * This ensures that log entries with different log levels align neatly when output.
+ */
+export const maxLogLevelNameLength = Math.max(...logLevels.map((level) => level.length));

--- a/frontend/app/.server/logging/logger-default.ts
+++ b/frontend/app/.server/logging/logger-default.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { LEVEL, SPLAT } from 'triple-beam';
+import type winston from 'winston';
+
+import type { LogLevel } from '~/.server/logging/log-levels';
+import type { Logger } from '~/.server/logging/logger';
+
+interface LogEntry {
+  label: string;
+  level: string;
+  message: string;
+  [LEVEL]: string;
+  [SPLAT]?: unknown;
+  [key: string | symbol]: unknown;
+}
+
+/**
+ * Implements the Logger interface using the Winston logging library.
+ * This class wraps Winston to provide structured logging with support for different log levels.
+ */
+export class DefaultLogger implements Logger {
+  private readonly logger: winston.Logger;
+  private readonly label: string;
+
+  /**
+   * Creates an instance of DefaultLogger.
+   * This logger instance will be configured with the provided `label` to prefix each log entry,
+   * ensuring that logs are properly categorized based on the service or context.
+   *
+   * @param logger - A pre-configured Winston Logger instance to use for logging.
+   * @param label - The label for the logger (e.g., 'auth', 'db'). This will be included in all log entries.
+   * @throws {Error} If the provided label is empty or consists only of whitespace.
+   */
+  constructor(logger: winston.Logger, label: string) {
+    this.logger = logger; // Use the provided Winston logger instance.
+    this.label = label.trim(); // Ensure the label is clean and trimmed.
+  }
+
+  // Various logging methods, each corresponding to a specific log level.
+  audit(message: unknown): void;
+  audit(message: string, ...meta: unknown[]): void {
+    this.logInternal('audit', message, meta);
+  }
+
+  debug(message: unknown): void;
+  debug(message: string, ...meta: unknown[]): void {
+    this.logInternal('debug', message, meta);
+  }
+
+  error(message: unknown): void;
+  error(message: string, ...meta: unknown[]): void {
+    this.logInternal('error', message, meta);
+  }
+
+  info(message: unknown): void;
+  info(message: string, ...meta: unknown[]): void {
+    this.logInternal('info', message, meta);
+  }
+
+  trace(message: unknown): void;
+  trace(message: string, ...meta: unknown[]): void {
+    this.logInternal('trace', message, meta);
+  }
+
+  warn(message: unknown): void;
+  warn(message: string, ...meta: unknown[]): void {
+    this.logInternal('warn', message, meta);
+  }
+
+  /**
+   * Internal log method that handles the actual logging process.
+   * This method processes the level, message, and any additional meta data before passing it to Winston.
+   *
+   * @param level - The log level (e.g., 'info', 'warn', 'error').
+   * @param messageOrObject - The message to be logged, or an object containing additional data.
+   * @param splat - Additional arguments to be logged, used in cases where message formatting is needed.
+   */
+  private logInternal(level: LogLevel, messageOrObject: string | unknown, splat: unknown[]): void {
+    const baseEntry = {
+      level: level,
+      [LEVEL]: level, // Attach the log level as the symbol.
+      label: this.label, // Attach the logger label.
+    } as const satisfies OmitStrict<LogEntry, 'message'>;
+
+    // Scenario 1: Logging with an object (messageOrObject is an object)
+    if (splat.length === 0 && typeof messageOrObject === 'object' && messageOrObject !== null && !Array.isArray(messageOrObject)) {
+      const entry = { ...messageOrObject, ...baseEntry }; // Merge object and base entry.
+      this.logger.log(entry as any); // Log the merged entry.
+      return;
+    }
+
+    // Scenario 2: Standard message logging with no splat args.
+    const msg = String(messageOrObject); // Ensure message is a string.
+    if (splat.length === 0) {
+      const entry: LogEntry = { ...baseEntry, message: msg }; // Merge baseEntry with message.
+      this.logger.log(entry);
+      return;
+    }
+
+    // Scenario 3: Logging with message formatting and splat args (e.g., 'User %s logged in').
+    const formatRegExp = /%[scdjifoO%]/g; // Regex for detecting format specifiers like %s, %d.
+    const tokens = msg.match(formatRegExp); // Find all tokens.
+
+    if (!tokens && typeof splat[0] === 'object') {
+      const entry: LogEntry = { ...splat[0], ...baseEntry, message: msg, [SPLAT]: splat };
+      this.logger.log(entry);
+      return;
+    }
+
+    // Scenario 4: Logging with splat args for more complex messages.
+    const entry: LogEntry = { ...baseEntry, message: msg, [SPLAT]: splat };
+    this.logger.log(entry);
+  }
+}

--- a/frontend/app/.server/logging/logger-factory.ts
+++ b/frontend/app/.server/logging/logger-factory.ts
@@ -1,0 +1,56 @@
+import invariant from 'tiny-invariant';
+import type winston from 'winston';
+
+import { singleton } from '../utils/instance-registry';
+import { getLoggingConfig } from './logging-config';
+import { createWinstonInstance } from './winston-factory';
+
+import type { Logger } from '~/.server/logging/logger';
+import { DefaultLogger } from '~/.server/logging/logger-default';
+
+/**
+ * Creates a contextual logger instance with the specified label.
+ *
+ * This function provides a standardized logging interface throughout the application,
+ * ensuring consistent log format and behavior. It leverages a singleton Winston instance
+ * under the hood for performance and resource efficiency.
+ *
+ * @remarks
+ * The logger attaches the provided label to all log messages, making it easier to
+ * identify the source of logs in a complex system. The underlying Winston instance
+ * is shared across all loggers for efficiency.
+ *
+ * If the Winston instance initialization fails, the error will propagate from the
+ * underlying factory functions. Callers should be prepared to handle these potential errors.
+ *
+ * @example
+ * ```typescript
+ * // In database service
+ * const logger = createLogger('Database');
+ * logger.info('Connection established');
+ *
+ * // In auth service
+ * const logger = createLogger('AuthService');
+ * logger.error('Authentication failed', { userId: '123', reason: 'invalid_token' });
+ * ```
+ *
+ * @param label - A string identifying the logging context (e.g., 'Database', 'AuthService')
+ * @throws {Error} If the label is empty, invalid, or contains only whitespace
+ * @returns A configured logger instance that prefixes all logs with the given label
+ */
+export function createLogger(label: string): Logger {
+  // Validate the label is non-empty
+  invariant(typeof label === 'string' && label.trim().length > 0, 'Logger label must be a non-empty string and cannot be just whitespace.');
+
+  // Get or create the singleton Winston logger instance
+  // This ensures we only create one logger for the entire application
+  const winstonLogger = singleton<winston.Logger>('winstonLogger', () => {
+    const config = getLoggingConfig();
+    const logger = createWinstonInstance(config);
+    logger.info('Winston Logger Singleton Initialized 🚀');
+    return logger;
+  });
+
+  // Create and return a new logger with the specified context
+  return new DefaultLogger(winstonLogger, label.trim());
+}

--- a/frontend/app/.server/logging/logger.ts
+++ b/frontend/app/.server/logging/logger.ts
@@ -1,0 +1,36 @@
+/**
+ * Defines the standard logging methods, allowing logging at various severity levels.
+ * Each method accepts a message and optional metadata for structured logging.
+ *
+ * The severity levels include:
+ * - `audit`: Critical system events requiring persistence.
+ * - `error`: Runtime errors that may require immediate attention.
+ * - `warn`: Warnings for potential issues that don't halt execution.
+ * - `info`: General system information.
+ * - `debug`: Detailed logs useful during development.
+ * - `trace`: Highly detailed tracing for diagnostics.
+ */
+export interface Logger {
+  audit: LeveledLogMethod;
+  debug: LeveledLogMethod;
+  error: LeveledLogMethod;
+  info: LeveledLogMethod;
+  trace: LeveledLogMethod;
+  warn: LeveledLogMethod;
+}
+
+/**
+ * Method signature for logging messages at different levels of severity.
+ *
+ * The method can accept:
+ * - A single `message` (string or any other type).
+ * - An optional spread of `meta` data (usually structured logging info).
+ *
+ * The method signature accommodates different logging scenarios:
+ * - Simple string messages.
+ * - More complex messages with metadata for structured logging.
+ */
+interface LeveledLogMethod {
+  (message: string, ...meta: unknown[]): void;
+  (message: unknown): void;
+}

--- a/frontend/app/.server/logging/logging-config.ts
+++ b/frontend/app/.server/logging/logging-config.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+import { singleton } from '../utils/instance-registry';
+
+import { logLevels } from '~/.server/logging/log-levels';
+import type { LogLevel } from '~/.server/logging/log-levels';
+
+/**
+ * Type definition for the application's logging configuration parameters.
+ * This configuration controls log levels, audit logging behavior, and file paths.
+ */
+export type LoggingConfig = {
+  /**
+   * The minimum log level to output (from most to least severe: audit, error, warn, info, debug, trace).
+   * Messages below this level will be filtered out.
+   */
+  LOG_LEVEL: LogLevel;
+
+  /**
+   * Whether to enable separate audit logging for security and compliance purposes.
+   * When true, audit logs will be written to separate files for easier tracking.
+   */
+  AUDIT_LOG_ENABLED: boolean;
+
+  /**
+   * Directory path where audit logs will be stored.
+   * Must be a valid directory path that the application has write permissions for.
+   */
+  AUDIT_LOG_DIRNAME: string;
+
+  /**
+   * Filename pattern for audit logs.
+   * The placeholder %DATE% will be replaced with the current date (format: YYYY-MM-DD).
+   */
+  AUDIT_LOG_FILENAME: string;
+};
+
+/**
+ * Default configuration values used when specific settings are not provided in the environment.
+ * These values serve as fallbacks if environment variables are missing or invalid.
+ *
+ * The LOG_LEVEL defaults are environment-aware:
+ * - 'info' in production (less verbose, better performance)
+ * - 'debug' in development/test (more verbose for troubleshooting)
+ */
+export const defaultsConfig = {
+  LOG_LEVEL: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  AUDIT_LOG_ENABLED: true,
+  AUDIT_LOG_DIRNAME: 'logs',
+  AUDIT_LOG_FILENAME: 'audit-%DATE%',
+} as const satisfies LoggingConfig;
+
+/**
+ * Zod schema for validating and parsing logging-related environment variables.
+ * This schema enforces type constraints and provides intelligent fallbacks to
+ * ensure the application always has valid logging configuration.
+ */
+const loggingConfigSchema = z.object({
+  LOG_LEVEL: z
+    .enum(logLevels) // Ensures the log level is one of the predefined levels
+    .catch(defaultsConfig.LOG_LEVEL),
+
+  AUDIT_LOG_ENABLED: z
+    .string() // Validates AUDIT_LOG_ENABLED as a string
+    .transform((val) => val.toLowerCase() === 'true') // Converts to boolean
+    .catch(defaultsConfig.AUDIT_LOG_ENABLED),
+
+  AUDIT_LOG_DIRNAME: z
+    .string() //
+    .trim()
+    .min(1, 'Audit log directory name cannot be empty.')
+    .catch(defaultsConfig.AUDIT_LOG_DIRNAME),
+
+  AUDIT_LOG_FILENAME: z
+    .string() //
+    .trim()
+    .min(1, 'Audit log file name pattern cannot be empty.')
+    .catch(defaultsConfig.AUDIT_LOG_FILENAME),
+});
+
+/**
+ * Retrieves and validates logging configuration from environment variables.
+ *
+ * This function uses the singleton pattern to ensure the configuration is parsed
+ * only once per application lifecycle, improving performance and consistency.
+ *
+ * @example
+ * ```typescript
+ * const config = getLoggingConfig();
+ * console.log(`Current log level: ${config.LOG_LEVEL}`);
+ *
+ * @returns The validated logging configuration object with all required fields
+ */
+export function getLoggingConfig(): LoggingConfig {
+  return singleton<LoggingConfig>('loggingConfig', () => {
+    // Parse environment variables, applying validation rules
+    // The singleton ensures we only validate once per application instance
+    return loggingConfigSchema.parse(process.env);
+  });
+}

--- a/frontend/app/.server/logging/winston-factory.ts
+++ b/frontend/app/.server/logging/winston-factory.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import type * as w from 'winston';
+import winston, { format } from 'winston';
+import 'winston-daily-rotate-file';
+import { fullFormat } from 'winston-error-format';
+
+import type { LogLevel } from '~/.server/logging/log-levels';
+import type { LoggingConfig } from '~/.server/logging/logging-config';
+import { createConsoleTransport, createDailyRotateFileTransport } from '~/.server/logging/winston-transport-factory';
+
+export type LevelsConfig = {
+  levels: Record<LogLevel, number>;
+  colors: Record<LogLevel, string>;
+};
+
+const levelsConfig = {
+  levels: {
+    audit: 0, // Highest priority - for security and compliance events
+    error: 1, // Application errors requiring immediate attention
+    warn: 2, // Warning conditions
+    info: 3, // Informational messages highlighting application progress
+    debug: 4, // Detailed debug information
+    trace: 5, // Fine-grained debug information
+  },
+  colors: {
+    audit: 'magenta',
+    error: 'red',
+    warn: 'yellow',
+    info: 'green',
+    debug: 'blue',
+    trace: 'dim',
+  },
+} as const satisfies LevelsConfig;
+
+winston.addColors(levelsConfig.colors);
+
+/**
+ * Creates a configured Winston logger instance based on the provided environment settings.
+ *
+ * @param config - The logging environment configuration containing settings like log level
+ *                and audit log parameters.
+ * @returns A configured Winston logger instance.
+ */
+export function createWinstonInstance(config: LoggingConfig): w.Logger {
+  // Validate that LOG_LEVEL is valid before creating the logger
+  if (!levelsConfig.levels[config.LOG_LEVEL]) {
+    throw new Error(`Invalid LOG_LEVEL: ${config.LOG_LEVEL}`);
+  }
+
+  // Create and configure the main logger instance
+  const winstonInstance = winston.createLogger({
+    level: config.LOG_LEVEL,
+    levels: levelsConfig.levels,
+    format: format.combine(
+      format.timestamp(),
+      format.splat(), // Enables string interpolation with %s, %d, etc.
+      fullFormat(), // Enhanced error formatting from winston-error-format
+    ),
+    transports: [createConsoleTransport(levelsConfig)],
+  });
+
+  // Configure audit logging if enabled
+  configureAuditLogging(winstonInstance, config);
+
+  winstonInstance.info('Logger initialized with level "%s"', winstonInstance.level);
+  return winstonInstance;
+}
+
+/**
+ * Configures and adds audit logging if enabled in the configuration.
+ *
+ * @param logger - The Winston logger instance
+ * @param config - The logging configuration
+ */
+function configureAuditLogging(logger: w.Logger, config: LoggingConfig): void {
+  if (config.AUDIT_LOG_ENABLED) {
+    const dailyRotateFileTransport = createDailyRotateFileTransport(config);
+    logger.add(dailyRotateFileTransport);
+
+    const logPath = path.join(dailyRotateFileTransport.dirname || '.', dailyRotateFileTransport.filename);
+    logger.info(`Audit logging enabled. Writing logs to ${logPath}`);
+  }
+}

--- a/frontend/app/.server/logging/winston-format.ts
+++ b/frontend/app/.server/logging/winston-format.ts
@@ -1,0 +1,110 @@
+import { isEmpty, omit } from 'moderndash';
+import { inspect } from 'node:util';
+import { LEVEL, MESSAGE, SPLAT } from 'triple-beam';
+import { format } from 'winston';
+import type { Logform } from 'winston';
+
+import { maxLogLevelNameLength } from '~/.server/logging/log-levels';
+
+type FormatLevelsOptions = {
+  /**
+   * Custom padding length (defaults to maxLogLevelNameLength)
+   */
+  padMaxLength?: number;
+};
+
+/**
+ * Winston format that uppercases and pads the log level for alignment.
+ *
+ * Transforms `info.level` to uppercase and pads it to a fixed width
+ * defined by `padMaxLength` (or `maxLogLevelNameLength` fallback).
+ * This ensures consistent visual alignment of log output regardless of level name length.
+ *
+ * @param options - Configuration options
+ * @returns A Winston formatter that modifies the log level
+ */
+export function formatLevels(options?: FormatLevelsOptions): Logform.Format {
+  const { padMaxLength = maxLogLevelNameLength } = options ?? {};
+
+  return format((info) => {
+    const level = info.level.toUpperCase().padStart(padMaxLength);
+    // Assign formatted level
+    info.level = level;
+    return info;
+  })();
+}
+
+type FormatLabelsOptions = {
+  /**
+   * The default value used when `info.label` is missing (default: 'unlabeled')
+   */
+  fallback?: string;
+
+  /**
+   * The maximum allowed length for the label before truncation (default: 25)
+   */
+  maxLength?: number;
+};
+
+/**
+ * Winston format that standardizes labels for consistent display in log output.
+ *
+ * Processes the `info.label` field to ensure the following:
+ * 1. Uses a default value (`fallback`) if the label is missing.
+ * 2. Truncates the label with an ellipsis (`…`) if it exceeds `maxLength`,
+ *    preserving the last `maxLength - 1` characters to fit the ellipsis.
+ * 3. Applies left-padding to align shorter labels to the specified `maxLength`.
+ * 4. Wraps the final label in square brackets for visibility and consistency.
+ *
+ * @param options - Configuration options for label formatting:
+ * @returns A Winston formatter that formats the `info.label` field according to the specified options.
+ */
+export function formatLabels(options?: FormatLabelsOptions): Logform.Format {
+  const { fallback = 'unlabeled', maxLength = 25 } = options ?? {};
+
+  return format((info) => {
+    const rawLabel = String(info.label ?? fallback);
+
+    // Format label with truncation and padding
+    // prettier-ignore
+    const paddedOrTruncated = rawLabel.length > maxLength
+      ? '…' + rawLabel.slice(rawLabel.length - (maxLength - 1)) // Leave space for ellipsis
+      : rawLabel.padStart(maxLength);
+
+    // Apply the formatted label
+    info.label = `[${paddedOrTruncated}]`;
+    return info;
+  })();
+}
+
+/**
+ * Formats Winston logs into a structured, human-readable console output.
+ *
+ * Creates a consistent output format with timestamp, level, label, message,
+ * and any additional metadata. The output is visually aligned for improved readability,
+ * with metadata displayed using Node.js's `util.inspect` when present.
+ *
+ * Output format:
+ *   "timestamp LEVEL --- [label]: message --- {metadata}"
+ *
+ * @returns A Winston formatter using printf for log message formatting
+ */
+export function formatPrintf(): Logform.Format {
+  return format.printf((info) => {
+    const { label, level, message, timestamp, ...rest } = info;
+
+    let msg = `${timestamp} ${level} --- ${label}: ${message}`;
+
+    // Append metadata if present, excluding Winston's internal properties
+    if (!isEmpty(rest)) {
+      const stripped = omit(rest, [LEVEL, MESSAGE, SPLAT]);
+
+      // Only append metadata if there are still properties after stripped internals
+      if (!isEmpty(stripped)) {
+        msg += ` --- ${inspect(stripped, false, 4, true)}`;
+      }
+    }
+
+    return msg;
+  });
+}

--- a/frontend/app/.server/logging/winston-transport-factory.ts
+++ b/frontend/app/.server/logging/winston-transport-factory.ts
@@ -1,0 +1,49 @@
+import os from 'node:os';
+import type * as w from 'winston';
+import { format, transports } from 'winston';
+import 'winston-daily-rotate-file';
+import type DailyRotateFile from 'winston-daily-rotate-file';
+
+import type { LoggingConfig } from '~/.server/logging/logging-config';
+import type { LevelsConfig } from '~/.server/logging/winston-factory';
+import { formatLabels, formatLevels, formatPrintf } from '~/.server/logging/winston-format';
+
+/**
+ * Creates and configures the console transport for Winston.
+ *
+ * @returns Configured console transport instance
+ */
+export function createConsoleTransport(levelsConfig: LevelsConfig): w.transports.ConsoleTransportInstance {
+  return new transports.Console({
+    handleExceptions: true, // Log uncaught exceptions
+    handleRejections: true, // Log unhandled promise rejections
+    format: format.combine(
+      formatLevels(),
+      formatLabels(),
+      format.cli({
+        all: false,
+        message: false,
+        level: true,
+        ...levelsConfig,
+      }), //
+      formatPrintf(),
+    ),
+  });
+}
+
+/**
+ * Creates and configures a daily rotating file transport for audit logs.
+ *
+ * @param config - The logging configuration
+ * @returns Configured DailyRotateFile transport instance
+ */
+export function createDailyRotateFileTransport(config: LoggingConfig): DailyRotateFile {
+  return new transports.DailyRotateFile({
+    level: 'audit',
+    dirname: config.AUDIT_LOG_DIRNAME,
+    filename: config.AUDIT_LOG_FILENAME,
+    format: format.printf((info) => `${info.message}`),
+    extension: `_${os.hostname()}.log`,
+    utc: true,
+  });
+}

--- a/frontend/app/.server/utils/instance-registry.ts
+++ b/frontend/app/.server/utils/instance-registry.ts
@@ -9,7 +9,7 @@
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 
-export const instanceNames = ['winstonLogger'] as const;
+export const instanceNames = ['loggingConfig', 'winstonLogger'] as const;
 export type InstanceName = (typeof instanceNames)[number];
 
 /**


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

**Logging Module Abstraction**

This PR introduces a new logging module that provides a clean abstraction over the Winston logger, shielding application code from direct dependency on any third-party logging library.

#### ✅ Key Features:
- **Encapsulated Logging Interface**: The app interacts only with our internal `Logger` abstraction, never directly with Winston.
- **Centralized Configuration**: Fully configurable via `logging-config.ts`.
- **Extensible Factory Pattern**: Factories (`logger-factory.ts`, `winston-factory.ts`, etc.) make it easy to swap or extend the underlying logger in the future.
- **Controlled Exposure**: Only logging methods (e.g., `log`, `info`, `warn`, `error`) are exposed to consumers; Winston internals are completely hidden.
- **Default Logger Export**: `logger-default.ts` provides a ready-to-use logger instance for most application use cases.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->