### PR TITLE
fix(gitops): Updating invalid mocks for training

### DIFF
--- a/gitops/overlays/training/configs/frontend/config.conf
+++ b/gitops/overlays/training/configs/frontend/config.conf
@@ -17,7 +17,7 @@ OTEL_ENVIRONMENT=training
 OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
 
-ENABLED_MOCKS=cct,gc-notify,power-platform,raoidc,verification-code,status-check,wsaddress
+ENABLED_MOCKS=cct,power-platform,raoidc,status-check,wsaddress
 
 MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-training.dev-dp-internal.dts-stn.com/auth/callback/raoidc
 


### PR DESCRIPTION
### Description
As per title. These mocks are not applicable in v4.3.0.