### PR TITLE
feat(frontend) modify communication preference in protected renew app

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -83,20 +83,21 @@ export interface ProtectedRenewState {
     readonly email?: string;
     readonly shouldReceiveEmailCommunication?: boolean;
   };
-  // temporary placeholder for email prior to verifying
-  readonly emailPreValidation?: string;
-  readonly emailPreviouslyValidated?: boolean;
+  readonly preferredLanguage?: string;
   readonly communicationPreferences?: {
-    readonly email?: string;
-    readonly preferredLanguage: string;
     readonly preferredMethod: string;
+    readonly preferredNotificationMethod: string;
   };
   readonly verifyEmail?: {
     verificationCode: string;
     verificationAttempts: number;
   };
+  readonly email?: string;
   readonly editModeEmail?: string;
-  readonly editModeCommunicationPreferences?: boolean;
+  readonly editModeCommunicationPreferences?: {
+    preferredMethod: string;
+    preferredNotificationMethod: string;
+  };
   readonly emailVerified?: boolean;
   readonly hasAddressChanged?: boolean;
   readonly isHomeAddressSameAsMailingAddress?: boolean;
@@ -269,7 +270,6 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
       phoneNumberAlt: clientApplication.contactInformation.phoneNumberAlt,
       email: clientApplication.isInvitationToApplyClient ? undefined : clientApplication.contactInformation.email,
     },
-    communicationPreferences: clientApplication.communicationPreferences,
     children: clientApplication.children
       // filter out children who will be 18 or older at the start of the coverage period as they are ineligible for renewal
       .filter((child) => getAgeFromDateString(child.information.dateOfBirth, applicationYear.coverageEndDate) < 18) //
@@ -387,7 +387,8 @@ interface ValidateProtectedRenewStateForReviewArgs {
 }
 
 export function validateProtectedRenewStateForReview({ params, state, demographicSurveyEnabled }: ValidateProtectedRenewStateForReviewArgs) {
-  const { applicationYear, maritalStatus, partnerInformation, mailingAddress, homeAddress, clientApplication, contactInformation, communicationPreferences, editMode, id, dentalBenefits, dentalInsurance, demographicSurvey } = state;
+  const { applicationYear, maritalStatus, partnerInformation, mailingAddress, homeAddress, clientApplication, contactInformation, communicationPreferences, editMode, id, dentalBenefits, dentalInsurance, demographicSurvey, email, preferredLanguage } =
+    state;
 
   const children = validateProtectedChildrenStateForReview(state.children, demographicSurveyEnabled);
 
@@ -410,6 +411,8 @@ export function validateProtectedRenewStateForReview({ params, state, demographi
     children,
     dentalBenefits,
     demographicSurvey,
+    email,
+    preferredLanguage,
   };
 }
 

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -130,6 +130,7 @@ export interface ProtectedRenewState {
   partnerInformation?: ProtectedPartnerInformationState;
   communicationPreferences?: ProtectedConmmunicationPreferenceState;
   emailVerified?: boolean;
+  preferredLanguage?: string;
 }
 
 export interface BenefitRenewalStateMapper {
@@ -511,6 +512,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       clientApplication,
       communicationPreferences,
       emailVerified,
+      preferredLanguage,
     }: ProtectedRenewState,
     userId: string,
     applicantStateCompleted: boolean,
@@ -530,8 +532,8 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
-        hasPreferredLanguageChanged: !!communicationPreferences?.preferredLanguage,
-        renewedPreferredLanguage: communicationPreferences?.preferredLanguage,
+        hasPreferredLanguageChanged: !!preferredLanguage,
+        renewedPreferredLanguage: preferredLanguage,
         hasEmailChanged: !!contactInformation?.email,
         renewedEmail: contactInformation?.email,
         renewedReceiveEmailCommunication: contactInformation?.shouldReceiveEmailCommunication,

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -103,6 +103,7 @@ export const pageIds = {
       confirmation: 'CDCP-PROT-RENW-0020',
       confirmAddress: 'CDCP-PROT-RENW-0021',
       verifyEmail: 'CDCP-PROT-RENW-0022',
+      communicationPreference: 'CDCP-PROT-RENW-0023',
     },
     dataUnavailable: 'CDCP-PROT-0099',
     unableToProcessRequest: 'CDCP-PROT-0999',

--- a/frontend/app/routes/protected/renew/$id/communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/communication-preference.tsx
@@ -1,0 +1,193 @@
+import { data, redirect, useFetcher } from 'react-router';
+
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import type { Route } from './+types/communication-preference';
+
+import { TYPES } from '~/.server/constants';
+import { isPrimaryApplicantStateComplete, loadProtectedRenewState, saveProtectedRenewState } from '~/.server/routes/helpers/protected-renew-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InlineLink } from '~/components/inline-link';
+import { InputRadios } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const PREFERRED_SUN_LIFE_METHOD = { email: 'email', mail: 'mail' } as const;
+export const PREFERRED_NOTIFICATION_METHOD = { msca: 'msca', mail: 'mail' } as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
+  pageIdentifier: pageIds.protected.renew.communicationPreference,
+  pageTitleI18nKey: 'protected-renew:communication-preference.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
+  return getTitleMetaTags(data.meta.title);
+});
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const state = loadProtectedRenewState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:communication-preference.page-title') }) };
+
+  return {
+    meta,
+    defaultState: { ...state.communicationPreferences },
+    editMode: state.editMode,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const state = loadProtectedRenewState({ params, request, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const { ENABLED_FEATURES } = appContainer.get(TYPES.configs.ClientConfig);
+  const demographicSurveyEnabled = ENABLED_FEATURES.includes('demographic-survey');
+
+  const formSchema = z.object({
+    preferredMethod: z.string().trim().min(1, t('protected-renew:communication-preference.error-message.preferred-method-required')),
+    preferredNotificationMethod: z.string().trim().min(1, t('protected-renew:communication-preference.error-message.preferred-notification-method-required')),
+  });
+
+  const parsedDataResult = formSchema.safeParse({
+    preferredMethod: String(formData.get('preferredMethod') ?? ''),
+    preferredNotificationMethod: String(formData.get('preferredNotificationMethod') ?? ''),
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(parsedDataResult.error.flatten()) }, { status: 400 });
+  }
+
+  if (state.editMode) {
+    if (parsedDataResult.data.preferredMethod !== PREFERRED_SUN_LIFE_METHOD.email && parsedDataResult.data.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail) {
+      saveProtectedRenewState({ params, request, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
+      return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+    }
+    saveProtectedRenewState({ params, request, session, state: { editModeCommunicationPreferences: parsedDataResult.data } });
+    return redirect(getPathById('protected/renew/$id/confirm-email', params));
+  }
+
+  if (parsedDataResult.data.preferredMethod !== PREFERRED_SUN_LIFE_METHOD.email && parsedDataResult.data.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail) {
+    saveProtectedRenewState({ params, request, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
+    if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
+      return redirect(getPathById('protected/renew/$id/review-child-information', params));
+    }
+    return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+  }
+  saveProtectedRenewState({ params, request, session, state: { communicationPreferences: parsedDataResult.data } });
+  return redirect(getPathById('protected/renew/$id/confirm-email', params));
+}
+
+export default function ProtectedRenewCommunicationPreferencePage({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, editMode } = loaderData;
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const mscaLinkAccount = <InlineLink to={t('protected-renew:communication-preference.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, {
+    preferredMethod: 'input-radio-preferred-methods-option-0',
+    preferredNotificationMethod: 'input-radio-preferred-notification-method-option-0',
+  });
+
+  return (
+    <div className="max-w-prose">
+      <p className="mb-4 italic">{t('renew:required-label')}</p>
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <div className="mb-8 space-y-6">
+          <InputRadios
+            id="preferred-methods"
+            legend={t('protected-renew:communication-preference.preferred-method')}
+            name="preferredMethod"
+            helpMessagePrimary={t('protected-renew:communication-preference.preferred-method-help-message')}
+            options={[
+              {
+                value: PREFERRED_SUN_LIFE_METHOD.email,
+                children: t('protected-renew:communication-preference.by-email'),
+                defaultChecked: defaultState.preferredMethod === PREFERRED_SUN_LIFE_METHOD.email,
+              },
+              {
+                value: PREFERRED_SUN_LIFE_METHOD.mail,
+                children: t('protected-renew:communication-preference.by-mail'),
+                defaultChecked: defaultState.preferredMethod === PREFERRED_SUN_LIFE_METHOD.mail,
+              },
+            ]}
+            errorMessage={errors?.preferredMethod}
+            required
+          />
+
+          <InputRadios
+            id="preferred-notification-method"
+            name="preferredNotificationMethod"
+            legend={t('protected-renew:communication-preference.preferred-notification-method')}
+            options={[
+              {
+                value: PREFERRED_NOTIFICATION_METHOD.msca,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:communication-preference.preferred-notification-method-msca" components={{ span: <span className="font-semibold" />, mscaLinkAccount }} />,
+                defaultChecked: defaultState.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.msca,
+              },
+              {
+                value: PREFERRED_NOTIFICATION_METHOD.mail,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:communication-preference.preferred-notification-method-mail" components={{ span: <span className="font-semibold" />, mscaLinkAccount }} />,
+                defaultChecked: defaultState.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail,
+              },
+            ]}
+            required
+            errorMessage={errors?.preferredNotificationMethod}
+          />
+        </div>
+        {editMode ? (
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Save - Communication click">
+              {t('protected-renew:communication-preference.save-btn')}
+            </Button>
+            <ButtonLink id="back-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Cancel - Communication click">
+              {t('protected-renew:communication-preference.cancel-btn')}
+            </ButtonLink>
+          </div>
+        ) : (
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - Communication click">
+              {t('protected-renew:communication-preference.continue')}
+            </LoadingButton>
+            <ButtonLink
+              id="back-button"
+              routeId="protected/renew/$id/member-selection"
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - Communication click"
+            >
+              {t('protected-renew:communication-preference.back')}
+            </ButtonLink>
+          </div>
+        )}
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-communication-preference.tsx
@@ -1,10 +1,6 @@
-import type { ChangeEventHandler } from 'react';
-import { useState } from 'react';
-
 import { data, redirect, useFetcher } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
-import validator from 'validator';
 import { z } from 'zod';
 
 import type { Route } from './+types/confirm-communication-preference';
@@ -17,8 +13,6 @@ import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { useErrorSummary } from '~/components/error-summary';
-import { InputField } from '~/components/input-field';
-import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -30,7 +24,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
   pageIdentifier: pageIds.protected.renew.confirmCommunicationPreference,
-  pageTitleI18nKey: 'protected-renew:communication-preference.page-title',
+  pageTitleI18nKey: 'protected-renew:confirm-communication-preference.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
@@ -41,31 +35,20 @@ export async function loader({ context: { appContainer, session }, params, reque
   const securityHandler = appContainer.get(TYPES.routes.security.SecurityHandler);
   await securityHandler.validateAuthSession({ request, session });
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
-
   const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const preferredLanguages = appContainer.get(TYPES.domain.services.PreferredLanguageService).listAndSortLocalizedPreferredLanguages(locale);
-  const preferredCommunicationMethods = appContainer.get(TYPES.domain.services.PreferredCommunicationMethodService).listAndSortLocalizedPreferredCommunicationMethods(locale);
 
-  const communicationMethodEmail = preferredCommunicationMethods.find((method) => method.id === COMMUNICATION_METHOD_EMAIL_ID);
-  if (!communicationMethodEmail) {
-    throw data('Expected communication method email not found!', { status: 500 });
-  }
-
-  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:communication-preference.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-communication-preference.page-title') }) };
 
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.confirm-communication-preference', { userId: idToken.sub });
 
   return {
-    communicationMethodEmail,
     meta,
-    preferredCommunicationMethods,
     preferredLanguages,
-    defaultState: { ...state.communicationPreferences, email: state.contactInformation?.email },
-    isReadOnlyEmail: !!state.contactInformation?.email,
+    defaultState: state.preferredLanguage ?? state.clientApplication.communicationPreferences.preferredLanguage,
   };
 }
 
@@ -76,43 +59,14 @@ export async function action({ context: { appContainer, session }, params, reque
   await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
-  const { COMMUNICATION_METHOD_EMAIL_ID } = appContainer.get(TYPES.configs.ClientConfig);
-
-  const state = loadProtectedRenewState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
-  const formSchema = z
-    .object({
-      preferredLanguage: z.string().trim().min(1, t('protected-renew:communication-preference.error-message.preferred-language-required')),
-      preferredMethod: z.string().trim().min(1, t('protected-renew:communication-preference.error-message.preferred-method-required')),
-      email: z.string().trim().max(64).optional(),
-      confirmEmail: z.string().trim().max(64).optional(),
-    })
-    .superRefine((val, ctx) => {
-      if (val.preferredMethod === COMMUNICATION_METHOD_EMAIL_ID) {
-        if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:communication-preference.error-message.email-required'), path: ['email'] });
-        } else if (!validator.isEmail(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:communication-preference.error-message.email-valid'), path: ['email'] });
-        }
-
-        if (!state.contactInformation?.email) {
-          if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:communication-preference.error-message.confirm-email-required'), path: ['confirmEmail'] });
-          } else if (!validator.isEmail(val.confirmEmail)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:communication-preference.error-message.confirm-email-valid'), path: ['confirmEmail'] });
-          } else if (val.email !== val.confirmEmail) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:communication-preference.error-message.email-match'), path: ['confirmEmail'] });
-          }
-        }
-      }
-    });
+  const formSchema = z.object({
+    preferredLanguage: z.string().trim().min(1, t('protected-renew:confirm-communication-preference.error-message.preferred-language-required')),
+  });
 
   const parsedDataResult = formSchema.safeParse({
-    confirmEmail: formData.get('confirmEmail') ? String(formData.get('confirmEmail') ?? '') : undefined,
-    email: formData.get('email') ? String(formData.get('email') ?? '') : undefined,
     preferredLanguage: String(formData.get('preferredLanguage') ?? ''),
-    preferredMethod: String(formData.get('preferredMethod') ?? ''),
   });
 
   if (!parsedDataResult.success) {
@@ -123,7 +77,7 @@ export async function action({ context: { appContainer, session }, params, reque
     params,
     request,
     session,
-    state: { communicationPreferences: parsedDataResult.data },
+    state: { preferredLanguage: parsedDataResult.data.preferredLanguage },
   });
 
   const idToken: IdToken = session.get('idToken');
@@ -134,75 +88,15 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ProtectedRenewConfirmCommunicationPreference({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { communicationMethodEmail, preferredLanguages, preferredCommunicationMethods, defaultState, isReadOnlyEmail } = loaderData;
+  const { preferredLanguages, defaultState } = loaderData;
 
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
-  const [preferredMethodValue, setPreferredMethodValue] = useState(defaultState.preferredMethod);
 
   const errors = fetcher.data?.errors;
   const errorSummary = useErrorSummary(errors, {
     preferredLanguage: 'input-radio-preferred-language-option-0',
-    preferredMethod: 'input-radio-preferred-methods-option-0',
-    email: 'email',
-    confirmEmail: 'confirm-email',
   });
-
-  const handleOnPreferredMethodChecked: ChangeEventHandler<HTMLInputElement> = (e) => {
-    setPreferredMethodValue(e.target.value);
-  };
-
-  const nonEmailOptions: InputRadiosProps['options'] = preferredCommunicationMethods
-    .filter((method) => method.id !== communicationMethodEmail.id)
-    .map((method) => ({
-      children: method.name,
-      value: method.id,
-      defaultChecked: defaultState.preferredMethod === method.id,
-      onChange: handleOnPreferredMethodChecked,
-    }));
-
-  const options: InputRadiosProps['options'] = [
-    {
-      children: communicationMethodEmail.name,
-      value: communicationMethodEmail.id,
-      defaultChecked: defaultState.preferredMethod === communicationMethodEmail.id,
-      append: preferredMethodValue === communicationMethodEmail.id && (
-        <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
-          <InputField
-            id="email"
-            type="email"
-            inputMode="email"
-            className="w-full"
-            label={t('protected-renew:communication-preference.email')}
-            maxLength={64}
-            name="email"
-            errorMessage={errors?.email}
-            autoComplete="email"
-            defaultValue={defaultState.email ?? ''}
-            required
-            readOnly={isReadOnlyEmail}
-          />
-          {!isReadOnlyEmail && (
-            <InputField
-              id="confirm-email"
-              type="email"
-              inputMode="email"
-              className="w-full"
-              label={t('protected-renew:communication-preference.confirm-email')}
-              maxLength={64}
-              name="confirmEmail"
-              errorMessage={errors?.confirmEmail}
-              autoComplete="email"
-              defaultValue={defaultState.email ?? ''}
-              required
-            />
-          )}
-        </div>
-      ),
-      onChange: handleOnPreferredMethodChecked,
-    },
-    ...nonEmailOptions,
-  ];
 
   return (
     <div className="max-w-prose">
@@ -215,9 +109,9 @@ export default function ProtectedRenewConfirmCommunicationPreference({ loaderDat
             <InputRadios
               id="preferred-language"
               name="preferredLanguage"
-              legend={t('protected-renew:communication-preference.preferred-language')}
+              legend={t('protected-renew:confirm-communication-preference.preferred-language')}
               options={preferredLanguages.map((language) => ({
-                defaultChecked: defaultState.preferredLanguage === language.id,
+                defaultChecked: defaultState === language.id,
                 children: language.name,
                 value: language.id,
               }))}
@@ -225,14 +119,13 @@ export default function ProtectedRenewConfirmCommunicationPreference({ loaderDat
               required
             />
           )}
-          {preferredCommunicationMethods.length > 0 && <InputRadios id="preferred-methods" legend={t('protected-renew:communication-preference.preferred-method')} name="preferredMethod" options={options} errorMessage={errors?.preferredMethod} required />}
         </div>
         <div className="flex flex-wrap items-center gap-3">
           <Button variant="primary" id="continue-button" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Communication click">
-            {t('protected-renew:communication-preference.save-btn')}
+            {t('protected-renew:confirm-communication-preference.save-btn')}
           </Button>
           <ButtonLink id="back-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Communication click">
-            {t('protected-renew:communication-preference.cancel-btn')}
+            {t('protected-renew:confirm-communication-preference.cancel-btn')}
           </ButtonLink>
         </div>
       </fetcher.Form>

--- a/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/confirm-email.tsx
@@ -42,7 +42,7 @@ const SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-renew', 'renew', 'gcweb'),
   pageIdentifier: pageIds.protected.renew.confirmEmail,
-  pageTitleI18nKey: 'protected-renew:confirm-email.page-title',
+  pageTitleI18nKey: 'protected-renew:confirm-email-ita.page-title',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ data }) => {
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw new Response('Not Found', { status: 404 });
   }
 
-  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-email.page-title') }) };
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:confirm-email-ita.page-title') }) };
 
   return {
     meta,
@@ -95,7 +95,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const emailSchema = z
     .object({
       shouldReceiveEmailCommunication: z.nativeEnum(SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION, {
-        errorMap: () => ({ message: t('protected-renew:confirm-email.error-message.ita-add-or-update-required') }),
+        errorMap: () => ({ message: t('protected-renew:confirm-email-ita.error-message.ita-add-or-update-required') }),
       }),
       email: z.string().trim().max(64).optional(),
       confirmEmail: z.string().trim().max(64).optional(),
@@ -103,17 +103,17 @@ export async function action({ context: { appContainer, session }, params, reque
     .superRefine((val, ctx) => {
       if (val.shouldReceiveEmailCommunication === SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes) {
         if (typeof val.email !== 'string' || validator.isEmpty(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-required'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email-ita.error-message.email-required'), path: ['email'] });
         } else if (!validator.isEmail(val.email)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-valid'), path: ['email'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email-ita.error-message.email-valid'), path: ['email'] });
         }
 
         if (typeof val.confirmEmail !== 'string' || validator.isEmpty(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.confirm-email-required'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email-ita.error-message.confirm-email-required'), path: ['confirmEmail'] });
         } else if (!validator.isEmail(val.confirmEmail)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.confirm-email-valid'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email-ita.error-message.confirm-email-valid'), path: ['confirmEmail'] });
         } else if (val.email !== val.confirmEmail) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email.error-message.email-match'), path: ['confirmEmail'] });
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: t('protected-renew:confirm-email-ita.error-message.email-match'), path: ['confirmEmail'] });
         }
       }
     })
@@ -155,7 +155,6 @@ export async function action({ context: { appContainer, session }, params, reque
           session,
           state: {
             editModeEmail: parsedDataResult.data.email,
-            editModeCommunicationPreferences: parsedDataResult.data.shouldReceiveEmailCommunication,
             ...(isNewEmail && {
               verifyEmail: {
                 verificationCode,
@@ -241,15 +240,15 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
         <CsrfTokenInput />
         <div className="mb-6">
           <p id="adding-email" className="mb-4">
-            {t('protected-renew:confirm-email.add-email')}
+            {t('protected-renew:confirm-email-ita.add-email')}
           </p>
           <InputRadios
             id="should-receive-email-communication"
             name="shouldReceiveEmailCommunication"
-            legend={t('protected-renew:confirm-email.add-or-update.legend')}
+            legend={t('protected-renew:confirm-email-ita.add-or-update.legend')}
             options={[
               {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-yes" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email-ita.option-yes" />,
                 value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.yes,
                 defaultChecked: shouldReceiveEmailCommunication === true,
                 onChange: handleShouldReceiveEmailCommunicationChanged,
@@ -264,7 +263,7 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
                       autoComplete="email"
                       defaultValue={defaultState.email}
                       errorMessage={errors?.email}
-                      label={t('protected-renew:confirm-email.email')}
+                      label={t('protected-renew:confirm-email-ita.email')}
                       maxLength={64}
                       aria-describedby="adding-email"
                     />
@@ -277,7 +276,7 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
                       autoComplete="email"
                       defaultValue={defaultState.email}
                       errorMessage={errors?.confirmEmail}
-                      label={t('protected-renew:confirm-email.confirm-email')}
+                      label={t('protected-renew:confirm-email-ita.confirm-email')}
                       maxLength={64}
                       aria-describedby="adding-email"
                     />
@@ -285,7 +284,7 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
                 ),
               },
               {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email.option-no" />,
+                children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-renew:confirm-email-ita.option-no" />,
                 value: SHOULD_RECEIVE_EMAIL_COMMUNICATION_OPTION.no,
                 defaultChecked: shouldReceiveEmailCommunication === false,
                 onChange: handleShouldReceiveEmailCommunicationChanged,
@@ -298,10 +297,10 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
         {editMode ? (
           <div className="flex flex-wrap items-center gap-3">
             <Button id="save-button" name="_action" value={FORM_ACTION.save} variant="primary" disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Save - Email click">
-              {t('protected-renew:confirm-email.save-btn')}
+              {t('protected-renew:confirm-email-ita.save-btn')}
             </Button>
             <ButtonLink id="cancel-button" routeId="protected/renew/$id/review-adult-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Cancel - Email click">
-              {t('protected-renew:confirm-email.cancel-btn')}
+              {t('protected-renew:confirm-email-ita.cancel-btn')}
             </ButtonLink>
           </div>
         ) : (
@@ -315,10 +314,10 @@ export default function ProtectedRenewProtectedConfirmEmail({ loaderData, params
               endIcon={faChevronRight}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Email click"
             >
-              {t('protected-renew:confirm-email.continue-btn')}
+              {t('protected-renew:confirm-email-ita.continue-btn')}
             </LoadingButton>
             <LoadingButton id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Email click">
-              {t('protected-renew:confirm-email.back-btn')}
+              {t('protected-renew:confirm-email-ita.back-btn')}
             </LoadingButton>
           </div>
         )}

--- a/frontend/app/routes/protected/renew/$id/ita/verify-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/ita/verify-email.tsx
@@ -166,7 +166,7 @@ export async function action({ context: { appContainer, session }, params, reque
             contactInformation: {
               ...state.contactInformation,
               email: state.editModeEmail,
-              shouldReceiveEmailCommunication: state.editModeCommunicationPreferences ?? state.contactInformation?.shouldReceiveEmailCommunication,
+              shouldReceiveEmailCommunication: state.contactInformation?.shouldReceiveEmailCommunication,
             },
             verifyEmail: {
               ...state.verifyEmail,

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -105,11 +105,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return { status: 'select-member' };
   }
 
-  if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
-    return redirect(getPathById('protected/renew/$id/review-child-information', params));
-  }
-
-  return redirect(getPathById('protected/renew/$id/review-adult-information', params));
+  return redirect(getPathById('protected/renew/$id/communication-preference', params));
 }
 
 export default function ProtectedRenewMemberSelection({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/protected/renew/$id/review-child-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-child-information.tsx
@@ -137,7 +137,7 @@ export async function action({ context: { appContainer, session }, params, reque
       state: { editMode: false },
     });
     if (!isPrimaryApplicantStateComplete(state, demographicSurveyEnabled)) {
-      return redirect(getPathById('protected/renew/$id/member-selection', params));
+      return redirect(getPathById('protected/renew/$id/communication-preference', params));
     }
     return redirect(getPathById('protected/renew/$id/review-adult-information', params));
   }

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -439,6 +439,11 @@ export const routes = [
             file: 'routes/protected/renew/$id/verify-email.tsx',
             paths: { en: '/:lang/protected/renew/:id/verify-email', fr: '/:lang/protege/renouveler/:id/verifier-courriel' },
           },
+          {
+            id: 'protected/renew/$id/communication-preference',
+            file: 'routes/protected/renew/$id/communication-preference.tsx',
+            paths: { en: '/:lang/protected/renew/:id/communication-preference', fr: '/:lang/protege/renouveler/:id/preference-communication' },
+          },
         ],
       },
     ],

--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -359,7 +359,7 @@
       "phone-number-alt-valid-international": "Phone number does not exist. If it's an international phone number, add '+' in front"
     }
   },
-  "confirm-email": {
+  "confirm-email-ita": {
     "page-title": "Email",
     "add-email": "Email communication will help the Government of Canada and Sun Life contact you regarding your Canadian Dental Care Plan coverage. Otherwise, we'll contact you by mail.",
     "add-or-update": {
@@ -381,6 +381,20 @@
       "email-required": "Enter an email address in the correct format, such as name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com",
       "confirm-email-valid": "Enter confirmation of email address in the correct format, such as name@example.com"
+    }
+  },
+  "confirm-email": {
+    "page-title": "Email",
+    "provide-email": "Provide the email address you'd like the Government of Canada and/or Sun Life to use to contact you about your Canadian Dental Care Plan coverage.",
+    "verify-email": "We will need to verify your email address.",
+    "email-legend": "Email address",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "email-required": "Enter email address, for example name@example.com",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com"
     }
   },
   "update-address": {
@@ -427,7 +441,7 @@
     "cancel-btn": "Cancel",
     "save-btn": "Save"
   },
-  "communication-preference": {
+  "confirm-communication-preference": {
     "page-title": "Communication",
     "preferred-language": "What is your preferred official language of communication?",
     "preferred-method": "How would you prefer to receive communication about your Canadian Dental Care Plan from Sun Life and the Government of Canada?",
@@ -535,7 +549,14 @@
     "continue-button": "Continue",
     "yes": "Yes",
     "no": "No",
-    "no-update": "No update"
+    "no-update": "No update",
+    "sun-life-comm-pref-title": "Sun Life communication preference",
+    "goc-comm-pref-title": "Government of Canada communication preference",
+    "sun-life-comm-pref-change": "Change Sun Life communication",
+    "goc-comm-pref-change": "Change Government of Canada communication",
+    "preferred-notification-method-email": "By email",
+    "preferred-notification-method-msca": "Digitally through My Service Canada Account (MSCA)",
+    "preferred-notification-method-mail": "By mail"
   },
   "review-submit": {
     "page-title": "Submit your renewal application",
@@ -626,6 +647,25 @@
     "code-sent": {
       "heading": "New verification code",
       "detail": "A new verification code has been sent to {{email}}."
+    }
+  },
+  "communication-preference": {
+    "page-title": "Communication",
+    "preferred-method": "How would you like Sun Life to communicate with you?",
+    "preferred-method-help-message": "If eligible, we will share your information with Sun Life. Sun Life will be responsible for handling member enrolment and claims processing for the Canadian Dental Care Plan.",
+    "by-email": "By email",
+    "by-mail": "By mail",
+    "preferred-notification-method": "How would you like to receive letters or notifications from the Government of Canada about your eligibility for the Canadian Dental Care Plan?",
+    "preferred-notification-method-msca": "<span>Digitally through My Service Canada Account (MSCA)</span><br>You <strong>will not receive</strong> your Canadian Dental Care Plan eligibility decision by mail. Visit <mscaLinkAccount>My Service Canada Account</mscaLinkAccount> to register for an account or to sign in.",
+    "preferred-notification-method-mail": "<span>By mail</span><br>You can also view your Canadian Dental Care Plan eligibility decision in your <mscaLinkAccount>My Service Canada Account</mscaLinkAccount>.",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "msca-link-account": "https://www.canada.ca/en/employment-social-development/services/my-account.html",
+    "error-message": {
+      "preferred-method-required": "Select preferred method of communication for Sun Life",
+      "preferred-notification-method-required": "Select preferred method of communication for the Government of Canada"
     }
   }
 }

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -359,7 +359,7 @@
       "phone-number-alt-valid-international": "Le numéro de téléphone n'existe pas.  S'il s'agit d'un numéro de téléphone international, ajoutez '+' devant"
     }
   },
-  "confirm-email": {
+  "confirm-email-ita": {
     "page-title": "Adresse courriel",
     "add-email": "La communication par courriel aidera le gouvernement du Canada et Sun Life à vous contacter au sujet de votre adhésion au Régime canadien de soins dentaires. Sinon, nous vous contacterons par la poste.",
     "add-or-update": {
@@ -381,6 +381,20 @@
       "email-required": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com",
       "confirm-email-valid": "Entrez la confirmation de l'adresse courriel dans le bon format, par exemple nom@exemple.com"
+    }
+  },
+  "confirm-email": {
+    "page-title": "Adresse courriel",
+    "provide-email": "Fournissez l'adresse courriel que vous souhaitez que le gouvernement du Canada ou la Sun Life utilise pour communiquer avec vous au sujet de votre adhésion au Régime canadien de soins dentaires.",
+    "verify-email": "Nous devons vérifier votre adresse courriel.",
+    "email-legend": "Adresse courriel",
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "email-required": "Entrez l'adresse courriel, par exemple nom@exemple.com",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com"
     }
   },
   "update-address": {
@@ -427,7 +441,7 @@
     "cancel-btn": "Annuler",
     "save-btn": "Enregistrer"
   },
-  "communication-preference": {
+  "confirm-communication-preference": {
     "page-title": "Communication",
     "preferred-language": "Quelle langue officielle de communication préférez-vous?",
     "preferred-method": "Comment préférez-vous recevoir les communications au sujet de votre Régime canadien de soins dentaires de la Sun Life et du gouvernement du Canada\u00a0?",
@@ -535,7 +549,14 @@
     "continue-button": "Continuer",
     "yes": "Oui",
     "no": "Non",
-    "no-update": "Pas de mise à jour"
+    "no-update": "Pas de mise à jour",
+    "sun-life-comm-pref-title": "Préférence de communication de Sun Life",
+    "goc-comm-pref-title": "Préférence de communication du gouvernement du Canada",
+    "sun-life-comm-pref-change": "Modifier la préférence de Sun Life",
+    "goc-comm-pref-change": "Modifier la communication du gouvernement du Canada",
+    "preferred-notification-method-email": "Par courriel",
+    "preferred-notification-method-msca": "Numériquement, dans Mon dossier Service Canada (MDSC)",
+    "preferred-notification-method-mail": "Par la poste"
   },
   "review-submit": {
     "page-title": "Soumettre votre demande de renouvellement",
@@ -626,6 +647,25 @@
     "code-sent": {
       "heading": "Nouveau code",
       "detail": "Un nouveau code de vérification a été envoyé à {{email}}."
+    }
+  },
+  "communication-preference": {
+    "page-title": "Communication",
+    "preferred-method": "Comment aimeriez-vous que la Sun Life communique avec vous?",
+    "preferred-method-help-message": "Si vous êtes admissible, nous communiquerons vos renseignements à la Sun Life du Canada, compagnie d'assurance-vie (Sun Life). La Sun Life sera responsable du traitement de l'adhésion des membres et de l'administration des demandes de réclamations et des prestations du Régime canadien de soins dentaires.",
+    "by-email": "Par courriel",
+    "by-mail": "Par la poste",
+    "preferred-notification-method": "Comment aimeriez-vous recevoir les lettres ou notifications du gouvernement du Canada au sujet de votre admissibilité au Régime canadien de soins dentaires?",
+    "preferred-notification-method-msca": "<span>Numériquement, dans Mon dossier Service Canada (MDSC)</span><br>Vous <strong>ne recevrez pas</strong> la décision d'admissibilité au Régime canadien de soins dentaires par la poste. Allez sur le site <mscaLinkAccount>Mon dossier Service Canada</mscaLinkAccount> pour y ouvrir un compte ou pour ouvrir une session.",
+    "preferred-notification-method-mail": "<span>Par la poste</span><br>Vous pouvez également consulter votre décision d'admissibilité au Régime canadien de soins dentaires dans <mscaLinkAccount>Mon dossier Service Canada</mscaLinkAccount>.",
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "msca-link-account": "https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier.html",
+    "error-message": {
+      "preferred-method-required": "Sélectionnez votre moyen de communication préféré avec la Sun Life",
+      "preferred-notification-method-required": "Sélectionnez votre moyen de communication préféré avec le gouvernement du Canada"
     }
   }
 }


### PR DESCRIPTION
### Description
Modifies/adds functionality similar to the public apply apps(s) for handling communication preference/email validation.  You may notice this PR is massive.  Unfortunately that means there are likely 'bugs' or things overlooked.  Please review carefully.  I will note that the interop payload will need to be reviewed and modifications to the mapper(s) will need to happen in a separate PR.  The ITA portion of the protected renew app will be addressed in a separate PR.

### Related Azure Boards Work Items
AB#6052

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`