### PR TITLE
feat(gitops): add external secrets configuration for proto

### DIFF
--- a/gitops/overlays/prototype/external-secrets.yaml
+++ b/gitops/overlays/prototype/external-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: AUTH_JWT_PRIVATE_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PRIVATE_KEY }
+    - secretKey: AUTH_JWT_PUBLIC_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PUBLIC_KEY }
+    - secretKey: GC_NOTIFY_API_KEY
+      remoteRef: { key: cdcp-dev, property: GC_NOTIFY_API_KEY }
+    - secretKey: HCAPTCHA_SECRET_KEY
+      remoteRef: { key: cdcp-dev, property: HCAPTCHA_SECRET_KEY }
+    - secretKey: INTEROP_API_SUBSCRIPTION_KEY
+      remoteRef: { key: cdcp-dev, property: INTEROP_API_SUBSCRIPTION_KEY_INT }
+    - secretKey: OTEL_API_KEY
+      remoteRef: { key: cdcp-dev, property: DYNATRACE_API_KEY }
+    - secretKey: SESSION_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: SESSION_COOKIE_SECRET }

--- a/gitops/overlays/prototype/kustomization.yaml
+++ b/gitops/overlays/prototype/kustomization.yaml
@@ -15,6 +15,7 @@ labels:
       app.kubernetes.io/tier: nonprod
 resources:
   - ../../base/frontend/
+  - ./external-secrets.yaml
   - ./ingresses.yaml
 patches:
   - path: ./patches/deployments.yaml


### PR DESCRIPTION
### Description

Add external secrets for proto pseudoenvironment. For a better description, see #3623.

⚠️⚠️⚠️ the `INTEROP_API_SUBSCRIPTION_KEY` being set to `INT` is intentional ⚠️⚠️⚠️