### PR TITLE
fix(frontend) fix a11y element cant be a child of

### DIFF
--- a/frontend/__tests__/components/collapsible.test.tsx
+++ b/frontend/__tests__/components/collapsible.test.tsx
@@ -19,7 +19,7 @@ describe('Collapsible Details', () => {
     expect(collapsibleDetailsElement.id).toBe(additionalProps.id + '-content');
 
     const collapsibleDetailsSummaryElement = getByText(additionalProps.summary);
-    expect(collapsibleDetailsSummaryElement.tagName).toBe('DIV');
+    expect(collapsibleDetailsSummaryElement.tagName).toBe('SPAN');
     expect(collapsibleDetailsSummaryElement.parentElement?.tagName).toBe('SUMMARY');
     expect(collapsibleDetailsSummaryElement.parentElement?.id).toBe(additionalProps.id + '-summary');
   });

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -8,7 +8,7 @@ export type CollapsibleSummaryProps = ComponentProps<'summary'>;
 export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
   return (
     <summary className={cn('cursor-pointer marker:text-blue-900', className)} {...props}>
-      <div className="ml-4 inline-block text-blue-900 hover:underline">{children}</div>
+      <span className="ml-4 inline-block text-blue-900 hover:underline">{children}</span>
     </summary>
   );
 }

--- a/frontend/app/components/input-help.tsx
+++ b/frontend/app/components/input-help.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps, ReactNode } from 'react';
 
 import { cn } from '~/utils/tw-utils';
 
-export interface InputHelpProps extends ComponentProps<'span'> {
+export interface InputHelpProps extends ComponentProps<'div'> {
   children: ReactNode;
   id: string;
 }
@@ -10,8 +10,8 @@ export interface InputHelpProps extends ComponentProps<'span'> {
 export function InputHelp(props: InputHelpProps) {
   const { children, className, ...restProps } = props;
   return (
-    <span className={cn('block max-w-prose text-gray-500', className)} data-testid="input-help" {...restProps}>
+    <div className={cn('max-w-prose text-gray-500', className)} data-testid="input-help" {...restProps}>
       {children}
-    </span>
+    </div>
   );
 }


### PR DESCRIPTION
### Description
According to [HTML validator](https://validator.w3.org/), some of our markup is invalid.  This was reported by the ITAO.

### Related Azure Boards Work Items
[AB#5647](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5647)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
