### PR TITLE
fix(frontend) update renew payload to include ApplicantEmailVerifiedIndicator

### DIFF
--- a/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-child-route-helpers.ts
@@ -141,6 +141,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
     isHomeAddressSameAsMailingAddress,
+    emailVerified,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -222,6 +223,7 @@ export function validateRenewAdultChildStateForReview({ params, state }: Validat
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
     isHomeAddressSameAsMailingAddress,
+    emailVerified,
   };
 }
 

--- a/frontend/app/.server/routes/helpers/renew-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-adult-route-helpers.ts
@@ -97,6 +97,7 @@ export function validateRenewAdultStateForReview({ params, state }: ValidateRene
     dentalInsurance,
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
+    emailVerified,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -179,5 +180,6 @@ export function validateRenewAdultStateForReview({ params, state }: ValidateRene
     hasAddressChanged,
     demographicSurvey,
     hasFederalProvincialTerritorialBenefitsChanged,
+    emailVerified,
   };
 }

--- a/frontend/app/.server/routes/helpers/renew-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-child-route-helpers.ts
@@ -138,6 +138,7 @@ export function validateRenewChildStateForReview({ params, state }: ValidateStat
     submissionInfo,
     typeOfRenewal,
     applicantInformation,
+    emailVerified,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -208,6 +209,7 @@ export function validateRenewChildStateForReview({ params, state }: ValidateStat
     mailingAddress,
     homeAddress,
     clientApplication,
+    emailVerified,
   };
 }
 

--- a/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-ita-route-helpers.ts
@@ -95,6 +95,7 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     dentalInsurance,
     hasAddressChanged,
     demographicSurvey,
+    emailVerified,
   } = state;
 
   if (typeOfRenewal === undefined) {
@@ -159,5 +160,6 @@ export function validateRenewItaStateForReview({ params, state }: ValidateRenewI
     partnerInformation,
     hasAddressChanged,
     demographicSurvey,
+    emailVerified,
   };
 }

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -14,7 +14,7 @@ import type { Session } from '~/.server/web/session';
 export interface RenewState {
   readonly id: string;
   readonly editMode: boolean;
-  lastUpdatedOn: string;
+  readonly lastUpdatedOn: string;
   readonly applicationYear: {
     renewalYearId: string;
     taxYear: string;
@@ -70,16 +70,16 @@ export interface RenewState {
     email?: string;
     shouldReceiveEmailCommunication?: boolean;
   };
-  editModeCommunicationPreferences?: {
+  readonly editModeCommunicationPreferences?: {
     email: string;
     shouldReceiveEmailCommunication?: boolean;
     isNewOrUpdatedEmail?: boolean;
   };
-  verifyEmail?: {
+  readonly verifyEmail?: {
     verificationCode: string;
     verificationAttempts: number;
   };
-  emailVerified?: boolean;
+  readonly emailVerified?: boolean;
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;
   readonly previousAddressState?: {

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -63,6 +63,7 @@ export interface RenewAdultState {
   mailingAddress?: MailingAddressState;
   maritalStatus?: string;
   partnerInformation?: PartnerInformationState;
+  emailVerified?: boolean;
 }
 
 export interface RenewAdultChildState {
@@ -80,6 +81,7 @@ export interface RenewAdultChildState {
   mailingAddress?: MailingAddressState;
   maritalStatus?: string;
   partnerInformation?: PartnerInformationState;
+  emailVerified?: boolean;
 }
 
 export interface RenewItaState {
@@ -95,6 +97,7 @@ export interface RenewItaState {
   mailingAddress?: MailingAddressState;
   maritalStatus?: string;
   partnerInformation?: PartnerInformationState;
+  emailVerified?: boolean;
 }
 
 export interface RenewChildState {
@@ -109,6 +112,7 @@ export interface RenewChildState {
   hasMaritalStatusChanged: boolean;
   maritalStatus?: string;
   partnerInformation?: PartnerInformationState;
+  emailVerified?: boolean;
 }
 
 export interface ProtectedRenewState {
@@ -227,6 +231,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     mailingAddress,
     maritalStatus,
     partnerInformation,
+    emailVerified,
   }: RenewAdultState): AdultBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
@@ -258,6 +263,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         renewedEmail: contactInformation.email,
         renewedReceiveEmailCommunication: contactInformation.shouldReceiveEmailCommunication,
+        emailVerified,
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
@@ -301,6 +307,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     mailingAddress,
     maritalStatus,
     partnerInformation,
+    emailVerified,
   }: RenewAdultChildState): AdultChildBenefitRenewalDto {
     const hasEmailChanged = contactInformation.isNewOrUpdatedEmail;
     if (hasEmailChanged === undefined) {
@@ -335,6 +342,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasEmailChanged,
         renewedEmail: contactInformation.email,
         renewedReceiveEmailCommunication: contactInformation.shouldReceiveEmailCommunication,
+        emailVerified,
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
@@ -376,6 +384,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     mailingAddress,
     maritalStatus,
     partnerInformation,
+    emailVerified,
   }: RenewItaState): ItaBenefitRenewalDto {
     return {
       ...clientApplication,
@@ -401,9 +410,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
-        hasEmailChanged: true,
+        hasEmailChanged: !!contactInformation.email,
         renewedEmail: contactInformation.email,
         renewedReceiveEmailCommunication: contactInformation.shouldReceiveEmailCommunication,
+        emailVerified,
       }),
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
@@ -763,8 +773,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     renewedPreferredLanguage,
     emailVerified,
   }: ToCommunicationPreferencesArgs): RenewalCommunicationPreferencesDto {
-    if (!hasEmailChanged && !hasPreferredLanguageChanged) return existingCommunicationPreferences;
-
     return {
       email: renewedReceiveEmailCommunication ? renewedEmail : undefined,
       emailVerified: renewedReceiveEmailCommunication ? emailVerified : undefined,


### PR DESCRIPTION
### Description
maps `ApplicantEmailVerifiedIndicator` in the payload for the public renew apps.

I'm not entirely sure the logic is sound, but it follows what's being done in the protected renew app.  Please advise.

### Related Azure Boards Work Items
AB#5951

