### PR TITLE
Refactor editModeCommunicationPreference state for renewal email verification

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -73,6 +73,7 @@ export interface RenewState {
   editModeCommunicationPreferences?: {
     email: string;
     shouldReceiveEmailCommunication?: boolean;
+    isNewOrUpdatedEmail?: boolean;
   };
   verifyEmail?: {
     verificationCode: string;

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -70,8 +70,10 @@ export interface RenewState {
     email?: string;
     shouldReceiveEmailCommunication?: boolean;
   };
-  editModeCommunicationPreferences?: boolean;
-  editModeEmail?: string;
+  editModeCommunicationPreferences?: {
+    email: string;
+    shouldReceiveEmailCommunication?: boolean;
+  };
   verifyEmail?: {
     verificationCode: string;
     verificationAttempts: number;

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -160,8 +160,10 @@ export async function action({ context: { appContainer, session }, params, reque
           params,
           session,
           state: {
-            editModeEmail: parsedDataResult.data.email,
-            editModeCommunicationPreferences: parsedDataResult.data.shouldReceiveEmailCommunication,
+            editModeCommunicationPreferences: {
+              email: parsedDataResult.data.email,
+              shouldReceiveEmailCommunication: parsedDataResult.data.shouldReceiveEmailCommunication,
+            },
             ...(isNewEmail && {
               verifyEmail: {
                 verificationCode,
@@ -180,7 +182,7 @@ export async function action({ context: { appContainer, session }, params, reque
           contactInformation: {
             ...state.contactInformation,
             email: parsedDataResult.data.email,
-            shouldReceiveEmailCommunication: state.editModeCommunicationPreferences,
+            shouldReceiveEmailCommunication: state.editModeCommunicationPreferences?.shouldReceiveEmailCommunication,
             isNewOrUpdatedEmail: parsedDataResult.data.isNewOrUpdatedEmail,
           },
           emailVerified: state.emailVerified,

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -163,6 +163,7 @@ export async function action({ context: { appContainer, session }, params, reque
             editModeCommunicationPreferences: {
               email: parsedDataResult.data.email,
               shouldReceiveEmailCommunication: parsedDataResult.data.shouldReceiveEmailCommunication,
+              isNewOrUpdatedEmail: parsedDataResult.data.isNewOrUpdatedEmail,
             },
             ...(isNewEmail && {
               verifyEmail: {
@@ -183,7 +184,7 @@ export async function action({ context: { appContainer, session }, params, reque
             ...state.contactInformation,
             email: parsedDataResult.data.email,
             shouldReceiveEmailCommunication: state.editModeCommunicationPreferences?.shouldReceiveEmailCommunication,
-            isNewOrUpdatedEmail: parsedDataResult.data.isNewOrUpdatedEmail,
+            isNewOrUpdatedEmail: state.editModeCommunicationPreferences?.isNewOrUpdatedEmail,
           },
           emailVerified: state.emailVerified,
           verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -165,6 +165,7 @@ export async function action({ context: { appContainer, session }, params, reque
             contactInformation: {
               ...state.contactInformation,
               shouldReceiveEmailCommunication: state.editModeCommunicationPreferences?.shouldReceiveEmailCommunication ?? state.contactInformation?.shouldReceiveEmailCommunication,
+              isNewOrUpdatedEmail: state.editModeCommunicationPreferences?.isNewOrUpdatedEmail ?? state.contactInformation?.isNewOrUpdatedEmail,
               email: state.editModeCommunicationPreferences?.email,
             },
             verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -57,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    email: state.editModeEmail ?? state.contactInformation?.email,
+    email: state.editModeCommunicationPreferences?.email ?? state.contactInformation?.email,
     editMode: state.editMode,
   };
 }
@@ -94,11 +94,11 @@ export async function action({ context: { appContainer, session }, params, reque
     });
 
     if (state.editMode) {
-      invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
+      invariant(state.editModeCommunicationPreferences?.email, 'Expected editModeEmail to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
       const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.clientApplication.communicationPreferences.preferredLanguage, locale).name;
       await verificationCodeService.sendVerificationCodeEmail({
-        email: state.editModeEmail,
+        email: state.editModeCommunicationPreferences.email,
         verificationCode: verificationCode,
         preferredLanguage: preferredLanguage === PREFERRED_LANGUAGE.en ? 'en' : 'fr',
         userId: 'anonymous',
@@ -164,8 +164,8 @@ export async function action({ context: { appContainer, session }, params, reque
           state: {
             contactInformation: {
               ...state.contactInformation,
-              shouldReceiveEmailCommunication: state.editModeCommunicationPreferences ?? state.contactInformation?.shouldReceiveEmailCommunication,
-              email: state.editModeEmail,
+              shouldReceiveEmailCommunication: state.editModeCommunicationPreferences?.shouldReceiveEmailCommunication ?? state.contactInformation?.shouldReceiveEmailCommunication,
+              email: state.editModeCommunicationPreferences?.email,
             },
             verifyEmail: {
               ...state.verifyEmail,


### PR DESCRIPTION
### Description
Moving `email` and `isNewOrUpdatedEmail` into `editModeCommunicationPreference` state.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->