### PR TITLE
feat(gitops): Add maintenance ingress configuration and HTML page for letters service downtime

### DIFF
--- a/gitops/overlays/prod/configs/maintenance/503.html
+++ b/gitops/overlays/prod/configs/maintenance/503.html
@@ -1,0 +1,111 @@
+<!--
+  Maintenance page copied (and slightly modified) from: https://www.canada.ca/errors/503.html
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Service Unavailable - Canada.ca</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+      integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4="
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="icon" type="image/x-icon"
+      href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <header>
+      <div id="wb-bnr" class="container">
+        <div class="row">
+          <div class="brand col-xs-8 col-sm-9 col-md-6">
+            <img
+              src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg"
+              alt="Government of Canada / Gouvernement du Canada"
+              crossorigin="anonymous"
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+    <main property="mainContentOfPage" resource="#wb-main" class="container">
+      <h1 id="wb-cont" class="wb-inv">Service Unavailable</h1>
+      <div class="row mrgn-tp-lg mrgn-bttm-lg">
+        <div class="col-md-12">
+          <div class="row">
+            <section>
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">This service is currently not available</h2>
+                    </div>
+                  </div>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p class="mrgn-tp-lg">Display of letters is temporarily unavailable.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section lang="fr">
+              <div class="col-md-6">
+                <div class="mwstext section">
+                  <div class="row">
+                    <div class="col-xs-3 col-sm-2 col-md-2 text-center mrgn-tp-md">
+                      <span class="glyphicon glyphicon-warning-sign glyphicon-error"></span>
+                    </div>
+                    <div class="col-xs-9 col-sm-10 col-md-10">
+                      <h2 class="mrgn-tp-md">Le service est actuellement indisponible</h2>
+                    </div>
+                  </div>
+                  <div class="row mrgn-bttm-lg">
+                    <div class="col-md-12">
+                      <p class="mrgn-tp-lg">Consulter mes lettres est temporairement indisponible.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer role="contentinfo" id="wb-info">
+      <div class="brand">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-6 visible-sm visible-xs tofpg">
+              <a href="#wb-cont">
+                <span lang="en">Top of page</span> / <span lang="fr">Haut de la page</span>
+                <span class="glyphicon glyphicon-chevron-up"></span>
+              </a>
+            </div>
+            <div class="col-xs-6 col-md-12 text-right">
+              <img
+                src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg"
+                alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
+                crossorigin="anonymous"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/gitops/overlays/prod/ingresses-letters-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-letters-maintenance.yaml
@@ -1,0 +1,66 @@
+# This file defines ingress resources that put the online application into "maintenance mode".
+#
+# To enable maintenance mode, reference this file in kustomization.yaml.
+# This will route traffic for the online application to the maintenance and OAuth proxy services,
+# while preserving access to the allowed routes.
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: srv024.service.canada.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(letters|lettres)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: maintenance
+                port:
+                  name: http
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-internal
+  labels:
+    app.kubernetes.io/name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k # required for OAuth proxy
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+          - path: /.+/(letters|lettres)(/.+)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: oauth-proxy

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -25,9 +25,10 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  - ./ingresses.yaml
+  # - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
+  - ./ingresses-letters-maintenance.yaml
   # - ./ingresses-renew-error-404.yaml
 patches:
   - path: ./patches/deployments-error-404.yaml
@@ -56,6 +57,10 @@ configMapGenerator:
       - ./configs/oauth-proxy/config.conf
   - name: maintenance
     behavior: merge
+    # TODO :: GjB :: this is a temporary override of the maintenance page HTML
+    #                it should be removed when the letters are brought back online
+    files:
+      - ./configs/maintenance/503.html
     literals:
       - startTimeEn=10:00pm EDT April 30, 2025
       - startTimeFr=30 avril 2025 à 22 h 00 HAE


### PR DESCRIPTION
### Description

Temporary maintenance page to block access to the display of letters feature.

![image](https://github.com/user-attachments/assets/f55a54a0-72af-4a13-a1e9-d37cf20c0884)
