### PR TITLE
Seb/settings tailwind css

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,39 +1,35 @@
 {
-  "[javascript]": {
+  "[javascript][json][jsonc][typescript][typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.tabSize": 2
   },
-  "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.tabSize": 2
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.removeUnusedImports": "explicit",
+    // rely on prettier to sort imports
+    "source.sortImports": "never"
   },
-  "[jsonc]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.tabSize": 2
-  },
-  "[typescript]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit",
-      "source.removeUnusedImports": "explicit"
-    },
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2
-  },
-  "[typescriptreact]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit",
-      "source.removeUnusedImports": "explicit"
-    },
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2
-  },
-  // clsx Tailwind Support
-  // https://github.com/lukeed/clsx/tree/master?tab=readme-ov-file#tailwind-support
+  // Tailwind Regex List
+  // see: https://github.com/paolotiu/tailwind-intellisense-regex-list?tab=readme-ov-file#classnames
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
-    ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-  ]
+    ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+    [
+      // JavaScript string that likely contains tailwind classes.
+      // This regex looks for lines of JavaScript code that:
+      //
+      // 1. Optionally start with `const`, `let`, or `var`.
+      // 2. Have a variable name, that:
+      // 3. End with `styles`, `classes`, or `classnames`.
+      // 4. Have an equals sign (=) or +=.
+      // 5. Have a string in single or double quotes.
+      "(?:\\b(?:const|let|var)\\s+)?[\\w$_]*(?:[Ss]tyles|[Cc]lasses|[Cc]lassnames)[\\w\\d]*\\s*(?:=|\\+=)\\s*['\"]([^'\"]*)['\"]"
+    ],
+    // https://github.com/paolotiu/tailwind-intellisense-regex-list/pull/44
+    ["(?:\\b(?:const|let|var)\\s+)?[\\w$_]*(?:[Ss]tyles|[Cc]lasses|[Cc]lassnames)[\\w\\d]*\\s*=\\s*{([\\s\\S]*?)}", "\\s?[\\w].*:\\s*?[\"'`]([^\"'`]*).*?,?\\s?"]
+  ],
+  // always import files from the root (~) of the project
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "vitest.disableWorkspaceWarning": true
 }

--- a/frontend/__tests__/components/progress.test.tsx
+++ b/frontend/__tests__/components/progress.test.tsx
@@ -18,9 +18,9 @@ describe('Progress component', () => {
   });
 
   it('renders with default props', () => {
-    const { getByTestId } = render(<Progress label="test" value={0} />);
+    const { getByTestId } = render(<Progress label="test" value={0} data-testid="progress-root" />);
     const rootElement = getByTestId('progress-root');
-    const indicatorElement = getByTestId('progress-indicator');
+    const indicatorElement = rootElement.children[0];
 
     expect(rootElement).toBeInTheDocument();
     expect(indicatorElement).toBeInTheDocument();
@@ -29,9 +29,9 @@ describe('Progress component', () => {
   });
 
   it('renders with custom size and variant', () => {
-    const { getByTestId } = render(<Progress size="lg" variant="blue" label="test" value={0} />);
+    const { getByTestId } = render(<Progress size="lg" variant="blue" label="test" value={0} data-testid="progress-root" />);
     const rootElement = getByTestId('progress-root');
-    const indicatorElement = getByTestId('progress-indicator');
+    const indicatorElement = rootElement.children[0];
 
     expect(rootElement).toBeInTheDocument();
     expect(indicatorElement).toBeInTheDocument();
@@ -40,20 +40,19 @@ describe('Progress component', () => {
   });
 
   it('renders with custom value', () => {
-    const { getByTestId } = render(<Progress value={50} label="test" />);
-    const indicatorElement = getByTestId('progress-indicator');
+    const { getByTestId } = render(<Progress value={50} label="test" data-testid="progress-root" />);
+    const rootElement = getByTestId('progress-root');
+    const indicatorElement = rootElement.children[0];
 
     expect(indicatorElement).toBeInTheDocument();
     expect(indicatorElement).toHaveStyle('transform: translateX(-50%)');
   });
 
   it('renders with custom className', () => {
-    const { getByTestId } = render(<Progress className="custom-class" label="test" value={0} />);
+    const { getByTestId } = render(<Progress className="custom-class" label="test" value={0} data-testid="progress-root" />);
     const rootElement = getByTestId('progress-root');
 
     expect(rootElement).toBeInTheDocument();
     expect(rootElement).toHaveClass('custom-class');
   });
-
-  // Add more tests as needed
 });

--- a/frontend/app/components/buttons.tsx
+++ b/frontend/app/components/buttons.tsx
@@ -8,7 +8,7 @@ import { cn } from '~/utils/tw-utils';
 type ButtonEndIconProps = ComponentProps<typeof ButtonEndIcon>;
 type ButtonStartIconProps = ComponentProps<typeof ButtonStartIcon>;
 
-const sizes = {
+const sizeStyles = {
   xs: 'px-3 py-2 text-xs',
   sm: 'px-3 py-2 text-sm',
   base: 'px-5 py-2.5 text-sm',
@@ -16,26 +16,26 @@ const sizes = {
   xl: 'px-6 py-3.5 text-base',
 };
 
-const variants = {
+const variantStyles = {
   alternative: 'border-gray-200 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
   default: 'border-gray-300 bg-gray-200 text-slate-700 hover:bg-neutral-300 focus:bg-neutral-300',
   dark: 'border-gray-800 bg-gray-800 text-white hover:bg-gray-900 focus:bg-gray-900',
   green: 'border-green-700 bg-green-700 text-white hover:bg-green-800 focus:bg-green-800',
   primary: 'border-slate-700 bg-slate-700 text-white hover:bg-sky-800 focus:bg-sky-800',
   red: 'border-red-700 bg-red-700 text-white hover:bg-red-800 focus:bg-red-800',
-  link: 'text-slate-700 underline hover:text-blue-700 focus:text-blue-700 border-none px-0',
+  link: 'border-none px-0 text-slate-700 underline hover:text-blue-700 focus:text-blue-700',
 };
 
-const baseClassName = 'inline-flex items-center justify-center rounded-sm border align-middle font-lato outline-offset-4';
+const baseStyles = 'inline-flex items-center justify-center rounded-sm border align-middle font-lato outline-offset-4';
 
 export interface ButtonProps extends ComponentProps<'button'> {
   endIcon?: ButtonEndIconProps['icon'];
   endIconProps?: OmitStrict<ButtonEndIconProps, 'icon'>;
   pill?: boolean;
-  size?: keyof typeof sizes;
+  size?: keyof typeof sizeStyles;
   startIcon?: ButtonStartIconProps['icon'];
   startIconProps?: OmitStrict<ButtonStartIconProps, 'icon'>;
-  variant?: keyof typeof variants;
+  variant?: keyof typeof variantStyles;
 }
 
 /**
@@ -46,9 +46,9 @@ export function Button({ children, className, endIcon, endIconProps, pill, size 
   return (
     <button
       className={cn(
-        baseClassName, //
-        sizes[size],
-        variants[variant],
+        baseStyles, //
+        sizeStyles[size],
+        variantStyles[variant],
         'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70',
         pill && 'rounded-full',
         className,
@@ -66,8 +66,8 @@ export interface ButtonLinkProps extends ComponentProps<typeof AppLink> {
   disabled?: boolean;
   endIcon?: ButtonEndIconProps['icon'];
   endIconProps?: OmitStrict<ButtonEndIconProps, 'icon'>;
-  size?: keyof typeof sizes;
-  variant?: keyof typeof variants;
+  size?: keyof typeof sizeStyles;
+  variant?: keyof typeof variantStyles;
   startIcon?: ButtonStartIconProps['icon'];
   startIconProps?: OmitStrict<ButtonStartIconProps, 'icon'>;
   pill?: boolean;
@@ -81,7 +81,7 @@ export interface ButtonLinkProps extends ComponentProps<typeof AppLink> {
  * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
  */
 export function ButtonLink({ children, className, disabled, endIcon, endIconProps, pill, size = 'base', routeId, startIcon, startIconProps, to, variant = 'default', ...props }: ButtonLinkProps) {
-  const buttonLinkClassName = cn(baseClassName, sizes[size], variants[variant], pill && 'rounded-full', className);
+  const buttonLinkStyles = cn(baseStyles, sizeStyles[size], variantStyles[variant], pill && 'rounded-full', className);
 
   const actualChildren = (
     <>
@@ -93,14 +93,14 @@ export function ButtonLink({ children, className, disabled, endIcon, endIconProp
 
   if (disabled) {
     return (
-      <a className={cn(buttonLinkClassName, 'pointer-events-none cursor-not-allowed opacity-70')} role="link" aria-disabled="true" {...props}>
+      <a className={cn(buttonLinkStyles, 'pointer-events-none cursor-not-allowed opacity-70')} role="link" aria-disabled="true" {...props}>
         {actualChildren}
       </a>
     );
   }
 
   return (
-    <AppLink className={buttonLinkClassName} routeId={routeId} to={to} {...props}>
+    <AppLink className={buttonLinkStyles} routeId={routeId} to={to} {...props}>
       {actualChildren}
     </AppLink>
   );

--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -14,9 +14,9 @@ import { extractDateParts, useMonths } from '~/utils/date-utils';
 import { padWithZero } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
+const inputBaseStyles = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden';
+const inputDisabledStyles = 'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70';
+const inputErrorStyles = 'border-red-500 focus:border-red-500 focus:ring-red-500';
 
 export interface DatePickerFieldProps {
   defaultValue: string;
@@ -225,7 +225,7 @@ function DatePickerMonth({ ariaErrorMessage, className, defaultValue, disabled, 
         aria-invalid={!!ariaErrorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, ariaErrorMessage && inputErrorClassName, className)}
+        className={cn(inputBaseStyles, inputDisabledStyles, ariaErrorMessage && inputErrorStyles, className)}
         data-testid="date-picker-month-select"
         defaultValue={defaultValue}
         disabled={disabled}
@@ -274,7 +274,7 @@ function DatePickerYear({ ariaErrorMessage, className, defaultValue, disabled, i
         aria-invalid={!!ariaErrorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, ariaErrorMessage && inputErrorClassName, className)}
+        className={cn(inputBaseStyles, inputDisabledStyles, ariaErrorMessage && inputErrorStyles, className)}
         data-testid="date-picker-year-input"
         defaultValue={defaultValue}
         disabled={disabled}
@@ -316,7 +316,7 @@ function DatePickerDay({ ariaErrorMessage, className, defaultValue, disabled, id
         aria-invalid={!!ariaErrorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, ariaErrorMessage && inputErrorClassName, className)}
+        className={cn(inputBaseStyles, inputDisabledStyles, ariaErrorMessage && inputErrorStyles, className)}
         data-testid="date-picker-day-input"
         defaultValue={defaultValue}
         disabled={disabled}

--- a/frontend/app/components/input-checkbox.tsx
+++ b/frontend/app/components/input-checkbox.tsx
@@ -4,11 +4,6 @@ import { InputError } from './input-error';
 
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'mt-0.5 size-5 rounded-sm border-gray-500 bg-gray-50 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:outline-hidden';
-const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
-const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
-const inputReadOnlyClassName = 'pointer-events-none cursor-not-allowed opacity-70';
-
 export interface InputCheckboxProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
   append?: ReactNode;
   appendClassName?: string;
@@ -38,11 +33,24 @@ export function InputCheckbox({ errorMessage, append, appendClassName, children,
           id={inputCheckboxId}
           aria-labelledby={inputLabelId}
           aria-errormessage={errorMessage ? inputErrorId : undefined}
-          className={cn(inputBaseClassName, restProps.readOnly && inputReadOnlyClassName, restProps.disabled && inputDisabledClassName, (errorMessage ?? hasError) && inputErrorClassName, inputClassName)}
+          className={cn(
+            'mt-0.5 size-5 rounded-sm border-gray-500 bg-gray-50 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:outline-hidden', //
+            (restProps.readOnly === true || restProps.disabled === true) && 'pointer-events-none cursor-not-allowed opacity-70',
+            (errorMessage ?? hasError) && 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500',
+            inputClassName,
+          )}
           data-testid="input-checkbox"
           {...restProps}
         />
-        <label id={inputLabelId} htmlFor={inputCheckboxId} className={cn('block pl-3 leading-6', restProps.readOnly && inputReadOnlyClassName, restProps.disabled && inputDisabledClassName, labelClassName)}>
+        <label
+          id={inputLabelId}
+          htmlFor={inputCheckboxId}
+          className={cn(
+            'block pl-3 leading-6', //
+            (restProps.readOnly === true || restProps.disabled === true) && 'pointer-events-none cursor-not-allowed opacity-70',
+            labelClassName,
+          )}
+        >
           {children}
         </label>
       </div>

--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -4,11 +4,6 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputFieldProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children'> {
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;
@@ -59,7 +54,13 @@ export function InputField(props: InputFieldProps) {
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          'read-only:pointer-events-none read-only:cursor-not-allowed read-only:bg-gray-100 read-only:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         data-testid="input-field"
         id={id}
         required={required}

--- a/frontend/app/components/input-pattern-field.tsx
+++ b/frontend/app/components/input-pattern-field.tsx
@@ -6,11 +6,6 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputPatternFieldProps extends OmitStrict<React.ComponentProps<typeof PatternFormat>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'value' | 'onChange'> {
   defaultValue: string;
   errorMessage?: string;
@@ -64,7 +59,13 @@ export function InputPatternField(props: InputPatternFieldProps) {
         aria-required={required}
         data-testid="input-pattern-field"
         id={id}
-        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          'read-only:pointer-events-none read-only:cursor-not-allowed read-only:bg-gray-100 read-only:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         required={required}
         value={defaultValue}
         {...restProps}

--- a/frontend/app/components/input-phone-field.tsx
+++ b/frontend/app/components/input-phone-field.tsx
@@ -9,11 +9,6 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputPhoneFieldProps extends OmitStrict<React.ComponentProps<typeof PhoneInput>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'children' | 'value'> {
   defaultValue?: string;
   errorMessage?: string;
@@ -73,7 +68,13 @@ export function InputPhoneField(props: InputPhoneFieldProps) {
         data-testid={inputPhoneTest}
         defaultCountry={defaultCountry ?? 'CA'}
         id={id}
-        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          'read-only:pointer-events-none read-only:cursor-not-allowed read-only:bg-gray-100 read-only:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         onChange={handleOnPhoneInputChange}
         required={required}
         value={value}

--- a/frontend/app/components/input-radio.tsx
+++ b/frontend/app/components/input-radio.tsx
@@ -2,11 +2,6 @@ import type { ReactNode } from 'react';
 
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'mt-0.5 size-5 border-gray-500 bg-gray-50 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:outline-hidden';
-const inputDisabledClassName = 'pointer-events-none cursor-not-allowed opacity-70';
-const inputErrorClassName = 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500';
-const inputReadOnlyClassName = 'pointer-events-none cursor-not-allowed opacity-70';
-
 export interface InputRadioProps extends OmitStrict<React.ComponentProps<'input'>, 'aria-labelledby' | 'children' | 'type'> {
   append?: ReactNode;
   appendClassName?: string;
@@ -28,11 +23,24 @@ export function InputRadio({ append, appendClassName, children, className, hasEr
           type="radio"
           id={inputRadioId}
           aria-labelledby={inputLabelId}
-          className={cn(inputBaseClassName, restProps.readOnly && inputReadOnlyClassName, restProps.disabled && inputDisabledClassName, hasError && inputErrorClassName, inputClassName)}
+          className={cn(
+            'mt-0.5 size-5 border-gray-500 bg-gray-50 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:outline-hidden', //
+            (restProps.readOnly === true || restProps.disabled === true) && 'pointer-events-none cursor-not-allowed opacity-70',
+            hasError && 'border-red-500 text-red-700 focus:border-red-500 focus:ring-red-500',
+            inputClassName,
+          )}
           data-testid={inputRadioId}
           {...restProps}
         />
-        <label id={inputLabelId} htmlFor={inputRadioId} className={cn('block pl-3 leading-6', restProps.readOnly && inputReadOnlyClassName, restProps.disabled && inputDisabledClassName, labelClassName)}>
+        <label
+          id={inputLabelId}
+          htmlFor={inputRadioId}
+          className={cn(
+            'block pl-3 leading-6', //
+            (restProps.readOnly === true || restProps.disabled === true) && 'pointer-events-none cursor-not-allowed opacity-70',
+            labelClassName,
+          )}
+        >
           {children}
         </label>
       </div>

--- a/frontend/app/components/input-sanitize-field.tsx
+++ b/frontend/app/components/input-sanitize-field.tsx
@@ -7,11 +7,6 @@ import { InputLabel } from '~/components/input-label';
 import { isAllValidInputCharacters, normalizeHyphens, removeInvalidInputCharacters } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputSanitizeFieldProps
   extends OmitStrict<React.ComponentProps<typeof NumberFormatBase>, 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required' | 'format' | 'type' | 'removeFormatting' | 'isValidInputCharacter' | 'getCaretBoundary'> {
   errorMessage?: string;
@@ -64,7 +59,13 @@ export function InputSanitizeField(props: InputSanitizeFieldProps) {
         aria-required={required}
         data-testid="input-sanitize-field"
         id={id}
-        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          'read-only:pointer-events-none read-only:cursor-not-allowed read-only:bg-gray-100 read-only:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         required={required}
         {...restProps}
         type="text"

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -7,10 +7,6 @@ import { InputOption } from './input-option';
 
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputSelectProps extends OmitStrict<ComponentProps<'select'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
   errorMessage?: string;
   helpMessage?: ReactNode;
@@ -51,7 +47,12 @@ export function InputSelect(props: InputSelectProps) {
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         data-testid={inputTestId}
         id={id}
         required={required}

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -4,11 +4,6 @@ import { InputHelp } from './input-help';
 import { InputLabel } from '~/components/input-label';
 import { cn } from '~/utils/tw-utils';
 
-const inputBaseClassName = 'block rounded-lg border-gray-500 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500';
-const inputDisabledClassName = 'disabled:bg-gray-100 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70';
-const inputReadOnlyClassName = 'read-only:bg-gray-100 read-only:pointer-events-none read-only:cursor-not-allowed read-only:opacity-70';
-const inputErrorClassName = 'border-red-500 focus:border-red-500 focus:ring-red-500';
-
 export interface InputTextareaProps extends OmitStrict<React.ComponentProps<'textarea'>, 'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'> {
   errorMessage?: string;
   helpMessage?: React.ReactNode;
@@ -47,7 +42,13 @@ export function InputTextarea(props: InputTextareaProps) {
         aria-invalid={!!errorMessage}
         aria-labelledby={inputLabelId}
         aria-required={required}
-        className={cn(inputBaseClassName, inputDisabledClassName, inputReadOnlyClassName, inputReadOnlyClassName, errorMessage && inputErrorClassName, className)}
+        className={cn(
+          'block rounded-lg border-gray-500 focus:border-blue-500 focus:ring-3 focus:ring-blue-500 focus:outline-hidden', //
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-70',
+          'read-only:pointer-events-none read-only:cursor-not-allowed read-only:bg-gray-100 read-only:opacity-70',
+          errorMessage && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+          className,
+        )}
         data-testid="input-textarea"
         id={id}
         required={required}

--- a/frontend/app/components/progress.tsx
+++ b/frontend/app/components/progress.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { useId } from 'react';
 
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 
@@ -6,7 +7,7 @@ import { useCurrentLanguage } from '~/hooks';
 import { formatPercent } from '~/utils/string-utils';
 import { cn } from '~/utils/tw-utils';
 
-const sizes = {
+const sizeStyles = {
   sx: 'h-1',
   sm: 'h-1.5',
   base: 'h-2.5',
@@ -14,7 +15,7 @@ const sizes = {
   xl: 'h-6',
 };
 
-const variants = {
+const variantStyles = {
   blue: 'bg-blue-600',
   default: 'bg-gray-600',
   green: 'bg-green-600',
@@ -22,24 +23,38 @@ const variants = {
   yellow: 'bg-yellow-400',
 };
 
-const rootBaseClassName = 'relative w-full overflow-hidden rounded-full bg-gray-200';
-const indicatorBaseClassName = 'h-full w-full flex-1 transition-all';
-
 export interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
-  size?: keyof typeof sizes;
-  variant?: keyof typeof variants;
+  size?: keyof typeof sizeStyles;
+  variant?: keyof typeof variantStyles;
   label: string;
   value: number;
 }
 
 export function Progress({ className, size = 'base', variant = 'default', value, label, ...props }: ProgressProps) {
   const { currentLanguage } = useCurrentLanguage();
+  const labelId = useId();
+
   return (
-    <>
-      {label && <p id="progress-label" className="mb-2">{`${label} ${formatPercent(value, currentLanguage)}`}</p>}
-      <ProgressPrimitive.Root className={cn(rootBaseClassName, sizes[size], className)} data-testid="progress-root" value={value} {...props} aria-labelledby={label && 'progress-label'}>
-        <ProgressPrimitive.Indicator className={cn(indicatorBaseClassName, variants[variant])} style={{ transform: `translateX(-${100 - value}%)` }} data-testid="progress-indicator" />
+    <div className="space-y-2">
+      {label && <p id={labelId}>{`${label} ${formatPercent(value, currentLanguage)}`}</p>}
+      <ProgressPrimitive.Root
+        className={cn(
+          'relative w-full overflow-hidden rounded-full bg-gray-200', //
+          sizeStyles[size],
+          className,
+        )}
+        value={value}
+        {...props}
+        aria-labelledby={labelId}
+      >
+        <ProgressPrimitive.Indicator
+          className={cn(
+            'h-full w-full flex-1 transition-all', //
+            variantStyles[variant],
+          )}
+          style={{ transform: `translateX(-${100 - value}%)` }}
+        />
       </ProgressPrimitive.Root>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request focuses on cleanup, consistency improvements, and minor refactoring across the frontend codebase.  
Key changes include:

- **Chore**
  - Updated VSCode settings to align with FSIR configuration.

- **Style Improvements**
  - Renamed button and `DatePickerField` style variable names for better Tailwind CSS IntelliSense support.
  - Removed unnecessary style variables across multiple input components:
    - `InputCheckbox`
    - `InputField`
    - `InputPatternField`
    - `InputPhoneField`
    - `InputRadio`
    - `InputSanitizeField`
    - `InputSelect`
    - `InputTextarea`

- **Refactor**
  - Improved the `Progress` component:
    - Removed redundant style variables.
    - Implemented dynamic label IDs.
    - Formatted code for better readability.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->