### PR TITLE
feat(gitops): add reloader base and shared configs

### DIFF
--- a/gitops/base/reloader/deployments.yaml
+++ b/gitops/base/reloader/deployments.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reloader
+  labels:
+    app.kubernetes.io/name: reloader
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reloader
+    spec:
+      containers:
+        # see https://github.com/stakater/Reloader/pkgs/container/reloader
+        - image: ghcr.io/stakater/reloader:v1.4.1
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /live
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: reloader
+          ports:
+            - containerPort: 9090
+              name: http
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: '1'
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 512Mi
+          securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: reloader

--- a/gitops/base/reloader/kustomization.yaml
+++ b/gitops/base/reloader/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+resources:
+  - ./deployments.yaml
+  - ./roles.yaml
+  - ./service-accounts.yaml

--- a/gitops/base/reloader/roles.yaml
+++ b/gitops/base/reloader/roles.yaml
@@ -1,0 +1,76 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reloader-role
+  labels:
+    app.kubernetes.io/name: reloader-role
+rules:
+  - apiGroups:
+      - '' # core API group
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+  - apiGroups:
+      - '' # core API group
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reloader-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reloader-role
+subjects:
+  - kind: ServiceAccount
+    name: reloader

--- a/gitops/base/reloader/service-accounts.yaml
+++ b/gitops/base/reloader/service-accounts.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reloader
+  labels:
+    app.kubernetes.io/name: reloader

--- a/gitops/overlays/shared/kustomization.yaml
+++ b/gitops/overlays/shared/kustomization.yaml
@@ -19,4 +19,5 @@ labels:
       app.kubernetes.io/tier: nonprod
 resources:
   - ../../base/maintenance/
+  - ../../base/reloader/
   - ../../base/squid-proxy/


### PR DESCRIPTION
### Description

Add [Reloader](https://github.com/stakater/Reloader) for detecting changes in configmaps and secrets; deploy it to `shared` pseudoenvironment.

This new component will be used to monitor external secrets and restart the relevant pods when they change.

**Note:** I have already deployed this to the cluster while testing.