### PR TITLE
AB#6008 -- Created mock repo for letter type when 'power-platform' mock is enabled

### DIFF
--- a/frontend/app/.server/container-modules/repositories.container-module.ts
+++ b/frontend/app/.server/container-modules/repositories.container-module.ts
@@ -32,6 +32,7 @@ import {
   MockBenefitRenewalRepository,
   MockClientApplicationRepository,
   MockLetterRepository,
+  MockLetterTypeRepository,
   MockVerificationCodeRepository,
 } from '~/.server/domain/repositories';
 import type { MockName } from '~/.server/utils/env.utils';
@@ -96,7 +97,9 @@ export function createRepositoriesContainerModule(serverConfig: Pick<ServerConfi
     options.bind(TYPES.domain.repositories.LetterRepository).to(DefaultLetterRepository).when(isMockEnabled(serverConfig, 'cct', false));
     options.bind(TYPES.domain.repositories.LetterRepository).to(MockLetterRepository).when(isMockEnabled(serverConfig, 'cct', true));
 
-    options.bind(TYPES.domain.repositories.LetterTypeRepository).to(DefaultLetterTypeRepository);
+    options.bind(TYPES.domain.repositories.LetterTypeRepository).to(DefaultLetterTypeRepository).when(isMockEnabled(serverConfig, 'power-platform', false));
+    options.bind(TYPES.domain.repositories.LetterTypeRepository).to(MockLetterTypeRepository).when(isMockEnabled(serverConfig, 'power-platform', true));
+
     options.bind(TYPES.domain.repositories.MaritalStatusRepository).to(DefaultMaritalStatusRepository);
 
     options.bind(TYPES.domain.repositories.VerificationCodeRepository).to(DefaultVerificationCodeRepository).when(isMockEnabled(serverConfig, 'gc-notify', false));

--- a/frontend/app/.server/domain/repositories/letter-type.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter-type.repository.ts
@@ -29,6 +29,25 @@ export class DefaultLetterTypeRepository implements LetterTypeRepository {
   }
 
   listAllLetterTypes(): ReadonlyArray<LetterTypeEntity> {
+    throw new Error('Letter type service is not yet implemented');
+    //TODO: Implement listAllLetterTypes service
+  }
+
+  findLetterTypeById(id: string): LetterTypeEntity | null {
+    throw new Error('Letter type service is not yet implemented');
+    //TODO: Implement findLetterTypeById service
+  }
+}
+
+@injectable()
+export class MockLetterTypeRepository implements LetterTypeRepository {
+  private readonly log: Logger;
+
+  constructor() {
+    this.log = createLogger('MockLetterTypeRepository');
+  }
+
+  listAllLetterTypes(): ReadonlyArray<LetterTypeEntity> {
     this.log.debug('Fetching all letter types');
     const letterTypeEntities = letterTypeJsonDataSource.value.at(0)?.OptionSet.Options;
 


### PR DESCRIPTION
### Description
Created a default/mock repository for the letter-type service when the 'power-platform' mock is enabled. Throws error 'Letter type service is not yet implemented' when disabled.

### Related Azure Boards Work Items
AB#6008 