### PR TITLE
feat(gitops): add external secrets configuration for staging

### DIFF
--- a/gitops/overlays/staging/external-secrets.yaml
+++ b/gitops/overlays/staging/external-secrets.yaml
@@ -1,0 +1,62 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: AUTH_JWT_PRIVATE_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PRIVATE_KEY }
+    - secretKey: AUTH_JWT_PUBLIC_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PUBLIC_KEY }
+    - secretKey: GC_NOTIFY_API_KEY
+      remoteRef: { key: cdcp-dev, property: GC_NOTIFY_API_KEY }
+    - secretKey: HCAPTCHA_SECRET_KEY
+      remoteRef: { key: cdcp-dev, property: HCAPTCHA_SECRET_KEY }
+    - secretKey: INTEROP_API_SUBSCRIPTION_KEY
+      remoteRef: { key: cdcp-dev, property: INTEROP_API_SUBSCRIPTION_KEY_UAT }
+    - secretKey: OTEL_API_KEY
+      remoteRef: { key: cdcp-dev, property: DYNATRACE_API_KEY }
+    - secretKey: SESSION_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: SESSION_COOKIE_SECRET }
+
+---
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: oauth-proxy
+  labels:
+    app.kubernetes.io/name: oauth-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: OAUTH2_PROXY_CLIENT_SECRET
+      remoteRef: { key: cdcp-dev, property: OAUTH2_PROXY_CLIENT_SECRET }
+    - secretKey: OAUTH2_PROXY_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: OAUTH2_PROXY_COOKIE_SECRET }
+
+---
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef: { key: cdcp-dev, property: REDIS_PASSWORD }

--- a/gitops/overlays/staging/kustomization.yaml
+++ b/gitops/overlays/staging/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../base/frontend/
   - ../../base/fluentd-archiver/
   - ../../base/redis/
+  - ./external-secrets.yaml
   - ./hpas.yaml
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml and comment ./ingresses.yaml
   - ./ingresses.yaml


### PR DESCRIPTION
### Description

Add external secrets for staging pseudoenvironment. For a better description, see #3623.

⚠️⚠️⚠️ the `INTEROP_API_SUBSCRIPTION_KEY` being set to `UAT` is intentional ⚠️⚠️⚠️