### PR TITLE
refactor(frontend) remove unused state.id from loader

### DIFF
--- a/frontend/__tests__/routes/public/application-delegate.test.tsx
+++ b/frontend/__tests__/routes/public/application-delegate.test.tsx
@@ -33,7 +33,6 @@ describe('_public.apply.id.application-delegate', () => {
       });
 
       expect(response).toEqual({
-        id: '123',
         meta: { title: 'gcweb:meta.title.template' },
       });
     });

--- a/frontend/__tests__/routes/public/communication-preference.test.tsx
+++ b/frontend/__tests__/routes/public/communication-preference.test.tsx
@@ -59,7 +59,6 @@ describe('_public.apply.id.communication-preference', () => {
       });
 
       expect(response).toMatchObject({
-        id: '123',
         meta: {},
         preferredLanguages: [
           { id: 'en', name: 'English' },

--- a/frontend/__tests__/routes/public/file-taxes.test.tsx
+++ b/frontend/__tests__/routes/public/file-taxes.test.tsx
@@ -32,7 +32,7 @@ describe('_public.apply.id.file-your-taxes', () => {
 
       const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/file-your-taxes'), context: mockContext, params: { id: '123', lang: 'en' } });
 
-      expect(response).toEqual({ id: '123', meta: { title: 'gcweb:meta.title.template' }, taxYear: '2024' });
+      expect(response).toEqual({ meta: { title: 'gcweb:meta.title.template' }, taxYear: '2024' });
     });
   });
 });

--- a/frontend/__tests__/routes/public/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/public/tax-filing.test.tsx
@@ -34,7 +34,7 @@ describe('_public.apply.id.tax-filing', () => {
 
       const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/tax-filing'), context: mockContext, params: { id: '123', lang: 'en' } });
 
-      expect(response).toMatchObject({ id: '123', meta: {}, defaultState: true });
+      expect(response).toMatchObject({ meta: {}, defaultState: true });
     });
   });
 

--- a/frontend/__tests__/routes/public/type-application.test.tsx
+++ b/frontend/__tests__/routes/public/type-application.test.tsx
@@ -25,7 +25,7 @@ describe('_public.apply.id.type-of-application', () => {
 
       const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application'), context: mockContext, params: { id: '123', lang: 'en' } });
 
-      expect(response).toMatchObject({ id: '123', meta: { title: 'gcweb:meta.title.template' }, defaultState: 'delegate' });
+      expect(response).toMatchObject({ meta: { title: 'gcweb:meta.title.template' }, defaultState: 'delegate' });
     });
   });
 

--- a/frontend/app/routes/protected/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/applicant-information.tsx
@@ -73,7 +73,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.applicant-information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.applicant-information', 200);
-  return { defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, meta };
+  return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/communication-preference.tsx
@@ -60,7 +60,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
     defaultState: {

--- a/frontend/app/routes/protected/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/dental-insurance.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.dental-insurance', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.dental-insurance', 200);
-  return { id: state, meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/email.tsx
@@ -56,7 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.email', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedApplyAdultChildState } from '~/.server/routes/helpers/protected-apply-adult-child-route-helpers';
 import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
@@ -35,8 +34,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadProtectedApplyAdultChildState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult-child:exit-application.page-title') }) };
 
@@ -44,7 +41,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.exit-application', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.exit-application', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -83,7 +83,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     regions,

--- a/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
@@ -72,7 +72,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.home-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/living-independently.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.living-independently', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.living-independently', 200);
-  return { id: state.id, meta, defaultState: state.livingIndependently, editMode: state.editMode };
+  return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
@@ -72,7 +72,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.mailing-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/marital-status.tsx
@@ -76,7 +76,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.marital-status', { userId: idToken.sub });
 
-  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/new-or-existing-member.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/new-or-existing-member.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.new-or-existing-member', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/parent-or-guardian.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult-child.parent-or-guardian', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.parent-or-guardian', 200);
-  return { id: state.id, meta, ageCategory };
+  return { meta, ageCategory };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/phone-number.tsx
@@ -58,7 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
@@ -142,7 +142,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.review-adult-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,

--- a/frontend/app/routes/protected/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/review-child-information.tsx
@@ -121,7 +121,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('protected.apply.adult-child.review-child-information', 200);
 
-  return { id: state.id, children, meta, payload };
+  return { children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/verify-email.tsx
@@ -68,7 +68,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult-child.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/applicant-information.tsx
@@ -74,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('protected.apply.adult.applicant-information', 200);
 
-  return { defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, meta };
+  return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/communication-preference.tsx
@@ -59,7 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
     defaultState: {

--- a/frontend/app/routes/protected/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/dental-insurance.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult.dental-insurance', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult.dental-insurance', 200);
-  return { id: state, meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/email.tsx
@@ -55,7 +55,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('protected.apply.adult.email', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedApplyAdultState } from '~/.server/routes/helpers/protected-apply-adult-route-helpers';
 import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
@@ -35,8 +34,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadProtectedApplyAdultState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:exit-application.page-title') }) };
 
@@ -44,7 +41,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult.exit-application', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult.exit-application', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -81,7 +81,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('protected.apply.adult.home-address', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/living-independently.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult.living-independently', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult.living-independently', 200);
-  return { id: state.id, meta, defaultState: state.livingIndependently, editMode: state.editMode };
+  return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('protected.apply.adult.mailing-address', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/marital-status.tsx
@@ -75,7 +75,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult.marital-status', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult.marital-status', 200);
-  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/new-or-existing-member.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.adult.new-or-existing-member', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.adult.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/parent-or-guardian.tsx
@@ -56,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   instrumentationService.countHttpStatus('protected.apply.adult.parent-or-guardian', 200);
-  return { ageCategory, id: state.id, meta };
+  return { ageCategory, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/phone-number.tsx
@@ -58,7 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
@@ -153,7 +153,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult.review-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,

--- a/frontend/app/routes/protected/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/verify-email.tsx
@@ -68,7 +68,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.adult.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/protected/apply/$id/application-delegate.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/application-delegate';
 
 import { TYPES } from '~/.server/constants';
-import { clearProtectedApplyState, loadProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
+import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -37,8 +37,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  const { id } = loadProtectedApplyState({ params, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply:application-delegate.page-title') }) };
 
@@ -46,7 +44,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.application-delegate', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply/application-delegate', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/applicant-information.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.child.applicant-information', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.applicant-information', 200);
-  return { id: state.id, meta, defaultState: state.applicantInformation, editMode: state.editMode };
+  return { meta, defaultState: state.applicantInformation, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
@@ -59,7 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
     defaultState: {

--- a/frontend/app/routes/protected/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/contact-apply-child.tsx
@@ -56,7 +56,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.child.contact-apply-child', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.contact-apply-child', 200);
-  return { id: state.id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/email.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/email.tsx
@@ -55,7 +55,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.email', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedApplyChildState } from '~/.server/routes/helpers/protected-apply-child-route-helpers';
 import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
@@ -34,8 +33,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadProtectedApplyChildState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:exit-application.page-title') }) };
 
@@ -43,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.child.exit-application', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.exit-application', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/home-address.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.home-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.mailing-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.child.marital-status', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.marital-status', 200);
-  return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/new-or-existing-member.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/new-or-existing-member.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.child.new-or-existing-member', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.child.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
@@ -57,7 +57,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
@@ -125,7 +125,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.review-adult-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,

--- a/frontend/app/routes/protected/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/review-child-information.tsx
@@ -111,7 +111,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  return { id: state.id, children, meta };
+  return { children, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/child/verify-email.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/verify-email.tsx
@@ -63,7 +63,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.apply.child.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/protected/apply/$id/file-taxes.tsx
+++ b/frontend/app/routes/protected/apply/$id/file-taxes.tsx
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  const { id, applicationYear } = loadProtectedApplyState({ params, session });
+  const { applicationYear } = loadProtectedApplyState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply:file-your-taxes.page-title') }) };
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.file-taxes', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.file-taxes', 200);
-  return { id, meta, taxYear: applicationYear.taxYear };
+  return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/apply/$id/tax-filing.tsx
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.tax-filing', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.tax-filing', 200);
-  return { id: state.id, meta, defaultState: state.hasFiledTaxes, taxYear: state.applicationYear.taxYear };
+  return { meta, defaultState: state.hasFiledTaxes, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/apply/$id/type-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/type-application.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.type-application', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.apply.type-of-application', 200);
-  return { id: state.id, meta, defaultState: state.typeOfApplication };
+  return { meta, defaultState: state.typeOfApplication };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -107,7 +107,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: dentalBenefits,
     childName,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-address.page-title') }) };
 
   instrumentationService.countHttpStatus('protected.renew.confirm-address', 200);
-  return { id: state.id, meta, defaultState: { isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
+  return { meta, defaultState: { isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     communicationMethodEmail,
-    id: state.id,
     meta,
     preferredCommunicationMethods,
     preferredLanguages,

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -109,7 +109,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   return {
     defaultState: dentalBenefits,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -54,7 +54,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.renew.confirm-phone', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/protected/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/protected/renew/$id/file-taxes.tsx
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  const { id, applicationYear } = loadProtectedRenewState({ params, request, session });
+  const { applicationYear } = loadProtectedRenewState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:file-your-taxes.page-title') }) };
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.file-taxes', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.renew.file-taxes', 200);
-  return { id, meta, taxYear: applicationYear.taxYear };
+  return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -205,7 +205,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('protected.renew.review-adult-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     homeAddressInfo,

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -109,7 +109,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   });
 
   instrumentationService.countHttpStatus('protected.renew.review-child-information', 200);
-  return { id: state.id, children, meta };
+  return { children, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/protected/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/$id/tax-filing.tsx
@@ -53,7 +53,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.tax-filing', { userId: idToken.sub });
 
   instrumentationService.countHttpStatus('protected.renew.tax-filing', 200);
-  return { id: state.id, meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
+  return { meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:applicant-information.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult-child.applicant-information', 200);
-  return { defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, meta };
+  return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -53,7 +53,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
     defaultState: {

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const backToEmail = state.communicationPreferences.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID || state.communicationPreferences.preferredNotificationMethod !== 'mail';
 
   instrumentationService.countHttpStatus('public.apply.adult-child.dental-insurance', 200);
-  return { id: state, meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/email.tsx
@@ -49,7 +49,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.email', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-child-route-helpers';
 import { clearApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -31,13 +30,11 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadApplyAdultChildState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:exit-application.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult-child.exit-application', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -76,7 +76,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     regions,

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:living-independently.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult-child.living-independently', 200);
-  return { id: state.id, meta, defaultState: state.livingIndependently, editMode: state.editMode };
+  return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
@@ -68,7 +68,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:marital-status.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult-child.marital-status', 200);
-  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   instrumentationService.countHttpStatus('public.apply.adult-child.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   instrumentationService.countHttpStatus('public.apply.adult-child.parent-or-guardian', 200);
-  return { id: state.id, meta, ageCategory };
+  return { meta, ageCategory };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
@@ -51,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -135,7 +135,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.review-adult-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,
@@ -143,7 +142,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     mailingAddressInfo,
     dentalInsurance,
     dentalBenefit,
-
     meta,
     siteKey: HCAPTCHA_SITE_KEY,
     hCaptchaEnabled,

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -114,7 +114,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 200);
 
-  return { id: state.id, children, meta, payload };
+  return { children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 200);
 
-  return { defaultState: state.applicantInformation, editMode: state.editMode, id: state.id, meta };
+  return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -52,12 +52,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
-    defaultState: {
-      ...(state.communicationPreferences ?? {}),
-    },
+    defaultState: { ...(state.communicationPreferences ?? {}) },
     editMode: state.editMode,
   };
 }

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const backToEmail = state.communicationPreferences.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID || state.communicationPreferences.preferredNotificationMethod !== 'mail';
 
   instrumentationService.countHttpStatus('public.apply.adult.dental-insurance', 200);
-  return { id: state, meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/email.tsx
@@ -48,7 +48,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('public.apply.adult.email', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-helpers';
 import { clearApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -31,13 +30,11 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadApplyAdultState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:exit-application.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult.exit-application', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -74,7 +74,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -64,7 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('public.apply.adult.home-address', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:living-independently.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult.living-independently', 200);
-  return { id: state.id, meta, defaultState: state.livingIndependently, editMode: state.editMode };
+  return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -64,7 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 200);
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
@@ -68,7 +68,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:marital-status.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.adult.marital-status', 200);
-  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/new-or-existing-member.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   instrumentationService.countHttpStatus('public.apply.adult.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -49,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   instrumentationService.countHttpStatus('public.apply.adult.parent-or-guardian', 200);
-  return { ageCategory, id: state.id, meta };
+  return { ageCategory, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
@@ -51,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -146,7 +146,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult.review-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,

--- a/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.adult.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/application-delegate';
 
 import { TYPES } from '~/.server/constants';
-import { clearApplyState, loadApplyState } from '~/.server/routes/helpers/apply-route-helpers';
+import { clearApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -33,13 +33,11 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id } = loadApplyState({ params, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:application-delegate.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.application-delegate', 200);
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -58,7 +58,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:applicant-information.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.child.applicant-information', 200);
-  return { id: state.id, meta, defaultState: state.applicantInformation, editMode: state.editMode };
+  return { meta, defaultState: state.applicantInformation, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -53,7 +53,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.communication-preference', 200);
 
   return {
-    id: state.id,
     meta,
     preferredLanguages,
     defaultState: {

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   instrumentationService.countHttpStatus('public.apply.child.contact-apply-child', 200);
-  return { id: state.id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/email.tsx
+++ b/frontend/app/routes/public/apply/$id/child/email.tsx
@@ -49,7 +49,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.email', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.home-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.mailing-address', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/child/marital-status.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:marital-status.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.child.marital-status', 200);
-  return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { newUser: state.newOrExistingMember?.isNewOrExistingMember, maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
@@ -57,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:new-or-existing-member.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.child.new-or-existing-member', 200);
-  return { id: state.id, meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
+  return { meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/child/phone-number.tsx
@@ -51,7 +51,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.phone-number', 200);
 
   return {
-    id: state.id,
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -119,7 +119,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.review-adult-information', 200);
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     preferredLanguage: preferredLanguage.name,

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -105,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  return { id: state.id, children, meta };
+  return { children, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/child/verify-email.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   instrumentationService.countHttpStatus('public.apply.child.verify-email', 200);
 
   return {
-    id: state.id,
     meta,
     email: state.editModeEmail ?? state.email,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/file-taxes.tsx
@@ -29,13 +29,13 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
 
-  const { id, applicationYear } = loadApplyState({ params, session });
+  const { applicationYear } = loadApplyState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:file-your-taxes.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.file-taxes', 200);
-  return { id, meta, taxYear: applicationYear.taxYear };
+  return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/apply/$id/tax-filing.tsx
@@ -40,7 +40,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:tax-filing.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.tax-filing', 200);
-  return { id: state.id, meta, defaultState: state.hasFiledTaxes, taxYear: state.applicationYear.taxYear };
+  return { meta, defaultState: state.hasFiledTaxes, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -43,7 +43,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:type-of-application.page-title') }) };
 
   instrumentationService.countHttpStatus('public.apply.type-application', 200);
-  return { id: state.id, meta, defaultState: state.typeOfApplication };
+  return { meta, defaultState: state.typeOfApplication };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -79,7 +79,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     childName,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-address.page-title') }) };
 
-  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
+  return { meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -61,8 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-email.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-marital-status.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
+  return { meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -56,8 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-phone.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedPhoneNumber: state.contactInformation?.isNewOrUpdatedPhoneNumber,

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -148,7 +148,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     children,
-
     dentalInsurance,
     homeAddressInfo,
     mailingAddressInfo,

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:dental-insurance.title') }) };
 
-  return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewAdultChildState } from '~/.server/routes/helpers/renew-adult-child-route-helpers';
 import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -29,12 +28,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewAdultChildState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:exit-application.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -135,7 +135,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalStateMapper.mapRenewAdultChildStateToAdultChildBenefitRenewalDto(state));
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     homeAddressInfo,

--- a/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-child-information.tsx
@@ -102,7 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  return { id: state.id, children, meta, payload };
+  return { children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.home-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -62,7 +62,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.mailing-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-address.page-title') }) };
 
-  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
+  return { meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -61,8 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-email.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,

--- a/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-marital-status.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-marital-status.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
+  return { meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -56,8 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:confirm-phone.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedPhoneNumber: state.contactInformation?.isNewOrUpdatedPhoneNumber,

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:dental-insurance.title') }) };
 
-  return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
 import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -29,12 +28,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewAdultState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:exit-application.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -135,7 +135,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapAdultBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalStateMapper.mapRenewAdultStateToAdultBenefitRenewalDto(state));
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     homeAddressInfo,

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -71,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.home-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.mailing-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/applicant-information.tsx
+++ b/frontend/app/routes/public/renew/$id/applicant-information.tsx
@@ -49,7 +49,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:applicant-information.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.applicantInformation };
+  return { meta, defaultState: state.applicantInformation };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -79,7 +79,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     childName,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-address.page-title') }) };
 
-  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
+  return { meta, defaultState: { hasAddressChanged: state.hasAddressChanged }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -61,8 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-email.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,

--- a/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-marital-status.tsx
@@ -45,7 +45,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-marital-status.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
+  return { meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -56,8 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:confirm-phone.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedPhoneNumber: state.contactInformation?.isNewOrUpdatedPhoneNumber,

--- a/frontend/app/routes/public/renew/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/child/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewChildState } from '~/.server/routes/helpers/renew-child-route-helpers';
 import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -29,12 +28,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewChildState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:exit-application.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
+++ b/frontend/app/routes/public/renew/$id/child/parent-intro.tsx
@@ -11,7 +11,6 @@ import { z } from 'zod';
 import type { Route } from './+types/parent-intro';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { Button } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -40,12 +39,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewState({ params, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:parent-intro.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -111,7 +111,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapChildBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalStateMapper.mapRenewChildStateToChildBenefitRenewalDto(state));
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     homeAddressInfo,

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.home-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -62,7 +62,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.mailing-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/renew/$id/file-taxes.tsx
@@ -31,12 +31,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id, applicationYear } = loadRenewState({ params, session });
+  const { applicationYear } = loadRenewState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:file-your-taxes.page-title') }) };
 
-  return { id, meta, taxYear: applicationYear.taxYear };
+  return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -53,7 +53,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:confirm-address.page-title') }) };
 
-  return { id: state.id, meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
+  return { meta, defaultState: { hasAddressChanged: state.hasAddressChanged, isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
@@ -56,8 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:confirm-email.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       isNewOrUpdatedEmail: state.contactInformation?.isNewOrUpdatedEmail,

--- a/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
@@ -48,8 +48,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:confirm-phone.page-title') }) };
 
   return {
-    id: state.id,
-
     meta,
     defaultState: {
       phoneNumber: state.contactInformation?.phoneNumber,

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -121,7 +121,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dentalInsurance,
     homeAddressInfo,
     mailingAddressInfo,
-
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:dental-insurance.title') }) };
 
-  return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode };
+  return { meta, defaultState: state.dentalInsurance, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/exit-application.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/exit-application';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewItaState } from '~/.server/routes/helpers/renew-ita-route-helpers';
 import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -29,12 +28,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewItaState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:exit-application.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -65,7 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
     federalSocialPrograms,
-    id: state.id,
     meta,
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -57,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:marital-status.page-title') }) };
 
-  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, id: state.id, maritalStatuses, meta };
+  return { defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -135,7 +135,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapItaBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalStateMapper.mapRenewItaStateToItaBenefitRenewalDto(state));
 
   return {
-    id: state.id,
     userInfo,
     spouseInfo,
     homeAddressInfo,

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -61,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.home-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -62,7 +62,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.mailing-address.page-title') }) };
 
   return {
-    id: state.id,
     meta,
     defaultState: state,
     countryList,

--- a/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
+++ b/frontend/app/routes/public/renew/$id/renewal-delegate.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/renewal-delegate';
 
 import { TYPES } from '~/.server/constants';
-import { clearRenewState, loadRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { clearRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -31,12 +31,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const { id } = loadRenewState({ params, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:renewal-delegate.page-title') }) };
 
-  return { id, meta };
+  return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/public/renew/$id/tax-filing.tsx
@@ -44,7 +44,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:tax-filing.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
+  return { meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:type-of-renewal.page-title') }) };
 
-  return { id: state.id, meta, defaultState: state.typeOfRenewal, hasFiledTaxes: state.clientApplication?.hasFiledTaxes };
+  return { meta, defaultState: state.typeOfRenewal, hasFiledTaxes: state.clientApplication?.hasFiledTaxes };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -57,7 +57,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     statusResult: { alertType, clientFriendlyStatus },
-
     meta,
   };
 }


### PR DESCRIPTION
### Description
Noticed we have many instances of returning `id: state.id` in the loaders of routes when it's unused.  This PR removes all instances of this unused parameter.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
