### PR TITLE
build(frontend): Bump node base image to v22.15.1

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -24,7 +24,7 @@
 
 
 # Base image used for all future stages
-ARG BASE_IMAGE=docker.io/node:22.15.0-bookworm-slim
+ARG BASE_IMAGE=docker.io/node:22.15.1-bookworm-slim
 FROM $BASE_IMAGE AS base
 ENV NODE_ENV production
 


### PR DESCRIPTION
### Description
Bump node base image to [v22.15.1](https://github.com/nodejs/node/releases/tag/v22.15.1)