### PR TITLE
feat(frontend) add client friendly status interop fetch call

### DIFF
--- a/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
@@ -28,10 +28,10 @@ describe('DefaultClientFriendlyStatusService', () => {
   });
 
   describe('getClientFriendlyStatusById', () => {
-    it('fetches client friendly status by id', () => {
+    it('fetches client friendly status by id', async () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockReturnValueOnce({
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce({
         esdc_clientfriendlystatusid: '1',
         esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
         esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
@@ -48,33 +48,33 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      const dto = service.getClientFriendlyStatusById(id);
+      const dto = await service.getClientFriendlyStatusById(id);
 
       expect(dto).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).toHaveBeenCalledOnce();
     });
 
-    it('fetches client friendly status by id throws not found exception', () => {
+    it('fetches client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockReturnValueOnce(null);
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(null);
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      expect(() => service.getClientFriendlyStatusById(id)).toThrow(ClientFriendlyStatusNotFoundException);
+      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).not.toHaveBeenCalled();
     });
   });
 
   describe('getLocalizedClientFriendlyStatusById', () => {
-    it('fetches localized client friendly status by id', () => {
+    it('fetches localized client friendly status by id', async () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockReturnValueOnce({
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce({
         esdc_clientfriendlystatusid: '1',
         esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
         esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
@@ -87,23 +87,23 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      const dto = service.getLocalizedClientFriendlyStatusById(id, 'en');
+      const dto = await service.getLocalizedClientFriendlyStatusById(id, 'en');
 
       expect(dto).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).toHaveBeenCalledOnce();
     });
 
-    it('fetches localized client friendly status by id throws not found exception', () => {
+    it('fetches localized client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockReturnValueOnce(null);
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(null);
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      expect(() => service.getClientFriendlyStatusById(id)).toThrow(ClientFriendlyStatusNotFoundException);
+      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).not.toHaveBeenCalled();
     });

--- a/frontend/app/.server/domain/services/client-friendly-status.service.ts
+++ b/frontend/app/.server/domain/services/client-friendly-status.service.ts
@@ -21,7 +21,7 @@ export interface ClientFriendlyStatusService {
    * @returns The ClientFriendlyStatus DTO corresponding to the specified ID.
    * @throws {ClientFriendlyStatusNotFoundException} If no client friendly status is found with the specified ID.
    */
-  getClientFriendlyStatusById(id: string): ClientFriendlyStatusDto;
+  getClientFriendlyStatusById(id: string): Promise<ClientFriendlyStatusDto>;
 
   /**
    * Retrieves a specific client friendly status by its ID with localized names.
@@ -31,7 +31,7 @@ export interface ClientFriendlyStatusService {
    * @returns The ClientFriendlyStatusLocalized DTO corresponding to the specified ID.
    * @throws {ClientFriendlyStatusNotFoundException} If no client friendly status is found with the specified ID.
    */
-  getLocalizedClientFriendlyStatusById(id: string, locale: AppLocale): ClientFriendlyStatusLocalizedDto;
+  getLocalizedClientFriendlyStatusById(id: string, locale: AppLocale): Promise<ClientFriendlyStatusLocalizedDto>;
 }
 
 export type ClientFriendlyStatusServiceImpl_ServerConfig = Pick<ServerConfig, 'LOOKUP_SVC_CLIENT_FRIENDLY_STATUS_CACHE_TTL_SECONDS'>;
@@ -90,9 +90,9 @@ export class DefaultClientFriendlyStatusService implements ClientFriendlyStatusS
    *
    * @returns An array of ClientFriendlyStatus DTOs.
    */
-  getClientFriendlyStatusById(id: string): ClientFriendlyStatusDto {
+  async getClientFriendlyStatusById(id: string): Promise<ClientFriendlyStatusDto> {
     this.log.debug('Get client friendly status with id: [%s]', id);
-    const clientFriendlyStatusEntity = this.clientFriendlyStatusRepository.findClientFriendlyStatusById(id);
+    const clientFriendlyStatusEntity = await this.clientFriendlyStatusRepository.findClientFriendlyStatusById(id);
 
     if (!clientFriendlyStatusEntity) {
       this.log.error('Client friendly status with id: [%s] not found', id);
@@ -104,9 +104,9 @@ export class DefaultClientFriendlyStatusService implements ClientFriendlyStatusS
     return clientFriendlyStatusDto;
   }
 
-  getLocalizedClientFriendlyStatusById(id: string, locale: AppLocale): ClientFriendlyStatusLocalizedDto {
+  async getLocalizedClientFriendlyStatusById(id: string, locale: AppLocale): Promise<ClientFriendlyStatusLocalizedDto> {
     this.log.debug('Get localized client friendly status with id: [%s] and locale: [%s]', id, locale);
-    const clientFriendlyStatusDto = this.getClientFriendlyStatusById(id);
+    const clientFriendlyStatusDto = await this.getClientFriendlyStatusById(id);
     const clientFriendlyStatusLocalizedDto = this.clientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto(clientFriendlyStatusDto, locale);
     this.log.trace('Returning localized client friendly status: [%j]', clientFriendlyStatusLocalizedDto);
     return clientFriendlyStatusLocalizedDto;

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -57,7 +57,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const statusId = statusCheckResult.statusId ?? null;
   const alertType = getContextualAlertType(statusId);
-  const clientFriendlyStatus = statusId ? appContainer.get(TYPES.domain.services.ClientFriendlyStatusService).getLocalizedClientFriendlyStatusById(statusId, locale) : null;
+  const clientFriendlyStatus = statusId ? await appContainer.get(TYPES.domain.services.ClientFriendlyStatusService).getLocalizedClientFriendlyStatusById(statusId, locale) : null;
 
   return {
     statusResult: { alertType, clientFriendlyStatus },


### PR DESCRIPTION
### Description
Fetches client friendly statuses from interop. In a future PR I'm guessing we should add the retries and backoff from #3800 once it's merged?

### Related Azure Boards Work Items
AB#6170

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`