### PR TITLE
refactor(frontend) remove redundant route-helper calls in routes

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
@@ -183,7 +183,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadProtectedApplyAdultChildState({ params, request, session });
   clearProtectedApplyState({ params, session });
 
   const idToken: IdToken = session.get('idToken');

--- a/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
@@ -148,7 +148,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadProtectedApplyAdultState({ params, request, session });
   clearProtectedApplyState({ params, session });
 
   const idToken: IdToken = session.get('idToken');

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -167,7 +167,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadProtectedApplyChildState({ params, request, session });
   clearProtectedApplyState({ params, session });
 
   const idToken: IdToken = session.get('idToken');

--- a/frontend/app/routes/protected/apply/$id/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/index.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'react-router';
 import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedApplyState, saveProtectedApplyState } from '~/.server/routes/helpers/protected-apply-route-helpers';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { getPathById } from '~/utils/route-utils';
 
@@ -12,9 +11,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
-
-  loadProtectedApplyState({ params, session });
-  saveProtectedApplyState({ params, session, state: {} });
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.apply.index', { userId: idToken.sub });

--- a/frontend/app/routes/protected/apply/$id/type-application.tsx
+++ b/frontend/app/routes/protected/apply/$id/type-application.tsx
@@ -66,7 +66,6 @@ export async function action({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
-  loadProtectedApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   /**

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -6,7 +6,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/terms-and-conditions';
 
 import { TYPES } from '~/.server/constants';
-import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -38,8 +37,6 @@ export async function loader({ context: { appContainer, session }, request, para
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  loadProtectedRenewState({ params, request, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:terms-and-conditions.page-title') }) };
 
@@ -58,13 +55,6 @@ export async function action({ context: { appContainer, session }, request, para
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
-
-  saveProtectedRenewState({
-    params,
-    request,
-    session,
-    state: {},
-  });
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.terms-and-conditions', { userId: idToken.sub });

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -174,7 +174,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadApplyAdultChildState({ params, request, session });
   clearApplyState({ params, session });
 
   instrumentationService.countHttpStatus('public.apply.adult-child.confirmation', 302);

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -140,7 +140,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadApplyAdultState({ params, request, session });
   clearApplyState({ params, session });
 
   instrumentationService.countHttpStatus('public.apply.adult.confirmation', 302);

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -160,7 +160,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  loadApplyChildState({ params, request, session });
   clearApplyState({ params, session });
 
   instrumentationService.countHttpStatus('public.apply.child.confirmation', 302);

--- a/frontend/app/routes/public/apply/$id/index.tsx
+++ b/frontend/app/routes/public/apply/$id/index.tsx
@@ -3,15 +3,11 @@ import { redirect } from 'react-router';
 import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
-import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getPathById } from '~/utils/route-utils';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
   const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
-  loadApplyState({ params, session });
-  saveApplyState({ params, session, state: {} });
 
   instrumentationService.countHttpStatus('public.apply', 302);
   return redirect(getPathById('public/apply/$id/terms-and-conditions', params));

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -53,7 +53,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
-  loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   /**

--- a/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/renew/$id/terms-and-conditions.tsx
@@ -6,7 +6,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/terms-and-conditions';
 
 import { TYPES } from '~/.server/constants';
-import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
@@ -31,8 +30,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
-  loadRenewState({ params, session });
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew:terms-and-conditions.page-title') }) };
 
@@ -44,8 +41,6 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
-
-  saveRenewState({ params, session, state: {} });
 
   return redirect(getPathById('public/renew/$id/applicant-information', params));
 }


### PR DESCRIPTION
### Description
This PR removes redundant calls to route-helper functions in some of the routes across the project.  Generally speaking, if we don't assign a variable to a `load[flowName]...`, or we call `save[flowName]...` without any updated state, it's a redundant operation and can be removed.


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
