### PR TITLE
fix(frontend): Root meta undefined data

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -30,6 +30,13 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export const meta: Route.MetaFunction = ({ data }) => {
+  // Fix: TypeError: Cannot read properties of undefined (reading 'meta')
+  // Related issue https://github.com/remix-run/react-router/issues/13541#issuecomment-2863959552
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (data === undefined) {
+    return [];
+  }
+
   return [
     ...getTitleMetaTags(data.meta.title),
     ...getDescriptionMetaTags(data.meta.description),

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -52,7 +52,7 @@ function toRouteConfigEntries(routes: I18nRoute[]): RouteConfigEntry[] {
  */
 export default [
   index('routes/language-chooser.tsx'), //
-  route('/:lang/*', 'routes/catchall.tsx'),
   ...routes,
   ...toRouteConfigEntries(i18nRoutes),
+  route('*', 'routes/catchall.tsx'),
 ] satisfies RouteConfig;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix for `TypeError` in root meta function. In some circumstances root `loader` is not executed and `data` argument is `undefined`.

Related issue https://github.com/remix-run/react-router/issues/13541#issuecomment-2863959552

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

GET 404 pages in the browser

- `http://localhost:3000/en/sadf` (English not found page)
- `http://localhost:3000/fr/sadf` (French not found page)
- `http://localhost:3000/asdf/test` (Bilingual not found page)
- `http://localhost:3000//c` (Bilingual not found page)

POST to not found resource and the server should respond with 500 Internal Server Error

```
curl -X POST http://localhost:3000/asdf
```

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->