### PR TITLE
fix(frontend): Fixing metric prefix transformation

### DIFF
--- a/frontend/app/.server/express-server/instrumentation.server.ts
+++ b/frontend/app/.server/express-server/instrumentation.server.ts
@@ -60,7 +60,7 @@ export function routeRequestCounter(): RequestHandler {
 
         if (routeId) {
           // Construct metric identifier (e.g., POST '/user/$id/profile' → 'user._id.profile.posts')
-          const metricPrefix = `${routeId.replaceAll('/', '.').replace(/.\$([^.]+)/g, '_$1')}.${req.method.toLowerCase()}s`;
+          const metricPrefix = `${routeId.replaceAll('/', '.').replace(/\$([^.]+)/g, '_$1')}.${req.method.toLowerCase()}s`;
           instrumentationService.countHttpStatus(metricPrefix, res.statusCode);
         }
       } catch (error) {


### PR DESCRIPTION
### Description
Before:
`public.apply_id.adult.mailing-address-en`

After:
`public.apply._id.adult.mailing-address-en`

### Screenshots
![image](https://github.com/user-attachments/assets/a636a96d-1941-430d-a37c-b5ea0316e80b)

### Checklist
- [x] I have tested the changes locally