### PR TITLE
feat(frontend) add default implementation for country service using interop code table fetch

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
 
+import type { DefaultCountryRepositoryServerConfig } from '~/.server/domain/repositories';
 import { DefaultCountryRepository, MockCountryRepository } from '~/.server/domain/repositories';
+import type { HttpClient } from '~/.server/http';
 
 const dataSource = vi.hoisted(() => ({
   default: {
@@ -24,21 +27,102 @@ const dataSource = vi.hoisted(() => ({
 vi.mock('~/.server/resources/power-platform/country.json', () => dataSource);
 
 describe('DefaultCountryRepository', () => {
+  let serverConfigMock: DefaultCountryRepositoryServerConfig;
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
-  it('should throw error on listAllCountries call', () => {
-    const repository = new DefaultCountryRepository();
-
-    expect(() => repository.listAllCountries()).toThrowError('Country service is not yet implemented');
+  beforeEach(() => {
+    serverConfigMock = {
+      INTEROP_API_BASE_URI: 'https://api.example.com',
+      INTEROP_API_SUBSCRIPTION_KEY: 'SUBSCRIPTION_KEY',
+      INTEROP_API_MAX_RETRIES: 10,
+      INTEROP_API_BACKOFF_MS: 3,
+    };
   });
 
-  it('should throw error on findCountryById call', () => {
-    const repository = new DefaultCountryRepository();
+  it('should return results for listAllCountries call', async () => {
+    const responseDataMock = [
+      {
+        esdc_countrycodealpha3: 'CAN',
+        esdc_countryid: '1',
+        esdc_nameenglish: 'Canada English',
+        esdc_namefrench: 'Canada Français',
+      },
+      {
+        esdc_countrycodealpha3: 'USA',
+        esdc_countryid: '2',
+        esdc_nameenglish: 'United States English',
+        esdc_namefrench: 'États-Unis Français',
+      },
+    ];
 
-    expect(() => repository.findCountryById('1')).toThrowError('Country service is not yet implemented');
+    const httpClientMock = mock<HttpClient>();
+    httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
+
+    // act
+    const repository = new DefaultCountryRepository(serverConfigMock, httpClientMock);
+    const actual = await repository.listAllCountries();
+
+    expect(actual).toEqual(responseDataMock);
+    expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
+      'http.client.interop-api.countries.gets',
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_countries?%24select=esdc_countryid%2Cesdc_nameenglish%2Cesdc_namefrench%2Cesdc_countrycodealpha3&%24filter=statecode+eq+0+and+esdc_enabledentalapplicationportal+eq+true'),
+      {
+        proxyUrl: serverConfigMock.HTTP_PROXY_URL,
+        method: 'GET',
+        headers: {
+          'Ocp-Apim-Subscription-Key': serverConfigMock.INTEROP_API_SUBSCRIPTION_KEY,
+        },
+        retryOptions: {
+          backoffMs: 3,
+          retries: 10,
+          retryConditions: {
+            '502': [],
+          },
+        },
+      },
+    );
+  });
+
+  it('should return singular result for findCountryById call', async () => {
+    const responseDataMock = [
+      {
+        esdc_countrycodealpha3: 'CAN',
+        esdc_countryid: '1',
+        esdc_nameenglish: 'Canada English',
+        esdc_namefrench: 'Canada Français',
+      },
+    ];
+
+    const httpClientMock = mock<HttpClient>();
+    httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
+
+    // act
+    const repository = new DefaultCountryRepository(serverConfigMock, httpClientMock);
+    const actual = await repository.findCountryById('1');
+
+    expect(actual).toEqual(responseDataMock[0]);
+    expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
+      'http.client.interop-api.countries.gets',
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_countries?%24select=esdc_countryid%2Cesdc_nameenglish%2Cesdc_namefrench%2Cesdc_countrycodealpha3&%24filter=statecode+eq+0+and+esdc_enabledentalapplicationportal+eq+true'),
+      {
+        proxyUrl: serverConfigMock.HTTP_PROXY_URL,
+        method: 'GET',
+        headers: {
+          'Ocp-Apim-Subscription-Key': serverConfigMock.INTEROP_API_SUBSCRIPTION_KEY,
+        },
+        retryOptions: {
+          backoffMs: 3,
+          retries: 10,
+          retryConditions: {
+            '502': [],
+          },
+        },
+      },
+    );
   });
 });
 
@@ -48,10 +132,10 @@ describe('MockCountryRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('should get all countries', () => {
+  it('should get all countries', async () => {
     const repository = new MockCountryRepository();
 
-    const countries = repository.listAllCountries();
+    const countries = await repository.listAllCountries();
 
     expect(countries).toEqual([
       {
@@ -69,20 +153,20 @@ describe('MockCountryRepository', () => {
     ]);
   });
 
-  it('should handle empty countries data', () => {
+  it('should handle empty countries data', async () => {
     vi.spyOn(dataSource, 'default', 'get').mockReturnValueOnce({ value: [] });
 
     const repository = new MockCountryRepository();
 
-    const countries = repository.listAllCountries();
+    const countries = await repository.listAllCountries();
 
     expect(countries).toEqual([]);
   });
 
-  it('should get a country by id', () => {
+  it('should get a country by id', async () => {
     const repository = new MockCountryRepository();
 
-    const country = repository.findCountryById('1');
+    const country = await repository.findCountryById('1');
 
     expect(country).toEqual({
       esdc_countryid: '1',
@@ -92,10 +176,10 @@ describe('MockCountryRepository', () => {
     });
   });
 
-  it('should return null for non-existent country id', () => {
+  it('should return null for non-existent country id', async () => {
     const repository = new MockCountryRepository();
 
-    const country = repository.findCountryById('non-existent-id');
+    const country = await repository.findCountryById('non-existent-id');
 
     expect(country).toBeNull();
   });

--- a/frontend/__tests__/.server/domain/services/country.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/country.service.test.ts
@@ -31,9 +31,9 @@ describe('DefaultCountryService', () => {
   });
 
   describe('listCountries', () => {
-    it('fetches all countries', () => {
+    it('fetches all countries', async () => {
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.listAllCountries.mockReturnValueOnce([
+      mockCountryRepository.listAllCountries.mockResolvedValueOnce([
         {
           esdc_countryid: '1',
           esdc_nameenglish: 'Canada English',
@@ -58,7 +58,7 @@ describe('DefaultCountryService', () => {
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      const dtos = service.listCountries();
+      const dtos = await service.listCountries();
 
       expect(dtos).toEqual(mockDtos);
       expect(mockCountryRepository.listAllCountries).toHaveBeenCalledOnce();
@@ -67,10 +67,10 @@ describe('DefaultCountryService', () => {
   });
 
   describe('getCountry', () => {
-    it('fetches country by id', () => {
+    it('fetches country by id', async () => {
       const id = '1';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockReturnValueOnce({
+      mockCountryRepository.findCountryById.mockResolvedValueOnce({
         esdc_countryid: '1',
         esdc_nameenglish: 'Canada English',
         esdc_namefrench: 'Canada Français',
@@ -84,32 +84,32 @@ describe('DefaultCountryService', () => {
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      const dto = service.getCountryById(id);
+      const dto = await service.getCountryById(id);
 
       expect(dto).toEqual(mockDto);
       expect(mockCountryRepository.findCountryById).toHaveBeenCalledOnce();
       expect(mockCountryDtoMapper.mapCountryEntityToCountryDto).toHaveBeenCalledOnce();
     });
 
-    it('fetches country by id throws not found exception', () => {
+    it('fetches country by id throws not found exception', async () => {
       const id = '1033';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockReturnValueOnce(null);
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(null);
 
       const mockCountryDtoMapper = mock<CountryDtoMapper>();
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      expect(() => service.getCountryById(id)).toThrow(CountryNotFoundException);
+      await expect(async () => await service.getCountryById(id)).rejects.toThrow(CountryNotFoundException);
       expect(mockCountryRepository.findCountryById).toHaveBeenCalledOnce();
       expect(mockCountryDtoMapper.mapCountryEntityToCountryDto).not.toHaveBeenCalled();
     });
   });
 
   describe('listAndSortLocalizedCountries', () => {
-    it('fetches and sorts localized countries with Canada first', () => {
+    it('fetches and sorts localized countries with Canada first', async () => {
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.listAllCountries.mockReturnValueOnce([
+      mockCountryRepository.listAllCountries.mockResolvedValueOnce([
         {
           esdc_countryid: '1',
           esdc_nameenglish: 'Canada English',
@@ -147,7 +147,7 @@ describe('DefaultCountryService', () => {
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      const dtos = service.listAndSortLocalizedCountries('en');
+      const dtos = await service.listAndSortLocalizedCountries('en');
 
       expect(dtos).toStrictEqual(expectedCountryLocalizedDtos);
       expect(mockCountryRepository.listAllCountries).toHaveBeenCalledOnce();
@@ -156,10 +156,10 @@ describe('DefaultCountryService', () => {
   });
 
   describe('getLocalizedCountryById', () => {
-    it('fetches localized country by id', () => {
+    it('fetches localized country by id', async () => {
       const id = '1';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockReturnValueOnce({
+      mockCountryRepository.findCountryById.mockResolvedValueOnce({
         esdc_countryid: '1',
         esdc_nameenglish: 'Canada English',
         esdc_namefrench: 'Canada Français',
@@ -173,23 +173,23 @@ describe('DefaultCountryService', () => {
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      const dto = service.getLocalizedCountryById(id, 'en');
+      const dto = await service.getLocalizedCountryById(id, 'en');
 
       expect(dto).toEqual(mockDto);
       expect(mockCountryRepository.findCountryById).toHaveBeenCalledOnce();
       expect(mockCountryDtoMapper.mapCountryDtoToCountryLocalizedDto).toHaveBeenCalledOnce();
     });
 
-    it('fetches localized country by id throws not found exception', () => {
+    it('fetches localized country by id throws not found exception', async () => {
       const id = '1033';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockReturnValueOnce(null);
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(null);
 
       const mockCountryDtoMapper = mock<CountryDtoMapper>();
 
       const service = new DefaultCountryService(mockCountryDtoMapper, mockCountryRepository, mockServerConfig);
 
-      expect(() => service.getLocalizedCountryById(id, 'en')).toThrow(CountryNotFoundException);
+      await expect(async () => await service.getLocalizedCountryById(id, 'en')).rejects.toThrow(CountryNotFoundException);
       expect(mockCountryRepository.findCountryById).toHaveBeenCalledOnce();
       expect(mockCountryDtoMapper.mapCountryDtoToCountryLocalizedDto).not.toHaveBeenCalled();
     });

--- a/frontend/app/.server/domain/repositories/country.repository.ts
+++ b/frontend/app/.server/domain/repositories/country.repository.ts
@@ -1,41 +1,93 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
 import type { CountryEntity } from '~/.server/domain/entities';
+import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
 import countryJsonDataSource from '~/.server/resources/power-platform/country.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
 
 export interface CountryRepository {
   /**
    * Fetch all country entities.
    * @returns All country entities.
    */
-  listAllCountries(): ReadonlyArray<CountryEntity>;
+  listAllCountries(): Promise<ReadonlyArray<CountryEntity>>;
 
   /**
    * Fetch a country entity by its id.
    * @param id The id of the country entity.
    * @returns The country entity or null if not found.
    */
-  findCountryById(id: string): CountryEntity | null;
+  findCountryById(id: string): Promise<CountryEntity | null>;
 }
+
+export type DefaultCountryRepositoryServerConfig = Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_API_MAX_RETRIES' | 'INTEROP_API_BACKOFF_MS'>;
 
 @injectable()
 export class DefaultCountryRepository implements CountryRepository {
   private readonly log: Logger;
+  private readonly serverConfig: DefaultCountryRepositoryServerConfig;
+  private readonly httpClient: HttpClient;
 
-  constructor() {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: DefaultCountryRepositoryServerConfig, @inject(TYPES.http.HttpClient) httpClient: HttpClient) {
     this.log = createLogger('DefaultCountryRepository');
+    this.serverConfig = serverConfig;
+    this.httpClient = httpClient;
   }
 
-  listAllCountries(): ReadonlyArray<CountryEntity> {
-    throw new Error('Country service is not yet implemented');
-    //TODO: Implement listAllCountries service
+  async listAllCountries(): Promise<ReadonlyArray<CountryEntity>> {
+    this.log.trace('Fetching all countries');
+
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1/esdc_countries`);
+    url.searchParams.set('$select', 'esdc_countryid,esdc_nameenglish,esdc_namefrench,esdc_countrycodealpha3');
+    url.searchParams.set('$filter', 'statecode eq 0 and esdc_enabledentalapplicationportal eq true');
+    const response = await this.httpClient.instrumentedFetch('http.client.interop-api.countries.gets', url, {
+      method: 'GET',
+      headers: {
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
+      },
+    });
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: 'Failed to fetch countries',
+        status: response.status,
+        statusText: response.statusText,
+        url,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to fetch countries. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    const countryEntities: CountryEntity[] = await response.json();
+    this.log.trace('Countries: [%j]', countryEntities);
+
+    return countryEntities;
   }
 
-  findCountryById(id: string): CountryEntity | null {
-    throw new Error('Country service is not yet implemented');
-    //TODO: Implement findCountryById service
+  async findCountryById(id: string): Promise<CountryEntity | null> {
+    this.log.debug('Fetching country with id: [%s]', id);
+
+    const countryEntities = await this.listAllCountries();
+    const countryEntity = countryEntities.find((status) => status.esdc_countryid === id);
+
+    if (!countryEntity) {
+      this.log.warn('Country not found; id: [%s]', id);
+      return null;
+    }
+
+    this.log.trace('Returning country: [%j]', countryEntity);
+    return countryEntity;
   }
 }
 
@@ -47,7 +99,7 @@ export class MockCountryRepository implements CountryRepository {
     this.log = createLogger('MockCountryRepository');
   }
 
-  listAllCountries(): ReadonlyArray<CountryEntity> {
+  async listAllCountries(): Promise<ReadonlyArray<CountryEntity>> {
     this.log.debug('Fetching all countries');
     const countryEntities = countryJsonDataSource.value;
 
@@ -57,10 +109,10 @@ export class MockCountryRepository implements CountryRepository {
     }
 
     this.log.trace('Returning countries: [%j]', countryEntities);
-    return countryEntities;
+    return await Promise.resolve(countryEntities);
   }
 
-  findCountryById(id: string): CountryEntity | null {
+  async findCountryById(id: string): Promise<CountryEntity | null> {
     this.log.debug('Fetching country with id: [%s]', id);
 
     const countryEntities = countryJsonDataSource.value;
@@ -71,6 +123,6 @@ export class MockCountryRepository implements CountryRepository {
       return null;
     }
 
-    return countryEntity;
+    return await Promise.resolve(countryEntity);
   }
 }

--- a/frontend/app/.server/domain/services/country.service.ts
+++ b/frontend/app/.server/domain/services/country.service.ts
@@ -20,7 +20,7 @@ export interface CountryService {
    *
    * @returns An array of Country DTOs.
    */
-  listCountries(): ReadonlyArray<CountryDto>;
+  listCountries(): Promise<ReadonlyArray<CountryDto>>;
 
   /**
    * Retrieves a specific country by its ID.
@@ -29,7 +29,7 @@ export interface CountryService {
    * @returns The Country DTO corresponding to the specified ID.
    * @throws {CountryNotFoundException} If no country is found with the specified ID.
    */
-  getCountryById(id: string): CountryDto;
+  getCountryById(id: string): Promise<CountryDto>;
 
   /**
    * Retrieves a list of all countries in the specified locale.
@@ -37,7 +37,7 @@ export interface CountryService {
    * @param locale - The desired locale (e.g., 'en' or 'fr').
    * @returns An array of Country DTOs in the specified locale.
    */
-  listAndSortLocalizedCountries(locale: AppLocale): ReadonlyArray<CountryLocalizedDto>;
+  listAndSortLocalizedCountries(locale: AppLocale): Promise<ReadonlyArray<CountryLocalizedDto>>;
 
   /**
    * Retrieves a specific country by its ID in the specified locale.
@@ -47,7 +47,7 @@ export interface CountryService {
    * @returns The Country DTO corresponding to the specified ID in the given locale.
    * @throws {CountryNotFoundException} If no country is found with the specified ID.
    */
-  getLocalizedCountryById(id: string, locale: AppLocale): CountryLocalizedDto;
+  getLocalizedCountryById(id: string, locale: AppLocale): Promise<CountryLocalizedDto>;
 }
 
 export type CountryServiceImpl_ServiceConfig = Pick<ServerConfig, 'CANADA_COUNTRY_ID' | 'LOOKUP_SVC_ALL_COUNTRIES_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_COUNTRY_CACHE_TTL_SECONDS'>;
@@ -117,9 +117,9 @@ export class DefaultCountryService implements CountryService {
    *
    * @returns An array of Country DTOs.
    */
-  listCountries(): ReadonlyArray<CountryDto> {
+  async listCountries(): Promise<ReadonlyArray<CountryDto>> {
     this.log.debug('Get all countries');
-    const countryEntities = this.countryRepository.listAllCountries();
+    const countryEntities = await this.countryRepository.listAllCountries();
     const countryDtos = this.countryDtoMapper.mapCountryEntitiesToCountryDtos(countryEntities);
     this.log.trace('Returning countries: [%j]', countryDtos);
     return countryDtos;
@@ -132,9 +132,9 @@ export class DefaultCountryService implements CountryService {
    * @returns The Country DTO corresponding to the specified ID.
    * @throws {CountryNotFoundException} If no country is found with the specified ID.
    */
-  getCountryById(id: string): CountryDto {
+  async getCountryById(id: string): Promise<CountryDto> {
     this.log.debug('Get country with id: [%s]', id);
-    const countryEntity = this.countryRepository.findCountryById(id);
+    const countryEntity = await this.countryRepository.findCountryById(id);
 
     if (!countryEntity) {
       this.log.error('Country with id: [%s] not found', id);
@@ -152,9 +152,9 @@ export class DefaultCountryService implements CountryService {
    * @param locale - The desired locale (e.g., 'en' or 'fr').
    * @returns An array of localized Country DTOs.
    */
-  listAndSortLocalizedCountries(locale: AppLocale): ReadonlyArray<CountryLocalizedDto> {
+  async listAndSortLocalizedCountries(locale: AppLocale): Promise<ReadonlyArray<CountryLocalizedDto>> {
     this.log.debug('Get and sort all localized countries with locale: [%s]', locale);
-    const countryDtos = this.listCountries();
+    const countryDtos = await this.listCountries();
     const localizedCountryDtos = this.countryDtoMapper.mapCountryDtosToCountryLocalizedDtos(countryDtos, locale);
     const sortedLocalizedCountryDtos = this.sortLocalizedCountries(localizedCountryDtos, locale);
     this.log.trace('Returning sorted localized countries: [%j]', sortedLocalizedCountryDtos);
@@ -169,9 +169,9 @@ export class DefaultCountryService implements CountryService {
    * @returns The localized Country DTO corresponding to the specified ID.
    * @throws {CountryNotFoundException} If no country is found with the specified ID.
    */
-  getLocalizedCountryById(id: string, locale: AppLocale): CountryLocalizedDto {
+  async getLocalizedCountryById(id: string, locale: AppLocale): Promise<CountryLocalizedDto> {
     this.log.debug('Get localized country with id: [%s] and locale: [%s]', id, locale);
-    const countryDto = this.getCountryById(id);
+    const countryDto = await this.getCountryById(id);
     const localizedCountryDto = this.countryDtoMapper.mapCountryDtoToCountryLocalizedDto(countryDto, locale);
     this.log.trace('Returning localized country: [%j]', localizedCountryDto);
     return localizedCountryDto;

--- a/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
@@ -72,8 +72,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -110,7 +110,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = {

--- a/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult-child:address.home-address.page-title') }) };
@@ -140,12 +140,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult-child:address.mailing-address.page-title') }) };
@@ -153,12 +153,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
@@ -71,8 +71,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -110,7 +110,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = state.dentalInsurance;

--- a/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
@@ -73,8 +73,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -111,7 +111,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = {

--- a/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:address.home-address.page-title') }) };
@@ -140,12 +140,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:address.mailing-address.page-title') }) };
@@ -154,12 +154,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
@@ -78,8 +78,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -117,7 +117,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = state.dentalInsurance;

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -64,8 +64,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -102,7 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const children = getChildrenState(state).map((child) => {

--- a/frontend/app/routes/protected/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/home-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.home-address.page-title') }) };
@@ -140,12 +140,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
@@ -63,7 +63,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadProtectedApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.mailing-address.page-title') }) };
@@ -154,12 +154,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
@@ -73,8 +73,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
 
@@ -112,7 +112,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:review-adult-information.page-title') }) };

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.home-address.page-title') }) };
@@ -138,12 +138,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };
@@ -145,12 +145,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -99,11 +99,11 @@ export async function loader({ context: { appContainer, session }, params, reque
   const clientApplicationHomeProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.homeProvince ? provinceTerritoryStateService.getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince).abbr : undefined;
 
   const mailingCountryId = state.mailingAddress?.country ?? state.clientApplication.contactInformation.mailingCountry;
-  const mailingCountryName = countryService.getLocalizedCountryById(mailingCountryId, locale).name;
+  const mailingCountryName = await countryService.getLocalizedCountryById(mailingCountryId, locale);
 
   const homeCountryId = state.homeAddress?.country ?? state.clientApplication.contactInformation.homeCountry;
   invariant(typeof homeCountryId === 'string', 'Expected homeCountryId to be defined');
-  const homeCountryName = countryService.getLocalizedCountryById(homeCountryId, locale).name;
+  const homeCountryName = await countryService.getLocalizedCountryById(homeCountryId, locale);
 
   const userInfo = {
     firstName: state.clientApplication.applicantInformation.firstName,
@@ -137,14 +137,14 @@ export async function loader({ context: { appContainer, session }, params, reque
         city: state.mailingAddress.city,
         province: mailingProvinceTerritoryStateAbbr,
         postalCode: state.mailingAddress.postalCode,
-        country: mailingCountryName,
+        country: mailingCountryName.name,
       }
     : {
         address: state.clientApplication.contactInformation.mailingAddress,
         city: state.clientApplication.contactInformation.mailingCity,
         province: clientApplicationHomeProvinceTerritoryStateAbbr,
         postalCode: state.clientApplication.contactInformation.mailingPostalCode,
-        country: mailingCountryName,
+        country: mailingCountryName.name,
         apartment: state.clientApplication.contactInformation.mailingApartment,
       };
 
@@ -156,7 +156,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       city: state.homeAddress.city,
       provinceState: homeProvinceTerritoryStateAbbr,
       postalZipCode: state.homeAddress.postalCode,
-      country: homeCountryName,
+      country: homeCountryName.name,
     };
   } else {
     invariant(state.clientApplication.contactInformation.homeAddress, 'Expected state.clientApplication.contactInformation.homeAddress to be defined');
@@ -167,7 +167,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       city: state.clientApplication.contactInformation.homeCity,
       provinceState: clientApplicationMailingProvinceTerritoryStateAbbr,
       postalZipCode: state.clientApplication.contactInformation.homePostalCode,
-      country: homeCountryName,
+      country: homeCountryName.name,
       apartment: state.clientApplication.contactInformation.homeApartment,
     };
   }

--- a/frontend/app/routes/public/address-validation/index.tsx
+++ b/frontend/app/routes/public/address-validation/index.tsx
@@ -57,7 +57,7 @@ export async function loader({ context: { appContainer, session }, request }: Ro
   const validationResult = await mailingAddressValidator.validateMailingAddress(session.find('route.address-validation') ?? {});
   const defaultMailingAddress = validationResult.success ? validationResult.data : undefined;
 
-  const countries = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countries = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const t = await getFixedT(request, handle.i18nNamespaces);
@@ -111,6 +111,8 @@ export async function action({ context: { appContainer, session }, request, para
   invariant(validatedMailingAddress.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedMailingAddress.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedMailingAddress.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   // for country and province/state into localized names for rendering on the screen.
   // The localized country and province/state names are retrieved based on the user's locale.
@@ -118,7 +120,7 @@ export async function action({ context: { appContainer, session }, request, para
     address: validatedMailingAddress.address,
     city: validatedMailingAddress.city,
     countryId: validatedMailingAddress.countryId,
-    country: countryService.getLocalizedCountryById(validatedMailingAddress.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedMailingAddress.postalZipCode,
     provinceStateId: validatedMailingAddress.provinceStateId,
     provinceState: validatedMailingAddress.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedMailingAddress.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/address-validation/review.tsx
+++ b/frontend/app/routes/public/address-validation/review.tsx
@@ -42,10 +42,11 @@ export async function loader({ context: { appContainer, session }, request }: Ro
   }
 
   const validatedMailingAddress = validationResult.data;
+  const country = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(validatedMailingAddress.countryId, locale);
   const formattedMailingAddress = {
     address: validatedMailingAddress.address,
     city: validatedMailingAddress.city,
-    country: appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(validatedMailingAddress.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedMailingAddress.postalZipCode,
     provinceState: validatedMailingAddress.provinceStateId && appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getLocalizedProvinceTerritoryStateById(validatedMailingAddress.provinceStateId, locale).abbr,
   };

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -69,8 +69,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -107,7 +107,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = {

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.home-address.page-title') }) };
@@ -130,12 +130,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.mailing-address.page-title') }) };
@@ -142,12 +142,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -106,7 +106,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = state.dentalInsurance;

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -70,8 +70,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -108,7 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = {

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.home-address.page-title') }) };
@@ -129,12 +129,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.mailing-address.page-title') }) };
@@ -142,12 +142,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -74,8 +74,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -113,7 +113,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const dentalInsurance = state.dentalInsurance;

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -61,8 +61,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
 
@@ -99,7 +99,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const children = getChildrenState(state).map((child) => {

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.home-address.page-title') }) };
@@ -130,12 +130,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadApplyChildState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.mailing-address.page-title') }) };
@@ -142,12 +142,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -69,8 +69,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale).name : undefined;
+  const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
 
@@ -108,7 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     city: state.homeAddress?.city,
     province: homeProvinceTerritoryStateAbbr,
     postalCode: state.homeAddress?.postalCode,
-    country: countryHome,
+    country: countryHome?.name,
   };
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:review-adult-information.page-title') }) };

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -66,8 +66,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.home-address.page-title') }) };
@@ -136,12 +136,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.mailing-address.page-title') }) };
@@ -151,12 +151,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     : undefined;
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.home-address.page-title') }) };
@@ -137,12 +137,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const state = loadRenewAdultState({ params, request, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.mailing-address.page-title') }) };
@@ -150,12 +150,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -59,8 +59,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.home-address.page-title') }) };
@@ -137,12 +137,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.mailing-address.page-title') }) };
@@ -150,12 +150,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -70,8 +70,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const countryMailing = state.mailingAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
-  const countryHome = state.homeAddress?.country ? appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
+  const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
+  const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
 
   const userInfo = {

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.home-address.page-title') }) };
@@ -137,12 +137,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
     address: parsedDataResult.data.address,
     city: parsedDataResult.data.city,
     countryId: parsedDataResult.data.countryId,
-    country: countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
     provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const countryList = appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
+  const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
   const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.mailing-address.page-title') }) };
@@ -150,12 +150,14 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.postalZipCode, 'Postal zip code is required for Canadian addresses');
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
+  const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
     address: validatedResult.data.address,
     city: validatedResult.data.city,
     countryId: validatedResult.data.countryId,
-    country: countryService.getLocalizedCountryById(validatedResult.data.countryId, locale).name,
+    country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
     provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,


### PR DESCRIPTION
### Description
Adds the default implementation as in the other PRs I've opened.  Something to note: the interop fetch call uses an endpoint for both countries AND provinces (the provinces are a nested property on a country if it exists).  This PR doesn't include that portion of the search params (`$expand`).  The PR for provinces will either need to refactor this service into a modular unit, or make a separate call to interop and perform filtering/transformation on our end to retrieve provinces.  This is just something to keep in mind.

### Related Azure Boards Work Items
AB#6170

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`