### PR TITLE
fix(frontend) update logic for fourth checkbox in TOC

### DIFF
--- a/frontend/app/routes/protected/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/apply/$id/terms-and-conditions.tsx
@@ -74,13 +74,13 @@ export async function action({ context: { appContainer, session }, request, para
       if (val.doNotConsent) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-apply:terms-and-conditions.checkboxes.error-message.consent-required'), path: ['doNotConsent'] });
       }
-      if (!val.acknowledgeTerms) {
+      if (!val.doNotConsent && !val.acknowledgeTerms) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-apply:terms-and-conditions.checkboxes.error-message.acknowledge-terms-required'), path: ['acknowledgeTerms'] });
       }
-      if (!val.acknowledgePrivacy) {
+      if (!val.doNotConsent && !val.acknowledgePrivacy) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-apply:terms-and-conditions.checkboxes.error-message.acknowledge-privacy-required'), path: ['acknowledgePrivacy'] });
       }
-      if (!val.shareData) {
+      if (!val.doNotConsent && !val.shareData) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-apply:terms-and-conditions.checkboxes.error-message.share-data-required'), path: ['shareData'] });
       }
     })

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -69,13 +69,13 @@ export async function action({ context: { appContainer, session }, request, para
       if (val.doNotConsent) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:terms-and-conditions.checkboxes.error-message.consent-required'), path: ['doNotConsent'] });
       }
-      if (!val.acknowledgeTerms) {
+      if (!val.doNotConsent && !val.acknowledgeTerms) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:terms-and-conditions.checkboxes.error-message.acknowledge-terms-required'), path: ['acknowledgeTerms'] });
       }
-      if (!val.acknowledgePrivacy) {
+      if (!val.doNotConsent && !val.acknowledgePrivacy) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:terms-and-conditions.checkboxes.error-message.acknowledge-privacy-required'), path: ['acknowledgePrivacy'] });
       }
-      if (!val.shareData) {
+      if (!val.doNotConsent && !val.shareData) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('apply:terms-and-conditions.checkboxes.error-message.share-data-required'), path: ['shareData'] });
       }
     })


### PR DESCRIPTION
### Description
Technically I introduced this "_bug_" when I updated the logic in a previous PR.  When a user selects the 4th consent checkbox, no other error messages should propagate to the other input fields.  If only the expected behaviour was detailed in the first place instead of having to guess 🙃

### Related Azure Boards Work Items
AB#20873
