### PR TITLE
feat(frontend): add handling for HTTP 429 Too Many Requests across repositories

### DIFF
--- a/frontend/app/.server/domain/repositories/applicant-repository.ts
+++ b/frontend/app/.server/domain/repositories/applicant-repository.ts
@@ -4,8 +4,11 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { ApplicantRequestEntity, ApplicantResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 /**
  * A repository that provides access to applicant data.
@@ -85,6 +88,11 @@ export class DefaultApplicantRepository implements ApplicantRepository {
       url: url,
       responseBody: await response.text(),
     });
+
+    if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+      // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+      throw new AppError('Failed to POST to /applicant. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
 
     throw new Error(`Failed to 'POST' for applicant. Status:  ${response.status}, Status Text: ${response.statusText}`);
   }

--- a/frontend/app/.server/domain/repositories/application-status.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-status.repository.ts
@@ -4,9 +4,12 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { ApplicationStatusBasicInfoRequestEntity, ApplicationStatusEntity, ApplicationStatusSinRequestEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
 import clientFriendlyStatusDataSource from '~/.server/resources/power-platform/client-friendly-status.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 /**
  * A repository that provides access to application status data.
@@ -84,6 +87,12 @@ export class DefaultApplicationStatusRepository implements ApplicationStatusRepo
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to POST to /status_fnlndob. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to 'POST' for application status by basic info. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
@@ -114,6 +123,12 @@ export class DefaultApplicationStatusRepository implements ApplicationStatusRepo
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to POST to /status. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to 'POST' for application status by sin. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 

--- a/frontend/app/.server/domain/repositories/application-year.repository.ts
+++ b/frontend/app/.server/domain/repositories/application-year.repository.ts
@@ -4,8 +4,11 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { ApplicationYearResultEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface ApplicationYearRepository {
   /**
@@ -53,6 +56,12 @@ export class DefaultApplicationYearRepository implements ApplicationYearReposito
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to GET /retrieve-benefit-application-config-dates. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to fetch application year(s). Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 

--- a/frontend/app/.server/domain/repositories/benefit-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/benefit-application.repository.ts
@@ -4,8 +4,11 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { BenefitApplicationRequestEntity, BenefitApplicationResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitApplicationRepository {
   /**
@@ -55,6 +58,12 @@ export class DefaultBenefitApplicationRepository implements BenefitApplicationRe
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to POST to /benefit-application. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to 'POST' for benefit application. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 

--- a/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
+++ b/frontend/app/.server/domain/repositories/benefit-renewal.repository.ts
@@ -4,8 +4,11 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { BenefitRenewalRequestEntity, BenefitRenewalResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitRenewalRepository {
   /**
@@ -53,6 +56,11 @@ export class DefaultBenefitRenewalRepository implements BenefitRenewalRepository
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to POST to /benefit-application. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
 
       throw new Error(`Failed to 'POST' for benefit renewal data. Status: ${response.status}, Status Text: ${response.statusText}`);
     }

--- a/frontend/app/.server/domain/repositories/client-application.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-application.repository.ts
@@ -4,10 +4,13 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { ClientApplicationBasicInfoRequestEntity, ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
 import clientApplicationItaJsonDataSource from '~/.server/resources/power-platform/client-application-ita.json';
 import clientApplicationJsonDataSource from '~/.server/resources/power-platform/client-application.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 /**
  * A repository that provides access to client application data.
@@ -74,6 +77,12 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
       url: url,
       responseBody: await response.text(),
     });
+
+    if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+      // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+      throw new AppError('Failed to POST for benefit application. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     throw new Error(`Failed to 'POST' for client application data by basic info. Status: ${response.status}, Status Text: ${response.statusText}`);
   }
 
@@ -109,6 +118,12 @@ export class DefaultClientApplicationRepository implements ClientApplicationRepo
       url: url,
       responseBody: await response.text(),
     });
+
+    if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+      // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+      throw new AppError('Failed to POST to /retrieve-benefit-application. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     throw new Error(`Failed to 'POST' for client application data by sin. Status: ${response.status}, Status Text: ${response.statusText}`);
   }
 }

--- a/frontend/app/.server/domain/repositories/letter.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter.repository.ts
@@ -4,9 +4,12 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { LetterEntity, PdfEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
 import getPdfByLetterIdJson from '~/.server/resources/cct/get-pdf-by-letter-id.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 /**
  * A repository that provides access to letters.
@@ -89,6 +92,11 @@ export class DefaultLetterRepository implements LetterRepository {
         responseBody: await response.text(),
       });
 
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to GET /GetDocInfoByClientId. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to find letters. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
@@ -120,6 +128,11 @@ export class DefaultLetterRepository implements LetterRepository {
         url: url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to GET /GetPdfByLetterId. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
 
       throw new Error(`Failed to get PDF. Status: ${response.status}, Status Text: ${response.statusText}`);
     }

--- a/frontend/app/.server/domain/repositories/verification-code.repository.ts
+++ b/frontend/app/.server/domain/repositories/verification-code.repository.ts
@@ -5,8 +5,11 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { VerificationCodeEmailRequestEntity, VerificationCodeEmailResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
-import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface VerificationCodeRepository {
   /**
@@ -70,6 +73,12 @@ export class DefaultVerificationCodeRepository implements VerificationCodeReposi
         url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to POST to /notifications/email. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to 'POST' email notification. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
@@ -106,6 +115,12 @@ export class DefaultVerificationCodeRepository implements VerificationCodeReposi
         url,
         responseBody: await response.text(),
       });
+
+      if (response.status === HttpStatusCodes.TOO_MANY_REQUESTS) {
+        // TODO ::: GjB ::: this throw is to facilitate enabling the application kill switch -- it should be removed once the killswitch functionality is removed
+        throw new AppError('Failed to GET /notifications. Status: 429, Status Text: Too Many Requests', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      }
+
       throw new Error(`Failed to 'GET' email notifications. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
   }

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -11,4 +11,5 @@ export const ErrorCodes = {
 
   // external api error codes
   XAPI_API_ERROR: 'XAPI-0001',
+  XAPI_TOO_MANY_REQUESTS: 'XAPI-0002',
 } as const;


### PR DESCRIPTION
### Description

This is an incremental PR that cherry picks some changes from #3441 so future PRs will not be as large. This PR adds a new error code that will be thrown when an HTTP429 response is returned from an API call.

This PR doesn't alter functionality in any way, other than changing a thrown `Error` to a thrown `AppError` (for 429 responses only).
