### PR TITLE
refactor(frontend): Removing route-level counters from public apply adult routes

### DIFF
--- a/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/applicant-information.tsx
@@ -58,21 +58,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:applicant-information.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 200);
-
   return { defaultState: state.applicantInformation, editMode: state.editMode, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -88,7 +81,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (formAction === FORM_ACTION.cancel) {
     invariant(state.applicantInformation, 'Expected state.applicantInformation to be defined');
-    instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -172,7 +164,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -225,8 +216,6 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult.applicant-information', 302);
 
   if (ageCategory === 'youth') {
     return redirect(getPathById('public/apply/$id/adult/living-independently', params));

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -40,16 +40,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const preferredLanguages = appContainer.get(TYPES.domain.services.PreferredLanguageService).listAndSortLocalizedPreferredLanguages(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:communication-preference.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.communication-preference', 200);
 
   return {
     meta,
@@ -60,8 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -83,11 +77,8 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.communication-preference', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult.communication-preference', 302);
 
   if (state.editMode) {
     if (parsedDataResult.data.preferredMethod !== PREFERRED_SUN_LIFE_METHOD.email && parsedDataResult.data.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail) {

--- a/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirm-federal-provincial-territorial-benefits.tsx
@@ -41,14 +41,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:confirm-dental-benefits.title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.confirm-federal-provincial-territorial-benefits', 200);
 
   return {
     defaultState: state.hasFederalProvincialTerritorialBenefits,
@@ -58,8 +54,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -81,7 +75,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedDentalBenefitsResult = dentalBenefitsChangedSchema.safeParse(dentalBenefits);
 
   if (!parsedDentalBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.confirm-federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -100,8 +93,6 @@ export async function action({ context: { appContainer, session }, params, reque
       dentalBenefits: parsedDentalBenefitsResult.data.hasFederalProvincialTerritorialBenefits ? state.dentalBenefits : undefined,
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult.confirm-federal-provincial-territorial-benefits', 302);
 
   if (dentalBenefits.hasFederalProvincialTerritorialBenefits) {
     return redirect(getPathById('public/apply/$id/adult/federal-provincial-territorial-benefits', params));

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -40,8 +40,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -117,8 +115,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:confirm.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.confirmation', 200);
-
   return {
     dentalInsurance,
     homeAddressInfo,
@@ -131,8 +127,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -143,7 +137,6 @@ export async function action({ context: { appContainer, session }, params, reque
   loadApplyAdultState({ params, request, session });
   clearApplyState({ params, session });
 
-  instrumentationService.countHttpStatus('public.apply.adult.confirmation', 302);
   return redirect(t('confirm.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/dental-insurance.tsx
@@ -36,8 +36,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
@@ -46,13 +44,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   invariant(state.communicationPreferences, 'Expected state.communicationPreferences to be defined');
   const backToEmail = state.communicationPreferences.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID || state.communicationPreferences.preferredNotificationMethod !== 'mail';
 
-  instrumentationService.countHttpStatus('public.apply.adult.dental-insurance', 200);
   return { meta, defaultState: state.dentalInsurance, backToEmail, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -71,13 +66,10 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.dental-insurance', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { dentalInsurance: parsedDataResult.data.dentalInsurance } });
-
-  instrumentationService.countHttpStatus('public.apply.adult.dental-insurance', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/email.tsx
@@ -39,14 +39,11 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:email.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.email', 200);
   return {
     meta,
     defaultState: state.email,
@@ -55,8 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -87,7 +82,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.email', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -106,8 +100,6 @@ export async function action({ context: { appContainer, session }, params, reque
       userId: 'anonymous',
     });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult.email', 302);
 
   if (state.editMode) {
     // Redirect to /verify-email only if emailVerified is false

--- a/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/exit-application.tsx
@@ -28,18 +28,12 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:exit-application.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.exit-application', 200);
   return { meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -49,7 +43,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   clearApplyState({ params, session });
 
-  instrumentationService.countHttpStatus('public.apply.adult.exit-application', 302);
   return redirect(t('exit-application.exit-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -55,8 +55,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const state = loadApplyAdultState({ params, request, session });
@@ -69,7 +67,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:dental-benefits.title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.federal-provincial-territorial-benefits', 200);
   return {
     defaultState: state.dentalBenefits,
     editMode: state.editMode,
@@ -81,8 +78,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -102,7 +97,6 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
     }
-    instrumentationService.countHttpStatus('public.apply.adult.federal-provincial-territorial-benefits', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -162,7 +156,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedProvincialTerritorialBenefitsResult = provincialTerritorialBenefitsSchema.safeParse(dentalBenefits);
 
   if (!parsedFederalBenefitsResult.success || !parsedProvincialTerritorialBenefitsResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.federal-provincial-territorial-benefits', 400);
     return data(
       {
         errors: {
@@ -186,7 +179,6 @@ export async function action({ context: { appContainer, session }, params, reque
     },
   });
 
-  instrumentationService.countHttpStatus('public.apply.adult.federal-provincial-territorial-benefits', 302);
   return redirect(getPathById('public/apply/$id/adult/review-information', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -51,8 +51,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -62,7 +60,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.home-address.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.home-address', 200);
   return {
     meta,
     defaultState: state,
@@ -73,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   const locale = getLocale(request);
@@ -89,7 +84,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultState({ params, request, session });
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult.home-address', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -104,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.home-address', 400);
     return data({ errors: parsedDataResult.errors }, { status: 400 });
   }
 
@@ -123,8 +116,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (canProceedToDental) {
     saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-    instrumentationService.countHttpStatus('public.apply.adult.home-address', 302);
-
     if (state.editMode) {
       return redirect(getPathById('public/apply/$id/adult/review-information', params));
     }
@@ -154,7 +145,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.adult.home-address.address-invalid', 200);
     return {
       invalidAddress: formattedHomeAddress,
       status: 'address-invalid',
@@ -163,7 +153,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.adult.home-address.address-suggestion', 200);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',
@@ -180,7 +169,6 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   saveApplyState({ params, session, state: { homeAddress, isHomeAddressSameAsMailingAddress: false } });
-  instrumentationService.countHttpStatus('public.apply.adult.home-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/living-independently.tsx
@@ -46,20 +46,14 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:living-independently.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.living-independently', 200);
   return { meta, defaultState: state.livingIndependently, editMode: state.editMode };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const state = loadApplyAdultState({ params, request, session });
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -69,7 +63,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult.living-independently', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -87,7 +80,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.living-independently', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
@@ -99,8 +91,6 @@ export async function action({ context: { appContainer, session }, params, reque
   } else {
     saveApplyState({ params, session, state: { livingIndependently: isLivingindependently } });
   }
-
-  instrumentationService.countHttpStatus('public.apply.adult.living-independently', 302);
 
   if (isLivingindependently) {
     return redirect(getPathById('public/apply/$id/adult/new-or-existing-member', params));

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
@@ -62,7 +60,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.mailing-address.page-title') }) };
 
-  instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 200);
   return {
     meta,
     defaultState: state,
@@ -73,8 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
   const locale = getLocale(request);
 
@@ -90,7 +85,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const isCopyMailingToHome = formData.get('syncAddresses') === 'true';
 
   if (formAction === FORM_ACTION.cancel) {
-    instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 302);
     return redirect(getPathById('public/apply/$id/adult/review-information', params));
   }
 
@@ -104,7 +98,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!validatedResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 400);
     return data({ errors: validatedResult.errors }, { status: 400 });
   }
 
@@ -133,8 +126,6 @@ export async function action({ context: { appContainer, session }, params, reque
         ...(homeAddress && { homeAddress }),
       },
     });
-
-    instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 302);
 
     if (state.editMode) {
       return redirect(isCopyMailingToHome ? getPathById('public/apply/$id/adult/review-information', params) : getPathById('public/apply/$id/adult/home-address', params));
@@ -167,7 +158,6 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (addressCorrectionResult.status === 'not-correct') {
-    instrumentationService.countHttpStatus('public.apply.adult.mailing-address.address-invalid', 200);
     return {
       invalidAddress: formattedMailingAddress,
       status: 'address-invalid',
@@ -176,7 +166,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   if (addressCorrectionResult.status === 'corrected') {
     const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
-    instrumentationService.countHttpStatus('public.apply.adult.mailing-address.address-suggestion', 200);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',
@@ -201,8 +190,6 @@ export async function action({ context: { appContainer, session }, params, reque
       ...(homeAddress && { homeAddress }),
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult.mailing-address', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -66,14 +64,10 @@ export async function loader({ context: { appContainer, session }, params, reque
   const isNewUser = Number(yearOfBirth) >= 2006;
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:marital-status.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.marital-status', 200);
   return { isNewUser, defaultState: { maritalStatus: state.maritalStatus, ...state.partnerInformation }, editMode: state.editMode, maritalStatuses, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -124,7 +118,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
 
   if (!parsedMaritalStatus.success || (applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
-    instrumentationService.countHttpStatus('public.apply.adult.marital-status', 400);
     return data(
       {
         errors: {
@@ -144,8 +137,6 @@ export async function action({ context: { appContainer, session }, params, reque
       partnerInformation: parsedPartnerInformation.data,
     },
   });
-
-  instrumentationService.countHttpStatus('public.apply.adult.marital-status', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/parent-or-guardian.tsx
@@ -33,8 +33,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -44,17 +42,13 @@ export async function loader({ context: { appContainer, session }, params, reque
   const ageCategory = state.editModeApplicantInformation?.dateOfBirth ? getAgeCategoryFromDateString(state.editModeApplicantInformation.dateOfBirth) : getAgeCategoryFromDateString(state.applicantInformation.dateOfBirth);
 
   if (ageCategory !== 'children' && ageCategory !== 'youth') {
-    instrumentationService.countHttpStatus('public.apply.adult.parent-or-guardian', 302);
     return redirect(getPathById('public/apply/$id/adult/applicant-information', params));
   }
 
-  instrumentationService.countHttpStatus('public.apply.adult.parent-or-guardian', 200);
   return { ageCategory, meta };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -64,7 +58,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   clearApplyState({ params, session });
 
-  instrumentationService.countHttpStatus('public.apply.adult.parent-or-guardian', 302);
   return redirect(t('apply-adult:parent-or-guardian.return-btn-link'));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
@@ -41,14 +41,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:phone-number.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.phone-number', 200);
 
   return {
     meta,
@@ -62,8 +58,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -89,13 +83,10 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   if (!parsedDataResult.success) {
-    instrumentationService.countHttpStatus('public.apply.adult.phone-number', 400);
     return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
   }
 
   saveApplyState({ params, session, state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } } });
-
-  instrumentationService.countHttpStatus('public.apply.adult.phone-number', 302);
 
   if (state.editMode) {
     return redirect(getPathById('public/apply/$id/adult/review-information', params));

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -52,8 +52,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultStateForReview({ params, request, session });
   invariant(state.mailingAddress?.country, `Unexpected mailing address country: ${state.mailingAddress?.country}`);
 
@@ -143,8 +141,6 @@ export async function loader({ context: { appContainer, session }, params, reque
   const benefitApplicationStateMapper = appContainer.get(TYPES.routes.mappers.BenefitApplicationStateMapper);
   const payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationStateMapper.mapApplyAdultStateToBenefitApplicationDto(state));
 
-  instrumentationService.countHttpStatus('public.apply.adult.review-information', 200);
-
   return {
     userInfo,
     spouseInfo,
@@ -160,7 +156,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
 
   const formData = await request.formData();
@@ -169,14 +164,12 @@ export async function action({ context: { appContainer, session }, params, reque
   securityHandler.validateCsrfToken({ formData, session });
   await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
     clearApplyState({ params, session });
-    instrumentationService.countHttpStatus('public.apply.adult.review-information', 302);
     throw redirect(getPathById('public/unable-to-process-request', params));
   });
 
   const formAction = z.nativeEnum(FORM_ACTION).parse(formData.get('_action'));
   if (formAction === FORM_ACTION.back) {
     saveApplyState({ params, session, state: { editMode: false } });
-    instrumentationService.countHttpStatus('public.apply.adult.review-information', 302);
     if (state.hasFederalProvincialTerritorialBenefits) {
       return redirect(getPathById('public/apply/$id/adult/federal-provincial-territorial-benefits', params));
     }
@@ -189,7 +182,6 @@ export async function action({ context: { appContainer, session }, params, reque
 
   saveApplyState({ params, session, state: { submissionInfo } });
 
-  instrumentationService.countHttpStatus('public.apply.adult.review-information', 302);
   return redirect(getPathById('public/apply/$id/adult/confirmation', params));
 }
 

--- a/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
@@ -51,14 +51,10 @@ export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
 });
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:verify-email.page-title') }) };
-
-  instrumentationService.countHttpStatus('public.apply.adult.verify-email', 200);
 
   return {
     meta,
@@ -68,8 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
-  const instrumentationService = appContainer.get(TYPES.observability.InstrumentationService);
-
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
@@ -110,7 +104,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.adult.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     } else if (state.email && state.communicationPreferences?.preferredLanguage) {
       const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale).name;
@@ -120,7 +113,6 @@ export async function action({ context: { appContainer, session }, params, reque
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
       });
-      instrumentationService.countHttpStatus('public.apply.adult.verify-email.verification-code-sent', 200);
       return { status: 'verification-code-sent' } as const;
     }
   }
@@ -144,7 +136,6 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (!parsedDataResult.success) {
-      instrumentationService.countHttpStatus('public.apply.adult.verify-email', 400);
       return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
     }
 
@@ -162,11 +153,8 @@ export async function action({ context: { appContainer, session }, params, reque
         },
       });
 
-      instrumentationService.countHttpStatus('public.apply.adult.verify-email.verification-code-mismatch', 200);
       return { status: 'verification-code-mismatch' } as const;
     }
-
-    instrumentationService.countHttpStatus('public.apply.adult.verify-email', 302);
 
     if (state.verifyEmail) {
       if (state.editMode) {


### PR DESCRIPTION
### Description
Incremental PR to remove route-level counters from all applicable routes.
These counters are redundant as a result of #3580

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`