### PR TITLE
fix(frontend): Set `emailVerified` field based on communication preferred method fields

### DIFF
--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -28,7 +28,6 @@ export interface ApplyAdultState {
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   email?: string;
-  emailVerified?: boolean;
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -49,7 +48,6 @@ export interface ApplyAdultChildState {
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance: boolean;
   email?: string;
-  emailVerified?: boolean;
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -68,7 +66,6 @@ export interface ApplyChildState {
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
   email?: string;
-  emailVerified?: boolean;
   homeAddress?: HomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -87,7 +84,6 @@ interface ToBenefitApplicationDtoArgs {
   communicationPreferences: CommunicationPreferencesState;
   contactInformation: ContactInformationState;
   email?: string;
-  emailVerified?: boolean;
   dentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
   dentalInsurance?: boolean;
   livingIndependently?: boolean;
@@ -116,7 +112,6 @@ interface ToHomeAddressArgs {
 interface ToCommunicationPreferencesArgs {
   communicationPreferences: CommunicationPreferencesState;
   email?: string;
-  emailVerified?: boolean;
 }
 
 interface ToContactInformationArgs {
@@ -175,7 +170,6 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     dentalBenefits,
     dentalInsurance,
     email,
-    emailVerified,
     homeAddress,
     isHomeAddressSameAsMailingAddress,
     livingIndependently,
@@ -193,7 +187,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       }),
       applicationYearId: applicationYear.applicationYearId,
       children: this.toChildren(children),
-      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences, email, emailVerified }),
+      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences, email }),
       contactInformation: this.toContactInformation({ contactInformation, email, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }),
       dateOfBirth: applicantInformation.dateOfBirth,
       maritalStatus,
@@ -241,10 +235,10 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     });
   }
 
-  private toCommunicationPreferences({ communicationPreferences, email, emailVerified }: ToCommunicationPreferencesArgs): CommunicationPreferencesDto {
+  private toCommunicationPreferences({ communicationPreferences, email }: ToCommunicationPreferencesArgs): CommunicationPreferencesDto {
     return {
       email,
-      emailVerified,
+      emailVerified: communicationPreferences.preferredMethod === 'email' || communicationPreferences.preferredNotificationMethod === 'msca' ? true : undefined,
       preferredLanguage: communicationPreferences.preferredLanguage,
       preferredMethod: communicationPreferences.preferredMethod,
       preferredMethodGovernmentOfCanada: communicationPreferences.preferredNotificationMethod,


### PR DESCRIPTION
### Description
The `emailVerified` field will be determined based on whether the applicant has selected Email (for Sun Life) or MSCA (for the Government of Canada) as their preferred method of communication. 

This approach helps prevent edge cases where the `emailVerified` field in the state object is incorrectly set to `false`, even though the user has already verified their email.

### Related Azure Boards Work Items
https://dev.azure.com/ESDCCM/CDCP/_workitems/edit/22220

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
This approach serves as a quick mitigation. In the future, when the intake and renewal front ends are redesigned, we should eliminate the edge cases that could lead to this issue.