### PR TITLE
refactor(frontend) update default implementation of letter-type service

### DIFF
--- a/frontend/__tests__/routes/protected/letters/index.test.tsx
+++ b/frontend/__tests__/routes/protected/letters/index.test.tsx
@@ -42,10 +42,11 @@ describe('Letters Page', () => {
           ]),
       } satisfies Partial<LetterService>);
       mockAppLoadContext.appContainer.get.calledWith(TYPES.domain.services.LetterTypeService).mockReturnValue({
-        listLetterTypes: () => [
-          { id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
-          { id: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
-        ],
+        listLetterTypes: async () =>
+          await Promise.resolve([
+            { id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
+            { id: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
+          ]),
       } satisfies Partial<LetterTypeService>);
 
       const response = await loader({
@@ -87,10 +88,11 @@ describe('Letters Page', () => {
         ]),
     } satisfies Partial<LetterService>);
     mockAppLoadContext.appContainer.get.calledWith(TYPES.domain.services.LetterTypeService).mockReturnValue({
-      listLetterTypes: () => [
-        { id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
-        { id: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
-      ],
+      listLetterTypes: async () =>
+        await Promise.resolve([
+          { id: 'ACC', nameEn: 'Accepted', nameFr: '(FR) Accepted' },
+          { id: 'DEN', nameEn: 'Denied', nameFr: '(FR) Denied' },
+        ]),
     } satisfies Partial<LetterTypeService>);
 
     const response = await loader({

--- a/frontend/app/.server/domain/repositories/letter-type.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter-type.repository.ts
@@ -1,41 +1,94 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
 import type { LetterTypeEntity } from '~/.server/domain/entities';
+import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
 import letterTypeJsonDataSource from '~/.server/resources/power-platform/letter-type.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
 
 export interface LetterTypeRepository {
   /**
    * Fetch all letter type entities.
    * @returns All letter type entities.
    */
-  listAllLetterTypes(): ReadonlyArray<LetterTypeEntity>;
+  listAllLetterTypes(): Promise<ReadonlyArray<LetterTypeEntity>>;
 
   /**
    * Fetch a letter type entity by its id.
    * @param id The id of the letter type entity.
    * @returns The letter type entity or null if not found.
    */
-  findLetterTypeById(id: string): LetterTypeEntity | null;
+  findLetterTypeById(id: string): Promise<LetterTypeEntity | null>;
 }
+
+export type DefaultLetterTypeRepositoryServerConfig = Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_API_MAX_RETRIES' | 'INTEROP_API_BACKOFF_MS'>;
 
 @injectable()
 export class DefaultLetterTypeRepository implements LetterTypeRepository {
   private readonly log: Logger;
+  private readonly serverConfig: DefaultLetterTypeRepositoryServerConfig;
+  private readonly httpClient: HttpClient;
 
-  constructor() {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: DefaultLetterTypeRepositoryServerConfig, @inject(TYPES.http.HttpClient) httpClient: HttpClient) {
     this.log = createLogger('DefaultLetterTypeRepository');
+    this.serverConfig = serverConfig;
+    this.httpClient = httpClient;
   }
 
-  listAllLetterTypes(): ReadonlyArray<LetterTypeEntity> {
-    throw new Error('Letter type service is not yet implemented');
-    //TODO: Implement listAllLetterTypes service
+  async listAllLetterTypes(): Promise<ReadonlyArray<LetterTypeEntity>> {
+    this.log.trace('Fetching all letter types');
+
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1/esdc_cctlettertypes`);
+    url.searchParams.set('$select', 'esdc_portalnameenglish,esdc_portalnamefrench,_esdc_parentid_value,esdc_value');
+    url.searchParams.set('$filter', 'esdc_displayonportal eq 1 and statecode eq 0');
+    url.searchParams.set('$expand', 'esdc_ParentId($select=esdc_portalnameenglish,esdc_portalnamefrench');
+    const response = await this.httpClient.instrumentedFetch('http.client.interop-api.letter-types.gets', url, {
+      method: 'GET',
+      headers: {
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
+      },
+    });
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: 'Failed to fetch letter types',
+        status: response.status,
+        statusText: response.statusText,
+        url,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to fetch letter types. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    const letterTypeEntities: LetterTypeEntity[] = await response.json();
+    this.log.trace('Letter types: [%j]', letterTypeEntities);
+
+    return letterTypeEntities;
   }
 
-  findLetterTypeById(id: string): LetterTypeEntity | null {
-    throw new Error('Letter type service is not yet implemented');
-    //TODO: Implement findLetterTypeById service
+  async findLetterTypeById(id: string): Promise<LetterTypeEntity | null> {
+    this.log.debug('Fetching letter type with id: [%s]', id);
+
+    const letterTypeEntities = await this.listAllLetterTypes();
+    const letterTypeEntity = letterTypeEntities.find((letter) => letter.esdc_value === id);
+
+    if (!letterTypeEntity) {
+      this.log.warn('Letter type not found; id: [%s]', id);
+      return null;
+    }
+
+    this.log.trace('Returning letter type: [%j]', letterTypeEntity);
+    return letterTypeEntity;
   }
 }
 
@@ -47,15 +100,15 @@ export class MockLetterTypeRepository implements LetterTypeRepository {
     this.log = createLogger('MockLetterTypeRepository');
   }
 
-  listAllLetterTypes(): ReadonlyArray<LetterTypeEntity> {
+  async listAllLetterTypes(): Promise<ReadonlyArray<LetterTypeEntity>> {
     this.log.debug('Fetching all letter types');
     const letterTypeEntities = letterTypeJsonDataSource.value;
 
     this.log.trace('Returning letter types: [%j]', letterTypeEntities);
-    return letterTypeEntities;
+    return await Promise.resolve(letterTypeEntities);
   }
 
-  findLetterTypeById(id: string): LetterTypeEntity | null {
+  async findLetterTypeById(id: string): Promise<LetterTypeEntity | null> {
     this.log.debug('Fetching letter type with id: [%s]', id);
 
     const letterTypeEntities = letterTypeJsonDataSource.value;
@@ -66,6 +119,6 @@ export class MockLetterTypeRepository implements LetterTypeRepository {
       return null;
     }
 
-    return letterTypeEntity;
+    return await Promise.resolve(letterTypeEntity);
   }
 }

--- a/frontend/app/routes/protected/letters/$id.download.ts
+++ b/frontend/app/routes/protected/letters/$id.download.ts
@@ -33,7 +33,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   const locale = getLocale(request);
-  const letterType = appContainer.get(TYPES.domain.services.LetterTypeService).getLocalizedLetterTypeById(letter.letterTypeId, locale);
+  const letterType = await appContainer.get(TYPES.domain.services.LetterTypeService).getLocalizedLetterTypeById(letter.letterTypeId, locale);
   const documentName = sanitize(letterType.name);
 
   const userInfoToken: UserinfoToken = session.get('userInfoToken');

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   }
 
   const allLetters = await appContainer.get(TYPES.domain.services.LetterService).findLettersByClientId({ clientId: clientNumber, userId: userInfoToken.sub, sortOrder });
-  const letterTypes = appContainer.get(TYPES.domain.services.LetterTypeService).listLetterTypes();
+  const letterTypes = await appContainer.get(TYPES.domain.services.LetterTypeService).listLetterTypes();
   const letters = allLetters.filter(({ letterTypeId }) => letterTypes.some(({ id }) => letterTypeId === id));
 
   session.set('clientNumber', clientNumber);


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->
follow-up to #3809.  This PR adds the default implementation which calls interop to fetch the letter-type code table.

### Related Azure Boards Work Items
AB#6170


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`