### PR TITLE
Adding instrumentation to `/apply/adult-child` flow

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -32,6 +32,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   loadApplyAdultSingleChildState({ params, request, session });
   const state = loadApplyAdultChildState({ params, request, session });
   const { APPLICATION_CURRENT_DATE } = getEnv();
@@ -46,15 +48,19 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const isBeforeCoverageStartDate = currentDate < coverageStartDate;
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.cannot-apply-child', 200);
   return { meta, isBeforeCoverageStartDate, coverageStartDate: formattedDate };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.cannot-apply-child', 302);
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -41,6 +41,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -52,6 +54,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.confirm-dental-benefits.title', { childName: childNumber }) }),
   };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 200);
+
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefits,
     editMode: state.editMode,
@@ -62,6 +66,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -84,11 +90,15 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    return {
-      errors: {
-        ...transformFlattenedError(parsedDentalBenefitsResult.error.flatten()),
+    instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 400);
+    return data(
+      {
+        errors: {
+          ...transformFlattenedError(parsedDentalBenefitsResult.error.flatten()),
+        },
       },
-    };
+      { status: 400 },
+    );
   }
 
   saveApplyState({
@@ -105,6 +115,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefits === true) {
     return redirect(getPathById('public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -55,6 +55,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -74,6 +76,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.dental-benefits.title', { childName: childNumber }) }),
   };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 200);
+
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -87,6 +91,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -113,6 +119,7 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
+    instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));
   }
 
@@ -172,12 +179,16 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    return {
-      errors: {
-        ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
-        ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+    instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 400);
+    return data(
+      {
+        errors: {
+          ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
+          ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+        },
       },
-    };
+      { status: 400 },
+    );
   }
 
   saveApplyState({
@@ -196,6 +207,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -31,20 +31,26 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.parent-or-guardian.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.parent-or-guardian', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.children.parent-or-guardian', 302);
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -52,6 +52,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -68,6 +70,9 @@ export async function loader({ context: { appContainer, session }, params, reque
       child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
         ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
         : undefined;
+
+    instrumentationService.countHttpStatus('public.apply.adult-child.children', 200);
+
     return {
       ...child,
       dentalBenefits: {
@@ -82,6 +87,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,6 +96,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.children', 302);
 
   if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -40,6 +40,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
@@ -56,6 +58,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:communication-preference.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 200);
+
   return {
     communicationMethodEmail,
     id: state.id,
@@ -70,6 +74,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -93,8 +99,11 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 302);
 
   if (state.editMode) {
     if (parsedDataResult.data.preferredMethod !== COMMUNICATION_METHOD_EMAIL_ID && parsedDataResult.data.preferredNotificationMethod === 'mail') {

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -40,6 +40,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -149,9 +151,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:confirm.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.confirmation', 200);
+
   return {
     children,
-
     dentalInsurance,
     homeAddressInfo,
     mailingAddressInfo,
@@ -163,6 +166,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -172,6 +177,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadApplyAdultChildState({ params, request, session });
   clearApplyState({ params, session });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.confirmation', 302);
   return redirect(t('confirm.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -29,15 +29,20 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const { id } = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:exit-application.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.exit-application', 200);
   return { id, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -46,6 +51,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.exit-application', 302);
   return redirect(t('apply-adult-child:exit-application.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -55,6 +55,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
@@ -68,6 +70,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:dental-benefits.title') }) };
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 200);
+
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -80,6 +84,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -98,6 +104,8 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
+
+    instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -157,12 +165,16 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    return {
-      errors: {
-        ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
-        ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+    instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 400);
+    return data(
+      {
+        errors: {
+          ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
+          ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+        },
       },
-    };
+      { status: 400 },
+    );
   }
 
   saveApplyState({
@@ -175,6 +187,8 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     },
   });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -51,6 +51,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -59,6 +61,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.home-address.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 200);
 
   return {
     id: state.id,
@@ -71,6 +75,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -85,6 +91,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
 
   if (formAction === FORM_ACTION.cancel) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -99,6 +106,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 400);
     return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
@@ -117,6 +125,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (canProceedToDental) {
     saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
+
+    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
@@ -147,6 +157,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
+    instrumentationService.countHttpStatus('public.apply.adult-child.home-address.address-invalid', 200);
     return {
       invalidAddress: formattedHomeAddress,
       status: 'address-invalid',
@@ -155,6 +166,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    instrumentationService.countHttpStatus('public.apply.adult-child.home-address.address-suggestion', 200);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',
@@ -170,6 +182,8 @@ export async function action({ context: { appContainer, session }, params, reque
     } as const satisfies AddressSuggestionResponse;
   }
   saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -52,6 +52,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -59,6 +61,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.mailing-address.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 200);
 
   return {
     id: state.id,
@@ -71,6 +75,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -86,6 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -99,6 +106,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!validatedResult.success) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 400);
     return data({ errors: validatedResult.errors }, { status: 400 });
   }
 
@@ -127,6 +135,8 @@ export async function action({ context: { appContainer, session }, params, reque
         ...(homeAddress && { homeAddress }),
       },
     });
+
+    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
 
     if (state.editMode) {
       return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult-child/review-adult-information', params) : getPathById('public/apply/$id/adult-child/home-address', params));
@@ -159,6 +169,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
+    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address.address-invalid', 200);
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
@@ -167,6 +178,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address.address-suggestion', 200);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',
@@ -191,6 +203,8 @@ export async function action({ context: { appContainer, session }, params, reque
       ...(homeAddress && { homeAddress }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -33,6 +33,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -45,10 +47,13 @@ export async function loader({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
   }
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.parent-or-guardian', 200);
   return { id: state.id, meta, ageCategory };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -57,6 +62,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.parent-or-guardian', 302);
   return redirect(t('apply-adult-child:parent-or-guardian.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
@@ -41,10 +41,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:phone-number.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 200);
 
   return {
     id: state.id,
@@ -59,6 +63,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -84,10 +90,13 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -51,6 +51,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
@@ -110,21 +112,27 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 200);
+
   return { id: state.id, children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearApplyState({ params, session });
+    instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: {} });
+    instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -135,6 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { submissionInfo } });
 
+  instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
   return redirect(getPathById('public/apply/$id/adult-child/confirmation', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
@@ -51,10 +51,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:verify-email.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 200);
 
   return {
     id: state.id,
@@ -65,6 +69,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -104,6 +110,7 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
+      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     } else if (state.email && state.communicationPreferences?.preferredLanguage) {
       const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name;
@@ -113,6 +120,7 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
+      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     }
   }
@@ -136,6 +144,7 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (!parsedDataResult.success) {
+      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 400);
       return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
     }
 
@@ -154,8 +163,11 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
 
+      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-mismatch', 200);
       return { status: 'verification-code-mismatch' } as const;
     }
+
+    instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 302);
 
     if (state.verifyEmail) {
       if (state.editMode) {

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -65,7 +65,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:applicant-information.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.applicant-information.', 200);
+  instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 200);
 
   return { defaultState: state.applicantInformation, taxYear: state.applicationYear.taxYear, editMode: state.editMode, id: state.id, meta };
 }
@@ -88,7 +88,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
-    instrumentationService.countHttpStatus('public.apply.adult.applicant-information.', 302);
+    instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -172,7 +172,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.applicant-information.', 400);
+    instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -226,7 +226,7 @@ export async function action({ context: { appContainer, session }, params, reque
     });
   }
 
-  instrumentationService.countHttpStatus('public.apply.adult.applicant-information.', 302);
+  instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 302);
 
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult/living-independently', params));


### PR DESCRIPTION
### Description
Similar to #3486 except for `adult-child` flow. Also fixes an event identifier within `/adult/applicant-information`.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`