### PR TITLE
chore(gitops): Deploy frontend v5.2.0 to prod

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.1.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.2.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
### Description
v5.2.0 is scheduled to be deployed at 7:00am Eastern on Friday, May 16, 2025.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/21944