### PR TITLE
Adding protected adult-child e2e tests.

### DIFF
--- a/frontend/e2e/models/protected/PlaywrightApplyAdultChildPage.ts
+++ b/frontend/e2e/models/protected/PlaywrightApplyAdultChildPage.ts
@@ -1,0 +1,140 @@
+import { PlaywrightBasePage } from '../PlaywrightBasePage';
+
+export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
+  async isLoaded(
+    applyAdultChildPage:
+      | 'applicant-information'
+      | 'marital-status'
+      | 'mailing-address'
+      | 'home-address'
+      | 'phone-number'
+      | 'children-cannot-apply-child'
+      | 'children-dental-insurance'
+      | 'children-confirm-federal-provincial-territorial-benefits'
+      | 'children-federal-provincial-territorial-benefits'
+      | 'children-information'
+      | 'children-parent-or-guardian'
+      | 'children'
+      | 'confirmation'
+      | 'communication-preference'
+      | 'email'
+      | 'verify-email'
+      | 'date-of-birth'
+      | 'dental-insurance'
+      | 'dob-eligibility'
+      | 'confirm-federal-provincial-territorial-benefits'
+      | 'federal-provincial-territorial-benefits'
+      | 'living-independently'
+      | 'parent-or-guardian'
+      | 'review-adult-information'
+      | 'review-child-information'
+      | 'new-or-existing-member',
+    heading?: string | RegExp,
+  ) {
+    let pageInfo: { url: string | RegExp; heading: string | RegExp } | undefined = undefined;
+
+    switch (applyAdultChildPage) {
+      case 'applicant-information':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/applicant-information/, heading: 'Applicant information' };
+        break;
+
+      case 'marital-status':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/marital-status/, heading: 'Marital Status' };
+        break;
+
+      case 'mailing-address':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/mailing-address/, heading: 'Mailing Address' };
+        break;
+
+      case 'home-address':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/home-address/, heading: 'Home Address' };
+        break;
+
+      case 'phone-number':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/phone-number/, heading: 'Phone Number' };
+        break;
+
+      case 'communication-preference':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/communication-preference/, heading: 'Communication' };
+        break;
+
+      case 'email':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/email/, heading: 'Email' };
+        break;
+      case 'verify-email':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/verify-email/, heading: 'Verify your email address' };
+        break;
+
+      case 'children':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children/, heading: "Child(ren)'s application" };
+        break;
+
+      case 'children-cannot-apply-child':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/cannot-apply-child/, heading: 'Your child must apply' };
+        break;
+
+      case 'children-dental-insurance':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/dental-insurance/, heading: /.*: access to private dental insurance/ };
+        break;
+
+      case 'children-confirm-federal-provincial-territorial-benefits':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/confirm-federal-provincial-territorial-benefits/, heading: /.*: access to other government dental benefits/ };
+        break;
+
+      case 'children-federal-provincial-territorial-benefits':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/federal-provincial-territorial-benefits/, heading: /.*: access to other federal, provincial or territorial dental benefits/ };
+        break;
+
+      case 'children-information':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/information/, heading: /.*: information/ };
+        break;
+
+      case 'children-parent-or-guardian':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/children\/[a-f0-9-]+\/parent-or-guardian/, heading: 'You must be a parent or legal guardian' };
+        break;
+
+      case 'confirmation':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/confirmation/, heading: 'Application successfully submitted' };
+        break;
+
+      case 'dental-insurance':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/dental-insurance/, heading: 'Access to private dental insurance' };
+        break;
+
+      case 'confirm-federal-provincial-territorial-benefits':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/confirm-federal-provincial-territorial-benefits/, heading: 'Access to other government dental benefits' };
+        break;
+
+      case 'federal-provincial-territorial-benefits':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/federal-provincial-territorial-benefits/, heading: 'Access to other federal, provincial or territorial dental benefits' };
+        break;
+
+      case 'living-independently':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/living-independently/, heading: 'Living independently' };
+        break;
+
+      case 'parent-or-guardian':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/parent-or-guardian/, heading: 'Parent or legal guardian needs to apply' };
+        break;
+
+      case 'new-or-existing-member':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/new-or-existing-member/, heading: 'New or existing member' };
+        break;
+
+      case 'review-adult-information':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/review-adult-information/, heading: 'Review your information' };
+        break;
+
+      case 'review-child-information':
+        pageInfo = { url: /\/en\/protected\/apply\/[a-f0-9-]+\/adult-child\/review-child-information/, heading: 'Review child(ren) information' };
+        break;
+
+      default:
+        pageInfo = undefined;
+        break;
+    }
+
+    if (!pageInfo) throw Error(`applyAdultChildPage '${applyAdultChildPage}' not implemented.`);
+    await super.isLoaded(pageInfo.url, heading ?? pageInfo.heading);
+  }
+}

--- a/frontend/e2e/protected/apply/adult-category.spec.ts
+++ b/frontend/e2e/protected/apply/adult-category.spec.ts
@@ -33,7 +33,7 @@ test.describe('Adult category', () => {
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
-            const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(35);
       await fillApplicantInformationForm({ firstName: 'John', lastName: 'Smith', sin: '900000001', day: day, month: month, year: year, dtcEligible: true, page });
 
       // DTC question

--- a/frontend/e2e/protected/apply/adult-child-category.spec.ts
+++ b/frontend/e2e/protected/apply/adult-child-category.spec.ts
@@ -1,11 +1,11 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../models/protected/PlaywrightApplyAdultPage';
+import { PlaywrightApplyAdultChildPage } from '../../models/protected/PlaywrightApplyAdultChildPage';
 import { PlaywrightApplyPage } from '../../models/protected/PlaywrightApplyPage';
-import { acceptLegalCheckboxes, calculateDOB, clickContinue, fillApplicantInformationForm, fillOutAddress } from '../../utils/helpers';
+import { acceptLegalCheckboxes, calculateDOB, clickContinue, fillApplicantInformationForm, fillChildrenInformationForm, fillOutAddress } from '../../utils/helpers';
 
-test.describe('Adult category', () => {
-  test.beforeEach('Navigate to adult application', async ({ page }) => {
+test.describe('Adult-Child category', () => {
+  test.beforeEach('Navigate to adult-child application', async ({ page }) => {
     test.setTimeout(60000);
 
     const applyPage = new PlaywrightApplyPage(page);
@@ -23,21 +23,19 @@ test.describe('Adult category', () => {
 
     // Type of Application
     await applyPage.isLoaded('type-application');
-    await page.getByRole('radio', { name: 'I am applying for myself', exact: true }).check();
+    await page.getByRole('radio', { name: 'I am applying for myself and my child(ren)', exact: true }).check();
     await clickContinue(page);
   });
 
   // TODO: Add test cases for living-independently and new-or-existing-user
-  test('Should complete flow as adult applicant', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+  test('Should complete flow as adult-child applicant', async ({ page }) => {
+    const applyAdultPage = new PlaywrightApplyAdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
-            const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(35);
       await fillApplicantInformationForm({ firstName: 'John', lastName: 'Smith', sin: '900000001', day: day, month: month, year: year, dtcEligible: true, page });
 
-      // DTC question
-      await page.getByRole('radio', { name: 'Yes', exact: true }).check();
       await clickContinue(page);
     });
 
@@ -121,8 +119,54 @@ test.describe('Adult category', () => {
       await clickContinue(page);
     });
 
-    await test.step('Should navigate to review informaton page', async () => {
-      await applyAdultPage.isLoaded('review-information');
+    await test.step('Should navigate to children page', async () => {
+      await applyAdultPage.isLoaded('children');
+      const addChildButton = page.getByRole('button', { name: 'Add a child' });
+      await addChildButton.click();
+    });
+
+    await test.step('Should navigate to children-information page', async () => {
+      await applyAdultPage.isLoaded('children-information');
+      const { year, month, day } = calculateDOB(10);
+      await fillChildrenInformationForm({ firstName: 'John Jr.', lastName: 'Smith', sin: '800000002', day: day, month: month, year: year, hasSin: true, isGuardian: true, page });
+      await clickContinue(page);
+    });
+
+    await test.step('Should navigate to children-dental-insurance page', async () => {
+      await applyAdultPage.isLoaded('children-dental-insurance');
+      await page.getByRole('radio', { name: 'Yes, this child has access to dental insurance or coverage', exact: true }).check();
+      await clickContinue(page);
+    });
+
+    await test.step('Should navigate to children-confirm-federal-provincial-territorial-benefits page', async () => {
+      await applyAdultPage.isLoaded('children-confirm-federal-provincial-territorial-benefits');
+      await page.getByRole('radio', { name: 'Yes, this child has federal, provincial or territorial dental benefits', exact: true }).check();
+      await clickContinue(page);
+    });
+
+    await test.step('Should navigate to children-federal-provincial-territorial-benefits page', async () => {
+      await applyAdultPage.isLoaded('children-federal-provincial-territorial-benefits');
+      await page.getByTestId('input-radio-has-federal-benefits-option-0').check();
+      await page.getByTestId('input-radio-federal-social-programs-option-0').check();
+      await page.getByTestId('input-radio-has-provincial-territorial-benefits-option-0').check();
+      await page.getByTestId('input-province-test').selectOption('Alberta');
+      await page.getByTestId('input-radio-provincial-territorial-social-programs-option-0').check();
+      await clickContinue(page);
+    });
+
+    await test.step('Should navigate to children page', async () => {
+      await applyAdultPage.isLoaded('children');
+      const continueButton = page.getByRole('button', { name: 'Continue with application' });
+      await continueButton.click();
+    });
+
+    await test.step('Should navigate to review adult informaton page', async () => {
+      await applyAdultPage.isLoaded('review-adult-information');
+      await clickContinue(page);
+    });
+
+    await test.step('Should navigate to review child informaton page', async () => {
+      await applyAdultPage.isLoaded('review-child-information');
       await page.getByRole('button', { name: 'Submit Application' }).click();
     });
 

--- a/frontend/e2e/utils/helpers.ts
+++ b/frontend/e2e/utils/helpers.ts
@@ -10,6 +10,29 @@ interface FillOutAddressArgs {
   province: string;
 }
 
+interface fillApplicantInformationFormArgs {
+  firstName: string;
+  lastName: string;
+  sin: string;
+  day: string;
+  month: string;
+  year: string;
+  dtcEligible: boolean;
+  page: Page;
+}
+
+interface fillChildrenInformationFormArgs {
+  firstName: string;
+  lastName: string;
+  sin: string;
+  day: string;
+  month: string;
+  year: string;
+  hasSin: boolean;
+  isGuardian: boolean;
+  page: Page;
+}
+
 // Reusable function to fill out address
 export async function fillOutAddress({ address, city, country, page, postalCode, province }: FillOutAddressArgs) {
   await page.getByRole('textbox', { name: 'Address', exact: true }).fill(address);
@@ -42,4 +65,37 @@ export async function clickContinue(page: Page) {
   const continueButton = page.getByRole('button', { name: 'Continue' });
   await expect(continueButton).toBeEnabled();
   await continueButton.click();
+}
+
+export async function fillApplicantInformationForm({ firstName, lastName, sin, day, month, year, dtcEligible, page }: fillApplicantInformationFormArgs) {
+  await page.getByRole('textbox', { name: 'First name' }).fill(firstName);
+  await page.getByRole('textbox', { name: 'Last name' }).fill(lastName);
+  await page.getByRole('textbox', { name: 'Social Insurance Number (SIN)' }).fill(sin);
+  await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
+  await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
+  await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);
+  if (dtcEligible) {
+    await page.getByRole('radio', { name: 'Yes', exact: true }).check();
+  } else {
+    await page.getByRole('radio', { name: 'No', exact: true }).check();
+  }
+}
+
+export async function fillChildrenInformationForm({ firstName, lastName, sin, day, month, year, hasSin, isGuardian, page }: fillChildrenInformationFormArgs) {
+  await page.getByRole('textbox', { name: 'First name' }).fill(firstName);
+  await page.getByRole('textbox', { name: 'Last name' }).fill(lastName);
+  await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
+  await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
+  await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);
+  if (hasSin) {
+    await page.getByRole('radio', { name: "Yes, enter the child's 9-digit SIN", exact: true }).check();
+    await page.getByRole('textbox', { name: 'Enter the 9-digit SIN' }).fill(sin);
+  } else {
+    await page.getByRole('radio', { name: 'No, this child does not have a SIN', exact: true }).check();
+  }
+  if (isGuardian) {
+    await page.getByRole('radio', { name: 'Yes', exact: true }).check();
+  } else {
+    await page.getByRole('radio', { name: 'No', exact: true }).check();
+  }
 }


### PR DESCRIPTION
### Description
As per title.

Only adding "Happy path". Will add conditional paths soon.

### Question

I've added `fillChildrenInformationForm` and `fillApplicantInformationForm` in our `utils/helpers.ts`. 

In our public e2e tests, these functions are in their models respectfully.  
Example: `frontend/e2e/models/PlaywrightApplyAdultChildPage.ts`

I'll remove the `fillApplicantInformation` and use the generic one in the `utils/helpers.ts` in a future PR. Any objections?