### PR TITLE
feat(frontend): Adding configurable retries and backoff for Interop API requests

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -93,6 +93,12 @@ INTEROP_API_BASE_URI=https://api.example.com
 # Interop API subscription key
 # (required; use the example below)
 INTEROP_API_SUBSCRIPTION_KEY=00000000000000000000000000000000
+# Maximum number of retry attempts if the Interop API request fails
+# Optional (Default: 3).
+INTEROP_API_MAX_RETRIES=3
+# Base backoff duration in milliseconds between specified Interop API retries.
+# Optional (Default: 100).
+INTEROP_API_BACKOFF_MS=100
 # Interop Address Validation API request:
 # Maximum length allowed for the 'city' parameter.
 # Optional (Default: 30).

--- a/frontend/app/.server/domain/repositories/letter.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter.repository.ts
@@ -52,14 +52,33 @@ export class DefaultLetterRepository implements LetterRepository {
   private readonly log: Logger;
   private readonly serverConfig: Pick<
     ServerConfig,
-    'HEALTH_PLACEHOLDER_REQUEST_VALUE' | 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_CCT_API_BASE_URI' | 'INTEROP_CCT_API_SUBSCRIPTION_KEY' | 'INTEROP_CCT_API_COMMUNITY'
+    | 'HEALTH_PLACEHOLDER_REQUEST_VALUE'
+    | 'HTTP_PROXY_URL'
+    | 'INTEROP_API_BASE_URI'
+    | 'INTEROP_API_SUBSCRIPTION_KEY'
+    | 'INTEROP_CCT_API_BASE_URI'
+    | 'INTEROP_CCT_API_SUBSCRIPTION_KEY'
+    | 'INTEROP_CCT_API_COMMUNITY'
+    | 'INTEROP_API_MAX_RETRIES'
+    | 'INTEROP_API_BACKOFF_MS'
   >;
   private readonly httpClient: HttpClient;
   private readonly baseUrl: string;
 
   constructor(
     @inject(TYPES.configs.ServerConfig)
-    serverConfig: Pick<ServerConfig, 'HEALTH_PLACEHOLDER_REQUEST_VALUE' | 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_CCT_API_BASE_URI' | 'INTEROP_CCT_API_SUBSCRIPTION_KEY' | 'INTEROP_CCT_API_COMMUNITY'>,
+    serverConfig: Pick<
+      ServerConfig,
+      | 'HEALTH_PLACEHOLDER_REQUEST_VALUE'
+      | 'HTTP_PROXY_URL'
+      | 'INTEROP_API_BASE_URI'
+      | 'INTEROP_API_SUBSCRIPTION_KEY'
+      | 'INTEROP_CCT_API_BASE_URI'
+      | 'INTEROP_CCT_API_SUBSCRIPTION_KEY'
+      | 'INTEROP_CCT_API_COMMUNITY'
+      | 'INTEROP_API_MAX_RETRIES'
+      | 'INTEROP_API_BACKOFF_MS'
+    >,
     @inject(TYPES.http.HttpClient) httpClient: HttpClient,
   ) {
     this.log = createLogger('DefaultLetterRepository');
@@ -80,6 +99,13 @@ export class DefaultLetterRepository implements LetterRepository {
         'Content-Type': 'application/json',
         'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_CCT_API_SUBSCRIPTION_KEY ?? this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
         'cct-community': this.serverConfig.INTEROP_CCT_API_COMMUNITY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
       },
     });
 
@@ -117,6 +143,13 @@ export class DefaultLetterRepository implements LetterRepository {
         'Content-Type': 'application/json',
         'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_CCT_API_SUBSCRIPTION_KEY ?? this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
         'cct-community': this.serverConfig.INTEROP_CCT_API_COMMUNITY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
       },
     });
 

--- a/frontend/app/.server/utils/env.utils.ts
+++ b/frontend/app/.server/utils/env.utils.ts
@@ -81,6 +81,8 @@ const serverEnv = clientEnvSchema.extend({
   // interop api settings
   INTEROP_API_BASE_URI: z.string().url(),
   INTEROP_API_SUBSCRIPTION_KEY: z.string().trim().min(1),
+  INTEROP_API_MAX_RETRIES: z.coerce.number().default(3),
+  INTEROP_API_BACKOFF_MS: z.coerce.number().default(100),
   INTEROP_ADDRESS_VALIDATION_REQUEST_CITY_MAX_LENGTH: z.coerce.number().int().positive().default(30),
   INTEROP_APPLICANT_API_BASE_URI: z.string().trim().transform(emptyToUndefined).optional(),
   INTEROP_APPLICANT_API_SUBSCRIPTION_KEY: z.string().trim().transform(emptyToUndefined).optional(),


### PR DESCRIPTION
### Description
- Implement retry logic using `INTEROP_API_MAX_RETRIES` and `INTEROP_API_BACKOFF_MS` configurable environment variables
- Apply retries to all idempotent `GET` requests and the application submission `POST` requests (Power Platform can handle duplicates by using the latest application)
- Use exponential backoff delay between retry attempts

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`