### PR TITLE
chore(frontend): Remove unnecessary condition for rendering continue button

### DIFF
--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -253,7 +253,7 @@ export async function action({ context: { appContainer, session }, params, reque
 }
 export default function ProtectedRenewReviewAdultInformation({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefits, hasChildren, primaryApplicantStateCompleted } = loaderData;
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, dentalBenefits, primaryApplicantStateCompleted } = loaderData;
   const fetcher = useFetcher<typeof action>();
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -481,33 +481,18 @@ export default function ProtectedRenewReviewAdultInformation({ loaderData, param
       </div>
       <fetcher.Form method="post" className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
         <CsrfTokenInput />
-        {hasChildren && (
-          <LoadingButton
-            variant="primary"
-            id="continue-button"
-            name="_action"
-            value={FORM_ACTION.submit}
-            disabled={isSubmitting}
-            loading={isSubmitting}
-            endIcon={faChevronRight}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Review your information click"
-          >
-            {t('protected-renew:review-adult-information.continue-button')}
-          </LoadingButton>
-        )}
-        {!hasChildren && (
-          <LoadingButton
-            id="confirm-button"
-            name="_action"
-            value={FORM_ACTION.submit}
-            variant="primary"
-            disabled={isSubmitting}
-            loading={isSubmitting}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Review your information click"
-          >
-            {t('protected-renew:review-adult-information.continue-button')}
-          </LoadingButton>
-        )}
+        <LoadingButton
+          variant="primary"
+          id="continue-button"
+          name="_action"
+          value={FORM_ACTION.submit}
+          disabled={isSubmitting}
+          loading={isSubmitting}
+          endIcon={faChevronRight}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Continue - Review your information click"
+        >
+          {t('protected-renew:review-adult-information.continue-button')}
+        </LoadingButton>
         <Button id="back-button" name="_action" value={FORM_ACTION.back} disabled={isSubmitting} startIcon={faChevronLeft} data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Back - Review your information click">
           {t('protected-renew:review-adult-information.back-button')}
         </Button>


### PR DESCRIPTION
### Description
While testing the protected renewal flow, I noticed the "Continue" button was missing the right chevron icon. While investigating the issue, I found that the `hasChildren` condition surrounding the button was unnecessary - both branches render the same button with identical `name`, `value`, and appearance.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/4318bd70-2ca2-4ee1-a9cd-cd98340a366e)

### Checklist
- [x] I have tested the changes locally