### PR TITLE
feat(frontend): Adding counters to public renewal adult-child flow routes

### DIFF
--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/demographic-survey.tsx
@@ -46,6 +46,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateFeatureEnabled('demographic-survey');
 
@@ -70,6 +72,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const locationBornStatuses = demographicSurveyService.listLocalizedLocationBornStatuses(locale);
   const genderStatuses = demographicSurveyService.listLocalizedGenderStatuses(locale);
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.demographic-survey', 200);
+
   return {
     meta,
     indigenousStatuses,
@@ -86,6 +90,8 @@ export async function loader({ context: { appContainer, session }, request, para
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -138,6 +144,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.renew.adult-child.children.demographic-survey', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -151,6 +158,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.demographic-survey', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -35,6 +35,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -46,10 +48,13 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('renew-adult-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, isNew: state.isNew, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -68,6 +73,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.renew.adult-child.children.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -81,6 +87,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -31,15 +31,20 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   loadRenewAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:children.parent-or-guardian.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.parent-or-guardian', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -47,6 +52,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadRenewAdultSingleChildState({ params, request, session });
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.parent-or-guardian', 302);
   return redirect(getPathById('public/renew/$id/adult-child/children/index', params));
 }
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -56,6 +56,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadRenewAdultSingleChildState({ params, request, session });
@@ -74,6 +76,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('renew-adult-child:children.information.page-title', { childName: childNumber }) }),
   };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.update-federal-provincial-territorial-benefits', 200);
+
   return {
     defaultState: state.dentalBenefits,
     childName,
@@ -86,6 +90,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -114,6 +120,7 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
+    instrumentationService.countHttpStatus('public.renew.adult-child.children.update-federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));
   }
 
@@ -173,12 +180,16 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    return {
-      errors: {
-        ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
-        ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+    instrumentationService.countHttpStatus('public.renew.adult-child.children.update-federal-provincial-territorial-benefits', 400);
+    return data(
+      {
+        errors: {
+          ...(!parsedFederalBenefitsResult.success ? transformFlattenedError(parsedFederalBenefitsResult.error.flatten()) : {}),
+          ...(!parsedProvincialTerritorialBenefitsResult.success ? transformFlattenedError(parsedProvincialTerritorialBenefitsResult.error.flatten()) : {}),
+        },
       },
-    };
+      { status: 400 },
+    );
   }
 
   saveRenewState({
@@ -197,6 +208,8 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.children.update-federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -50,6 +50,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -74,10 +76,13 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.children', 200);
   return { meta, children, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -87,6 +92,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.children', 302);
 
   if (formAction === FORM_ACTION.back) {
     if (demographicSurveyEnabled) {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -55,10 +55,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-email.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-email', 200);
 
   return {
     meta,
@@ -72,6 +76,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -132,10 +138,13 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.renew.adult-child.confirm-email', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-email', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { data, redirect, useFetcher } from 'react-router';
 
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -41,10 +41,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-dental-benefits.title') }) };
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-federal-provincial-territorial-benefits', 200);
 
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefitsChanged,
@@ -54,6 +58,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -77,11 +83,15 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    return {
-      errors: {
-        ...transformFlattenedError(parsedDentalBenefitsResult.error.flatten()),
+    instrumentationService.countHttpStatus('public.renew.adult-child.confirm-federal-provincial-territorial-benefits', 400);
+    return data(
+      {
+        errors: {
+          ...transformFlattenedError(parsedDentalBenefitsResult.error.flatten()),
+        },
       },
-    };
+      { status: 400 },
+    );
   }
 
   saveRenewState({
@@ -92,6 +102,8 @@ export async function action({ context: { appContainer, session }, params, reque
       dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefitsChanged ? state.dentalBenefits : undefined,
     },
   });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefitsChanged) {
     return redirect(getPathById('public/renew/$id/adult-child/update-federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-marital-status.tsx
@@ -40,15 +40,20 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-marital-status.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-marital-status', 200);
   return { meta, defaultState: state.hasMaritalStatusChanged, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -68,6 +73,7 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.renew.adult-child.confirm-marital-status', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -78,6 +84,8 @@ export async function action({ context: { appContainer, session }, params, reque
       hasMaritalStatusChanged: parsedDataResult.data.hasMaritalStatusChanged,
     },
   });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-marital-status', 302);
 
   if (state.editMode) {
     if (parsedDataResult.data.hasMaritalStatusChanged) {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -50,10 +50,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm-phone.page-title') }) };
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-phone', 200);
 
   return {
     meta,
@@ -69,6 +73,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -110,10 +116,13 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
+    instrumentationService.countHttpStatus('public.renew.adult-child.confirm-phone', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveRenewState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirm-phone', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -39,6 +39,8 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const state = loadRenewAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -146,6 +148,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:confirm.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirmation', 200);
+
   return {
     children,
     dentalInsurance,
@@ -159,6 +163,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -167,6 +173,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearRenewState({ params, session });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.confirmation', 302);
   return redirect(t('confirm.exit-link'));
 }
 

--- a/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/exit-application.tsx
@@ -28,13 +28,18 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:exit-application.page-title') }) };
 
+  instrumentationService.countHttpStatus('public.renew.adult-child.exit-application', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -43,6 +48,8 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearRenewState({ params, session });
+
+  instrumentationService.countHttpStatus('public.renew.adult-child.exit-application', 302);
   return redirect(t('exit-application.exit-link'));
 }
 


### PR DESCRIPTION
### Description
As per title. Similar to what was previously implemented for apply flows.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
Other flows will be taken care of in a separate PR.