### PR TITLE
feat(frontend): add dev-only killswitch API for force-enabling application killswitch

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -51,7 +51,7 @@ AUTH_RASCL_LOGOUT_URL=http://localhost:3000/
 
 # Application feature flags -- see ./app/utils/env-utils.server.ts for valid values
 # (optional; default: "")
-ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey,apply-eligibility
+ENABLED_FEATURES=address-validation,hcaptcha,view-letters,view-letters-online-application,status,view-payload,stub-login,demographic-survey,apply-eligibility,killswitch-api
 
 
 # GC Notify API key

--- a/frontend/app/routes/api/killswitch.ts
+++ b/frontend/app/routes/api/killswitch.ts
@@ -1,0 +1,47 @@
+/**
+ * A dev-only API that force-enabled the application killswitch.
+ */
+import type { Route } from './+types/killswitch';
+
+import { TYPES } from '~/.server/constants';
+import { KILLSWITCH_KEY } from '~/.server/domain/services';
+import { createLogger } from '~/.server/logging';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+
+export async function loader({ context, params, request }: Route.LoaderArgs) {
+  const log = createLogger('killswitch/loader');
+
+  const serverConfig = context.appContainer.get(TYPES.configs.ServerConfig);
+
+  if (!serverConfig.ENABLED_FEATURES.includes('killswitch-api')) {
+    log.warn('killswitch-api is not enabled; returning 404 response');
+    throw Response.json(null, { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  const redisService = context.appContainer.find(TYPES.data.services.RedisService);
+  const currentRemainingTime = await redisService?.ttl(KILLSWITCH_KEY);
+
+  if (currentRemainingTime && currentRemainingTime >= 0) {
+    log.debug('Killswitch already engaged; returning killswitch status');
+    return { engaged: true, remainingTimeSecs: currentRemainingTime };
+  }
+
+  const searchParams = new URL(request.url).searchParams;
+  const engage = searchParams.get('engage') !== null;
+
+  if (engage) {
+    log.info('Force-enabling killswitch via killswitch API call');
+
+    // note: `redisService` might not be defined, so we have to check that the return value is `OK` to know if the switch has been flipped
+    const killswitchEngaged = (await redisService?.set(KILLSWITCH_KEY, true, serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS)) === 'OK';
+
+    return {
+      engaged: killswitchEngaged,
+      ...(killswitchEngaged && {
+        remainingTimeSecs: serverConfig.APPLICATION_KILLSWITCH_TTL_SECONDS,
+      }),
+    };
+  }
+
+  return { engaged: false };
+}

--- a/frontend/app/routes/api/routes.ts
+++ b/frontend/app/routes/api/routes.ts
@@ -46,4 +46,9 @@ export const routes = [
     file: 'routes/api/session.ts',
     path: '/api/session',
   },
+  {
+    id: 'api/killswitch',
+    file: 'routes/api/killswitch.ts',
+    path: '/api/killswitch',
+  },
 ] as const satisfies RouteConfig;

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const validFeatureNames = ['address-validation', 'hcaptcha', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-payload', 'demographic-survey', 'apply-eligibility'] as const;
+const validFeatureNames = ['address-validation', 'hcaptcha', 'killswitch-api', 'show-prototype-banner', 'stub-login', 'status', 'view-letters', 'view-letters-online-application', 'view-payload', 'demographic-survey', 'apply-eligibility'] as const;
 
 export type FeatureName = (typeof validFeatureNames)[number];
 


### PR DESCRIPTION
### Description

Add a dev-only API that can be used to enable and query the status of the application killswitch.

``` shell
➜  ~ curl --silent 'http://localhost:3000/api/killswitch' | jq
{
  "engaged": false
}

➜  ~ curl --silent 'http://localhost:3000/api/killswitch?engage' | jq
{
  "engaged": true,
  "remainingTimeSecs": 300
}

#
# ONE ETERNITY LATER...
#

➜  ~ curl --silent 'http://localhost:3000/api/killswitch' | jq
{
  "engaged": false
}
```

### Test Instructions

- enable feature in `.env`
- ensure that the application is configured to use Redis
- hit <http://localhost:3000/api/killswitch> and <http://localhost:3000/api/killswitch?engage>
