### PR TITLE
ci: Limit frontend build workflow to e2e smoke tests on PRs

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -35,7 +35,7 @@ jobs:
         working-directory: frontend/
       - run: npx playwright install chromium --with-deps
         working-directory: frontend/
-      - run: npm run test:e2e
+      - run: npm run test:e2e:smoke
         working-directory: frontend/
   build-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Related:
#3706
#3710