### PR TITLE
fix(frontend): remove .env support from production start command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "build:application": "react-router build",
     "build:server": "vite build --config ./vite.server.config.ts",
     "dev": "nodemon --config nodemon.json",
-    "start": "cross-env NODE_ENV=production node --env-file-if-exists=./.env --import ./build/server/opentelemetry.server.js ./build/server/express.server.js",
+    "start": "cross-env NODE_ENV=production node --import ./build/server/opentelemetry.server.js ./build/server/express.server.js",
     "check:all": "npm run format:check && npm run lint && npm run typecheck",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",


### PR DESCRIPTION
### Description

`npm start` is for production use; it shouldn't load a local .env file

(also.. this has unintended side effects like making reproducible e2e tests impossible)