### PR TITLE
fix(frontend) fix typos in client-friendly-status.repoistory.ts

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
@@ -60,7 +60,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     expect(actual).toEqual(responseDataMock);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdcesdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',
@@ -97,7 +97,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     expect(actual).toEqual(responseDataMock[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdcesdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',

--- a/frontend/app/.server/domain/repositories/client-friendly-status.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-friendly-status.repository.ts
@@ -41,7 +41,7 @@ export class DefaultClientFriendlyStatusRepository implements ClientFriendlyStat
   async listAllClientFriendlyStatuses(): Promise<ClientFriendlyStatusEntity[]> {
     this.log.trace('Fetching all client friendly statuses');
 
-    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1/esdcesdc_clientfriendlystatuses`);
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses`);
     url.searchParams.set('$select', 'esdc_clientfriendlystatusid,esdc_descriptionenglish,esdc_descriptionfrench');
     url.searchParams.set('$filter', 'statecode eq 0');
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.client-friendly-statuses.gets', url, {
@@ -66,7 +66,7 @@ export class DefaultClientFriendlyStatusRepository implements ClientFriendlyStat
         url,
         responseBody: await response.text(),
       });
-      throw new Error(`Failed fetch client friendly statuses. Status: ${response.status}, Status Text: ${response.statusText}`);
+      throw new Error(`Failed to fetch client friendly statuses. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
     const clientFriendlyStatusEntities: ClientFriendlyStatusEntity[] = await response.json();
@@ -100,26 +100,26 @@ export class MockClientFriendlyStatusRepository implements ClientFriendlyStatusR
   }
 
   async listAllClientFriendlyStatuses(): Promise<ClientFriendlyStatusEntity[]> {
-    this.log.debug('Fetching all client-friendly statuses');
+    this.log.debug('Fetching all client friendly statuses');
     const clientFriendlyStatusEntities = clientFriendlyStatusJsonDataSource.value;
 
     if (clientFriendlyStatusEntities.length === 0) {
-      this.log.warn('No client-friendly statuses found');
+      this.log.warn('No client friendly statuses found');
       return [];
     }
 
-    this.log.trace('Returning client-friendly statuses: [%j]', clientFriendlyStatusEntities);
+    this.log.trace('Returning client friendly statuses: [%j]', clientFriendlyStatusEntities);
     return await Promise.resolve(clientFriendlyStatusEntities);
   }
 
   async findClientFriendlyStatusById(id: string): Promise<ClientFriendlyStatusEntity | null> {
-    this.log.debug('Fetching client-friendly status with id: [%s]', id);
+    this.log.debug('Fetching client friendly status with id: [%s]', id);
 
     const clientFriendlyStatusEntities = clientFriendlyStatusJsonDataSource.value;
     const clientFriendlyStatusEntity = clientFriendlyStatusEntities.find(({ esdc_clientfriendlystatusid }) => esdc_clientfriendlystatusid === id);
 
     if (!clientFriendlyStatusEntity) {
-      this.log.warn('Client-friendly status not found; id: [%s]', id);
+      this.log.warn('Client friendly status not found; id: [%s]', id);
       return null;
     }
 


### PR DESCRIPTION
### Description
The endpoint has a duplicate `esdc` and then I was just being nit-picky with the hyphens 🤷 
