### PR TITLE
feat(gitops): Add `otto` environment for automated testing

### DIFF
--- a/gitops/overlays/otto/configs/frontend/config.conf
+++ b/gitops/overlays/otto/configs/frontend/config.conf
@@ -1,0 +1,27 @@
+# LOG_LEVEL=debug
+
+AUTH_LOGOUT_REDIRECT_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc_ii/v1/logout?client_id={clientId}&shared_session_id={sharedSessionId}&ui_locales={uiLocales}
+AUTH_RAOIDC_BASE_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc_ii/v1
+AUTH_RAOIDC_CLIENT_ID=CDCP
+AUTH_RASCL_LOGOUT_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/Support/GlobalLogout.aspx
+
+ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application,killswitch-api
+
+HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
+
+INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1
+
+OTEL_ENVIRONMENT=otto
+OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
+OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
+
+SESSION_STORAGE_TYPE=redis
+
+REDIS_SENTINEL_NAME=myprimary
+REDIS_SENTINEL_HOST=redis-otto
+REDIS_SENTINEL_PORT=26379
+
+ECAS_BASE_URI=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/SCL
+SCCH_BASE_URI=https://mscad-sys2-s1.bdm.dshp-phdn.net
+
+ADOBE_ANALYTICS_SRC=https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js

--- a/gitops/overlays/otto/configs/redis/replica.conf
+++ b/gitops/overlays/otto/configs/redis/replica.conf
@@ -1,0 +1,1 @@
+slaveof redis-otto-0.redis-headless-otto 6379

--- a/gitops/overlays/otto/configs/redis/sentinel.conf
+++ b/gitops/overlays/otto/configs/redis/sentinel.conf
@@ -1,0 +1,4 @@
+sentinel monitor myprimary redis-otto-0.redis-headless-otto 6379 2
+sentinel down-after-milliseconds myprimary 5000
+sentinel failover-timeout myprimary 60000
+sentinel resolve-hostnames yes

--- a/gitops/overlays/otto/external-secrets.yaml
+++ b/gitops/overlays/otto/external-secrets.yaml
@@ -1,0 +1,60 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: AUTH_JWT_PRIVATE_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PRIVATE_KEY }
+    - secretKey: AUTH_JWT_PUBLIC_KEY
+      remoteRef: { key: cdcp-dev, property: AUTH_JWT_PUBLIC_KEY }
+    - secretKey: GC_NOTIFY_API_KEY
+      remoteRef: { key: cdcp-dev, property: GC_NOTIFY_API_KEY }
+    - secretKey: HCAPTCHA_SECRET_KEY
+      remoteRef: { key: cdcp-dev, property: HCAPTCHA_SECRET_KEY }
+    - secretKey: INTEROP_API_SUBSCRIPTION_KEY
+      remoteRef: { key: cdcp-dev, property: INTEROP_API_SUBSCRIPTION_KEY_UAT }
+    - secretKey: OTEL_API_KEY
+      remoteRef: { key: cdcp-dev, property: DYNATRACE_API_KEY }
+    - secretKey: SESSION_COOKIE_SECRET
+      remoteRef: { key: cdcp-dev, property: SESSION_COOKIE_SECRET }
+
+---
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef: { key: cdcp-dev, property: REDIS_PASSWORD }
+
+---
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: basic-auth
+  labels:
+    app.kubernetes.io/name: basic-auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  data:
+    - secretKey: auth
+      remoteRef: { key: cdcp-dev, property: OTTO_TEST_BASIC_AUTH_SECRET }

--- a/gitops/overlays/otto/ingresses.yaml
+++ b/gitops/overlays/otto/ingresses.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth-otto
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: cdcp-otto.dev-dp.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: http
+    - host: cdcp-otto.dev-dp-internal.dts-stn.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  name: application

--- a/gitops/overlays/otto/kustomization.yaml
+++ b/gitops/overlays/otto/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: canada-dental-care-plan
+nameSuffix: -otto
+commonLabels:
+  # commonLabels must have at least one unique label
+  # per environment to ensure selectors are applied correctly
+  app.kubernetes.io/instance: otto
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: canada-dental-care-plan
+      app.kubernetes.io/managed-by: teamcity
+      app.kubernetes.io/cluster: dts-dev-sced-rhp-spoke-aks
+      app.kubernetes.io/environment: otto
+      app.kubernetes.io/tier: nonprod
+resources:
+  - ../../base/frontend/
+  - ../../base/redis/
+  - ./external-secrets.yaml
+  - ./ingresses.yaml
+patches:
+  - path: ./patches/deployments.yaml
+  - path: ./patches/services.yaml
+  - path: ./patches/stateful-sets.yaml
+configMapGenerator:
+  - name: frontend
+    behavior: merge
+    envs:
+      - ./configs/frontend/config.conf
+  - name: redis
+    behavior: merge
+    files:
+      - ./configs/redis/replica.conf
+      - ./configs/redis/sentinel.conf
+secretGenerator:
+  - name: frontend
+    behavior: replace
+    options:
+      # disable suffix hash so it can effectively
+      # be managed by external secrets operator
+      disableNameSuffixHash: true
+  - name: redis
+    behavior: replace
+    options:
+      # disable suffix hash so it can effectively
+      # be managed by external secrets operator
+      disableNameSuffixHash: true

--- a/gitops/overlays/otto/patches/deployments.yaml
+++ b/gitops/overlays/otto/patches/deployments.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  annotations:
+    # reload the pod whenever the secrets change
+    secret.reloader.stakater.com/auto: 'true'
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    spec:
+      containers:
+        - name: canada-dental-care-plan-frontend
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.2.0
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: frontend
+            - secretRef:
+                name: frontend
+            - secretRef:
+                name: redis

--- a/gitops/overlays/otto/patches/services.yaml
+++ b/gitops/overlays/otto/patches/services.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  ports:
+    - name: application
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: frontend

--- a/gitops/overlays/otto/patches/stateful-sets.yaml
+++ b/gitops/overlays/otto/patches/stateful-sets.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  annotations:
+    # reload the pod whenever the secrets change
+    secret.reloader.stakater.com/auto: 'true'
+spec:
+  serviceName: redis-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    #
+    # pin all versions to v7.2
+    #
+    spec:
+      initContainers:
+        - name: init
+          image: docker.io/redis:7.2
+      containers:
+        - name: redis
+          image: docker.io/redis:7.2
+        - name: redis-sentinel
+          image: docker.io/redis:7.2


### PR DESCRIPTION
### Description
- Restricting access using basic auth in NGINX (as opposed to the OAuth2 Proxy we generally use)
- Uses same config as UAT1 until Interop/Power Platform introduce their own otto environment
- Tested locally at https://cdcp-otto.dev-dp.dts-stn.com (credentials available from Nick)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/95b1ce5f-bce3-47aa-bbe8-7003c4bc3163)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally