### PR TITLE
ci: Adding nightly end-to-end tests for main and release branches

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,0 +1,27 @@
+name: Nightly e2e tests (main & release)
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+env:
+  CI: true
+
+permissions: read-all
+
+jobs:
+  run-e2e-tests:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm clean-install
+        working-directory: frontend/
+      - run: npx playwright install chromium --with-deps
+        working-directory: frontend/
+      - run: npm run test:e2e
+        working-directory: frontend/


### PR DESCRIPTION
### Description
This PR adds a GitHub Actions workflow to run nightly e2e tests on the `main` branch and any `release/*` branches. 
Note that this workflow won't run on `release/*` branches where the workflow YAML file does not exist.

### Additional Notes
https://github.com/DTS-STN/canadian-dental-care-plan/actions/workflows/nightly-e2e.yaml