### PR TITLE
chore(gitops): Configure frontend timezone and age 18-34 start date in dev

### DIFF
--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -22,3 +22,5 @@ MOCK_AUTH_ALLOWED_REDIRECTS=https://cdcp-dev.dev-dp.dts-stn.com/auth/callback/ra
 
 SCCH_BASE_URI=https://secure-client-hub-dev.bdm.dshp-phdn.net
 
+# TODO remove this config when 18-35 is tested
+APPLY_ELIGIBILITY_RULES='[{"minAge":55,"maxAge":64,"startDate":"2025-05-01"},{"minAge":18,"maxAge":34,"startDate":"2025-05-14"},{"minAge":35,"maxAge":54,"startDate":"2025-05-29"}]'

--- a/gitops/overlays/dev/patches/deployments.yaml
+++ b/gitops/overlays/dev/patches/deployments.yaml
@@ -13,6 +13,9 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
+          env:
+            - name: TZ
+              value: America/Toronto
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
The default pod time zone is UTC, which means a person aged 18–34 could currently apply on May 14 at 8:00 PM Eastern, since that corresponds to May 15 at 12:00 AM UTC - the configured eligibility start date.

The purpose of this change is to test that a person aged 18–34 cannot apply until May 14 at 12:00 AM Eastern. If successful, the `TZ` change will be applied in production, where the eligibility start date remains May 15.