### PR TITLE
fix(frontend) a11y add role to radiogroup fieldset

### DIFF
--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -36,7 +36,7 @@ const InputRadios = ({ errorMessage, helpMessagePrimary, helpMessagePrimaryClass
   }
 
   return (
-    <fieldset id={inputWrapperId} data-testid={inputWrapperId} aria-labelledby={`${inputLegendId} ${inputHelpMessagePrimaryId}`} aria-required={required}>
+    <fieldset role="radiogroup" id={inputWrapperId} data-testid={inputWrapperId} aria-labelledby={`${inputLegendId} ${inputHelpMessagePrimaryId}`} aria-required={required}>
       <InputLegend id={inputLegendId} className={cn('mb-2', legendClassName)} aria-describedby={getAriaDescribedby()}>
         {legend}
       </InputLegend>

--- a/frontend/e2e/public/apply/child-flow/children-application.spec.ts
+++ b/frontend/e2e/public/apply/child-flow/children-application.spec.ts
@@ -100,13 +100,13 @@ test.describe('Children application', () => {
     await test.step('Should navigate to children other dental benefits page', async () => {
       await applyChildPage.isLoaded('children-federal-provincial-territorial-benefits');
 
-      await page.getByRole('group', { name: 'Federal benefits' }).getByRole('radio', { name: 'Yes, this child has federal dental benefits' }).check();
-      await page.getByRole('group', { name: 'Provincial or territorial benefits' }).getByRole('radio', { name: 'Yes, this child has provincial or territorial dental benefits' }).check();
+      await page.getByRole('radiogroup', { name: 'Federal benefits' }).getByRole('radio', { name: 'Yes, this child has federal dental benefits' }).check();
+      await page.getByRole('radiogroup', { name: 'Provincial or territorial benefits' }).getByRole('radio', { name: 'Yes, this child has provincial or territorial dental benefits' }).check();
 
-      await page.getByRole('group', { name: 'Federal benefits' }).getByRole('radio', { name: 'Correctional Service Canada Health Services' }).check();
-      await page.getByRole('group', { name: 'Provincial or territorial benefits' }).getByRole('combobox', { name: 'If yes, through which province or territory?' }).selectOption('Alberta');
+      await page.getByRole('radiogroup', { name: 'Federal benefits' }).getByRole('radio', { name: 'Correctional Service Canada Health Services' }).check();
+      await page.getByRole('radiogroup', { name: 'Provincial or territorial benefits' }).getByRole('combobox', { name: 'If yes, through which province or territory?' }).selectOption('Alberta');
 
-      await page.getByRole('group', { name: 'Provincial or territorial benefits' }).getByRole('radio', { name: 'Alberta Adult Health Benefit' }).check();
+      await page.getByRole('radiogroup', { name: 'Provincial or territorial benefits' }).getByRole('radio', { name: 'Alberta Adult Health Benefit' }).check();
       await page.getByRole('button', { name: 'Continue' }).click();
     });
 


### PR DESCRIPTION
### Description
The ITAO raised this issue in a recent re-audit.  To summarize, `aria-required=true` is not valid on `fieldset`, unless the `fieldset` has an allowed `role`.  In this case, because the fieldset encapsulates radio buttons, we can assign a role of `radiogroup` which is allowed.