### PR TITLE
fix(frontend) add yob validation on marital-status routes

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/marital-status.tsx
@@ -99,14 +99,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('protected-apply-adult-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('protected-apply-adult-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('protected-apply-adult-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('protected-apply-adult-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('protected-apply-adult-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('protected-apply-adult-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/protected/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/marital-status.tsx
@@ -93,14 +93,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('protected-apply-adult:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('protected-apply-adult:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('protected-apply-adult:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('protected-apply-adult:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('protected-apply-adult:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('protected-apply-adult:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/marital-status.tsx
@@ -92,14 +92,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('protected-apply-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('protected-apply-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('protected-apply-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('protected-apply-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('protected-apply-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('protected-apply-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -104,14 +104,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('protected-renew:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('protected-renew:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('protected-renew:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('protected-renew:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('protected-renew:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('protected-renew:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/marital-status.tsx
@@ -89,14 +89,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('apply-adult-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('apply-adult-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('apply-adult-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('apply-adult-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('apply-adult-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('apply-adult-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/marital-status.tsx
@@ -84,14 +84,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('apply-adult:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('apply-adult:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('apply-adult:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('apply-adult:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('apply-adult:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('apply-adult:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/apply/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/apply/$id/child/marital-status.tsx
@@ -82,14 +82,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('apply-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('apply-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('apply-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('apply-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('apply-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('apply-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/marital-status.tsx
@@ -95,14 +95,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-adult-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-adult-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('renew-adult-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('renew-adult-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('renew-adult-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('renew-adult-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/marital-status.tsx
@@ -95,14 +95,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-adult:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-adult:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('renew-adult:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('renew-adult:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('renew-adult:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('renew-adult:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/renew/$id/child/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/child/marital-status.tsx
@@ -95,14 +95,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-child:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-child:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('renew-child:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('renew-child:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('renew-child:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('renew-child:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -77,14 +77,15 @@ export async function action({ context: { appContainer, session }, params, reque
       .min(1, t('renew-ita:marital-status.error-message.marital-status-required')),
   });
 
-  const currentYear = new Date().getFullYear().toString();
+  const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
     confirm: z.boolean().refine((val) => val === true, t('renew-ita:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()
       .min(1, t('renew-ita:marital-status.error-message.date-of-birth-year-required'))
-      .refine((year) => year < currentYear, t('renew-ita:marital-status.error-message.yob-is-future')),
+      .refine((year) => parseInt(year) > currentYear - 150, t('renew-ita:marital-status.error-message.yob-is-past'))
+      .refine((year) => parseInt(year) < currentYear, t('renew-ita:marital-status.error-message.yob-is-future')),
     socialInsuranceNumber: z
       .string()
       .trim()

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -68,6 +68,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -66,6 +66,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -55,6 +55,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/protected-apply-adult-child.json
+++ b/frontend/public/locales/en/protected-apply-adult-child.json
@@ -68,6 +68,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/protected-apply-adult.json
+++ b/frontend/public/locales/en/protected-apply-adult.json
@@ -66,6 +66,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/protected-apply-child.json
+++ b/frontend/public/locales/en/protected-apply-child.json
@@ -55,6 +55,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -211,6 +211,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -35,6 +35,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -35,6 +35,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -280,6 +280,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Select marital status",
       "confirm-required": "Consent from spouse or common-law partner is required to proceed",
       "date-of-birth-year-required": "Enter year of birth, for example 1950",
+      "yob-is-past": "Year of birth too far in the past",
       "yob-is-future": "Year of birth must be in the past",
       "sin-required": "Enter 9-digit SIN, for example 123 456 789",
       "sin-valid": "Must be a valid SIN",

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -68,6 +68,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -66,6 +66,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -55,6 +55,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/protected-apply-adult-child.json
+++ b/frontend/public/locales/fr/protected-apply-adult-child.json
@@ -68,6 +68,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/protected-apply-adult.json
+++ b/frontend/public/locales/fr/protected-apply-adult.json
@@ -66,6 +66,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/protected-apply-child.json
+++ b/frontend/public/locales/fr/protected-apply-child.json
@@ -55,6 +55,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -211,6 +211,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -35,6 +35,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -35,6 +35,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -282,6 +282,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -19,6 +19,7 @@
       "marital-status-required": "Sélectionnez l'état civil",
       "confirm-required": "Le consentement de l'époux/épouse ou du conjoint de fait est requis pour procéder",
       "date-of-birth-year-required": "Entrez l'année de naissance, par exemple 1950",
+      "yob-is-past": "Année de naissance trop éloignée dans le passé",
       "yob-is-future": "L'année de naissance doit être dans le passé",
       "sin-required": "Entrez un NAS de 9 chiffres, par exemple 123 456 789",
       "sin-valid": "Le NAS doit être valide",


### PR DESCRIPTION
### Description
Adds validation to check if a spouse/partner's Y.O.B. is greater than the current year minus 150 years.  

### Related Azure Boards Work Items
[AB#5881](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/5881)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/15a98d58-926b-439f-b3a4-ab9eb4e550ec)
### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
