### PR TITLE
feat(frontend): Add conditional retry based on status code and/or response body content

### DIFF
--- a/frontend/__tests__/.server/http/http-client.test.ts
+++ b/frontend/__tests__/.server/http/http-client.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { DefaultHttpClient } from '~/.server/http/http-client';
+import type { InstrumentationService } from '~/.server/observability';
+import { AppError } from '~/errors/app-error';
+
+describe('DefaultHttpClient', () => {
+  let httpClient: DefaultHttpClient;
+
+  const mockFetch = vi.fn();
+  const mockInstrumentationService = mock<InstrumentationService>();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+
+    httpClient = new DefaultHttpClient(mockInstrumentationService);
+    vi.spyOn(httpClient, 'getFetchFn').mockReturnValue(mockFetch);
+  });
+
+  describe('instrumentedFetch', () => {
+    it('calls fetch and instrumentationService on success', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const res = await httpClient.instrumentedFetch('example-metric', 'http://api.example.com');
+
+      expect(res.status).toBe(200);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 200);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledOnce();
+    });
+
+    it('retries on matched status and body condition', async () => {
+      const response = new Response('retry this', { status: 503 });
+      mockFetch.mockResolvedValue(response);
+
+      await expect(
+        async () =>
+          await httpClient.instrumentedFetch('example-metric', 'http://api.example.com', {
+            retryOptions: {
+              retries: 1,
+              backoffMs: 1,
+              retryConditions: {
+                503: [/retry this/],
+              },
+            },
+          }),
+      ).rejects.toThrow(AppError);
+
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on matched status and no body condition', async () => {
+      const response = new Response('retry this', { status: 503 });
+      mockFetch.mockResolvedValue(response);
+
+      await expect(
+        async () =>
+          await httpClient.instrumentedFetch('example-metric', 'http://api.example.com', {
+            retryOptions: {
+              retries: 1,
+              backoffMs: 1,
+              retryConditions: {
+                503: [],
+              },
+            },
+          }),
+      ).rejects.toThrow(AppError);
+
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry if body does not match', async () => {
+      const response = new Response('not matching', { status: 503 });
+      mockFetch.mockResolvedValue(response);
+
+      const res = await httpClient.instrumentedFetch('example-metric', 'http://api.example.com', {
+        retryOptions: {
+          retries: 1,
+          backoffMs: 1,
+          retryConditions: {
+            503: [/something else/],
+          },
+        },
+      });
+
+      expect(res.status).toBe(503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledOnce();
+    });
+
+    it('uses default retry options if none provided', async () => {
+      const response = new Response(null, { status: 503 });
+      mockFetch.mockResolvedValue(response);
+
+      const res = await httpClient.instrumentedFetch('example-metric', 'http://api.example.com', {
+        retryOptions: {},
+      });
+
+      expect(res.status).toBe(503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 503);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledOnce();
+    });
+
+    it('calls instrumentationService with 500 on unexpected error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network fail'));
+
+      await expect(async () => await httpClient.instrumentedFetch('example-metric', 'http://api.example.com')).rejects.toThrow();
+
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledWith('example-metric', 500);
+      expect(mockInstrumentationService.countHttpStatus).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/.server/http/http-client.ts
+++ b/frontend/app/.server/http/http-client.ts
@@ -1,4 +1,5 @@
 import { inject } from 'inversify';
+import { retry } from 'moderndash';
 import { ProxyAgent } from 'undici';
 
 import { TYPES } from '~/.server/constants';
@@ -6,6 +7,8 @@ import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
 import type { InstrumentationService } from '~/.server/observability';
 import { getEnv } from '~/.server/utils/env.utils';
+import { AppError, isAppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 
 /**
  * A custom fetch(..) function that can be used for making HTTP requests.
@@ -31,9 +34,49 @@ export interface FetchOptions {
 }
 
 /**
+ * Options for configuring a retry mechanism for fetch function.
+ */
+export interface RetryOptions {
+  /**
+   * Maximum number of retry attempts (excluding the first try).
+   * Set to 0 or undefined to disable retries.
+   */
+  retries?: number;
+
+  /**
+   * Base delay in milliseconds before the first retry attempt.
+   * Subsequent retries will use exponential backoff.
+   */
+  backoffMs?: number;
+
+  /**
+   * A mapping of HTTP status codes to body matchers (string or RegExp) that should trigger a retry.
+   * If the array is empty, any response with the corresponding status code will trigger a retry.
+   */
+  retryConditions?: {
+    [statusCode: number]: (string | RegExp)[];
+  };
+}
+
+/**
+ * Options for performing a fetch request with conditional retry logic
+ * based on HTTP status codes and optional response body matchers.
+ */
+interface FetchRetryOptions {
+  fetchFn: typeof fetch;
+  input: RequestInfo | URL;
+  init: RequestInit;
+  metricPrefix: string;
+  retryConditions: Record<number, (string | RegExp)[]>;
+}
+
+/**
  * Extended options for instrumented fetch calls.
  */
-export type InstrumentedFetchOptions = RequestInit & FetchOptions;
+export type InstrumentedFetchOptions = RequestInit &
+  FetchOptions & {
+    retryOptions?: RetryOptions;
+  };
 
 /**
  * Service interface for managing HTTP requests with optional instrumentation and proxy support.
@@ -52,7 +95,7 @@ export interface HttpClient {
    *
    * @param metricPrefix - The prefix used for instrumentation metrics.
    * @param input - The input for the HTTP request, which can be a URL or a `RequestInfo` object.
-   * @param options - (Optional) Additional options for the request, including proxy settings and initialization options.
+   * @param options - (Optional) Additional options for the request, including proxy settings, initialization options and retry configuration.
    * @returns A promise that resolves with the `Response` object from the HTTP request.
    * @throws Will throw an error if the HTTP request fails.
    */
@@ -90,17 +133,74 @@ export class DefaultHttpClient implements HttpClient {
 
   async instrumentedFetch(metricPrefix: string, input: RequestInfo | URL, options: InstrumentedFetchOptions = {}): Promise<Response> {
     this.log.debug('Executing instumented fetch function; metricPrefix: [%s], input: [%s], options: [%j]', metricPrefix, input, options);
-    const { proxyUrl, timeout, ...init } = options;
+    const { proxyUrl, timeout, retryOptions, ...init } = options;
+
+    // Configure default retry options if not specified
+    const { retries = 0, backoffMs = 100, retryConditions = {} } = retryOptions ?? {};
+
     const fetchFn = this.getFetchFn({ proxyUrl, timeout });
+
     try {
-      const response = await fetchFn(input, init);
-      this.log.trace('HTTP request completed; status: [%d]', response.status);
+      const response = await retry(async () => await this.fetchWithRetryConditions({ fetchFn, input, init, metricPrefix, retryConditions }), {
+        maxRetries: retries,
+        backoff: (retries) => retries * backoffMs,
+        onRetry: (error, attempt) => {
+          this.log.warn('HTTP request failed; metricPrefix: [%s]; attempt [%d] of [%d]; [%s]', metricPrefix, attempt, retries, error);
+        },
+      });
+
+      this.log.trace('HTTP request completed; metricPrefix: [%s]; status: [%d]', metricPrefix, response.status);
       this.instrumentationService.countHttpStatus(metricPrefix, response.status);
+
       return response;
     } catch (error) {
-      this.log.error('HTTP request failed; error: [%s]', error);
-      this.instrumentationService.countHttpStatus(metricPrefix, 500);
+      // Only instrument with status 500 if the failure was not due to an expected AppError
+      // (e.g., not a retry condition match); this indicates the fetch itself failed.
+      if (!isAppError(error)) {
+        this.instrumentationService.countHttpStatus(metricPrefix, 500);
+      }
+
       throw error;
     }
+  }
+
+  /**
+   * Fetches a resource and checks for retry conditions based on the response status and body.
+   *
+   * @param fetchFn - The fetch function to use for making the request.
+   * @param input - The input for the HTTP request, which can be a URL or a `RequestInfo` object.
+   * @param init - The initialization options for the fetch request.
+   * @param metricPrefix - The prefix used for instrumentation metrics.
+   * @param retryConditions - A map of status codes to response body contents that should trigger a retry.
+   * @returns A promise that resolves with the `Response` object from the HTTP request.
+   */
+  private async fetchWithRetryConditions({ fetchFn, input, init, metricPrefix, retryConditions }: FetchRetryOptions): Promise<Response> {
+    const response = await fetchFn(input, init);
+
+    // Check if the response status is configured to be retried
+    const conditions = retryConditions[response.status];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!conditions) {
+      return response;
+    }
+
+    // Clone the response before reading its body to avoid consuming the original stream
+    const body = await response.clone().text();
+
+    // Retry on this status regardless of body content
+    if (conditions.length === 0) {
+      this.instrumentationService.countHttpStatus(metricPrefix, response.status);
+      throw new AppError(`Retryable response thrown with http status: [${response.status} ${response.statusText}]; response body: [${body}]`, ErrorCodes.XAPI_RETRY_NO_CONDITIONS);
+    }
+
+    // Retry only if the body matches one of the configured retry conditions (string or regex)
+    const matchedCondition = conditions.find((condition) => (typeof condition === 'string' ? condition === body : condition.test(body)));
+    if (matchedCondition) {
+      this.instrumentationService.countHttpStatus(metricPrefix, response.status);
+      throw new AppError(`Retryable response thrown with http status: [${response.status} ${response.statusText}]; matched condition: [${matchedCondition}]; response body: [${body}]`, ErrorCodes.XAPI_RETRY_CONDITION_MATCHED);
+    }
+
+    // Response matched a retriable status but not a retriable body - treat as successful
+    return response;
   }
 }

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -15,4 +15,6 @@ export const ErrorCodes = {
   // external api error codes
   XAPI_API_ERROR: 'XAPI-0001',
   XAPI_TOO_MANY_REQUESTS: 'XAPI-0002',
+  XAPI_RETRY_NO_CONDITIONS: 'XAPI-0003',
+  XAPI_RETRY_CONDITION_MATCHED: 'XAPI-0004',
 } as const;


### PR DESCRIPTION
### Description
- Introduces `RetryOptions` and `retryConditions` to support (instrumented fetch) retries based on HTTP status codes and optional response body matchers (with either `string` or `RegExp`)
  - If the array for a status code is empty, any response with that status triggers a retry
  - If the array contains matchers, a retry is triggered only if the response body matches one of them
- Improves logging to clearly indicate when retries are triggered and which conditions caused the retry
- Includes the `metricPrefix` in logs for better traceability and correlation with metrics

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Additional Notes
I tested this change by modifying an arbitrary repository. Updates to the impacted repositories will be addressed in a future PR.