### PR TITLE
chore(gitops): Bumping uat1, uat2, prototype to `0.0.0-28d1189e`

### DIFF
--- a/gitops/overlays/prototype/patches/deployments.yaml
+++ b/gitops/overlays/prototype/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-71cfa21b
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-28d1189e
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/uat1/configs/frontend/config.conf
+++ b/gitops/overlays/uat1/configs/frontend/config.conf
@@ -26,7 +26,5 @@ SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
 
 ADOBE_ANALYTICS_SRC=https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js
 
-LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS=300
-
 # temporarily set killswitch TTL to two minute for easier testing
 APPLICATION_KILLSWITCH_TTL_SECONDS=120

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-71cfa21b
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-28d1189e
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat2/configs/frontend/config.conf
+++ b/gitops/overlays/uat2/configs/frontend/config.conf
@@ -25,5 +25,3 @@ ECAS_BASE_URI=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/SCL
 SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
 
 ADOBE_ANALYTICS_SRC=https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js
-
-LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS=300

--- a/gitops/overlays/uat2/patches/deployments.yaml
+++ b/gitops/overlays/uat2/patches/deployments.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-71cfa21b
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-28d1189e
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
Also removing `LOOKUP_SVC_APPLICATION_YEAR_CACHE_TTL_SECONDS=300` - application uses static values for the "application year" results.