### PR TITLE
Add protected child audit.

### DIFF
--- a/frontend/app/routes/protected/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/applicant-information.tsx
@@ -12,6 +12,7 @@ import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected
 import { getAgeCategoryFromDateString, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import type { ApplicantInformationState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
@@ -58,6 +59,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:applicant-information.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.applicant-information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.applicant-information', 200);
   return { id: state.id, meta, defaultState: state.applicantInformation, editMode: state.editMode };
@@ -194,6 +198,9 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
   }
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.applicant-information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.applicant-information', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -8,6 +8,7 @@ import type { Route } from './+types/cannot-apply-child';
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplySingleChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -38,6 +39,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.cannot-apply-child.page-title') }) };
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.cannot-apply-child', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.children.cannot-apply-child', 200);
   return { meta };
 }
@@ -50,6 +54,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const formData = await request.formData();
 
   securityHandler.validateCsrfToken({ formData, session });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.cannot-apply-child', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.cannot-apply-child', 302);
   return redirect(getPathById('protected/apply/$id/child/children/index', params));

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState, loadProtectedApplySingleChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -55,6 +56,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.confirm-dental-benefits.title', { childName }) }),
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.confirm-dental-benefits.title', { childName: childNumber }) }),
   };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.confirm-federal-provincial-territorial-benefits', 200);
 
@@ -118,6 +122,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.confirm-federal-provincial-territorial-benefits', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -10,6 +10,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState, loadProtectedApplySingleChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
@@ -49,6 +50,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.dental-insurance.title', { childName }) }),
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.dental-insurance', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
@@ -90,6 +94,9 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.dental-insurance', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.dental-insurance', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -14,6 +14,7 @@ import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsSta
 import { loadProtectedApplyChildState, loadProtectedApplySingleChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -77,6 +78,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.dental-benefits.title', { childName }) }),
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.dental-benefits.title', { childName: childNumber }) }),
   };
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.federal-provincial-territorial-benefits', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.federal-provincial-territorial-benefits', 200);
 
@@ -211,6 +214,9 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.federal-provincial-territorial-benefits', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.federal-provincial-territorial-benefits', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/information.tsx
@@ -14,6 +14,7 @@ import { loadProtectedApplyChildState, loadProtectedApplySingleChildState } from
 import type { ChildInformationState, ChildSinState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getAgeCategoryFromDateString, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
@@ -67,6 +68,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.information.page-title', { childName }) }),
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.information.page-title', { childName: childNumber }) }),
   };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.information', 200);
   return { meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew };
@@ -218,6 +222,9 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.information', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplySingleChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -40,6 +41,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:children.parent-or-guardian.page-title') }) };
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.parent-guardian', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.children.parent-or-guardian', 200);
   return { meta };
 }
@@ -58,6 +62,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearProtectedApplyState({ params, session });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.parent-guardian', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.children.parent-or-guardian', 302);
   return redirect(t('protected-apply-child:children.parent-or-guardian.return-btn-link'));

--- a/frontend/app/routes/protected/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/index.tsx
@@ -15,6 +15,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { getChildrenState, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -69,6 +70,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     instrumentationService.countHttpStatus('protected.apply.child.children', 200);
     return { ...child, dentalBenefits: { ...child.dentalBenefits, federalSocialProgram: federalGovernmentInsurancePlanService?.name, provincialTerritorialSocialProgram: provincialTerritorialSocialProgram?.name } };
   });
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.children.index', { userId: idToken.sub });
 
   return { meta, children, editMode: state.editMode };
 }

--- a/frontend/app/routes/protected/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/index.tsx
@@ -88,6 +88,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.children.index', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.children', 302);
 
   if (formAction === FORM_ACTION.add) {

--- a/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected
 import type { CommunicationPreferencesState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -51,6 +52,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const preferredLanguages = appContainer.get(TYPES.domain.services.PreferredLanguageService).listAndSortLocalizedPreferredLanguages(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:communication-preference.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.communication-preference', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.communication-preference', 200);
 
@@ -93,6 +97,9 @@ export async function action({ context: { appContainer, session }, params, reque
     instrumentationService.countHttpStatus('protected.apply.child.communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.communication-preference', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.communication-preference', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -10,6 +10,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { clearProtectedApplyState, getChildrenState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Address } from '~/components/address';
 import { Button } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
@@ -139,6 +140,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:confirm.page-title') }) };
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.confirmation', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.confirmation', 200);
 
   return {
@@ -165,6 +169,9 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadProtectedApplyChildState({ params, request, session });
   clearProtectedApplyState({ params, session });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.confirmation', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.confirmation', 302);
   return redirect(t('confirm.exit-link'));

--- a/frontend/app/routes/protected/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/contact-apply-child.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { getAgeCategoryFromDateString } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -51,6 +52,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     return redirect(getPathById('protected/apply/$id/child/applicant-information', params));
   }
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.contact-apply-child', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.contact-apply-child', 200);
   return { id: state.id, meta };
 }
@@ -65,6 +69,9 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.contact-apply-child', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.contact-apply-child', 302);
   return redirect(t('protected-apply-child:contact-apply-child.return-btn-link'));

--- a/frontend/app/routes/protected/apply/$id/child/email.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/email.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -47,6 +48,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:email.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.email', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.email', 200);
 
@@ -111,6 +115,8 @@ export async function action({ context: { appContainer, session }, params, reque
       userId: 'anonymous',
     });
   }
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.email', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.email', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -38,6 +39,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:exit-application.page-title') }) };
 
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.exit-application', { userId: idToken.sub });
+
   instrumentationService.countHttpStatus('protected.apply.child.exit-application', 200);
   return { id, meta };
 }
@@ -54,6 +58,9 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearProtectedApplyState({ params, session });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.exit-application', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.exit-application', 302);
   return redirect(t('exit-application.exit-link'));

--- a/frontend/app/routes/protected/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/home-address.tsx
@@ -13,6 +13,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -63,6 +64,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.home-address.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.home-address', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.home-address', 200);
 
@@ -185,6 +189,9 @@ export async function action({ context: { appContainer, session }, params, reque
     } as const satisfies AddressSuggestionResponse;
   }
   saveProtectedApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.home-address', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.home-address', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
@@ -13,6 +13,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -63,6 +64,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.mailing-address.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.mailing-address', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.mailing-address', 200);
 
@@ -138,6 +142,9 @@ export async function action({ context: { appContainer, session }, params, reque
         ...(homeAddress && { homeAddress }),
       },
     });
+
+    const idToken: IdToken = session.get('idToken');
+    appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.mailing-address', { userId: idToken.sub });
 
     instrumentationService.countHttpStatus('protected.apply.child.mailing-address', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
@@ -14,6 +14,7 @@ import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected
 import type { PartnerInformationState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { applicantInformationStateHasPartner, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -61,6 +62,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const maritalStatuses = appContainer.get(TYPES.domain.services.MaritalStatusService).listLocalizedMaritalStatuses(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:marital-status.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.marital-status', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.marital-status', 200);
   return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
@@ -153,6 +157,9 @@ export async function action({ context: { appContainer, session }, params, reque
       partnerInformation: parsedPartnerInformation.data,
     },
   });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.marital-status', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.marital-status', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/new-or-existing-member.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/new-or-existing-member.tsx
@@ -12,6 +12,7 @@ import type { Route } from './+types/new-or-existing-member';
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyState, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -57,6 +58,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:new-or-existing-member.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.new-or-existing-member', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.new-or-existing-member', 200);
   return { id: state.id, meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
@@ -119,6 +123,9 @@ export async function action({ context: { appContainer, session }, params, reque
     instrumentationService.countHttpStatus('protected.apply.child.new-or-existing-member', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.new-or-existing-member', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.new-or-existing-member', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
@@ -10,6 +10,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { phoneSchema } from '~/.server/validation/phone-schema';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -49,6 +50,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:phone-number.page-title') }) };
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.phone-number', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.phone-number', 200);
 
@@ -98,6 +102,9 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   saveProtectedApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.phone-number', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.phone-number', 302);
 

--- a/frontend/app/routes/protected/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/review-child-information.tsx
@@ -15,6 +15,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplyChildStateForReview } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { clearProtectedApplyState, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -83,6 +84,9 @@ export async function loader({ context: { appContainer, session }, params, reque
       ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
+    const idToken: IdToken = session.get('idToken');
+    appContainer.get(TYPES.domain.services.AuditService).createAudit('view-page.apply.child.review-child-information', { userId: idToken.sub });
+
     instrumentationService.countHttpStatus('protected.apply.child.review-child-information', 200);
 
     return {
@@ -141,6 +145,9 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {},
   });
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.apply.child.review-child-information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.review-child-information', 302);
   return redirect(getPathById('protected/apply/$id/child/review-adult-information', params));


### PR DESCRIPTION
### Description
As per title.

- For the files under our `child/children`, I wrote the audit with `children` instead of `child`. Should it be `child`?
- For pages where no actions are required, like `exit-application` , `cannot-apply-child`, and `parent-or-guardian`, should there be an audit in the `action`?

### Related Azure Boards Work Items
[AB#5580](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5580)
[AB#5576](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5576)
