### PR TITLE
refactor(frontend): Removing route-level counters from public apply child routes

### DIFF
--- a/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/applicant-information.tsx
@@ -50,20 +50,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:applicant-information.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.applicant-information', 200);
   return { meta, defaultState: state.applicantInformation, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -76,7 +70,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
-    instrumentationService.countHttpStatus('public.apply.child.applicant-information', 302);
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
   }
 
@@ -149,7 +142,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.applicant-information', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -191,8 +183,6 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.child.applicant-information', 302);
 
   if (ageCategory === 'children') {
     return redirect(getPathById('public/apply/$id/child/contact-apply-child', params));

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/cannot-apply-child.tsx
@@ -29,26 +29,20 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:children.cannot-apply-child.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.cannot-apply-child', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  instrumentationService.countHttpStatus('public.apply.child.children.cannot-apply-child', 302);
   return redirect(getPathById('public/apply/$id/child/children/index', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -41,8 +41,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -54,8 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-child:children.confirm-dental-benefits.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.confirm-federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefits,
     editMode: state.editMode,
@@ -66,8 +62,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -90,7 +84,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.children.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -115,8 +108,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.children.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefits === true) {
     return redirect(getPathById('public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/dental-insurance.tsx
@@ -35,8 +35,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,13 +46,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -73,7 +68,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.children.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -87,8 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.children.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -55,8 +55,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplySingleChildState({ params, request, session });
 
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
@@ -76,8 +74,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-child:children.dental-benefits.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -91,8 +87,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -119,8 +113,6 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
-
-    instrumentationService.countHttpStatus('public.apply.child.children.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/child/review-child-information', params));
   }
 
@@ -180,7 +172,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.children.federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -208,8 +199,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.children.federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/information.tsx
@@ -53,8 +53,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -66,13 +64,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-child:children.information.page-title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.information', 200);
   return { meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -187,7 +182,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success || !parsedSinDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.children.information', 400);
     return data(
       {
         errors: {
@@ -215,8 +209,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.children.information', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/parent-or-guardian.tsx
@@ -31,20 +31,15 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   loadApplySingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:children.parent-or-guardian.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.child.children.parent-or-guardian', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -55,8 +50,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.child.children.parent-or-guardian', 302);
   return redirect(t('apply-child:children.parent-or-guardian.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -41,8 +41,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -60,7 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
         ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
         : undefined;
 
-    instrumentationService.countHttpStatus('public.apply.child.children', 200);
     return { ...child, dentalBenefits: { ...child.dentalBenefits, federalSocialProgram: federalGovernmentInsurancePlanService?.name, provincialTerritorialSocialProgram: provincialTerritorialSocialProgram?.name } };
   });
 
@@ -68,8 +65,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -77,8 +72,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyChildState({ params, request, session });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-
-  instrumentationService.countHttpStatus('public.apply.child.children', 302);
 
   if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -49,8 +47,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const preferredLanguages = appContainer.get(TYPES.domain.services.PreferredLanguageService).listAndSortLocalizedPreferredLanguages(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:communication-preference.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.communication-preference', 200);
 
   return {
     meta,
@@ -63,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -86,11 +80,8 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  instrumentationService.countHttpStatus('public.apply.child.communication-preference', 302);
 
   if (state.editMode) {
     if (parsedDataResult.data.preferredMethod !== PREFERRED_SUN_LIFE_METHOD.email && parsedDataResult.data.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail) {

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -137,8 +135,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:confirm.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.child.confirmation', 200);
-
   return {
     children,
     homeAddressInfo,
@@ -151,8 +147,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -162,8 +156,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadApplyChildState({ params, request, session });
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.child.confirmation', 302);
   return redirect(t('confirm.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/child/contact-apply-child.tsx
@@ -34,8 +34,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -45,17 +43,13 @@ export async function loader({ context: { appContainer, session }, params, reque
   const ageCategory = state.editModeApplicantInformation?.dateOfBirth ? getAgeCategoryFromDateString(state.editModeApplicantInformation.dateOfBirth) : getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children') {
-    instrumentationService.countHttpStatus('public.apply.child.contact-apply-child', 302);
     return redirect(getPathById('public/apply/$id/child/applicant-information', params));
   }
 
-  instrumentationService.countHttpStatus('public.apply.child.contact-apply-child', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -63,7 +57,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  instrumentationService.countHttpStatus('public.apply.child.contact-apply-child', 302);
   return redirect(t('apply-child:contact-apply-child.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/email.tsx
+++ b/frontend/app/routes/public/apply/$id/child/email.tsx
@@ -39,14 +39,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:email.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.email', 200);
 
   return {
     meta,
@@ -56,8 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -88,7 +82,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.email', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -107,8 +100,6 @@ export async function action({ context: { appContainer, session }, params, reque
       userId: 'anonymous',
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.child.email', 302);
 
   if (state.editMode) {
     // Redirect to /verify-email only if emailVerified is false

--- a/frontend/app/routes/public/apply/$id/child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/child/exit-application.tsx
@@ -29,20 +29,15 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const { id } = loadApplyChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:exit-application.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.child.exit-application', 200);
   return { id, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -51,8 +46,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.child.exit-application', 302);
   return redirect(t('exit-application.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -51,8 +51,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -61,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.home-address.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.home-address', 200);
 
   return {
     meta,
@@ -74,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -90,7 +84,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyChildState({ params, request, session });
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.child.home-address', 302);
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
   }
 
@@ -105,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.home-address', 400);
     return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
@@ -124,8 +116,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (canProceedToDental) {
     saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-
-    instrumentationService.countHttpStatus('public.apply.child.home-address', 302);
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
@@ -156,7 +146,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.child.home-address.address-invalid', 200);
     return {
       invalidAddress: formattedHomeAddress,
       status: 'address-invalid',
@@ -165,7 +154,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.child.home-address.address-suggestion', 200);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',
@@ -181,8 +169,6 @@ export async function action({ context: { appContainer, session }, params, reque
     } as const satisfies AddressSuggestionResponse;
   }
   saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-
-  instrumentationService.countHttpStatus('public.apply.child.home-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -61,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.mailing-address.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.mailing-address', 200);
 
   return {
     meta,
@@ -74,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -91,7 +85,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.child.mailing-address', 302);
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
   }
 
@@ -105,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!validatedResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.mailing-address', 400);
     return data({ errors: validatedResult.errors }, { status: 400 });
   }
 
@@ -134,8 +126,6 @@ export async function action({ context: { appContainer, session }, params, reque
         ...(homeAddress && { homeAddress }),
       },
     });
-
-    instrumentationService.countHttpStatus('public.apply.child.mailing-address', 302);
 
     if (state.editMode) {
       return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/child/review-adult-information', params) : getPathById('public/apply/$id/child/home-address', params));
@@ -168,7 +158,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.child.mailing-address.address-invalid', 200);
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
@@ -177,7 +166,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.child.mailing-address.address-suggestion', 200);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',
@@ -202,8 +190,6 @@ export async function action({ context: { appContainer, session }, params, reque
       ...(homeAddress && { homeAddress }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.mailing-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/child/new-or-existing-member.tsx
@@ -49,20 +49,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:new-or-existing-member.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.new-or-existing-member', 200);
   return { meta, defaultState: state.newOrExistingMember, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const state = loadApplyState({ params, session });
 
@@ -74,7 +68,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.child.new-or-existing-member', 302);
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
   }
 
@@ -113,11 +106,8 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.new-or-existing-member', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  instrumentationService.countHttpStatus('public.apply.child.new-or-existing-member', 302);
 
   if (state.editMode) {
     // Save editMode data to state.

--- a/frontend/app/routes/public/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/child/phone-number.tsx
@@ -41,14 +41,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:phone-number.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.phone-number', 200);
 
   return {
     meta,
@@ -62,8 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,13 +83,10 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.child.phone-number', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
-
-  instrumentationService.countHttpStatus('public.apply.child.phone-number', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-child-information.tsx
@@ -49,8 +49,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
@@ -81,8 +79,6 @@ export async function loader({ context: { appContainer, session }, params, reque
       ? provincialGovernmentInsurancePlanService.getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
       : undefined;
 
-    instrumentationService.countHttpStatus('public.apply.child.review-child-information', 200);
-
     return {
       id: child.id,
       firstName: child.information.firstName,
@@ -109,8 +105,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const state = loadApplyChildStateForReview({ params, request, session });
 
@@ -118,7 +112,6 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearApplyState({ params, session });
-    instrumentationService.countHttpStatus('public.apply.child.review-child-information', 302);
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
@@ -129,7 +122,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
-    instrumentationService.countHttpStatus('public.apply.child.review-child-information', 302);
     return backToEmail ? redirect(getPathById('public/apply/$id/child/email', params)) : redirect(getPathById('public/apply/$id/child/communication-preference', params));
   }
 
@@ -138,8 +130,6 @@ export async function action({ context: { appContainer, session }, params, reque
     session,
     state: {},
   });
-
-  instrumentationService.countHttpStatus('public.apply.child.review-child-information', 302);
   return redirect(getPathById('public/apply/$id/child/review-adult-information', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/child/verify-email.tsx
@@ -51,14 +51,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:verify-email.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.child.verify-email', 200);
 
   return {
     meta,
@@ -68,8 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -110,7 +104,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     } else if (state.email && state.communicationPreferences?.preferredLanguage) {
       const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name;
@@ -120,7 +113,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     }
   }
@@ -144,7 +136,6 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (!parsedDataResult.success) {
-      instrumentationService.countHttpStatus('public.apply.child.verify-email', 400);
       return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
     }
 
@@ -163,11 +154,8 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
 
-      instrumentationService.countHttpStatus('public.apply.child.verify-email.verification-code-mismatch', 200);
       return { status: 'verification-code-mismatch' } as const;
     }
-
-    instrumentationService.countHttpStatus('public.apply.child.verify-email', 302);
 
     if (state.verifyEmail) {
       if (state.editMode) {


### PR DESCRIPTION
### Description
Incremental PR to remove route-level counters from all applicable routes.
These counters are redundant as a result of #3580

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`