### PR TITLE
[gitops] Removing `APPLICATION_CURRENT_DATE` from uat1 and uat2

### DIFF
--- a/gitops/overlays/uat1/configs/frontend/config.conf
+++ b/gitops/overlays/uat1/configs/frontend/config.conf
@@ -11,8 +11,6 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 
 INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
 
-APPLICATION_CURRENT_DATE=2025-04-01
-
 OTEL_ENVIRONMENT=uat1
 OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces

--- a/gitops/overlays/uat2/configs/frontend/config.conf
+++ b/gitops/overlays/uat2/configs/frontend/config.conf
@@ -11,8 +11,6 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 
 INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream2
 
-APPLICATION_CURRENT_DATE=2025-03-05
-
 OTEL_ENVIRONMENT=uat1
 OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces


### PR DESCRIPTION
### Description
As per title.