### PR TITLE
Clean up renew state and mapper

### DIFF
--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -142,12 +142,9 @@ describe('DefaultBenefitRenewalStateMapper', () => {
         ],
         clientApplication: mockClientApplication,
         contactInformation: {
-          email: 'new@example.com',
           phoneNumber: '555-555-1234',
           phoneNumberAlt: '555-555-5678',
-          isNewOrUpdatedEmail: true,
           isNewOrUpdatedPhoneNumber: true,
-          shouldReceiveEmailCommunication: true,
         },
         demographicSurvey: {
           ethnicGroups: ['Group 1'],

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -81,7 +81,6 @@ export interface ProtectedRenewState {
     readonly phoneNumber?: string;
     readonly phoneNumberAlt?: string;
     readonly email?: string;
-    readonly shouldReceiveEmailCommunication?: boolean;
   };
   readonly preferredLanguage?: string;
   readonly communicationPreferences?: {

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -64,23 +64,14 @@ export interface RenewState {
   readonly maritalStatus?: string;
   readonly contactInformation?: {
     isNewOrUpdatedPhoneNumber?: boolean;
-    isNewOrUpdatedEmail?: boolean;
     phoneNumber?: string;
     phoneNumberAlt?: string;
-    email?: string;
-    shouldReceiveEmailCommunication?: boolean;
   };
   readonly communicationPreferences?: {
     readonly preferredMethod: string;
     readonly preferredNotificationMethod: string;
   };
-  // TODO: Remove this state once all the flows are updated.
   readonly editModeCommunicationPreferences?: {
-    email: string;
-    shouldReceiveEmailCommunication?: boolean;
-    isNewOrUpdatedEmail?: boolean;
-  };
-  readonly editModeCommunicationPreference?: {
     preferredMethod: string;
     preferredNotificationMethod: string;
   };

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -177,6 +177,7 @@ interface ToContactInformationArgs {
   renewedContactInformation?: ContactInformationState;
   renewedHomeAddress?: HomeAddressState;
   renewedMailingAddress?: MailingAddressState;
+  renewedEmail?: string;
 }
 
 interface ToDentalBenefitsArgs {
@@ -274,12 +275,13 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         hasAddressChanged,
-        hasEmailChanged: !!contactInformation.email,
+        hasEmailChanged: !!email,
         hasPhoneChanged,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: contactInformation,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmail: email,
       }),
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
@@ -352,12 +354,13 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         hasAddressChanged,
-        hasEmailChanged: !!contactInformation.email,
+        hasEmailChanged: !!email,
         hasPhoneChanged,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: contactInformation,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmail: email,
       }),
       demographicSurvey,
       dentalBenefits: this.toDentalBenefits({
@@ -417,6 +420,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedContactInformation: contactInformation,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmail: email,
       }),
       communicationPreferences: this.toCommunicationPreferences({
         communicationPreferences,
@@ -492,12 +496,13 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         hasAddressChanged,
-        hasEmailChanged: !!contactInformation.email,
+        hasEmailChanged: !!email,
         hasPhoneChanged,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: contactInformation,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmail: email,
       }),
       dentalBenefits: [],
       dentalInsurance: undefined,
@@ -564,6 +569,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedContactInformation: contactInformation,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmail: email,
       }),
       dentalBenefits: applicantStateCompleted
         ? this.toDentalBenefits({
@@ -656,6 +662,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     renewedContactInformation,
     renewedHomeAddress,
     renewedMailingAddress,
+    renewedEmail,
   }: ToContactInformationArgs): RenewalContactInformationDto {
     return {
       ...(hasAddressChanged
@@ -702,7 +709,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
           }),
       ...(hasEmailChanged
         ? {
-            email: renewedContactInformation?.email,
+            email: renewedEmail,
           }
         : {
             email: existingContactInformation.email,

--- a/frontend/app/routes/public/renew/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/communication-preference.tsx
@@ -83,7 +83,7 @@ export async function action({ context: { appContainer, session }, params, reque
       saveRenewState({ params, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
       return redirect(getPathById('public/renew/$id/adult-child/review-adult-information', params));
     }
-    saveRenewState({ params, session, state: { editModeCommunicationPreference: parsedDataResult.data } });
+    saveRenewState({ params, session, state: { editModeCommunicationPreferences: parsedDataResult.data } });
     return redirect(getPathById('public/renew/$id/adult-child/confirm-email', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-email.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        communicationPreferences: state.editModeCommunicationPreference,
+        communicationPreferences: state.editModeCommunicationPreferences,
         email: parsedDataResult.data.email,
         emailVerified: state.emailVerified,
         verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreference, 'Expected editModeCommunicationPreferences to be defined');
+      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
@@ -155,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
           params,
           session,
           state: {
-            communicationPreferences: state.editModeCommunicationPreference ?? state.communicationPreferences,
+            communicationPreferences: state.editModeCommunicationPreferences ?? state.communicationPreferences,
             email: state.editModeEmail,
             verifyEmail: {
               ...state.verifyEmail,

--- a/frontend/app/routes/public/renew/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/communication-preference.tsx
@@ -84,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
       saveRenewState({ params, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
       return redirect(getPathById('public/renew/$id/adult/review-adult-information', params));
     }
-    saveRenewState({ params, session, state: { editModeCommunicationPreference: parsedDataResult.data } });
+    saveRenewState({ params, session, state: { editModeCommunicationPreferences: parsedDataResult.data } });
     return redirect(getPathById('public/renew/$id/adult/confirm-email', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-email.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        communicationPreferences: state.editModeCommunicationPreference,
+        communicationPreferences: state.editModeCommunicationPreferences,
         email: parsedDataResult.data.email,
         emailVerified: state.emailVerified,
         verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreference, 'Expected editModeCommunicationPreferences to be defined');
+      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
@@ -155,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
           params,
           session,
           state: {
-            communicationPreferences: state.editModeCommunicationPreference ?? state.communicationPreferences,
+            communicationPreferences: state.editModeCommunicationPreferences ?? state.communicationPreferences,
             email: state.editModeEmail,
             verifyEmail: {
               ...state.verifyEmail,

--- a/frontend/app/routes/public/renew/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/child/communication-preference.tsx
@@ -83,7 +83,7 @@ export async function action({ context: { appContainer, session }, params, reque
       saveRenewState({ params, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
       return redirect(getPathById('public/renew/$id/child/review-adult-information', params));
     }
-    saveRenewState({ params, session, state: { editModeCommunicationPreference: parsedDataResult.data } });
+    saveRenewState({ params, session, state: { editModeCommunicationPreferences: parsedDataResult.data } });
     return redirect(getPathById('public/renew/$id/child/confirm-email', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-email.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        communicationPreferences: state.editModeCommunicationPreference,
+        communicationPreferences: state.editModeCommunicationPreferences,
         email: parsedDataResult.data.email,
         emailVerified: state.emailVerified,
         verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/verify-email.tsx
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreference, 'Expected editModeCommunicationPreferences to be defined');
+      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
@@ -155,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
           params,
           session,
           state: {
-            communicationPreferences: state.editModeCommunicationPreference ?? state.communicationPreferences,
+            communicationPreferences: state.editModeCommunicationPreferences ?? state.communicationPreferences,
             email: state.editModeEmail,
             verifyEmail: {
               ...state.verifyEmail,

--- a/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
@@ -84,7 +84,7 @@ export async function action({ context: { appContainer, session }, params, reque
       saveRenewState({ params, session, state: { communicationPreferences: parsedDataResult.data, email: undefined, emailVerified: undefined } });
       return redirect(getPathById('public/renew/$id/ita/review-information', params));
     }
-    saveRenewState({ params, session, state: { editModeCommunicationPreference: parsedDataResult.data } });
+    saveRenewState({ params, session, state: { editModeCommunicationPreferences: parsedDataResult.data } });
     return redirect(getPathById('public/renew/$id/ita/confirm-email', params));
   }
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-email.tsx
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
       params,
       session,
       state: {
-        communicationPreferences: state.editModeCommunicationPreference,
+        communicationPreferences: state.editModeCommunicationPreferences,
         email: parsedDataResult.data.email,
         emailVerified: state.emailVerified,
         verifyEmail: {

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -81,7 +81,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     altPhoneNumber: state.contactInformation.phoneNumberAlt,
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     martialStatus: maritalStatus.name,
-    contactInformationEmail: state.contactInformation.email,
+    contactInformationEmail: state.email,
     clientNumber: state.applicantInformation.clientNumber,
   };
 

--- a/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreference, 'Expected editModeCommunicationPreferences to be defined');
+      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
       invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
@@ -155,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
           params,
           session,
           state: {
-            communicationPreferences: state.editModeCommunicationPreference ?? state.communicationPreferences,
+            communicationPreferences: state.editModeCommunicationPreferences ?? state.communicationPreferences,
             email: state.editModeEmail,
             verifyEmail: {
               ...state.verifyEmail,


### PR DESCRIPTION
### Description

- address TODO for removing unused state
- `email` and `shouldReceiveEmailCommunication` no longer exist in the `contactInformation` state due to the recent change in communication preference and email flow
- update state mapper to reflect the state change

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->