### PR TITLE
feat(gitops): disable letters maintenance page in prod

### DIFF
--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -25,10 +25,11 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  # - ./ingresses.yaml
+  - ./ingresses.yaml
   # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
-  - ./ingresses-letters-maintenance.yaml
+  # Note: for the letters maintenance page, see the maintenance configMapGenerator below
+  # - ./ingresses-letters-maintenance.yaml
   # - ./ingresses-renew-error-404.yaml
 patches:
   - path: ./patches/deployments-error-404.yaml
@@ -59,8 +60,10 @@ configMapGenerator:
     behavior: merge
     # TODO :: GjB :: this is a temporary override of the maintenance page HTML
     #                it should be removed when the letters are brought back online
-    files:
-      - ./configs/maintenance/503.html
+    # TODO :: GjB :: I am commenting this out but leaving the updated 503 page in
+    #                the project as a reference for future, similar deployments
+    # files:
+    #   - ./configs/maintenance/503.html
     literals:
       - startTimeEn=10:00pm EDT April 30, 2025
       - startTimeFr=30 avril 2025 à 22 h 00 HAE


### PR DESCRIPTION
Remove the maintenance page that is blocking /en/protected/letters and /fr/protege/lettres.
This deployment is scheduled to take place:

## Saturday, May 03 @ 06h00 ET