### PR TITLE
refactor(frontend): Removing route-level counters from protected renew routes

### DIFF
--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -47,8 +47,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -101,8 +99,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.child-confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.confirm-federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: dentalBenefits,
     childName,
@@ -114,8 +110,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -185,7 +179,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalProvincialTerritorialBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.children.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -218,7 +211,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.confirm-federal-provincial-territorial-benefits', 302);
   return redirect(getPathById('protected/renew/$id/review-child-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/demographic-survey.tsx
@@ -46,8 +46,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateFeatureEnabled('demographic-survey');
@@ -76,8 +74,6 @@ export async function loader({ context: { appContainer, session }, request, para
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.child-demographic-survey', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.demographic-survey', 200);
-
   return {
     meta,
     indigenousStatuses,
@@ -94,8 +90,6 @@ export async function loader({ context: { appContainer, session }, request, para
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -149,7 +143,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.children.demographic-survey', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -167,8 +160,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-demographic-survey', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.children.demographic-survey', 302);
 
   if (state.editMode) {
     return redirect(getPathById('protected/renew/$id/review-child-information', params));

--- a/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/dental-insurance.tsx
@@ -34,8 +34,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -53,13 +51,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.child-dental-insurance', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -81,7 +76,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.children.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -99,8 +93,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-dental-insurance', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.children.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('protected/renew/$id/review-child-information', params));

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian-required.tsx
@@ -29,8 +29,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -41,13 +39,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.child-parent-or-guardian-required', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.parent-or-guardian-required', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -57,7 +52,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-parent-or-guardian-required', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.parent-or-guardian-required', 302);
   return redirect(getPathById('protected/renew/$id/member-selection', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/parent-or-guardian.tsx
@@ -39,8 +39,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -59,13 +57,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.child-parent-or-guardian', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.children.parent-or-guardian', 200);
   return { meta, defaultState: state.isParentOrLegalGuardian, childName, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -88,7 +83,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.children.parent-or-guardian', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -109,8 +103,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.child-parent-or-guardian', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.children.parent-or-guardian', 302);
 
   if (parsedDataResult.data.parentOrGuardian === PARENT_OR_GUARDIAN_OPTION.no) {
     return redirect(getPathById('protected/renew/$id/$childId/parent-or-guardian-required', params));

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -44,8 +44,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -53,19 +51,14 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-address', 404);
     throw new Response('Not Found', { status: 404 });
   }
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-address.page-title') }) };
-
-  instrumentationService.countHttpStatus('protected.renew.confirm-address', 200);
   return { meta, defaultState: { isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress }, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -84,7 +77,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-address', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -108,8 +100,6 @@ export async function action({ context: { appContainer, session }, params, reque
       homeAddress,
     },
   });
-
-  instrumentationService.countHttpStatus('protected.renew.confirm-address', 302);
 
   if (parsedDataResult.data.isHomeAddressSameAsMailingAddress === ADDRESS_RADIO_OPTIONS.no) {
     return redirect(getPathById('protected/renew/$id/confirm-home-address', params));

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -38,8 +38,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -61,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-communication-preference', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-communication-preference', 200);
-
   return {
     communicationMethodEmail,
     meta,
@@ -74,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -122,7 +116,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -136,7 +129,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-communication-preference', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-communication-preference', 302);
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -38,8 +38,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -51,13 +49,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-email', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-email', 200);
   return { meta, defaultState: { email: state.contactInformation?.email } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -96,7 +91,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-email', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -110,7 +104,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-email', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-email', 302);
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -54,15 +54,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
   const state = loadProtectedRenewState({ params, request, session });
 
   if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-federal-provincial-territorial-benefits', 404);
     throw new Response('Not Found', { status: 404 });
   }
 
@@ -104,8 +101,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: dentalBenefits,
     federalSocialPrograms,
@@ -117,8 +112,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -190,7 +183,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalProvincialTerritorialBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -217,8 +209,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-federal-provincial-territorial-benefits', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.confirm-federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -51,15 +51,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
   const state = loadProtectedRenewState({ params, request, session });
 
   if (!isInvitationToApplyClient(state.clientApplication) && !state.editMode) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-home-address', 404);
     throw new Response('Not Found', { status: 404 });
   }
 
@@ -74,8 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-home-address', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-home-address', 200);
-
   return {
     meta,
     defaultState: state.homeAddress,
@@ -86,8 +81,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -113,7 +106,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-home-address', 400);
     return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
@@ -131,7 +123,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const canProceedToReview = isNotCanada || isUseInvalidAddressAction || isUseSelectedAddressAction;
   if (canProceedToReview) {
     saveProtectedRenewState({ params, request, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-    instrumentationService.countHttpStatus('protected.renew.confirm-home-address', 302);
     if (state.editMode === false && isInvitationToApplyClient(state.clientApplication)) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
@@ -162,7 +153,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('protected.renew.confirm-home-address.address-invalid', 200);
     return {
       invalidAddress: formattedHomeAddress,
       status: 'address-invalid',
@@ -171,7 +161,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('protected.renew.confirm-home-address.address-suggestion', 200);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',
@@ -195,8 +184,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-home-address', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.confirm-home-address', 302);
 
   if (state.editMode === false && isInvitationToApplyClient(state.clientApplication)) {
     return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -49,8 +49,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -66,8 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-mailing-address', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address', 200);
-
   return {
     meta,
     defaultState: {
@@ -80,8 +76,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -107,7 +101,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!validatedResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address', 400);
     return data({ errors: validatedResult.errors }, { status: 400 });
   }
 
@@ -141,7 +134,6 @@ export async function action({ context: { appContainer, session }, params, reque
     const idToken: IdToken = session.get('idToken');
     appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-mailing-address', { userId: idToken.sub });
 
-    instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address', 302);
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }
 
@@ -169,7 +161,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address.address-invalid', 200);
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
@@ -178,7 +169,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address.address-suggestion', 200);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',
@@ -205,7 +195,6 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-mailing-address', 302);
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -38,8 +38,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -51,8 +49,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-phone', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-phone', 200);
-
   return {
     meta,
     defaultState: {
@@ -63,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -91,7 +85,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.confirm-phone', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -105,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-phone', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirm-phone', 302);
   return redirect(getPathById('protected/renew/$id/review-adult-information', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -35,8 +35,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -106,8 +104,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirmation', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirmation', 200);
-
   return {
     primaryApplicantInfo,
     children,
@@ -116,8 +112,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -132,7 +126,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirmation', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.confirmation', 302);
   return redirect(t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI }));
 }
 

--- a/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
+++ b/frontend/app/routes/protected/renew/$id/demographic-survey.tsx
@@ -46,8 +46,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateFeatureEnabled('demographic-survey');
@@ -74,8 +72,6 @@ export async function loader({ context: { appContainer, session }, request, para
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.demographic-survey', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.demographic-survey', 200);
-
   return {
     meta,
     indigenousStatuses,
@@ -91,8 +87,6 @@ export async function loader({ context: { appContainer, session }, request, para
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -145,7 +139,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.demographic-survey', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -162,8 +155,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.demographic-survey', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.demographic-survey', 302);
 
   if (state.editMode) {
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));

--- a/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
+++ b/frontend/app/routes/protected/renew/$id/dental-insurance.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -58,13 +56,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.dental-insurance', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.dental-insurance', 200);
   return { id: state, meta, defaultState: state.dentalInsurance, editMode: state.editMode, i18nOptions: { memberName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -78,7 +73,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
-    instrumentationService.countHttpStatus('protected.renew.dental-insurance', 302);
     if (isInvitationToApplyClient(state.clientApplication)) {
       return redirect(getPathById('protected/renew/$id/ita/confirm-email', params));
     }
@@ -95,7 +89,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -111,8 +104,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.dental-insurance', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));

--- a/frontend/app/routes/protected/renew/$id/file-taxes.tsx
+++ b/frontend/app/routes/protected/renew/$id/file-taxes.tsx
@@ -32,8 +32,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -45,13 +43,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.file-taxes', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.file-taxes', 200);
   return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -66,7 +61,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.file-taxes', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.file-taxes', 302);
   return redirect(t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI }));
 }
 

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -202,8 +200,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.review-adult-information', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.review-adult-information', 200);
-
   return {
     userInfo,
     spouseInfo,
@@ -218,8 +214,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -227,7 +221,6 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearProtectedRenewState({ params, request, session });
-    instrumentationService.countHttpStatus('protected.renew.review-adult-information', 302);
     throw redirect(getPathById('protected/unable-to-process-request', params));
   });
 
@@ -235,8 +228,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
 
   const state = loadProtectedRenewState({ params, request, session });
-
-  instrumentationService.countHttpStatus('protected.renew.review-adult-information', 302);
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {

--- a/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-and-submit.tsx
@@ -44,8 +44,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -78,8 +76,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         .get(TYPES.domain.mappers.BenefitRenewalDtoMapper)
         .mapProtectedBenefitRenewalDtoToBenefitRenewalRequestEntity(appContainer.get(TYPES.routes.mappers.BenefitRenewalStateMapper).mapProtectedRenewStateToProtectedBenefitRenewalDto(copiedState, userInfoToken.sub, isPrimaryApplicantStateComplete(state,demographicSurveyEnabled)));
 
-  instrumentationService.countHttpStatus('protected.renew.review-and-submit', 200);
-
   return {
     meta,
     primaryApplicantName,
@@ -91,15 +87,12 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearProtectedRenewState({ params, request, session });
-    instrumentationService.countHttpStatus('protected.renew.review-and-submit', 302);
     throw redirect(getPathById('protected/unable-to-process-request', params));
   });
 
@@ -111,7 +104,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
-    instrumentationService.countHttpStatus('protected.renew.review-and-submit', 302);
     if (!primaryApplicantStateCompleted || validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled).length === 0) {
       return redirect(getPathById('protected/renew/$id/review-adult-information', params));
     }
@@ -133,7 +125,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.review-and-submit', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.review-and-submit', 302);
   return redirect(getPathById('protected/renew/$id/confirmation', params));
 }
 

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -41,8 +41,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -108,13 +106,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  instrumentationService.countHttpStatus('protected.renew.review-child-information', 200);
   return { children, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -123,7 +118,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearProtectedRenewState({ params, request, session });
-    instrumentationService.countHttpStatus('protected.renew.review-child-information', 302);
     throw redirect(getPathById('protected/unable-to-process-request', params));
   });
 
@@ -133,8 +127,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.review-child-information', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.review-child-information', 302);
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {

--- a/frontend/app/routes/protected/renew/$id/tax-filing.tsx
+++ b/frontend/app/routes/protected/renew/$id/tax-filing.tsx
@@ -39,8 +39,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -52,13 +50,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.tax-filing', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.tax-filing', 200);
   return { meta, defaultState: state.taxFiling, taxYear: state.applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -78,7 +73,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('protected.renew.tax-filing', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -91,8 +85,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.tax-filing', { userId: idToken.sub });
-
-  instrumentationService.countHttpStatus('protected.renew.tax-filing', 302);
 
   if (parsedDataResult.data.taxFiling === TAX_FILING_OPTION.no) {
     return redirect(getPathById('protected/renew/$id/file-taxes', params));

--- a/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/protected/renew/$id/terms-and-conditions.tsx
@@ -33,8 +33,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
@@ -46,13 +44,10 @@ export async function loader({ context: { appContainer, session }, request, para
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.terms-and-conditions', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.terms-and-conditions', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, request, params }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -69,7 +64,6 @@ export async function action({ context: { appContainer, session }, request, para
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.terms-and-conditions', { userId: idToken.sub });
 
-  instrumentationService.countHttpStatus('protected.renew.terms-and-conditions', 302);
   return redirect(getPathById('protected/renew/$id/tax-filing', params));
 }
 


### PR DESCRIPTION
### Description
Incremental PR to remove route-level counters from all applicable routes.
These counters are redundant as a result of #3580

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`