### PR TITLE
ESDCCM#21276 -- Removed confirmation email text

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
@@ -219,7 +219,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
@@ -184,7 +184,6 @@ export default function ProtectedApplyFlowConfirm({ loaderData, params }: Route.
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -199,7 +199,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
       </ContextualAlert>
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -210,7 +210,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -176,7 +176,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -192,7 +192,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
       </ContextualAlert>
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.keep-copy')}</h2>
-        <p className="mt-4">{t('confirm.print-copy-text')}</p>
         <p className="mt-4">{t('confirm.print-copy-important')}</p>
         <Button
           variant="primary"

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -382,7 +382,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -136,7 +136,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -376,7 +376,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/en/protected-apply-adult-child.json
+++ b/frontend/public/locales/en/protected-apply-adult-child.json
@@ -382,7 +382,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/en/protected-apply-adult.json
+++ b/frontend/public/locales/en/protected-apply-adult.json
@@ -136,7 +136,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/en/protected-apply-child.json
+++ b/frontend/public/locales/en/protected-apply-child.json
@@ -374,7 +374,6 @@
     "app-code-is": "Your application code is:",
     "make-note": "Save this code, you'll need it to check the status of your application.",
     "keep-copy": "Print or save a copy of your application",
-    "print-copy-text": "If you provided an email address, you will receive a confirmation email. It may take up to one hour to receive this email.",
     "print-copy-important": "It is important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -382,7 +382,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -136,7 +136,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -376,7 +376,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/protected-apply-adult-child.json
+++ b/frontend/public/locales/fr/protected-apply-adult-child.json
@@ -382,7 +382,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/protected-apply-adult.json
+++ b/frontend/public/locales/fr/protected-apply-adult.json
@@ -136,7 +136,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/protected-apply-child.json
+++ b/frontend/public/locales/fr/protected-apply-child.json
@@ -374,7 +374,6 @@
     "app-code-is": "Votre code de demande est\u00a0:",
     "make-note": "Prenez ce code en note, car vous en aurez besoin pour vérifier l'état de votre demande.",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande",
-    "print-copy-text": "Si vous avez fourni votre adresse courriel, vous recevrez un courriel de confirmation. Le courriel peut prendre jusqu'à une heure avant d'arriver.",
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -334,7 +334,7 @@
   "confirm": {
     "page-title": "Votre demande de renouvellement au Régime canadien de soins dentaires est terminée!",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande.",
-    "print-copy-text": "Vous ne recevrez pas de courriel de confirmation. Il est important de conserver une copie de votre demande.",
+    "print-copy-text": "Vous ne recevrez <strong>pas</strong> de courriel de confirmation. Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer",
     "print-or-save-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -448,7 +448,7 @@
   "confirm": {
     "page-title": "Votre demande de renouvellement au Régime canadien de soins dentaires est terminée!",
     "keep-copy": "Imprimez ou sauvegardez une copie de votre demande.",
-    "print-copy-text": "Vous ne recevrez pas de courriel de confirmation. Il est important de conserver une copie de votre demande.",
+    "print-copy-text": "Vous ne recevrez <strong>pas</strong> de courriel de confirmation. Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer",
     "print-or-save-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",


### PR DESCRIPTION
### Description
Removed confirmation email text from confirm pages to match figma design

Fixed missing formatting for french renew confirm page text

### Related Azure Boards Work Items
[ESDCCM#21276](https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/21276)
