### PR TITLE
fix(frontend): Unsupported URL canParse static method

### DIFF
--- a/frontend/__tests__/utils/url-utils.test.ts
+++ b/frontend/__tests__/utils/url-utils.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 
-import { removePathSegment } from '~/utils/url-utils';
+import { parseUrl, removePathSegment } from '~/utils/url-utils';
 
 describe('removePathSegment function', () => {
   it('removes the segment at the specified position from the URL pathname', () => {
@@ -43,5 +43,50 @@ describe('removePathSegment function', () => {
     const newPosition = 3;
     const expectedUrl = 'https://example.com/path/segment1/segment2';
     expect(removePathSegment(url, newPosition)).toBe(expectedUrl);
+  });
+});
+
+describe('parseUrl', () => {
+  it('should parse a valid absolute URL string', () => {
+    const result = parseUrl('https://example.com');
+    expect(result).toEqual({
+      success: true,
+      url: new URL('https://example.com'),
+    });
+  });
+
+  it('should parse a valid relative URL with base', () => {
+    const result = parseUrl('/path', 'https://example.com');
+    expect(result).toEqual({
+      success: true,
+      url: new URL('/path', 'https://example.com'),
+    });
+  });
+
+  it('should parse a URL object without changing it', () => {
+    const inputUrl = new URL('https://example.com');
+    const result = parseUrl(inputUrl);
+    expect(result).toEqual({
+      success: true,
+      url: inputUrl,
+    });
+  });
+
+  it('should fail to parse an invalid URL string', () => {
+    const result = parseUrl('http://[invalid-url]');
+    assert(result.success === false);
+    expect(result.error).toBeInstanceOf(TypeError);
+  });
+
+  it('should fail when given an invalid base URL', () => {
+    const result = parseUrl('/path', 'not-a-valid-base');
+    assert(result.success === false);
+    expect(result.error).toBeInstanceOf(TypeError);
+  });
+
+  it('should fail when both url and base are invalid', () => {
+    const result = parseUrl('not-a-url', 'also-not-a-url');
+    assert(result.success === false);
+    expect(result.error).toBeInstanceOf(TypeError);
   });
 });

--- a/frontend/app/utils/link-utils.ts
+++ b/frontend/app/utils/link-utils.ts
@@ -1,16 +1,25 @@
+import { parseUrl } from '~/utils/url-utils';
+
 /**
  * Scrolls and focuses on the element identified by the anchor link's hash.
  *
  * @param {string} href - The anchor link URL.
  */
 export function scrollAndFocusFromAnchorLink(href: string): void {
-  if (!URL.canParse(href)) return;
+  const urlResult = parseUrl(href);
+  if (!urlResult.success) {
+    return;
+  }
 
-  const { hash } = new URL(href);
-  if (!hash) return;
+  const { hash } = urlResult.url;
+  if (!hash) {
+    return;
+  }
 
   const targetElement = document.querySelector<HTMLElement>(hash);
-  if (!targetElement) return;
+  if (!targetElement) {
+    return;
+  }
 
   targetElement.scrollIntoView({ behavior: 'smooth' });
   targetElement.focus();

--- a/frontend/app/utils/url-utils.ts
+++ b/frontend/app/utils/url-utils.ts
@@ -11,3 +11,24 @@ export function removePathSegment(url: string | URL, position: number) {
   urlObj.pathname = segments.join('/');
   return urlObj.toString();
 }
+
+type ParseUrlSuccess = { success: true; url: URL };
+type ParseUrlFailure = { success: false; error: TypeError };
+type ParseUrlResult = ParseUrlSuccess | ParseUrlFailure;
+
+/**
+ * Attempts to parse a given string or URL into a `URL` object.
+ *
+ * Returns a result object indicating success or failure. This function avoids
+ * throwing by returning a typed result instead of using exceptions.
+ *
+ * @param url - A URL string or an existing `URL` object to be parsed.
+ * @param base - An optional base URL to resolve relative URLs against. Can be a string or `URL` object.
+ */
+export function parseUrl(url: string | URL, base?: string | URL): ParseUrlResult {
+  try {
+    return { success: true, url: new URL(url, base) };
+  } catch (error) {
+    return { success: false, error: error as TypeError };
+  }
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix JavaScript error in older browsers. [URL.canParse()](https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static) is fully supported in modern browsers as of 2023, but it causes issues for users on older browsers. This has been tested locally with Firefox 110.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->