### PR TITLE
feat(frontend) add `ttl()` method to `RedisService` for retrieving key expiration time

### DIFF
--- a/frontend/__tests__/.server/data/redis.service.test.ts
+++ b/frontend/__tests__/.server/data/redis.service.test.ts
@@ -13,6 +13,7 @@ vi.mock('ioredis', () => {
       get: vi.fn(),
       set: vi.fn(),
       del: vi.fn(),
+      ttl: vi.fn(),
     }),
   };
 });
@@ -103,6 +104,16 @@ describe('DefaultRedisService', () => {
 
       await redisService.del('key');
       expect(mockRedisClient.del).toHaveBeenCalledWith('key');
+    });
+  });
+
+  describe('ttl', () => {
+    it('should call redisClient.ttl()', async () => {
+      const redisService = new DefaultRedisService(mock<ServerConfig>());
+      const mockRedisClient = new Redis();
+
+      await redisService.ttl('key');
+      expect(mockRedisClient.ttl).toHaveBeenCalledWith('key');
     });
   });
 });

--- a/frontend/app/.server/data/redis.service.ts
+++ b/frontend/app/.server/data/redis.service.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from 'inversify';
-import Redis from 'ioredis';
 import type { RedisOptions } from 'ioredis';
+import Redis from 'ioredis';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
 
 /**
  * The RedisService is a service module for interacting with a Redis server. It
@@ -30,6 +30,10 @@ export interface RedisService {
    * @see https://redis.io/commands/ping/
    */
   ping: () => Promise<'PONG'>;
+  /**
+   * @see https://redis.io/commands/ttl/
+   */
+  ttl: (key: string) => Promise<number>;
 }
 
 @injectable()
@@ -67,6 +71,10 @@ export class DefaultRedisService implements RedisService {
 
   async ping(): Promise<'PONG'> {
     return await this.redisClient.ping();
+  }
+
+  async ttl(key: string): Promise<number> {
+    return await this.redisClient.ttl(key);
   }
 
   private getRedisConfig(serverConfig: ServerConfig): RedisOptions {


### PR DESCRIPTION
### Description

To facilitate adding a rate-limiting killswitch to the application, we will need a way to retrieve the TTL for a specific key.

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
