### PR TITLE
fix(frontend): correct typo in `APPLICATION_CURRENT_DATE` variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -123,7 +123,7 @@ INTEROP_STATUS_CHECK_API_SUBSCRIPTION_KEY=
 
 # Config that holds a custom current date used for the application year request and apply eligibility. This date can be overridden for simulation or testing purposes -- ex. 2025-03-05 (yyyy-mm-dd)
 # (optional; default: undefined;)
-# APPICATION_CURRENT_DATE=2025-03-05
+# APPLICATION_CURRENT_DATE=2025-03-05
 
 # OpenTelemetry log level; valid values are: none, error, warn, info, debug, verbose, all
 # (optional; default: info)


### PR DESCRIPTION
The diff should be self explanatory. 😄