### PR TITLE
refactor(frontend): Removing route-level counters from public apply adult-child routes

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/applicant-information.tsx
@@ -58,20 +58,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:applicant-information.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.applicant-information', 200);
   return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -87,7 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
-    instrumentationService.countHttpStatus('public.apply.adult-child.applicant-information', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -177,7 +170,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.applicant-information', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -232,8 +224,6 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.applicant-information', 302);
 
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult-child/living-independently', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/cannot-apply-child.tsx
@@ -32,8 +32,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   loadApplyAdultSingleChildState({ params, request, session });
   const state = loadApplyAdultChildState({ params, request, session });
   const { APPLICATION_CURRENT_DATE } = getEnv();
@@ -48,19 +46,15 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const isBeforeCoverageStartDate = currentDate < coverageStartDate;
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.cannot-apply-child', 200);
   return { meta, isBeforeCoverageStartDate, coverageStartDate: formattedDate };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.cannot-apply-child', 302);
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -41,8 +41,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -54,8 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.confirm-dental-benefits.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefits,
     editMode: state.editMode,
@@ -66,8 +62,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -90,7 +84,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -115,8 +108,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefits === true) {
     return redirect(getPathById('public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/dental-insurance.tsx
@@ -35,8 +35,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -48,13 +46,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.dental-insurance.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, childName, editMode: state.editMode, i18nOptions: { childName } };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -73,7 +68,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.children.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -87,8 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -55,8 +55,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultSingleChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -76,8 +74,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.dental-benefits.title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -91,8 +87,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -119,7 +113,6 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
-    instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));
   }
 
@@ -179,7 +172,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -207,8 +199,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/information.tsx
@@ -55,8 +55,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -68,13 +66,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.information.page-title', { childName: childNumber }) }),
   };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.information', 200);
   return { meta, defaultState: state.information, childName, editMode: state.editMode, isNew: state.isNew };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -191,7 +186,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success || !parsedSinDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.children.information', 400);
     return data(
       {
         errors: {
@@ -219,8 +213,6 @@ export async function action({ context: { appContainer, session }, params, reque
       }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.information', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/parent-or-guardian.tsx
@@ -31,26 +31,20 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   loadApplyAdultSingleChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:children.parent-or-guardian.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.parent-or-guardian', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.children.parent-or-guardian', 302);
   return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -70,9 +68,6 @@ export async function loader({ context: { appContainer, session }, params, reque
       child.hasFederalProvincialTerritorialBenefits && child.dentalBenefits?.provincialTerritorialSocialProgram
         ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(child.dentalBenefits.provincialTerritorialSocialProgram, locale)
         : undefined;
-
-    instrumentationService.countHttpStatus('public.apply.adult-child.children', 200);
-
     return {
       ...child,
       dentalBenefits: {
@@ -87,8 +82,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -96,8 +89,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.children', 302);
 
   if (formAction === FORM_ACTION.add) {
     const childId = randomUUID();

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -49,8 +47,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const preferredLanguages = appContainer.get(TYPES.domain.services.PreferredLanguageService).listAndSortLocalizedPreferredLanguages(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:communication-preference.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 200);
 
   return {
     meta,
@@ -63,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -86,11 +80,8 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.communication-preference', 302);
 
   if (state.editMode) {
     if (parsedDataResult.data.preferredMethod !== PREFERRED_SUN_LIFE_METHOD.email && parsedDataResult.data.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail) {

--- a/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirm-federal-provincial-territorial-benefits.tsx
@@ -41,14 +41,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:confirm-dental-benefits.title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.confirm-federal-provincial-territorial-benefits', 200);
 
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefits,
@@ -58,8 +54,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -80,7 +74,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -99,8 +92,6 @@ export async function action({ context: { appContainer, session }, params, reque
       dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? state.dentalBenefits : undefined,
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefits) {
     return redirect(getPathById('public/apply/$id/adult-child/federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -150,8 +148,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:confirm.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.confirmation', 200);
-
   return {
     children,
     dentalInsurance,
@@ -165,8 +161,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -176,8 +170,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   loadApplyAdultChildState({ params, request, session });
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.confirmation', 302);
   return redirect(t('confirm.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/dental-insurance.tsx
@@ -36,8 +36,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
@@ -47,13 +45,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   invariant(state.communicationPreferences, 'Expected state.communicationPreferences to be defined');
   const backToEmail = state.communicationPreferences.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID || state.communicationPreferences.preferredNotificationMethod !== 'mail';
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -71,13 +66,10 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDataResult = dentalInsuranceSchema.safeParse(dentalInsurance);
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { dentalInsurance: parsedDataResult.data.dentalInsurance } });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/email.tsx
@@ -39,14 +39,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:email.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.email', 200);
 
   return {
     meta,
@@ -56,8 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -88,7 +82,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.email', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -107,8 +100,6 @@ export async function action({ context: { appContainer, session }, params, reque
       userId: 'anonymous',
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.email', 302);
 
   if (state.editMode) {
     // Redirect to /verify-email only if emailVerified is false

--- a/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/exit-application.tsx
@@ -28,18 +28,13 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:exit-application.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.exit-application', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -48,8 +43,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.exit-application', 302);
   return redirect(t('apply-adult-child:exit-application.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -55,8 +55,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultChildState({ params, request, session });
@@ -70,8 +68,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:dental-benefits.title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 200);
-
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -83,8 +79,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -103,8 +97,6 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
-
-    instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -164,7 +156,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -186,8 +177,6 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.federal-provincial-territorial-benefits', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -51,8 +51,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -61,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.home-address.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 200);
 
   return {
     meta,
@@ -74,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -90,7 +84,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -105,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 400);
     return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
@@ -124,8 +116,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (canProceedToDental) {
     saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-
-    instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
 
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
@@ -156,7 +146,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.adult-child.home-address.address-invalid', 200);
     return {
       invalidAddress: formattedHomeAddress,
       status: 'address-invalid',
@@ -165,7 +154,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.adult-child.home-address.address-suggestion', 200);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',
@@ -181,8 +169,6 @@ export async function action({ context: { appContainer, session }, params, reque
     } as const satisfies AddressSuggestionResponse;
   }
   saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.home-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/living-independently.tsx
@@ -46,20 +46,15 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:living-independently.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.living-independently', 200);
   return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const state = loadApplyAdultChildState({ params, request, session });
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -70,7 +65,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.living-independently', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -88,7 +82,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.living-independently', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -100,8 +93,6 @@ export async function action({ context: { appContainer, session }, params, reque
   } else {
     saveApplyState({ params, session, state: { livingIndependently: isLivingindependently } });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.living-independently', 302);
 
   if (isLivingindependently) {
     return redirect(getPathById('public/apply/$id/adult-child/new-or-existing-member', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -61,8 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.mailing-address.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 200);
 
   return {
     meta,
@@ -74,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -91,7 +85,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -105,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!validatedResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 400);
     return data({ errors: validatedResult.errors }, { status: 400 });
   }
 
@@ -134,8 +126,6 @@ export async function action({ context: { appContainer, session }, params, reque
         ...(homeAddress && { homeAddress }),
       },
     });
-
-    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
 
     if (state.editMode) {
       return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult-child/review-adult-information', params) : getPathById('public/apply/$id/adult-child/home-address', params));
@@ -168,7 +158,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address.address-invalid', 200);
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
@@ -177,7 +166,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address.address-suggestion', 200);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',
@@ -202,8 +190,6 @@ export async function action({ context: { appContainer, session }, params, reque
       ...(homeAddress && { homeAddress }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.mailing-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -66,14 +64,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const isNewUser = Number(yearOfBirth) >= 2006;
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:marital-status.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.marital-status', 200);
   return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -84,7 +78,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.marital-status', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -137,7 +130,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
 
   if (!parsedMaritalStatus.success || (applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.marital-status', 400);
     return data(
       {
         errors: {
@@ -157,8 +149,6 @@ export async function action({ context: { appContainer, session }, params, reque
       partnerInformation: parsedPartnerInformation.data,
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.marital-status', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/new-or-existing-member.tsx
@@ -50,8 +50,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -59,13 +57,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   invariant(state.applicantInformation?.dateOfBirth, 'Expected applicantInformation.dateOfBirth to be defined');
   const ageCategory = getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.new-or-existing-member', 200);
   return { meta, defaultState: state.newOrExistingMember, userAgeCategory: ageCategory, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const state = loadApplyState({ params, session });
 
@@ -77,7 +72,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.new-or-existing-member', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -116,11 +110,8 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.new-or-existing-member', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.new-or-existing-member', 302);
 
   if (state.editMode) {
     // Save editMode data to state.

--- a/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/parent-or-guardian.tsx
@@ -33,8 +33,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -47,13 +45,10 @@ export async function loader({ context: { appContainer, session }, params, reque
     return redirect(getPathById('public/apply/$id/adult-child/applicant-information', params));
   }
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.parent-or-guardian', 200);
   return { meta, ageCategory };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -62,8 +57,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   clearApplyState({ params, session });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.parent-or-guardian', 302);
   return redirect(t('apply-adult-child:parent-or-guardian.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
@@ -41,14 +41,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:phone-number.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 200);
 
   return {
     meta,
@@ -62,8 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,13 +83,10 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.phone-number', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -49,8 +49,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   invariant(state.mailingAddress?.country, `Unexpected mailing address country: ${state.mailingAddress?.country}`);
@@ -132,8 +130,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:review-adult-information.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.review-adult-information', 200);
-
   return {
     userInfo,
     spouseInfo,
@@ -149,14 +145,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearApplyState({ params, session });
-    instrumentationService.countHttpStatus('public.apply.adult-child.review-adult-information', 302);
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
@@ -164,13 +157,11 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
-    instrumentationService.countHttpStatus('public.apply.adult-child.review-adult-information', 302);
     return redirect(getPathById('public/apply/$id/adult-child/children/index', params));
   }
 
   saveApplyState({ params, session, state: {} });
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.review-adult-information', 302);
   return redirect(getPathById('public/apply/$id/adult-child/review-child-information', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-child-information.tsx
@@ -51,8 +51,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildStateForReview({ params, request, session });
 
   // apply state is valid then edit mode can be set to true
@@ -112,27 +110,21 @@ export async function loader({ context: { appContainer, session }, params, reque
     };
   });
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 200);
-
   return { children, meta, payload };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   const formData = await request.formData();
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearApplyState({ params, session });
-    instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: {} });
-    instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
     return redirect(getPathById('public/apply/$id/adult-child/review-adult-information', params));
   }
 
@@ -143,7 +135,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { submissionInfo } });
 
-  instrumentationService.countHttpStatus('public.apply.adult-child.review-child-information', 302);
   return redirect(getPathById('public/apply/$id/adult-child/confirmation', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
@@ -51,14 +51,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:verify-email.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 200);
 
   return {
     meta,
@@ -68,8 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -109,7 +103,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     } else if (state.email && state.communicationPreferences?.preferredLanguage) {
       const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name;
@@ -119,7 +112,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     }
   }
@@ -143,7 +135,6 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (!parsedDataResult.success) {
-      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 400);
       return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
     }
 
@@ -162,11 +153,8 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
 
-      instrumentationService.countHttpStatus('public.apply.adult-child.verify-email.verification-code-mismatch', 200);
       return { status: 'verification-code-mismatch' } as const;
     }
-
-    instrumentationService.countHttpStatus('public.apply.adult-child.verify-email', 302);
 
     if (state.verifyEmail) {
       if (state.editMode) {


### PR DESCRIPTION
### Description
Incremental PR to remove route-level counters from all applicable routes.
These counters are redundant as a result of #3580

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`