### PR TITLE
fix(frontend) un-default check hasSocialInsurance radios

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/children/$childId/information.tsx
@@ -256,7 +256,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber ?? true);
+  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
@@ -279,7 +279,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-apply-adult-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
       value: YES_NO_OPTION.yes,
-      defaultChecked: defaultState?.hasSocialInsuranceNumber ?? true,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
           <InputPatternField

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/information.tsx
@@ -250,7 +250,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber ?? true);
+  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
@@ -273,7 +273,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-apply-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
       value: YES_NO_OPTION.yes,
-      defaultChecked: defaultState?.hasSocialInsuranceNumber ?? true,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
           <InputPatternField

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -244,7 +244,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber ?? true);
+  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
@@ -267,7 +267,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-adult-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
       value: YES_NO_OPTION.yes,
-      defaultChecked: defaultState?.hasSocialInsuranceNumber ?? true,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
           <InputPatternField

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -240,7 +240,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber ?? true);
+  const [hasSocialInsuranceNumberValue, setHasSocialInsuranceNumberValue] = useState(defaultState?.hasSocialInsuranceNumber);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
@@ -263,7 +263,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
     {
       children: <Trans ns={handle.i18nNamespaces} i18nKey="apply-child:children.information.sin-yes" components={{ bold: <strong /> }} />,
       value: YES_NO_OPTION.yes,
-      defaultChecked: defaultState?.hasSocialInsuranceNumber ?? true,
+      defaultChecked: defaultState?.hasSocialInsuranceNumber,
       append: hasSocialInsuranceNumberValue === true && (
         <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
           <InputPatternField


### PR DESCRIPTION
### Description
I could be mistaken and missed a key conversation when I was working on fsir, but I don't think it makes sense to have the children's `hasSocialInsuranceNumberValue` be coerced to `true` if the value is `undefined`, which makes it default checked when a user initially lands on the page.
