### PR TITLE
feat(frontend): implement killswitch functionality across benefit application and renewal services + add dialog to layouts

### DIFF
--- a/frontend/app/.server/domain/services/benefit-application.service.ts
+++ b/frontend/app/.server/domain/services/benefit-application.service.ts
@@ -1,12 +1,17 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
+import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
+import type { RedisService } from '~/.server/data';
 import type { BenefitApplicationDto } from '~/.server/domain/dtos';
 import type { BenefitApplicationDtoMapper } from '~/.server/domain/mappers';
 import type { BenefitApplicationRepository } from '~/.server/domain/repositories';
 import type { AuditService } from '~/.server/domain/services';
-import { createLogger } from '~/.server/logging';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { AppError, isAppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitApplicationService {
   /**
@@ -32,16 +37,27 @@ export class DefaultBenefitApplicationService implements BenefitApplicationServi
   private readonly benefitApplicationDtoMapper: BenefitApplicationDtoMapper;
   private readonly benefitApplicationRepository: BenefitApplicationRepository;
   private readonly auditService: AuditService;
+  private readonly serverConfig: ServerConfig;
+
+  // TODO :: GjB :: the redis service is temporary.. it should be removed when HTTP429 mitigation is removed
+  private readonly redisService?: RedisService;
 
   constructor(
     @inject(TYPES.domain.mappers.BenefitApplicationDtoMapper) benefitApplicationDtoMapper: BenefitApplicationDtoMapper,
     @inject(TYPES.domain.repositories.BenefitApplicationRepository) benefitApplicationRepository: BenefitApplicationRepository,
     @inject(TYPES.domain.services.AuditService) auditService: AuditService,
+    @inject(TYPES.configs.ServerConfig) serverConfig: ServerConfig,
+    @inject(TYPES.data.services.RedisService) @optional() redisService?: RedisService,
   ) {
     this.log = createLogger('DefaultBenefitApplicationService');
     this.benefitApplicationDtoMapper = benefitApplicationDtoMapper;
     this.benefitApplicationRepository = benefitApplicationRepository;
     this.auditService = auditService;
+    this.serverConfig = serverConfig;
+
+    // TODO :: GjB :: the redis service is temporary.. it should be removed when HTTP429 mitigation is removed
+    this.redisService = redisService;
+
     this.init();
   }
 
@@ -52,14 +68,30 @@ export class DefaultBenefitApplicationService implements BenefitApplicationServi
   async createBenefitApplication(benefitApplicationRequestDto: BenefitApplicationDto): Promise<string> {
     this.log.trace('Creating benefit application for request [%j]', benefitApplicationRequestDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to create benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to create benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('application-submit.post', { userId: benefitApplicationRequestDto.userId });
 
-    const benefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationRequestDto);
-    const benefitApplicationResponseEntity = await this.benefitApplicationRepository.createBenefitApplication(benefitApplicationRequestEntity);
-    const applicationCode = this.benefitApplicationDtoMapper.mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity);
+    try {
+      const benefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationRequestDto);
+      const benefitApplicationResponseEntity = await this.benefitApplicationRepository.createBenefitApplication(benefitApplicationRequestEntity);
+      const applicationCode = this.benefitApplicationDtoMapper.mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity);
 
-    this.log.trace('Returning application code: [%s]', applicationCode);
-    return applicationCode;
+      this.log.trace('Returning application code: [%s]', applicationCode);
+      return applicationCode;
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.error('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 
   async createProtectedBenefitApplication(protectedBenefitApplicationRequestDto: BenefitApplicationDto): Promise<string> {

--- a/frontend/app/.server/domain/services/benefit-renewal.service.ts
+++ b/frontend/app/.server/domain/services/benefit-renewal.service.ts
@@ -1,12 +1,17 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
+import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
+import type { RedisService } from '~/.server/data';
 import type { AdultBenefitRenewalDto, AdultChildBenefitRenewalDto, ChildBenefitRenewalDto, ItaBenefitRenewalDto, ProtectedBenefitRenewalDto } from '~/.server/domain/dtos';
 import type { BenefitRenewalDtoMapper } from '~/.server/domain/mappers';
 import type { BenefitRenewalRepository } from '~/.server/domain/repositories';
 import type { AuditService } from '~/.server/domain/services';
-import { createLogger } from '~/.server/logging';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+import { AppError, isAppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitRenewalService {
   /**
@@ -51,16 +56,27 @@ export class DefaultBenefitRenewalService implements BenefitRenewalService {
   private readonly benefitRenewalDtoMapper: BenefitRenewalDtoMapper;
   private readonly benefitRenewalRepository: BenefitRenewalRepository;
   private readonly auditService: AuditService;
+  private readonly serverConfig: ServerConfig;
+
+  // TODO :: GjB :: the redis service is temporary.. it should be removed when HTTP429 mitigation is removed
+  private readonly redisService?: RedisService;
 
   constructor(
     @inject(TYPES.domain.mappers.BenefitRenewalDtoMapper) benefitRenewalDtoMapper: BenefitRenewalDtoMapper,
     @inject(TYPES.domain.repositories.BenefitRenewalRepository) benefitRenewalRepository: BenefitRenewalRepository,
     @inject(TYPES.domain.services.AuditService) auditService: AuditService,
+    @inject(TYPES.configs.ServerConfig) serverConfig: ServerConfig,
+    @inject(TYPES.data.services.RedisService) @optional() redisService?: RedisService,
   ) {
     this.log = createLogger('DefaultBenefitRenewalService');
     this.benefitRenewalDtoMapper = benefitRenewalDtoMapper;
     this.benefitRenewalRepository = benefitRenewalRepository;
     this.auditService = auditService;
+    this.serverConfig = serverConfig;
+
+    // TODO :: GjB :: the redis service is temporary.. it should be removed when HTTP429 mitigation is removed
+    this.redisService = redisService;
+
     this.init();
   }
 
@@ -71,55 +87,135 @@ export class DefaultBenefitRenewalService implements BenefitRenewalService {
   async createAdultBenefitRenewal(adultBenefitRenewalDto: AdultBenefitRenewalDto): Promise<void> {
     this.log.trace('Creating adult benefit renewal for request [%j]', adultBenefitRenewalDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to renew adult benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to renew adult benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('adult-renewal-submit.post', { userId: adultBenefitRenewalDto.userId });
 
-    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapAdultBenefitRenewalDtoToBenefitRenewalRequestEntity(adultBenefitRenewalDto);
-    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+    try {
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapAdultBenefitRenewalDtoToBenefitRenewalRequestEntity(adultBenefitRenewalDto);
+      await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
 
-    this.log.trace('Successfully created adult benefit renewal for request [%j]', adultBenefitRenewalDto);
+      this.log.trace('Successfully created adult benefit renewal for request [%j]', adultBenefitRenewalDto);
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.error('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 
   async createAdultChildBenefitRenewal(adultChildBenefitRenewalDto: AdultChildBenefitRenewalDto): Promise<void> {
     this.log.trace('Creating adult child benefit renewal for request [%j]', adultChildBenefitRenewalDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to renew adult child benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to renew adult child benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('adult-child-renewal-submit.post', { userId: adultChildBenefitRenewalDto.userId });
 
-    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(adultChildBenefitRenewalDto);
-    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+    try {
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapAdultChildBenefitRenewalDtoToBenefitRenewalRequestEntity(adultChildBenefitRenewalDto);
+      await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
 
-    this.log.trace('Successfully created adult child benefit renewal for request [%j]', adultChildBenefitRenewalDto);
+      this.log.trace('Successfully created adult child benefit renewal for request [%j]', adultChildBenefitRenewalDto);
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.warn('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 
   async createItaBenefitRenewal(itaBenefitRenewalDto: ItaBenefitRenewalDto): Promise<void> {
     this.log.trace('Creating ITA benefit renewal for request [%j]', itaBenefitRenewalDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to renew ITA benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to renew ITA benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('ita-renewal-submit.post', { userId: itaBenefitRenewalDto.userId });
 
-    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapItaBenefitRenewalDtoToBenefitRenewalRequestEntity(itaBenefitRenewalDto);
-    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+    try {
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapItaBenefitRenewalDtoToBenefitRenewalRequestEntity(itaBenefitRenewalDto);
+      await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
 
-    this.log.trace('Successfully created ITA benefit renewal for request [%j]', itaBenefitRenewalDto);
+      this.log.trace('Successfully created ITA benefit renewal for request [%j]', itaBenefitRenewalDto);
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.warn('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 
   async createChildBenefitRenewal(childBenefitRenewalDto: ChildBenefitRenewalDto): Promise<void> {
     this.log.trace('Creating child benefit renewal for request [%j]', childBenefitRenewalDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to renew child benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to renew child benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('child-renewal-submit.post', { userId: childBenefitRenewalDto.userId });
 
-    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapChildBenefitRenewalDtoToBenefitRenewalRequestEntity(childBenefitRenewalDto);
-    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+    try {
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapChildBenefitRenewalDtoToBenefitRenewalRequestEntity(childBenefitRenewalDto);
+      await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
 
-    this.log.trace('Successfully created child benefit renewal for request [%j]', childBenefitRenewalDto);
+      this.log.trace('Successfully created child benefit renewal for request [%j]', childBenefitRenewalDto);
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.warn('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 
   async createProtectedBenefitRenewal(protectedBenefitRenewalDto: ProtectedBenefitRenewalDto): Promise<void> {
     this.log.trace('Creating protected benefit renewal for request [%j]', protectedBenefitRenewalDto);
 
+    const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
+
+    if (killswitchEngaged) {
+      this.log.error('Request to renew protected benefit application is unavailable (killswitch engaged).');
+      new AppError('Request to renew protected benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
     this.auditService.createAudit('protected-renewal-submit.post', { userId: protectedBenefitRenewalDto.userId });
 
-    const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapProtectedBenefitRenewalDtoToBenefitRenewalRequestEntity(protectedBenefitRenewalDto);
-    await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
+    try {
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapProtectedBenefitRenewalDtoToBenefitRenewalRequestEntity(protectedBenefitRenewalDto);
+      await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
 
-    this.log.trace('Successfully created protected benefit renewal for request [%j]', protectedBenefitRenewalDto);
+      this.log.trace('Successfully created protected benefit renewal for request [%j]', protectedBenefitRenewalDto);
+    } catch (error) {
+      if (isAppError(error) && error.errorCode === ErrorCodes.XAPI_TOO_MANY_REQUESTS) {
+        this.log.warn('Received XAPI_TOO_MANY_REQUESTS; killswitch engage!');
+        await this.redisService?.set(KILLSWITCH_KEY, true, this.serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS);
+      }
+
+      throw error;
+    }
   }
 }

--- a/frontend/app/.server/domain/services/index.ts
+++ b/frontend/app/.server/domain/services/index.ts
@@ -18,3 +18,9 @@ export * from './preferred-language.service';
 export * from './province-territory-state.service';
 export * from './provincial-government-insurance-plan.service';
 export * from './verification-code.service';
+
+/**
+ * Key that holds the killswitch boolean value in redis.
+ * TODO ::: GjB ::: this is temporary.. it should be removed when HTTP429 mitigation is removed
+ */
+export const KILLSWITCH_KEY = 'APPLICATION_KILLSWITCH_ENGAGED';

--- a/frontend/app/routes/protected/apply/layout.tsx
+++ b/frontend/app/routes/protected/apply/layout.tsx
@@ -5,7 +5,9 @@ import { Outlet, useNavigate } from 'react-router';
 import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import { getLocale } from '~/.server/utils/locale.utils';
+import { KillswitchDialog } from '~/components/killswitch-dialog';
 import { i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/protected-apply-route-helpers';
@@ -21,15 +23,18 @@ export const handle = {
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
+
+  const redisService = appContainer.find(TYPES.data.services.RedisService);
+  const killswitchTimeout = (await redisService?.ttl(KILLSWITCH_KEY)) ?? 0;
+
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
-  return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
+  return { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
 export default function Layout({ loaderData, params }: Route.ComponentProps) {
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
+  const { killswitchTimeout, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
 
@@ -65,6 +70,7 @@ export default function Layout({ loaderData, params }: Route.ComponentProps) {
 
   return (
     <>
+      <KillswitchDialog timeoutSecs={killswitchTimeout} />
       <SessionTimeout promptBeforeIdle={SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={SESSION_TIMEOUT_SECONDS * 1000} onSessionEnd={handleOnSessionEnd} onSessionExtend={handleOnSessionExtend} />
       <Outlet />
     </>

--- a/frontend/app/routes/protected/renew/layout.tsx
+++ b/frontend/app/routes/protected/renew/layout.tsx
@@ -5,7 +5,9 @@ import { Outlet, useNavigate } from 'react-router';
 import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import { getLocale } from '~/.server/utils/locale.utils';
+import { KillswitchDialog } from '~/components/killswitch-dialog';
 import { i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/protected-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/protected-renew-route-helpers';
@@ -21,15 +23,18 @@ export const handle = {
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
+
+  const redisService = appContainer.find(TYPES.data.services.RedisService);
+  const killswitchTimeout = (await redisService?.ttl(KILLSWITCH_KEY)) ?? 0;
+
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
-  return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
+  return { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
 export default function Layout({ loaderData, params }: Route.ComponentProps) {
-  const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
+  const { killswitchTimeout, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
 
@@ -65,6 +70,7 @@ export default function Layout({ loaderData, params }: Route.ComponentProps) {
 
   return (
     <>
+      <KillswitchDialog timeoutSecs={killswitchTimeout} />
       <SessionTimeout promptBeforeIdle={SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={SESSION_TIMEOUT_SECONDS * 1000} onSessionEnd={handleOnSessionEnd} onSessionExtend={handleOnSessionExtend} />
       <Outlet />
     </>

--- a/frontend/app/routes/public/apply/layout.tsx
+++ b/frontend/app/routes/public/apply/layout.tsx
@@ -5,7 +5,9 @@ import { Outlet, useNavigate } from 'react-router';
 import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import { getLocale } from '~/.server/utils/locale.utils';
+import { KillswitchDialog } from '~/components/killswitch-dialog';
 import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/apply-route-helpers';
@@ -20,15 +22,18 @@ export const handle = {
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
+
+  const redisService = appContainer.find(TYPES.data.services.RedisService);
+  const killswitchTimeout = (await redisService?.ttl(KILLSWITCH_KEY)) ?? 0;
+
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
-  return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
+  return { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
 export default function Layout({ loaderData, params }: Route.ComponentProps) {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
+  const { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
 
@@ -64,6 +69,7 @@ export default function Layout({ loaderData, params }: Route.ComponentProps) {
 
   return (
     <PublicLayout>
+      <KillswitchDialog timeoutSecs={killswitchTimeout} />
       <SessionTimeout promptBeforeIdle={SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={SESSION_TIMEOUT_SECONDS * 1000} onSessionEnd={handleOnSessionEnd} onSessionExtend={handleOnSessionExtend} />
       <Outlet />
     </PublicLayout>

--- a/frontend/app/routes/public/renew/layout.tsx
+++ b/frontend/app/routes/public/renew/layout.tsx
@@ -5,7 +5,9 @@ import { Outlet, useNavigate } from 'react-router';
 import type { Route } from './+types/layout';
 
 import { TYPES } from '~/.server/constants';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
 import { getLocale } from '~/.server/utils/locale.utils';
+import { KillswitchDialog } from '~/components/killswitch-dialog';
 import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/renew-route-helpers';
@@ -20,15 +22,18 @@ export const handle = {
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
   const locale = getLocale(request);
+
+  const redisService = appContainer.find(TYPES.data.services.RedisService);
+  const killswitchTimeout = (await redisService?.ttl(KILLSWITCH_KEY)) ?? 0;
+
   const { SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = appContainer.get(TYPES.configs.ClientConfig);
-  return { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
+  return { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS };
 }
 
 export default function Route({ loaderData, params }: Route.ComponentProps) {
-  const { locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
+  const { killswitchTimeout, locale, SESSION_TIMEOUT_PROMPT_SECONDS, SESSION_TIMEOUT_SECONDS } = loaderData;
 
   const navigate = useNavigate();
 
@@ -64,6 +69,7 @@ export default function Route({ loaderData, params }: Route.ComponentProps) {
 
   return (
     <PublicLayout>
+      <KillswitchDialog timeoutSecs={killswitchTimeout} />
       <SessionTimeout promptBeforeIdle={SESSION_TIMEOUT_PROMPT_SECONDS * 1000} timeout={SESSION_TIMEOUT_SECONDS * 1000} onSessionEnd={handleOnSessionEnd} onSessionExtend={handleOnSessionExtend} />
       <Outlet />
     </PublicLayout>


### PR DESCRIPTION
### Description

This PR adds killswitch functionality across all apply and renew routes in the application.

### How it works

- When an HTTP429 is received from specific API endpoints, a specially coded `AppError` is thrown from the repository making the call;
- The specially coded `AppError` is caught in the calling service module, and a boolean flag is set in Redis under the `APPLICATION_KILLSWITCH_ENGAGED` key;
- Each route layout checks for the presence of `APPLICATION_KILLSWITCH_ENGAGED` in Redis before rendering; if detected, the killswitch dialog is displayed;
- The killswitch dialog automatically hides itself when the `APPLICATION_KILLSWITCH_ENGAGED` value in Redis is removed (it does this by checking the value's TTL and using a countdown).

### Screenshots

![image](https://github.com/user-attachments/assets/2f2d8498-0ef4-47f7-8a01-5e59a055e11f)

### Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions

It is difficult to test this because of the required integration with an API that we do not control. Contact me directly for a demo if you need one.
