### PR TITLE
refactor(frontend): Reorganizing e2e directory

### DIFF
--- a/frontend/e2e/pages/base-page.ts
+++ b/frontend/e2e/pages/base-page.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
-export class PlaywrightBasePage {
+export class BasePage {
   readonly page: Page;
 
   constructor(page: Page) {

--- a/frontend/e2e/pages/protected/apply/adult-child-page.ts
+++ b/frontend/e2e/pages/protected/apply/adult-child-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from '../playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
+export class AdultChildPage extends BasePage {
   async isLoaded(
     applyAdultChildPage:
       | 'applicant-information'

--- a/frontend/e2e/pages/protected/apply/adult-page.ts
+++ b/frontend/e2e/pages/protected/apply/adult-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from '../playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyAdultPage extends PlaywrightBasePage {
+export class AdultPage extends BasePage {
   async isLoaded(
     applyAdultPage:
       | 'applicant-information'

--- a/frontend/e2e/pages/protected/apply/child-page.ts
+++ b/frontend/e2e/pages/protected/apply/child-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from '../playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyChildPage extends PlaywrightBasePage {
+export class ChildPage extends BasePage {
   async isLoaded(
     applyChildPage:
       | 'applicant-information'

--- a/frontend/e2e/pages/protected/apply/initial-page.ts
+++ b/frontend/e2e/pages/protected/apply/initial-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from '../playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyPage extends PlaywrightBasePage {
+export class InitialPage extends BasePage {
   async gotoIndexPage() {
     await this.page.goto('/en/protected/apply');
   }

--- a/frontend/e2e/pages/public/apply/adult-child-page.ts
+++ b/frontend/e2e/pages/public/apply/adult-child-page.ts
@@ -1,13 +1,13 @@
-import { PlaywrightBasePage } from './playwright-base-page';
+import { BasePage } from '../../base-page';
 
-interface fillApplicantInformationFormArgs {
+interface FillApplicantInformationFormArgs {
   day: string;
   month: string;
   year: string;
   dtcEligible: boolean;
 }
 
-export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
+export class AdultChildPage extends BasePage {
   async isLoaded(
     applyAdultChildPage:
       | 'applicant-information'
@@ -135,7 +135,7 @@ export class PlaywrightApplyAdultChildPage extends PlaywrightBasePage {
     await super.isLoaded(pageInfo.url, heading ?? pageInfo.heading);
   }
 
-  async fillApplicantInformationForm({ day, month, year, dtcEligible }: fillApplicantInformationFormArgs) {
+  async fillApplicantInformationForm({ day, month, year, dtcEligible }: FillApplicantInformationFormArgs) {
     await this.isLoaded('applicant-information');
     await this.page.getByRole('textbox', { name: 'First name' }).fill('John');
     await this.page.getByRole('textbox', { name: 'Last name' }).fill('Smith');

--- a/frontend/e2e/pages/public/apply/adult-page.ts
+++ b/frontend/e2e/pages/public/apply/adult-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from './playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyAdultPage extends PlaywrightBasePage {
+export class AdultPage extends BasePage {
   async isLoaded(
     applyAdultPage:
       | 'applicant-information'

--- a/frontend/e2e/pages/public/apply/child-page.ts
+++ b/frontend/e2e/pages/public/apply/child-page.ts
@@ -1,7 +1,7 @@
-import { calculateDOB } from '../utils/helpers';
-import { PlaywrightBasePage } from './playwright-base-page';
+import { calculateDOB } from '../../../utils/helpers';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyChildPage extends PlaywrightBasePage {
+export class ChildPage extends BasePage {
   async isLoaded(
     applyChildPage:
       | 'applicant-information'

--- a/frontend/e2e/pages/public/apply/initial-page.ts
+++ b/frontend/e2e/pages/public/apply/initial-page.ts
@@ -1,6 +1,6 @@
-import { PlaywrightBasePage } from './playwright-base-page';
+import { BasePage } from '../../base-page';
 
-export class PlaywrightApplyPage extends PlaywrightBasePage {
+export class InitialPage extends BasePage {
   async gotoIndexPage() {
     await this.page.goto('/en/apply');
   }

--- a/frontend/e2e/protected/apply/adult-category.spec.ts
+++ b/frontend/e2e/protected/apply/adult-category.spec.ts
@@ -1,14 +1,14 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../models/protected/playwright-apply-adult-page';
-import { PlaywrightApplyPage } from '../../models/protected/playwright-apply-page';
+import { AdultPage } from '../../pages/protected/apply/adult-page';
+import { InitialPage } from '../../pages/protected/apply/initial-page';
 import { acceptLegalCheckboxes, calculateDOB, clickContinue, fillApplicantInformationForm, fillOutAddress } from '../../utils/helpers';
 
 test.describe('Adult category', () => {
   test.beforeEach('Navigate to adult application', async ({ page }) => {
     test.setTimeout(60_000);
 
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     // Accept Terms
@@ -29,7 +29,7 @@ test.describe('Adult category', () => {
 
   // TODO: Add test cases for living-independently and new-or-existing-user
   test('Should complete flow as adult applicant', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -134,7 +134,7 @@ test.describe('Adult category', () => {
   });
 
   test('Applicant is under 16 years old', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -151,7 +151,7 @@ test.describe('Adult category', () => {
   });
 
   test('Applicant is 16 or 17 years old and lives with parents', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -175,7 +175,7 @@ test.describe('Adult category', () => {
   });
 
   test('Applicant is 16 or 17 years old and does not lives with parents', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -207,7 +207,7 @@ test.describe('Adult category', () => {
   });
 
   test('Applicantis born on 2006', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');

--- a/frontend/e2e/protected/apply/adult-child-category.spec.ts
+++ b/frontend/e2e/protected/apply/adult-child-category.spec.ts
@@ -1,14 +1,14 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultChildPage } from '../../models/protected/playwright-apply-adult-child-page';
-import { PlaywrightApplyPage } from '../../models/protected/playwright-apply-page';
+import { AdultChildPage } from '../../pages/protected/apply/adult-child-page';
+import { InitialPage } from '../../pages/protected/apply/initial-page';
 import { acceptLegalCheckboxes, calculateDOB, clickContinue, fillApplicantInformationForm, fillChildrenInformationForm, fillOutAddress } from '../../utils/helpers';
 
 test.describe('Adult-Child category', () => {
   test.beforeEach('Navigate to adult-child application', async ({ page }) => {
     test.setTimeout(60_000);
 
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     // Accept Terms
@@ -29,7 +29,7 @@ test.describe('Adult-Child category', () => {
 
   // TODO: Add test cases for living-independently and new-or-existing-member
   test('Should complete flow as adult-child applicant', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultChildPage.isLoaded('applicant-information');
@@ -185,7 +185,7 @@ test.describe('Adult-Child category', () => {
   });
 
   test('Applicant is under 16 years old', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultChildPage.isLoaded('applicant-information');
@@ -202,7 +202,7 @@ test.describe('Adult-Child category', () => {
   });
 
   test('Applicant is 16 or 17 years old and lives with parents', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultChildPage.isLoaded('applicant-information');
@@ -226,7 +226,7 @@ test.describe('Adult-Child category', () => {
   });
 
   test('Applicant is 16 or 17 years old and does not lives with parents', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultChildPage.isLoaded('applicant-information');
@@ -258,7 +258,7 @@ test.describe('Adult-Child category', () => {
   });
 
   test('Applicantis born on 2006', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultChildPage.isLoaded('applicant-information');

--- a/frontend/e2e/protected/apply/child-category.spec.ts
+++ b/frontend/e2e/protected/apply/child-category.spec.ts
@@ -1,14 +1,14 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyChildPage } from '../../models/protected/playwright-apply-child-page';
-import { PlaywrightApplyPage } from '../../models/protected/playwright-apply-page';
+import { ChildPage } from '../../pages/protected/apply/child-page';
+import { InitialPage } from '../../pages/protected/apply/initial-page';
 import { acceptLegalCheckboxes, calculateDOB, clickContinue, fillApplicantInformationForm, fillChildrenInformationForm, fillOutAddress } from '../../utils/helpers';
 
 test.describe('Child category', () => {
   test.beforeEach('Navigate to child application', async ({ page }) => {
     test.setTimeout(60_000);
 
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     // Accept Terms
@@ -29,7 +29,7 @@ test.describe('Child category', () => {
 
   // TODO: Add test cases for living-independently and new-or-existing-user
   test('Should complete flow as child applicant', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children page', async () => {
       await applyChildPage.isLoaded('children');
@@ -150,7 +150,7 @@ test.describe('Child category', () => {
   });
 
   test('Applicant is not parent or legal guardian of child', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children page', async () => {
       await applyChildPage.isLoaded('children');
@@ -172,7 +172,7 @@ test.describe('Child category', () => {
   });
 
   test('Child is 18 or older and has no sin', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children page', async () => {
       await applyChildPage.isLoaded('children');
@@ -193,7 +193,7 @@ test.describe('Child category', () => {
   });
 
   test('Child is 17 or younger and has no sin', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children page', async () => {
       await applyChildPage.isLoaded('children');
@@ -218,8 +218,8 @@ test.describe('Child category - parent or legual guardian miscellaneous checks',
   test.beforeEach('Navigate to child application', async ({ page }) => {
     test.setTimeout(60_000);
 
-    const applyPage = new PlaywrightApplyPage(page);
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyPage = new InitialPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await applyPage.gotoIndexPage();
 
@@ -274,7 +274,7 @@ test.describe('Child category - parent or legual guardian miscellaneous checks',
   });
 
   test('Parent or guardian is 15 or younger', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
     await test.step('Should navigate to applicant information page', async () => {
       await applyChildPage.isLoaded('applicant-information');
       const { year, month, day } = calculateDOB(15);
@@ -289,7 +289,7 @@ test.describe('Child category - parent or legual guardian miscellaneous checks',
   });
 
   test('Parent or guardian born or 2006', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
     await test.step('Should navigate to applicant information page', async () => {
       await applyChildPage.isLoaded('applicant-information');
       await fillApplicantInformationForm({ firstName: 'John', lastName: 'Smith', sin: '900000001', day: '10', month: '10', year: '2006', dtcEligible: undefined, page });

--- a/frontend/e2e/public/apply/adult-child/adult-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-child/adult-category.spec.ts
@@ -1,14 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultChildPage } from '../../../models/playwright-apply-adult-child-page';
-// import { PlaywrightApplyAdultPage } from '../../../models/PlaywrightApplyAdultPage';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultChildPage } from '../../../pages/public/apply/adult-child-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
-test.describe('Children application', () => {
+test.describe('Adult category', () => {
   test.beforeEach('Navigate to adult and child application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -28,36 +27,39 @@ test.describe('Children application', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
   });
 
-  test('Child is not eligible, applicant want tp apply for themself', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('Should return to CDCP main page if applicant and child are not eligible', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(70);
+      const { year, month, day } = calculateDOB(35);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-    // TODO: Add the rest of the children flow tests.
+
+    // TODO: Add remaining tests when pages are added/reworked.
   });
 
-  test('applicant is not eligible to apply for children, but want to apply for themself', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('Should navigate to child flow if applicant is not eligible but wish to apply for children', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(70);
+      const { year, month, day } = calculateDOB(35);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-    // TODO: Add the rest of the children flow tests.
+
+    // TODO: Add remaining tests when pages are added/reworked.
   });
 
-  test('Should complete application if applicant is senior and child is under 18', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('Should navigate to adult flow if child is not eligible but applicant wish to apply for themself', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(70);
+      const { year, month, day } = calculateDOB(35);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-    // TODO: Add the rest of the children flow tests.
+
+    // TODO: Add remaining tests when pages are added/reworked.
   });
 });

--- a/frontend/e2e/public/apply/adult-child/children-application.spec.ts
+++ b/frontend/e2e/public/apply/adult-child/children-application.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultChildPage } from '../../../models/playwright-apply-adult-child-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultChildPage } from '../../../pages/public/apply/adult-child-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
-test.describe('Adult category', () => {
+test.describe('Children application', () => {
   test.beforeEach('Navigate to adult and child application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -27,39 +27,36 @@ test.describe('Adult category', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
   });
 
-  test('Should return to CDCP main page if applicant and child are not eligible', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('Child is not eligible, applicant want tp apply for themself', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(70);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-
-    // TODO: Add remaining tests when pages are added/reworked.
+    // TODO: Add the rest of the children flow tests.
   });
 
-  test('Should navigate to child flow if applicant is not eligible but wish to apply for children', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('applicant is not eligible to apply for children, but want to apply for themself', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(70);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-
-    // TODO: Add remaining tests when pages are added/reworked.
+    // TODO: Add the rest of the children flow tests.
   });
 
-  test('Should navigate to adult flow if child is not eligible but applicant wish to apply for themself', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+  test('Should complete application if applicant is senior and child is under 18', async ({ page }) => {
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
-      const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(70);
       await applyAdultChildPage.fillApplicantInformationForm({ day: day, month: month, year: year, dtcEligible: true });
       await page.getByRole('button', { name: 'Continue' }).click();
     });
-
-    // TODO: Add remaining tests when pages are added/reworked.
+    // TODO: Add the rest of the children flow tests.
   });
 });

--- a/frontend/e2e/public/apply/adult-child/senior-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-child/senior-category.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultChildPage } from '../../../models/playwright-apply-adult-child-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultChildPage } from '../../../pages/public/apply/adult-child-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
 test.describe('Senior category', () => {
   test.beforeEach('Navigate to adult and child application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -28,7 +28,7 @@ test.describe('Senior category', () => {
   });
 
   test('Should navigate to adult flow if child is not eligible but applicant wish to apply for themself', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       const { year, month, day } = calculateDOB(70);

--- a/frontend/e2e/public/apply/adult-child/youth-category.spec.ts
+++ b/frontend/e2e/public/apply/adult-child/youth-category.spec.ts
@@ -1,13 +1,13 @@
 import { expect, test } from '@playwright/test';
 
-import { PlaywrightApplyAdultChildPage } from '../../../models/playwright-apply-adult-child-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultChildPage } from '../../../pages/public/apply/adult-child-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
 test.describe('Youth category', () => {
   test.beforeEach('Navigate to adult and child application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -28,7 +28,7 @@ test.describe('Youth category', () => {
   });
 
   test('Should navigate to New or existing member page if applicant is 16 or 17, child is not under 18', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       const { year, month, day } = calculateDOB(16);
@@ -47,7 +47,7 @@ test.describe('Youth category', () => {
   });
 
   test('Should return to CDCP main page if applicant is 16, child is under 18', async ({ page }) => {
-    const applyAdultChildPage = new PlaywrightApplyAdultChildPage(page);
+    const applyAdultChildPage = new AdultChildPage(page);
 
     await test.step('Should navigate to date of birth page', async () => {
       const { year, month, day } = calculateDOB(15);

--- a/frontend/e2e/public/apply/adult/adult-category.spec.ts
+++ b/frontend/e2e/public/apply/adult/adult-category.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../../models/playwright-apply-adult-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultPage } from '../../../pages/public/apply/adult-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
-test.describe('Youth category', () => {
+test.describe('Adult category', () => {
   test.beforeEach('Navigate to adult application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -27,8 +27,8 @@ test.describe('Youth category', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
   });
 
-  test('Should return to CDCP main page if applicant is 16 or 17 and not living independently', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+  test('Should complete flow as adult applicant', async ({ page }) => {
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -37,26 +37,7 @@ test.describe('Youth category', () => {
       await page.getByRole('textbox', { name: 'Last name' }).fill('Smith');
       await page.getByRole('textbox', { name: 'Social Insurance Number (SIN)' }).fill('900000001');
 
-      const { year, month, day } = calculateDOB(16);
-      await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
-      await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
-      await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);
-
-      await page.getByRole('button', { name: 'Continue' }).click();
-    });
-  });
-
-  test('Should complete flow as youth applicant', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
-
-    await test.step('Should navigate to applicant information page', async () => {
-      await applyAdultPage.isLoaded('applicant-information');
-
-      await page.getByRole('textbox', { name: 'First name' }).fill('John');
-      await page.getByRole('textbox', { name: 'Last name' }).fill('Smith');
-      await page.getByRole('textbox', { name: 'Social Insurance Number (SIN)' }).fill('900000001');
-
-      const { year, month, day } = calculateDOB(16);
+      const { year, month, day } = calculateDOB(35);
       await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
       await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
       await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);

--- a/frontend/e2e/public/apply/adult/senior-category.spec.ts
+++ b/frontend/e2e/public/apply/adult/senior-category.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../../models/playwright-apply-adult-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultPage } from '../../../pages/public/apply/adult-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
 test.describe('Senior category', () => {
   test.beforeEach('Navigate to adult application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -28,7 +28,7 @@ test.describe('Senior category', () => {
   });
 
   test('Should complete flow as senior applicant', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');

--- a/frontend/e2e/public/apply/adult/youth-category.spec.ts
+++ b/frontend/e2e/public/apply/adult/youth-category.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../../models/playwright-apply-adult-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { AdultPage } from '../../../pages/public/apply/adult-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 import { calculateDOB } from '../../../utils/helpers';
 
-test.describe('Adult category', () => {
+test.describe('Youth category', () => {
   test.beforeEach('Navigate to adult application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -27,8 +27,8 @@ test.describe('Adult category', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
   });
 
-  test('Should complete flow as adult applicant', async ({ page }) => {
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+  test('Should return to CDCP main page if applicant is 16 or 17 and not living independently', async ({ page }) => {
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should navigate to applicant information page', async () => {
       await applyAdultPage.isLoaded('applicant-information');
@@ -37,7 +37,26 @@ test.describe('Adult category', () => {
       await page.getByRole('textbox', { name: 'Last name' }).fill('Smith');
       await page.getByRole('textbox', { name: 'Social Insurance Number (SIN)' }).fill('900000001');
 
-      const { year, month, day } = calculateDOB(35);
+      const { year, month, day } = calculateDOB(16);
+      await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
+      await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
+      await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);
+
+      await page.getByRole('button', { name: 'Continue' }).click();
+    });
+  });
+
+  test('Should complete flow as youth applicant', async ({ page }) => {
+    const applyAdultPage = new AdultPage(page);
+
+    await test.step('Should navigate to applicant information page', async () => {
+      await applyAdultPage.isLoaded('applicant-information');
+
+      await page.getByRole('textbox', { name: 'First name' }).fill('John');
+      await page.getByRole('textbox', { name: 'Last name' }).fill('Smith');
+      await page.getByRole('textbox', { name: 'Social Insurance Number (SIN)' }).fill('900000001');
+
+      const { year, month, day } = calculateDOB(16);
       await page.getByRole('combobox', { name: 'Month' }).selectOption(month);
       await page.getByRole('textbox', { name: 'Day (DD)' }).fill(day);
       await page.getByRole('textbox', { name: 'Year (YYYY)' }).fill(year);

--- a/frontend/e2e/public/apply/apply.smoke.spec.ts
+++ b/frontend/e2e/public/apply/apply.smoke.spec.ts
@@ -1,15 +1,15 @@
 import { test } from '@playwright/test';
 
-import { PlaywrightApplyAdultPage } from '../../models/playwright-apply-adult-page';
-import { PlaywrightApplyPage } from '../../models/playwright-apply-page';
+import { AdultPage } from '../../pages/public/apply/adult-page';
+import { InitialPage } from '../../pages/public/apply/initial-page';
 import { acceptLegalCheckboxes, clickContinue, fillApplicantInformationForm, fillOutAddress } from '../../utils/helpers';
 
 test.describe('Public Apply Flow - Minimal Scenario', { tag: '@smoke' }, () => {
   test.describe.configure({ timeout: 60_000 });
 
   test('Should complete minimal public apply adult flow', async ({ page }) => {
-    const applyPage = new PlaywrightApplyPage(page);
-    const applyAdultPage = new PlaywrightApplyAdultPage(page);
+    const applyPage = new InitialPage(page);
+    const applyAdultPage = new AdultPage(page);
 
     await test.step('Should accept terms and conditions and proceed', async () => {
       await applyPage.gotoIndexPage();

--- a/frontend/e2e/public/apply/child/children-application.spec.ts
+++ b/frontend/e2e/public/apply/child/children-application.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from '@playwright/test';
 
-import { PlaywrightApplyChildPage } from '../../../models/playwright-apply-child-page';
-import { PlaywrightApplyPage } from '../../../models/playwright-apply-page';
+import { ChildPage } from '../../../pages/public/apply/child-page';
+import { InitialPage } from '../../../pages/public/apply/initial-page';
 
 test.describe('Children application', () => {
   test.beforeEach('Navigate to child application', async ({ page }) => {
     test.setTimeout(60_000);
-    const applyPage = new PlaywrightApplyPage(page);
+    const applyPage = new InitialPage(page);
     await applyPage.gotoIndexPage();
 
     await applyPage.isLoaded('terms-and-conditions');
@@ -25,7 +25,7 @@ test.describe('Children application', () => {
   });
 
   test('Should return to CDCP main page if child is over 18', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children application page', async () => {
       await applyChildPage.isLoaded('children');
@@ -48,7 +48,7 @@ test.describe('Children application', () => {
   });
 
   test('Should return to CDCP main page if applicant is not legal guardian', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children application page', async () => {
       await applyChildPage.isLoaded('children');
@@ -71,7 +71,7 @@ test.describe('Children application', () => {
   });
 
   test('Should complete application for children', async ({ page }) => {
-    const applyChildPage = new PlaywrightApplyChildPage(page);
+    const applyChildPage = new ChildPage(page);
 
     await test.step('Should navigate to children application page', async () => {
       await applyChildPage.isLoaded('children');


### PR DESCRIPTION
### Description
This PR reorganizes the e2e directory to improve its clarity and consistency, including the following changes:
- Removed redundant `Playwright` prefixes 
    (eg. `PlaywrightApplyAdultChildPage` to `AdultChildPage`)
- Renamed the `models` directory to `pages`
- Organizing Pages into feature-based sub-directories 
    (eg. `/protected/playwright-apply-child-page` to `/protected/apply/adult-child-page`

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`