### PR TITLE
fix(frontend): Display primary applicant even when renewing a child application

### DIFF
--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -62,27 +62,22 @@ export async function loader({ context: { appContainer, session }, params, reque
   const idToken: IdToken = session.get('idToken');
   appContainer.get(TYPES.domain.services.AuditService).createAudit('page-view.renew.member-selection', { userId: idToken.sub });
 
-  const members: Member[] = [];
-
-  // primary member
-  if (state.clientApplication.typeOfApplication !== 'child') {
-    members.push({
+  const members: Member[] = [
+    // primary member
+    {
       id: state.id,
       applicantName: `${state.clientApplication.applicantInformation.firstName} ${state.clientApplication.applicantInformation.lastName}`,
       previouslyReviewed: state.previouslyReviewed,
       typeOfApplicant: 'primary',
-    });
-  }
-
-  // children members
-  members.push(
+    },
+    // children members
     ...state.children.map<Member>((child) => ({
       id: child.id,
       applicantName: `${child.information?.firstName} ${child.information?.lastName}`,
       previouslyReviewed: child.previouslyReviewed,
       typeOfApplicant: 'child',
     })),
-  );
+  ];
 
   return { meta, members, isItaCandidate: isInvitationToApplyClient(state.clientApplication) };
 }


### PR DESCRIPTION
### Description
When in the protected renew flow, the primary applicant should now always display.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/22143

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`


### Additional Notes
I tested this locally using the SIN provided in the ADO ticket above, and by port-forwarding to the Squid proxy instance to connect to Interop's UAT1 environment.