### PR TITLE
fix(frontend) descriptive aria-label for edit and remove buttons in children/index routes

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/children/index.tsx
@@ -226,6 +226,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('protected-apply-adult-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -238,7 +239,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('protected-apply-adult-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('protected-apply-adult-child:children.index.modal.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/app/routes/protected/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/index.tsx
@@ -190,6 +190,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('protected-apply-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -202,7 +203,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('protected-apply-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('protected-apply-child:children.index.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -212,6 +212,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('apply-adult-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -224,7 +225,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('apply-adult-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('apply-adult-child:children.index.modal.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -177,6 +177,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('apply-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -189,7 +190,7 @@ export default function ApplyFlowChildSummary({ loaderData, params }: Route.Comp
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('apply-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('apply-child:children.index.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -194,6 +194,7 @@ export default function RenewFlowChildSummary({ loaderData, params }: Route.Comp
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('renew-adult-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -206,7 +207,7 @@ export default function RenewFlowChildSummary({ loaderData, params }: Route.Comp
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('renew-adult-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('renew-adult-child:children.index.modal.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -177,6 +177,7 @@ export default function RenewChildIndex({ loaderData, params }: Route.ComponentP
                   <div className="flex flex-wrap items-center gap-3">
                     <ButtonLink
                       id="edit-child"
+                      aria-label={t('renew-child:children.index.edit-child-aria', { childName })}
                       disabled={isSubmitting}
                       size="sm"
                       variant="alternative"
@@ -189,7 +190,7 @@ export default function RenewChildIndex({ loaderData, params }: Route.ComponentP
                     </ButtonLink>
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button aria-expanded={undefined} id="remove-child" disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
+                        <Button aria-expanded={undefined} id="remove-child" aria-label={t('renew-child:children.index.remove-child-aria', { childName })} disabled={isSubmitting} size="sm" variant="alternative" startIcon={faRemove}>
                           {t('renew-child:children.index.modal.remove-btn')}
                         </Button>
                       </DialogTrigger>

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -153,6 +153,8 @@
       "add-child": "Add a child",
       "add-another-child": "Add another child",
       "remove-child": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -139,6 +139,8 @@
       "add-child": "Add a child",
       "add-another-child": "Add another child",
       "remove-btn": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/protected-apply-adult-child.json
+++ b/frontend/public/locales/en/protected-apply-adult-child.json
@@ -153,6 +153,8 @@
       "add-child": "Add a child",
       "add-another-child": "Add another child",
       "remove-child": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/protected-apply-child.json
+++ b/frontend/public/locales/en/protected-apply-child.json
@@ -139,6 +139,8 @@
       "add-child": "Add a child",
       "add-another-child": "Add another child",
       "remove-btn": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -270,6 +270,8 @@
       "add-child": "Renew a child",
       "add-another-child": "Renew another child",
       "remove-child": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -11,6 +11,8 @@
       "add-child": "Renew a child",
       "add-another-child": "Renew another child",
       "remove-child": "Remove child",
+      "edit-child-aria": "Edit child's information {{childName}}",
+      "remove-child-aria": "Remove child {{childName}}",
       "back-btn": "Back",
       "continue-btn": "Continue with application",
       "cancel-btn": "Cancel",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -153,6 +153,8 @@
       "add-child": "Ajouter un enfant",
       "add-another-child": "Ajouter un autre enfant",
       "remove-child": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Continuer avec la demande",
       "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -139,6 +139,8 @@
       "add-child": "Ajouter un enfant",
       "add-another-child": "Ajouter un autre enfant",
       "remove-btn": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Continuer avec la demande",
       "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/protected-apply-adult-child.json
+++ b/frontend/public/locales/fr/protected-apply-adult-child.json
@@ -153,6 +153,8 @@
       "add-child": "Ajouter un enfant",
       "add-another-child": "Ajouter un autre enfant",
       "remove-child": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Continuer avec la demande",
       "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/protected-apply-child.json
+++ b/frontend/public/locales/fr/protected-apply-child.json
@@ -139,6 +139,8 @@
       "add-child": "Ajouter un enfant",
       "add-another-child": "Ajouter un autre enfant",
       "remove-btn": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Continuer avec la demande",
       "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -271,6 +271,8 @@
       "add-child": "Renouveler pour un enfant",
       "add-another-child": "Renouveler pour un autre enfant",
       "remove-child": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Poursuivre la demande",
       "cancel-btn": "Annuler",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -11,6 +11,8 @@
       "add-child": "Renouveler pour un enfant",
       "add-another-child": "Renouveler pour un autre enfant",
       "remove-child": "Retirer l'enfant",
+      "edit-child-aria": "Modifier les renseignements sur l'enfant {{childName}}",
+      "remove-child-aria": "Retirer l'enfant {{childName}}",
       "back-btn": "Retour",
       "continue-btn": "Poursuivre la demande",
       "cancel-btn": "Annuler",


### PR DESCRIPTION
### Description
Screen readers will not discern for which child the "edit child information" and "remove child" buttons.  A sighted user can easily see which buttons belong to which sections, but for a user using a screen reader, this may be less intuitive.  This change was recommended by the ITAO to add an aria-label with the child's name on the edit/remove buttons to remove the ambiguity for users of assisted technology.

### Related Azure Boards Work Items
AB#5647
