### PR TITLE
fix(frontend) set preferredLanguage to correct value in sendVerificationCodeEmail

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -105,7 +105,6 @@ export async function action({ context: { appContainer, session }, params, reque
       emailPreValidation: parsedDataResult.data.email,
       emailPreviouslyValidated: state.emailVerified,
     },
-    // state: { contactInformation: { ...state.contactInformation, ...parsedDataResult.data } },
   });
 
   appContainer.get(TYPES.domain.services.AuditService).createAudit('update-data.renew.confirm-email', { userId: idToken.sub });

--- a/frontend/app/routes/protected/renew/$id/ita/verify-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/verify-email.tsx
@@ -11,7 +11,7 @@ import type { Route } from './+types/verify-email';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
-import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -36,8 +36,6 @@ const FORM_ACTION = {
 } as const;
 
 const MAX_ATTEMPTS = 5;
-
-export const PREFERRED_LANGUAGE = { en: 'English', fr: 'French' } as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
@@ -72,7 +70,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const locale = getLocale(request);
+  const { ENGLISH_LANGUAGE_CODE } = appContainer.get(TYPES.configs.ServerConfig);
 
   // Fetch verification code service
   const verificationCodeService = appContainer.get(TYPES.domain.services.VerificationCodeService);
@@ -99,21 +97,19 @@ export async function action({ context: { appContainer, session }, params, reque
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
-      const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
         verificationCode: verificationCode,
-        preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: idToken.sub,
       });
       return { status: 'verification-code-sent' } as const;
     } else if (state.contactInformation?.email) {
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
-      const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.contactInformation.email,
         verificationCode: verificationCode,
-        preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: idToken.sub,
       });
       return { status: 'verification-code-sent' } as const;

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/verify-email';
 import { TYPES } from '~/.server/constants';
 import { loadRenewAdultState } from '~/.server/routes/helpers/renew-adult-route-helpers';
 import { saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
-import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -36,8 +36,6 @@ const FORM_ACTION = {
 } as const;
 
 const MAX_ATTEMPTS = 5;
-
-export const PREFERRED_LANGUAGE = { en: 'English', fr: 'French' } as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('renew-adult', 'renew', 'gcweb'),
@@ -70,7 +68,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
-  const locale = getLocale(request);
+  const { ENGLISH_LANGUAGE_CODE } = appContainer.get(TYPES.configs.ServerConfig);
 
   // Fetch verification code service
   const verificationCodeService = appContainer.get(TYPES.domain.services.VerificationCodeService);
@@ -96,21 +94,19 @@ export async function action({ context: { appContainer, session }, params, reque
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
-      const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
         verificationCode: verificationCode,
-        preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',
       });
       return { status: 'verification-code-sent' } as const;
     } else if (state.contactInformation?.email) {
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
-      const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.contactInformation.email,
         verificationCode: verificationCode,
-        preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',
       });
       return { status: 'verification-code-sent' } as const;


### PR DESCRIPTION
### Description
Similar to #3734, except this targets the renew app(s) and the main branch as opposed to the release branch.

### Related Azure Boards Work Items
AB#6037


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`