### PR TITLE
refactor(frontend): Removing route-level counters from common public apply routes

### DIFF
--- a/frontend/__tests__/routes/public/tax-filing.test.tsx
+++ b/frontend/__tests__/routes/public/tax-filing.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { TYPES } from '~/.server/constants';
-import type { InstrumentationService } from '~/.server/observability';
 import type { SecurityHandler } from '~/.server/routes/security';
 import { action, loader } from '~/routes/public/apply/$id/tax-filing';
 
@@ -29,10 +28,7 @@ describe('_public.apply.id.tax-filing', () => {
 
   describe('loader()', () => {
     it('should load id, and hasFiledTaxes', async () => {
-      const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
-
-      const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/tax-filing'), context: mockContext, params: { id: '123', lang: 'en' } });
+      const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/tax-filing'), context: mock<AppLoadContext>(), params: { id: '123', lang: 'en' } });
 
       expect(response).toMatchObject({ meta: {}, defaultState: true });
     });
@@ -41,7 +37,6 @@ describe('_public.apply.id.tax-filing', () => {
   describe('action()', () => {
     it('should validate missing tax filing selection', async () => {
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: new FormData() }), context: mockContext, params: { id: '123', lang: 'en' } });
@@ -54,7 +49,6 @@ describe('_public.apply.id.tax-filing', () => {
       formData.append('hasFiledTaxes', 'yes');
 
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }), context: mockContext, params: { lang: 'en', id: '123' } });
@@ -69,7 +63,6 @@ describe('_public.apply.id.tax-filing', () => {
       formData.append('hasFiledTaxes', 'no');
 
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/tax-filing', { method: 'POST', body: formData }), context: mockContext, params: { lang: 'en', id: '123' } });

--- a/frontend/__tests__/routes/public/type-application.test.tsx
+++ b/frontend/__tests__/routes/public/type-application.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { TYPES } from '~/.server/constants';
-import type { InstrumentationService } from '~/.server/observability';
 import type { SecurityHandler } from '~/.server/routes/security';
 import { action, loader } from '~/routes/public/apply/$id/type-application';
 
@@ -19,20 +18,16 @@ describe('_public.apply.id.type-of-application', () => {
   });
 
   describe('loader()', () => {
-    it('should load id and typeOfApplication', async () => {
-      const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
-
-      const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application'), context: mockContext, params: { id: '123', lang: 'en' } });
+    it('should load id, and typeOfApplication', async () => {
+      const response = await loader({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application'), context: mock<AppLoadContext>(), params: { id: '123', lang: 'en' } });
 
       expect(response).toMatchObject({ meta: { title: 'gcweb:meta.title.template' }, defaultState: 'delegate' });
     });
   });
 
   describe('action()', () => {
-    it('should validate missing application type selection', async () => {
+    it('should validate missing applcation type selection', async () => {
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: new FormData() }), context: mockContext, params: { id: '123', lang: 'en' } });
@@ -45,7 +40,6 @@ describe('_public.apply.id.type-of-application', () => {
       formData.append('typeOfApplication', 'delegate');
 
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: formData }), context: mockContext, params: { lang: 'en', id: '123' } });
@@ -60,7 +54,6 @@ describe('_public.apply.id.type-of-application', () => {
       formData.append('typeOfApplication', 'adult');
 
       const mockContext = mockDeep<AppLoadContext>();
-      mockContext.appContainer.get.calledWith(TYPES.observability.InstrumentationService).mockReturnValueOnce(mock<InstrumentationService>());
       mockContext.appContainer.get.calledWith(TYPES.routes.security.SecurityHandler).mockReturnValueOnce(mock<SecurityHandler>());
 
       const response = await action({ request: new Request('http://localhost:3000/en/apply/123/adult/type-of-application', { method: 'POST', body: formData }), context: mockContext, params: { lang: 'en', id: '123' } });

--- a/frontend/app/routes/public/apply/$id/application-delegate.tsx
+++ b/frontend/app/routes/public/apply/$id/application-delegate.tsx
@@ -31,18 +31,13 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:application-delegate.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.application-delegate', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -52,7 +47,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   clearApplyState({ params, session });
 
-  instrumentationService.countHttpStatus('public.apply.application-delegate', 302);
   return redirect(t('apply:application-delegate.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/file-taxes.tsx
+++ b/frontend/app/routes/public/apply/$id/file-taxes.tsx
@@ -27,20 +27,15 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const { applicationYear } = loadApplyState({ params, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:file-your-taxes.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.file-taxes', 200);
   return { meta, taxYear: applicationYear.taxYear };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,8 +44,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.file-taxes', 302);
   return redirect(t('apply:file-your-taxes.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/index.tsx
+++ b/frontend/app/routes/public/apply/$id/index.tsx
@@ -2,17 +2,12 @@ import { redirect } from 'react-router';
 
 import type { Route } from './+types/index';
 
-import { TYPES } from '~/.server/constants';
 import { loadApplyState, saveApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getPathById } from '~/utils/route-utils';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   loadApplyState({ params, session });
   saveApplyState({ params, session, state: {} });
-
-  instrumentationService.countHttpStatus('public.apply', 302);
   return redirect(getPathById('public/apply/$id/terms-and-conditions', params));
 }

--- a/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
+++ b/frontend/app/routes/public/apply/$id/terms-and-conditions.tsx
@@ -39,19 +39,13 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request, params }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:terms-and-conditions.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.terms-and-conditions', 200);
   return { defaultState: state.termsAndConditions, meta };
 }
 
 export async function action({ context: { appContainer, session }, request, params }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -93,7 +87,6 @@ export async function action({ context: { appContainer, session }, request, para
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.terms-and-conditions', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -104,8 +97,6 @@ export async function action({ context: { appContainer, session }, request, para
       termsAndConditions: parsedDataResult.data,
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.terms-and-conditions', 302);
   return redirect(getPathById('public/apply/$id/tax-filing', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/type-application.tsx
+++ b/frontend/app/routes/public/apply/$id/type-application.tsx
@@ -35,20 +35,15 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:type-of-application.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.type-application', 200);
   return { meta, defaultState: state.typeOfApplication };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -64,13 +59,10 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = typeOfApplicationSchema.safeParse({ typeOfApplication: String(formData.get('typeOfApplication') ?? '') });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.type-application', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { editMode: false, typeOfApplication: parsedDataResult.data.typeOfApplication } });
-
-  instrumentationService.countHttpStatus('public.apply.type-application', 302);
 
   if (parsedDataResult.data.typeOfApplication === APPLICANT_TYPE.adult) {
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));

--- a/frontend/app/routes/public/apply/index.tsx
+++ b/frontend/app/routes/public/apply/index.tsx
@@ -28,8 +28,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
@@ -41,7 +39,6 @@ export async function loader({ context: { appContainer, session }, request }: Ro
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply:index.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply', 200);
   return { id: state.id, locale, meta };
 }
 


### PR DESCRIPTION
### Description
Incremental PR to remove route-level counters from all applicable routes.
These counters are redundant as a result of #3580

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`