### PR TITLE
feat(frontend): Adding Express middleware to count route requests

### DIFF
--- a/frontend/app/.server/express-server/express.server.ts
+++ b/frontend/app/.server/express-server/express.server.ts
@@ -2,6 +2,7 @@ import compression from 'compression';
 import express from 'express';
 import sourceMapSupport from 'source-map-support';
 
+import { routeRequestCounter } from '~/.server/express-server/instrumentation.server';
 import { logging, securityHeaders, session } from '~/.server/express-server/middleware.server';
 import { globalErrorHandler, rrRequestHandler } from '~/.server/express-server/request-handlers.server';
 import { createViteDevServer } from '~/.server/express-server/vite.server';
@@ -65,6 +66,9 @@ if (viteDevServer) {
   log.info('    ✓ vite dev server middlewares');
   app.use(viteDevServer.middlewares);
 }
+
+log.info('  ✓ registering route request counter');
+app.use(routeRequestCounter());
 
 log.info('  ✓ registering react router request handler');
 // In Express v5, the path route matching syntax has changed.

--- a/frontend/app/.server/express-server/instrumentation.server.ts
+++ b/frontend/app/.server/express-server/instrumentation.server.ts
@@ -1,0 +1,73 @@
+import { matchRoutes } from 'react-router';
+
+import type { RequestHandler } from 'express';
+
+import { getAppContainerProvider } from '~/.server/app.container';
+import { TYPES } from '~/.server/constants';
+import { createLogger } from '~/.server/logging';
+import routes from '~/routes';
+
+// Define a type for the cache value (can be string or null/undefined if no match/id)
+type CachedRouteId = string | null | undefined;
+
+/**
+ * Creates an Express middleware to count requests based on matched React Router routes.
+ * It caches the result of route matching for performance.
+ *
+ * @returns Express RequestHandler middleware.
+ */
+export function routeRequestCounter(): RequestHandler {
+  const log = createLogger('express.server/routeRequestCounter');
+
+  const appContainer = getAppContainerProvider();
+  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
+
+  // Cache to store: normalizedPath -> routeId (or null/undefined if no match)
+  // This Map persists across requests for this middleware instance.
+  const pathCache = new Map<string, CachedRouteId>();
+
+  log.info('Initializing request counter middleware with route matching cache.');
+
+  return (req, res, next) => {
+    // Hook into the 'finish' event to capture the final status code
+    res.on('finish', () => {
+      try {
+        // Use req.path to ignore query strings for routing/caching purposes
+        // Normalize path (e.g., remove trailing .data for React Router loaders/actions)
+        const normalizedPath = req.path.replace(/\.data$/, '');
+
+        let routeId: CachedRouteId = undefined;
+
+        // Check cache first
+        if (pathCache.has(normalizedPath)) {
+          routeId = pathCache.get(normalizedPath);
+          log.debug(`Cache hit for path: ${normalizedPath}, routeId: ${routeId}`);
+        } else {
+          log.debug(`Cache miss for path: ${normalizedPath}. Matching routes...`);
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const matches = matchRoutes(routes as any, normalizedPath);
+
+          // Get the ID from the most specific matched route (last in the array)
+          // Ensure the route and ID exist
+          const lastMatch = matches?.at(-1); // Get the last match object
+          routeId = lastMatch?.route.id ?? null; // Use null if no ID
+
+          // Update cache with the result (even if null)
+          pathCache.set(normalizedPath, routeId);
+          log.debug(`Cached routeId '${routeId}' for path: ${normalizedPath}`);
+        }
+
+        if (routeId) {
+          // Construct metric identifier (e.g., POST '/user/$id/profile' → 'user._id.profile.posts')
+          const metricPrefix = `${routeId.replaceAll('/', '.').replace(/.\$([^.]+)/g, '_$1')}.${req.method.toLowerCase()}s`;
+          instrumentationService.countHttpStatus(metricPrefix, res.statusCode);
+        }
+      } catch (error) {
+        log.error('Error during request counting in "finish" handler:', error);
+      }
+    });
+
+    next();
+  };
+}


### PR DESCRIPTION
### Description
This PR adds a new `routeRequestCounter` Express middleware that:
- Uses `matchRoutes` to resolve the route for each request
- Caches matched route IDs by normalized path for performance
- Strips dynamic `$params` from metric/route IDs (e.g., `public.apply.$id.review` → `public.apply.review`)
- Sends a count metric to `InstrumentationService` using a route-based key like `public.apply.review.gets` to follow existing application metric conventions

### Screenshots
![image](https://github.com/user-attachments/assets/8ef6bfce-2d66-4e7e-b98a-97558a620e08)

**Dynatrace:**
![image](https://github.com/user-attachments/assets/fbdb184d-320d-43cd-8ba7-5221786a34fc)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional notes
Credit to ~~@sebastien-comeau~~ @sebcomeau for previous review and implementation