### PR TITLE
feat(frontend): add `<KillswitchDialog>`

### DIFF
--- a/frontend/__tests__/components/killswitch-dialog.test.tsx
+++ b/frontend/__tests__/components/killswitch-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from '@testing-library/react';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KillswitchDialog } from '~/components/killswitch-dialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    /**
+     * Implementation of the t() function that will add stringify any options that are passed.
+     */
+    t: (key?: string | string[], options?: Record<string, unknown>) => {
+      const i18nKey = Array.isArray(key) ? key.join('.') : key;
+      return options ? JSON.stringify({ key: i18nKey, options }) : i18nKey;
+    },
+  }),
+}));
+
+describe('KillswitchDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('should render nothing if timeoutSecs is 0', () => {
+    render(<KillswitchDialog timeoutSecs={0} />);
+    expect(screen.queryByText('killswitch.title')).not.toBeInTheDocument();
+  });
+
+  it('should render the dialog if timeoutSecs is greater than 0', () => {
+    render(<KillswitchDialog timeoutSecs={600} />);
+    expect(screen.queryByText('killswitch.title')).toBeInTheDocument();
+  });
+
+  it('should decrement the remaining time every second', () => {
+    render(<KillswitchDialog timeoutSecs={300} />);
+    expect(screen.queryByText('{"key":"killswitch.remaining-time","options":{"mins":5,"secs":0}}')).toBeInTheDocument();
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(screen.queryByText('{"key":"killswitch.remaining-time","options":{"mins":4,"secs":59}}')).toBeInTheDocument();
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(screen.queryByText('{"key":"killswitch.remaining-time","options":{"mins":4,"secs":58}}')).toBeInTheDocument();
+  });
+
+  it('should hide the dialog when the timer reaches zero', () => {
+    render(<KillswitchDialog timeoutSecs={300} />);
+    expect(screen.queryByText('killswitch.title')).toBeInTheDocument();
+
+    act(() => void vi.advanceTimersByTime(300_000));
+    expect(screen.queryByText('killswitch.title')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/killswitch-dialog.tsx
+++ b/frontend/app/components/killswitch-dialog.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
+
+type KillswitchDialogProps = {
+  /**
+   * The initial duration (in seconds) for the killswitch countdown.
+   * The dialog will remain visible and block the user until this timer counts down to zero.
+   */
+  timeoutSecs: number;
+};
+
+export function KillswitchDialog({ timeoutSecs }: KillswitchDialogProps) {
+  const [remainingTime, setRemainingTime] = useState(timeoutSecs);
+  const { t } = useTranslation(['common']);
+
+  // the dialog should only activate when `remainingTime` is not zero
+  const isDialogActive = remainingTime > 0;
+
+  //
+  // decrements `remainingTime` by one every second
+  //
+  useEffect(() => {
+    if (isDialogActive) {
+      const timeout = globalThis.setInterval(() => setRemainingTime((prevRemainingTime) => prevRemainingTime - 1), 1000);
+      // we must clear the timer when the component unmounts to prevent memory
+      // leaks and and errors from trying to update state on an unmounted component
+      return () => globalThis.clearInterval(timeout);
+    }
+  }, [isDialogActive]);
+
+  //
+  // resets `remainingTime` if the parent changes the timeout
+  //
+  useEffect(() => setRemainingTime(timeoutSecs), [timeoutSecs]);
+
+  if (isDialogActive) {
+    const { mins, secs } = getTimeComponents(remainingTime);
+
+    return (
+      <Dialog open={true}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>
+              <FontAwesomeIcon icon={faExclamationTriangle} className="inline" />
+              <span> {t('killswitch.title')}</span>
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <p>{t('killswitch.overloaded')}</p>
+            <p>{t('killswitch.dont-worry-be-happy')}</p>
+          </div>
+          <DialogFooter>{t('killswitch.remaining-time', { mins, secs })}</DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+/**
+ * Converts a total duration in seconds into an object representing whole
+ * minutes and remaining seconds. Negative input values are treated as 0 seconds
+ * before conversion.
+ */
+function getTimeComponents(seconds: number): { mins: number; secs: number } {
+  const time = seconds < 0 ? 0 : seconds;
+
+  const mins = Math.floor(time / 60);
+  const secs = time % 60;
+
+  return { mins, secs };
+}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -42,5 +42,11 @@
       "province-state-required": "Select a province, territory, state or region for your home address",
       "zip-code-valid": "Enter home address zip code in the correct format, such as 12345 or 12345-6789"
     }
+  },
+  "killswitch": {
+    "title": "Please hold on",
+    "overloaded": "We're getting a lot of visitors right now, which is slowing things down. You will be able to continue when the timer reaches zero.",
+    "dont-worry-be-happy": "Don't worry\u2014your information is saved. Do not close your browser, or you will have to start the application over again.",
+    "remaining-time": "Continuing to application in: {{mins}} min {{secs}} sec"
   }
 }

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -42,5 +42,11 @@
       "province-state-required": "Sélectionnez une province, un territoire, un état ou une région pour votre adresse du domicile",
       "zip-code-valid": "Entrez un code postal américain pour l'adresse du domicile dans le bon format, par exemple 12345 ou 12345-6789"
     }
+  },
+  "killswitch": {
+    "title": "Veuillez patienter",
+    "overloaded": "Nous recevons beaucoup de visiteurs en ce moment, ce qui ralentit le processus. Vous pourrez continuer lorsque le minuteur atteindra zéro.",
+    "dont-worry-be-happy": "Ne vous inquiétez pas\u2014vos renseignements sont enregistrés. Ne fermez pas votre navigateur, sinon vous devrez recommencer l'application.",
+    "remaining-time": "Accéder à l'application dans\u00a0: {{mins}} min {{secs}} sec"
   }
 }


### PR DESCRIPTION
### Description

This PR adds a new react component: `<KillswitchDialog>` which is intended to block users from progressing within a multi-page form (ie: apply and renew) when the application is under heavy load.

The dialog accepts a single prop, `timeoutSecs`, which determines whether or not the dialog is active. If `timeoutSecs` is greater than zero, the dialog is displayed and `timeoutSecs` counts down to zero.

### Screenshots

![Screenshot from 2025-04-16 08-47-35](https://github.com/user-attachments/assets/b6c7d262-9313-4e89-9b65-be00b799c8db)

![Screenshot from 2025-04-16 08-47-21](https://github.com/user-attachments/assets/c671ca68-f60f-421f-803a-d31506ac07f5)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`
