### PR TITLE
fix(frontend) add outerAriaDescribedById to InputRadios

### DIFF
--- a/frontend/app/components/address-validation-dialog.tsx
+++ b/frontend/app/components/address-validation-dialog.tsx
@@ -77,12 +77,13 @@ export function AddressSuggestionDialogContent({ enteredAddress, suggestedAddres
     <DialogContent aria-describedby={undefined} className="sm:max-w-md">
       <DialogHeader>
         <DialogTitle>{t('common:dialog.address-suggestion.header')}</DialogTitle>
-        <DialogDescription>{t('common:dialog.address-suggestion.description')}</DialogDescription>
+        <DialogDescription id="verify-description">{t('common:dialog.address-suggestion.description')}</DialogDescription>
       </DialogHeader>
       <InputRadios
         id="addressSelection"
         name="addressSelection"
         legend={t('common:dialog.address-suggestion.address-selection-legend')}
+        outerAriaDescribedById="verify-description"
         options={[
           {
             value: enteredAddressOptionValue,

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -18,9 +18,10 @@ export interface InputRadiosProps {
   name: string;
   required?: boolean;
   legendClassName?: string;
+  outerAriaDescribedById?: string;
 }
 
-export function InputRadios({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName }: InputRadiosProps) {
+export function InputRadios({ errorMessage, helpMessagePrimary, helpMessagePrimaryClassName, helpMessageSecondary, helpMessageSecondaryClassName, id, legend, name, options, required, legendClassName, outerAriaDescribedById }: InputRadiosProps) {
   const inputErrorId = `input-radios-${id}-error`;
   const inputHelpMessagePrimaryId = `input-radios-${id}-help-primary`;
   const inputHelpMessageSecondaryId = `input-radios-${id}-help-secondary`;
@@ -31,6 +32,7 @@ export function InputRadios({ errorMessage, helpMessagePrimary, helpMessagePrima
     [
       !!helpMessagePrimary && inputHelpMessagePrimaryId, //
       !!helpMessageSecondary && inputHelpMessageSecondaryId,
+      !!outerAriaDescribedById && outerAriaDescribedById,
     ]
       .filter(Boolean)
       .join(' ') || undefined;


### PR DESCRIPTION
### Description
This got raised as an issue by the ITAO where text isn't being read by a screenreader, specifically in the AddressSuggestionDialog component.  The intent of this PR is add an additional prop to InputRadios that can accept an outer aria-describedby id which is then associated with the fieldset.  This approach is necessary if we don't want to make style changes by moving the description text to the primaryHelpMessage of the InputRadios.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
