### PR TITLE
chore(gitops): Removing `APPLICATION_CURRENT_DATE` config from dev

### DIFF
--- a/gitops/overlays/dev/configs/frontend/config.conf
+++ b/gitops/overlays/dev/configs/frontend/config.conf
@@ -11,8 +11,6 @@ HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 
 INTEROP_API_BASE_URI=https://interop.api.example.com/
 
-APPLICATION_CURRENT_DATE=2025-05-01
-
 OTEL_ENVIRONMENT=dev
 OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces


### PR DESCRIPTION
### Description
As per title.