### PR TITLE
feat(gitops): add external secrets configuration for dev

### DIFF
--- a/gitops/overlays/dev/external-secrets.yaml
+++ b/gitops/overlays/dev/external-secrets.yaml
@@ -1,0 +1,45 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: AUTH_JWT_PRIVATE_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PRIVATE_KEY }
+    - secretKey: AUTH_JWT_PUBLIC_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PUBLIC_KEY }
+    - secretKey: GC_NOTIFY_API_KEY
+      remoteRef: { key: cdcp-dev, property: GC_NOTIFY_API_KEY }
+    - secretKey: HCAPTCHA_SECRET_KEY
+      remoteRef: { key: cdcp-dev, property: HCAPTCHA_SECRET_KEY }
+    - secretKey: INTEROP_API_SUBSCRIPTION_KEY
+      remoteRef: { key: cdcp-dev, property: INTEROP_API_SUBSCRIPTION_KEY_INT_OLD }
+    - secretKey: OTEL_API_KEY
+      remoteRef: { key: cdcp-dev, property: DYNATRACE_API_KEY }
+    - secretKey: SESSION_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: SESSION_COOKIE_SECRET }
+
+---
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: oauth-proxy
+  labels:
+    app.kubernetes.io/name: oauth-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: OAUTH2_PROXY_CLIENT_SECRET
+      remoteRef: { key: cdcp-dev, property: OAUTH2_PROXY_CLIENT_SECRET }
+    - secretKey: OAUTH2_PROXY_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: OAUTH2_PROXY_COOKIE_SECRET }

--- a/gitops/overlays/dev/kustomization.yaml
+++ b/gitops/overlays/dev/kustomization.yaml
@@ -15,6 +15,7 @@ labels:
       app.kubernetes.io/tier: nonprod
 resources:
   - ../../base/frontend/
+  - ./external-secrets.yaml
   - ./ingresses.yaml
 patches:
   - path: ./patches/deployments.yaml


### PR DESCRIPTION
### Description

This is an incremental PR that will eventually lead to CDCP using external secrets everywhere.

This PR adds the `ExternalSecret` resources to the cluster, but doesn't configure the application to use them. Once approved, similar PRs will be created for other pseudoenvironments.

Once external secrets have been created everywhere, PRs will be submitted to reconfigure the pods to use them.

---

```console
➜  gitops git:(development) kubectl --namespace canada-dental-care-plan --selector app.kubernetes.io/environment=dev get externalsecrets
NAME              STORETYPE     STORE           REFRESH INTERVAL   STATUS         READY
frontend-dev      SecretStore   vault-backend   1h                 SecretSynced   True
oauth-proxy-dev   SecretStore   vault-backend   1h                 SecretSynced   True

➜  gitops git:(development) kubectl --namespace canada-dental-care-plan --selector app.kubernetes.io/environment=dev,reconcile.external-secrets.io/managed=true get secrets
NAME              TYPE     DATA   AGE
frontend-dev      Opaque   7      16m
oauth-proxy-dev   Opaque   2      8m29s
```