### PR TITLE
fix(frontend): Sanitize `routeId` to replace all `$` in metric names

### DIFF
--- a/frontend/app/.server/express-server/instrumentation.server.ts
+++ b/frontend/app/.server/express-server/instrumentation.server.ts
@@ -61,7 +61,7 @@ export function routeRequestCounter(build: ServerBuild): RequestHandler {
 
         if (routeId) {
           // Construct metric identifier (e.g., POST '/user/$id/profile' → 'user._id.profile.posts')
-          const metricPrefix = `${routeId.replaceAll('/', '.').replace(/\$([^.]+)/g, '_$1')}.${req.method.toLowerCase()}s`;
+          const metricPrefix = `${routeId.replaceAll('/', '.').replaceAll('$', '_')}.${req.method.toLowerCase()}s`;
           instrumentationService.countHttpStatus(metricPrefix, res.statusCode);
         }
       } catch (error) {


### PR DESCRIPTION
### Description
Fixes invalid metric name. For example:
```
Invalid metric name: "auth.$.gets.requests.status.302". The metric name should be a ASCII string with a length no greater than 255 characters.
Invalid metric name: "auth.$.gets.requests.status.success". The metric name should be a ASCII string with a length no greater than 255 characters.
```

### Screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/4013cc74-d0c3-46ab-a2e8-011bcf25d7a3)

After:
![image](https://github.com/user-attachments/assets/166b3e0c-9c97-4b7e-b5c2-a1a75b9dfa79)

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`