### PR TITLE
feat(frontend) update provnice-territory-state service default impl

### DIFF
--- a/frontend/__tests__/.server/domain/services/province-territory-state.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/province-territory-state.service.test.ts
@@ -30,9 +30,9 @@ describe('DefaultProvinceTerritoryStateService', () => {
   });
 
   describe('listProvinceTerritoryStates', () => {
-    it('fetches all province territory states', () => {
+    it('fetches all province territory states', async () => {
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockReturnValueOnce([
+      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockResolvedValueOnce([
         {
           esdc_provinceterritorystateid: '1',
           _esdc_countryid_value: '1',
@@ -59,7 +59,7 @@ describe('DefaultProvinceTerritoryStateService', () => {
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      const dtos = service.listProvinceTerritoryStates();
+      const dtos = await service.listProvinceTerritoryStates();
 
       expect(dtos).toEqual(mockDtos);
       expect(mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates).toHaveBeenCalledOnce();
@@ -68,10 +68,10 @@ describe('DefaultProvinceTerritoryStateService', () => {
   });
 
   describe('getProvinceTerritoryStateById', () => {
-    it('fetches province territory state by id', () => {
+    it('fetches province territory state by id', async () => {
       const id = '1';
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockReturnValueOnce({
+      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockResolvedValueOnce({
         esdc_provinceterritorystateid: '1',
         _esdc_countryid_value: '1',
         esdc_nameenglish: 'English',
@@ -86,33 +86,33 @@ describe('DefaultProvinceTerritoryStateService', () => {
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      const dto = service.getProvinceTerritoryStateById(id);
+      const dto = await service.getProvinceTerritoryStateById(id);
 
       expect(dto).toEqual(mockDto);
       expect(mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById).toHaveBeenCalledOnce();
       expect(mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto).toHaveBeenCalledOnce();
     });
 
-    it('fetches province territory state by id and throws exception if not found', () => {
+    it('fetches province territory state by id and throws exception if not found', async () => {
       const id = '1033';
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockReturnValueOnce(null);
+      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockResolvedValueOnce(null);
 
       const mockProvinceTerritoryStateDtoMapper = mock<ProvinceTerritoryStateDtoMapper>();
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      expect(() => service.getProvinceTerritoryStateById(id)).toThrow(ProvinceTerritoryStateNotFoundException);
+      await expect(async () => await service.getProvinceTerritoryStateById(id)).rejects.toThrow(ProvinceTerritoryStateNotFoundException);
       expect(mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById).toHaveBeenCalledOnce();
       expect(mockProvinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntityToProvinceTerritoryStateDto).not.toHaveBeenCalled();
     });
   });
 
   describe('listAndSortLocalizedProvinceTerritoryStates', () => {
-    it('fetches and sorts all localized province territory states', () => {
+    it('fetches and sorts all localized province territory states', async () => {
       const locale = 'en';
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockReturnValueOnce([
+      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockResolvedValueOnce([
         {
           esdc_provinceterritorystateid: '1',
           _esdc_countryid_value: '1',
@@ -145,7 +145,7 @@ describe('DefaultProvinceTerritoryStateService', () => {
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      const dtos = service.listAndSortLocalizedProvinceTerritoryStates(locale);
+      const dtos = await service.listAndSortLocalizedProvinceTerritoryStates(locale);
 
       expect(dtos).toEqual(mockLocalizedDtos);
       expect(mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates).toHaveBeenCalledOnce();
@@ -155,11 +155,11 @@ describe('DefaultProvinceTerritoryStateService', () => {
   });
 
   describe('listAndSortLocalizedProvinceTerritoryStatesByCountryId', () => {
-    it('fetches, filters by countryId, localizes, and sorts all province territory states', () => {
+    it('fetches, filters by countryId, localizes, and sorts all province territory states', async () => {
       const countryId = '1';
       const locale = 'en';
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockReturnValueOnce([
+      mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates.mockResolvedValueOnce([
         {
           esdc_provinceterritorystateid: '1',
           _esdc_countryid_value: '1',
@@ -200,7 +200,7 @@ describe('DefaultProvinceTerritoryStateService', () => {
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      const dtos = service.listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId, locale);
+      const dtos = await service.listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId, locale);
 
       expect(dtos).toEqual(mockLocalizedDtos);
       expect(mockProvinceTerritoryStateRepository.listAllProvinceTerritoryStates).toHaveBeenCalledOnce();
@@ -210,11 +210,11 @@ describe('DefaultProvinceTerritoryStateService', () => {
   });
 
   describe('getLocalizedProvinceTerritoryStateById', () => {
-    it('fetches localized province territory state by id', () => {
+    it('fetches localized province territory state by id', async () => {
       const id = '1';
       const locale = 'en';
       const mockProvinceTerritoryStateRepository = mock<ProvinceTerritoryStateRepository>();
-      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockReturnValueOnce({
+      mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById.mockResolvedValueOnce({
         esdc_provinceterritorystateid: '1',
         _esdc_countryid_value: '1',
         esdc_nameenglish: 'English',
@@ -231,7 +231,7 @@ describe('DefaultProvinceTerritoryStateService', () => {
 
       const service = new DefaultProvinceTerritoryStateService(mockProvinceTerritoryStateDtoMapper, mockProvinceTerritoryStateRepository, mockServerConfig);
 
-      const dto = service.getLocalizedProvinceTerritoryStateById(id, locale);
+      const dto = await service.getLocalizedProvinceTerritoryStateById(id, locale);
 
       expect(dto).toEqual(mockLocalizedDto);
       expect(mockProvinceTerritoryStateRepository.findProvinceTerritoryStateById).toHaveBeenCalledOnce();

--- a/frontend/app/.server/domain/entities/province-territory-state.entity.ts
+++ b/frontend/app/.server/domain/entities/province-territory-state.entity.ts
@@ -5,3 +5,9 @@ export type ProvinceTerritoryStateEntity = Readonly<{
   esdc_namefrench: string;
   esdc_internationalalphacode: string;
 }>;
+
+export type CountriesWithProvinceTerritoryStates = Readonly<{
+  value: ReadonlyArray<{
+    esdc_ProvinceTerritoryState_Countryid_esd: Readonly<ProvinceTerritoryStateEntity>;
+  }>;
+}>;

--- a/frontend/app/.server/domain/repositories/province-territory-state.repository.ts
+++ b/frontend/app/.server/domain/repositories/province-territory-state.repository.ts
@@ -1,53 +1,117 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
-import type { ProvinceTerritoryStateEntity } from '~/.server/domain/entities';
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { CountriesWithProvinceTerritoryStates, ProvinceTerritoryStateEntity } from '~/.server/domain/entities';
+import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
 import provinceTerritoryStateJsonDataSource from '~/.server/resources/power-platform/province-territory-state.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
 
 export interface ProvinceTerritoryStateRepository {
   /**
    * Fetch all province territory state entities.
    * @returns All province territory state entities.
    */
-  listAllProvinceTerritoryStates(): ProvinceTerritoryStateEntity[];
+  listAllProvinceTerritoryStates(): Promise<ProvinceTerritoryStateEntity[]>;
 
   /**
    * Fetch a province territory state entity by its id.
    * @param id The id of the province territory state entity.
    * @returns The province territory state entity or null if not found.
    */
-  findProvinceTerritoryStateById(id: string): ProvinceTerritoryStateEntity | null;
+  findProvinceTerritoryStateById(id: string): Promise<ProvinceTerritoryStateEntity | null>;
 
   /**
    * Fetch a province territory state entity by its id.
    * @param id The id of the province territory state entity.
    * @returns The province territory state entity or null if not found.
    */
-  findProvinceTerritoryStateByCode(code: string): ProvinceTerritoryStateEntity | null;
+  findProvinceTerritoryStateByCode(code: string): Promise<ProvinceTerritoryStateEntity | null>;
 }
+
+export type DefaultProvinceTerritoryStateRepositoryServerConfig = Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_API_MAX_RETRIES' | 'INTEROP_API_BACKOFF_MS'>;
 
 @injectable()
 export class DefaultProvinceTerritoryStateRepository implements ProvinceTerritoryStateRepository {
   private readonly log: Logger;
+  private readonly serverConfig: DefaultProvinceTerritoryStateRepositoryServerConfig;
+  private readonly httpClient: HttpClient;
 
-  constructor() {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: DefaultProvinceTerritoryStateRepositoryServerConfig, @inject(TYPES.http.HttpClient) httpClient: HttpClient) {
     this.log = createLogger('DefaultProvinceTerritoryStateRepository');
+    this.serverConfig = serverConfig;
+    this.httpClient = httpClient;
   }
 
-  listAllProvinceTerritoryStates(): ProvinceTerritoryStateEntity[] {
-    throw new Error('Province territory state service is not yet implemented');
-    //TODO: Implement listAllProvinceTerritoryStates service
+  async listAllProvinceTerritoryStates(): Promise<ProvinceTerritoryStateEntity[]> {
+    this.log.trace('Fetching all province territory states');
+
+    const url = new URL(`${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1/esdc_countries`);
+    url.searchParams.set('$select', 'esdc_groupkey');
+    url.searchParams.set('$filter', 'statecode eq 0 and esdc_groupkey ne null');
+    url.searchParams.set('$expand', 'esdc_ProvinceTerritoryState_Countryid_esd($select=esdc_provinceterritorystateid,esdc_nameenglish,esdc_namefrench,esdc_internationalalphacode;$filter=statecode eq 0 and esdc_enabledentalapplicationportal eq true)');
+    const response = await this.httpClient.instrumentedFetch('http.client.interop-api.province-territory-states.gets', url, {
+      method: 'GET',
+      headers: {
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
+      },
+    });
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: 'Failed to fetch provinces, territories, and states',
+        status: response.status,
+        statusText: response.statusText,
+        url,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to fetch provinces, territories, and states. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    const countriesWithprovinceTerritoryStates: CountriesWithProvinceTerritoryStates = await response.json();
+    const provinceTerritoryStateEntities: ProvinceTerritoryStateEntity[] = countriesWithprovinceTerritoryStates.value.flatMap((e) => e.esdc_ProvinceTerritoryState_Countryid_esd);
+    this.log.trace('Provinces, territories, and states: [%j]', provinceTerritoryStateEntities);
+
+    return provinceTerritoryStateEntities;
   }
 
-  findProvinceTerritoryStateById(id: string): ProvinceTerritoryStateEntity | null {
-    throw new Error('Province territory state service is not yet implemented');
-    //TODO: Implement findProvinceTerritoryStateById service
+  async findProvinceTerritoryStateById(id: string): Promise<ProvinceTerritoryStateEntity | null> {
+    this.log.debug('Fetching provinces, territories, and states with id: [%s]', id);
+
+    const provinceTerritoryStateEntities = await this.listAllProvinceTerritoryStates();
+    const provinceTerritoryEntity = provinceTerritoryStateEntities.find((status) => status.esdc_provinceterritorystateid === id);
+
+    if (!provinceTerritoryEntity) {
+      this.log.warn('ProvinceTerritoryState not found; id: [%s]', id);
+      return null;
+    }
+
+    this.log.trace('Returning province, territory, and state : [%j]', provinceTerritoryEntity);
+    return provinceTerritoryEntity;
   }
 
-  findProvinceTerritoryStateByCode(code: string): ProvinceTerritoryStateEntity | null {
-    throw new Error('Province territory state service is not yet implemented');
-    //TODO: Implement findProvinceTerritoryStateByCode service
+  async findProvinceTerritoryStateByCode(code: string): Promise<ProvinceTerritoryStateEntity | null> {
+    this.log.debug('Fetching provinces, territories, and states with id: [%s]', code);
+
+    const provinceTerritoryStateEntities = await this.listAllProvinceTerritoryStates();
+    const provinceTerritoryEntity = provinceTerritoryStateEntities.find((status) => status.esdc_internationalalphacode === code);
+
+    if (!provinceTerritoryEntity) {
+      this.log.warn('ProvinceTerritoryState not found; code: [%s]', code);
+      return null;
+    }
+
+    this.log.trace('Returning province, territory, and state : [%j]', provinceTerritoryEntity);
+    return provinceTerritoryEntity;
   }
 }
 
@@ -59,9 +123,9 @@ export class MockProvinceTerritoryStateRepository implements ProvinceTerritorySt
     this.log = createLogger('MockProvinceTerritoryStateRepository');
   }
 
-  listAllProvinceTerritoryStates(): ProvinceTerritoryStateEntity[] {
+  async listAllProvinceTerritoryStates(): Promise<ProvinceTerritoryStateEntity[]> {
     this.log.debug('Fetching all province territory states');
-    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value;
+    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value.flatMap((e) => e.esdc_ProvinceTerritoryState_Countryid_esd);
 
     if (provinceTerritoryStateEntities.length === 0) {
       this.log.warn('No province territory states found');
@@ -69,13 +133,13 @@ export class MockProvinceTerritoryStateRepository implements ProvinceTerritorySt
     }
 
     this.log.trace('Returning province territory states: [%j]', provinceTerritoryStateEntities);
-    return provinceTerritoryStateEntities;
+    return await Promise.resolve(provinceTerritoryStateEntities);
   }
 
-  findProvinceTerritoryStateById(id: string): ProvinceTerritoryStateEntity | null {
+  async findProvinceTerritoryStateById(id: string): Promise<ProvinceTerritoryStateEntity | null> {
     this.log.debug('Fetching province territory state with id: [%s]', id);
 
-    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value;
+    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value.flatMap((e) => e.esdc_ProvinceTerritoryState_Countryid_esd);
     const provinceTerritoryStateEntity = provinceTerritoryStateEntities.find(({ esdc_provinceterritorystateid }) => esdc_provinceterritorystateid === id);
 
     if (!provinceTerritoryStateEntity) {
@@ -83,13 +147,13 @@ export class MockProvinceTerritoryStateRepository implements ProvinceTerritorySt
       return null;
     }
 
-    return provinceTerritoryStateEntity;
+    return await Promise.resolve(provinceTerritoryStateEntity);
   }
 
-  findProvinceTerritoryStateByCode(code: string): ProvinceTerritoryStateEntity | null {
+  async findProvinceTerritoryStateByCode(code: string): Promise<ProvinceTerritoryStateEntity | null> {
     this.log.debug('Fetching province territory state with code: [%s]', code);
 
-    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value;
+    const provinceTerritoryStateEntities = provinceTerritoryStateJsonDataSource.value.flatMap((e) => e.esdc_ProvinceTerritoryState_Countryid_esd);
     const provinceTerritoryStateEntity = provinceTerritoryStateEntities.find(({ esdc_internationalalphacode }) => esdc_internationalalphacode === code);
 
     if (!provinceTerritoryStateEntity) {
@@ -97,6 +161,6 @@ export class MockProvinceTerritoryStateRepository implements ProvinceTerritorySt
       return null;
     }
 
-    return provinceTerritoryStateEntity;
+    return await Promise.resolve(provinceTerritoryStateEntity);
   }
 }

--- a/frontend/app/.server/domain/services/province-territory-state.service.ts
+++ b/frontend/app/.server/domain/services/province-territory-state.service.ts
@@ -19,7 +19,7 @@ export interface ProvinceTerritoryStateService {
    *
    * @returns An array of province territory state DTOs.
    */
-  listProvinceTerritoryStates(): ReadonlyArray<ProvinceTerritoryStateDto>;
+  listProvinceTerritoryStates(): Promise<ReadonlyArray<ProvinceTerritoryStateDto>>;
 
   /**
    * Retrieves a specific province territory state by its ID.
@@ -28,7 +28,7 @@ export interface ProvinceTerritoryStateService {
    * @returns The province territory state DTO corresponding to the specified ID.
    * @throws {ProvinceTerritoryStateNotFoundException} If no province territory state is found with the specified ID.
    */
-  getProvinceTerritoryStateById(id: string): ProvinceTerritoryStateDto;
+  getProvinceTerritoryStateById(id: string): Promise<ProvinceTerritoryStateDto>;
 
   /**
    * Retrieves a specific province territory state by its Code.
@@ -37,15 +37,14 @@ export interface ProvinceTerritoryStateService {
    * @returns The province territory state DTO corresponding to the specified code.
    * @throws {ProvinceTerritoryStateNotFoundException} If no province territory state is found with the specified Code.
    */
-  getProvinceTerritoryStateByCode(code: string): ProvinceTerritoryStateDto;
-
+  getProvinceTerritoryStateByCode(code: string): Promise<ProvinceTerritoryStateDto>;
   /**
    * Retrieves a list of all province territory states, localized to the specified locale.
    *
    * @param locale - The locale code for localization.
    * @returns An array of localized province territory state DTOs.
    */
-  listAndSortLocalizedProvinceTerritoryStates(locale: AppLocale): ReadonlyArray<ProvinceTerritoryStateLocalizedDto>;
+  listAndSortLocalizedProvinceTerritoryStates(locale: AppLocale): Promise<ReadonlyArray<ProvinceTerritoryStateLocalizedDto>>;
 
   /**
    * Retrieves a list of province territory states filtered by country ID and localized to the specified locale, then sorted by name.
@@ -54,7 +53,7 @@ export interface ProvinceTerritoryStateService {
    * @param locale - The locale code for localization.
    * @returns An array of localized province territory state DTOs filtered by country ID and sorted by name.
    */
-  listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId: string, locale: AppLocale): ReadonlyArray<ProvinceTerritoryStateLocalizedDto>;
+  listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId: string, locale: AppLocale): Promise<ReadonlyArray<ProvinceTerritoryStateLocalizedDto>>;
 
   /**
    * Retrieves a specific province territory state by its ID, localized to the specified locale.
@@ -64,7 +63,7 @@ export interface ProvinceTerritoryStateService {
    * @returns The localized province territory state DTO corresponding to the specified ID.
    * @throws {ProvinceTerritoryStateNotFoundException} If no province territory state is found with the specified ID.
    */
-  getLocalizedProvinceTerritoryStateById(id: string, locale: AppLocale): ProvinceTerritoryStateLocalizedDto;
+  getLocalizedProvinceTerritoryStateById(id: string, locale: AppLocale): Promise<ProvinceTerritoryStateLocalizedDto>;
 
   /**
    * Retrieves a specific province territory state by its code, localized to the specified locale.
@@ -74,7 +73,7 @@ export interface ProvinceTerritoryStateService {
    * @returns The localized province territory state DTO corresponding to the specified code.
    * @throws {ProvinceTerritoryStateNotFoundException} If no province territory state is found with the specified code.
    */
-  getLocalizedProvinceTerritoryStateByCode(code: string, locale: AppLocale): ProvinceTerritoryStateLocalizedDto;
+  getLocalizedProvinceTerritoryStateByCode(code: string, locale: AppLocale): Promise<ProvinceTerritoryStateLocalizedDto>;
 }
 
 @injectable()
@@ -113,7 +112,6 @@ export class DefaultProvinceTerritoryStateService implements ProvinceTerritorySt
       maxSize: Infinity,
       onCacheAdd: () => this.log.info('Creating new getProvinceTerritoryStateById memo'),
     });
-
     this.getProvinceTerritoryStateByCode = moize(this.getProvinceTerritoryStateByCode, {
       maxAge: provinceTerritoryStateCacheTTL,
       maxSize: Infinity,
@@ -123,17 +121,17 @@ export class DefaultProvinceTerritoryStateService implements ProvinceTerritorySt
     this.log.debug('DefaultProvinceTerritoryStateService initiated.');
   }
 
-  listProvinceTerritoryStates(): ReadonlyArray<ProvinceTerritoryStateDto> {
+  async listProvinceTerritoryStates(): Promise<ReadonlyArray<ProvinceTerritoryStateDto>> {
     this.log.debug('Get all province territory states');
-    const provinceTerritoryStateEntities = this.provinceTerritoryStateRepository.listAllProvinceTerritoryStates();
+    const provinceTerritoryStateEntities = await this.provinceTerritoryStateRepository.listAllProvinceTerritoryStates();
     const provinceTerritoryStateDtos = this.provinceTerritoryStateDtoMapper.mapProvinceTerritoryStateEntitiesToProvinceTerritoryStateDtos(provinceTerritoryStateEntities);
     this.log.trace('Returning province territory states: [%j]', provinceTerritoryStateDtos);
     return provinceTerritoryStateDtos;
   }
 
-  getProvinceTerritoryStateById(id: string): ProvinceTerritoryStateDto {
+  async getProvinceTerritoryStateById(id: string): Promise<ProvinceTerritoryStateDto> {
     this.log.debug('Get province territory state with id: [%s]', id);
-    const provinceTerritoryStateEntity = this.provinceTerritoryStateRepository.findProvinceTerritoryStateById(id);
+    const provinceTerritoryStateEntity = await this.provinceTerritoryStateRepository.findProvinceTerritoryStateById(id);
 
     if (!provinceTerritoryStateEntity) {
       throw new ProvinceTerritoryStateNotFoundException(`Province territory state: [${id}] not found`);
@@ -144,9 +142,9 @@ export class DefaultProvinceTerritoryStateService implements ProvinceTerritorySt
     return provinceTerritoryStateDto;
   }
 
-  getProvinceTerritoryStateByCode(code: string): ProvinceTerritoryStateDto {
+  async getProvinceTerritoryStateByCode(code: string): Promise<ProvinceTerritoryStateDto> {
     this.log.debug('Get province territory state with code: [%s]', code);
-    const provinceTerritoryStateEntity = this.provinceTerritoryStateRepository.findProvinceTerritoryStateByCode(code);
+    const provinceTerritoryStateEntity = await this.provinceTerritoryStateRepository.findProvinceTerritoryStateByCode(code);
 
     if (!provinceTerritoryStateEntity) {
       throw new ProvinceTerritoryStateNotFoundException(`Province territory state with code [${code}] not found`);
@@ -157,41 +155,41 @@ export class DefaultProvinceTerritoryStateService implements ProvinceTerritorySt
     return provinceTerritoryStateDto;
   }
 
-  listAndSortLocalizedProvinceTerritoryStates(locale: AppLocale): ReadonlyArray<ProvinceTerritoryStateLocalizedDto> {
+  async listAndSortLocalizedProvinceTerritoryStates(locale: AppLocale): Promise<ReadonlyArray<ProvinceTerritoryStateLocalizedDto>> {
     this.log.debug('Get and sort all localized province territory states with locale: [%s]', locale);
-    const provinceTerritoryStateDtos = this.listProvinceTerritoryStates();
+    const provinceTerritoryStateDtos = await this.listProvinceTerritoryStates();
     const localizedProvinceTerritoryStateDtos = this.provinceTerritoryStateDtoMapper.mapProvinceTerritoryStateDtosToProvinceTerritoryStateLocalizedDtos(provinceTerritoryStateDtos, locale);
     const sortedLocalizedProvinceTerritoryStateDtos = this.sortLocalizedProvinceTerritoryStateDtos(localizedProvinceTerritoryStateDtos, locale);
     this.log.trace('Returning localized and sorted province territory states: [%j]', sortedLocalizedProvinceTerritoryStateDtos);
     return sortedLocalizedProvinceTerritoryStateDtos;
   }
 
-  listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId: string, locale: AppLocale): ReadonlyArray<ProvinceTerritoryStateLocalizedDto> {
+  async listAndSortLocalizedProvinceTerritoryStatesByCountryId(countryId: string, locale: AppLocale): Promise<ReadonlyArray<ProvinceTerritoryStateLocalizedDto>> {
     this.log.debug('Get and sort all localized province territory states with countryId: [%s] and locale: [%s]', countryId, locale);
     const filterByCountryIdPredicate = (dto: ProvinceTerritoryStateDto) => dto.countryId === countryId;
-    const provinceTerritoryStateDtos = this.listProvinceTerritoryStates().filter(filterByCountryIdPredicate);
+    const provincesTerritoriesStates = await this.listProvinceTerritoryStates();
+    const provinceTerritoryStateDtos = provincesTerritoriesStates.filter(filterByCountryIdPredicate);
     const localizedProvinceTerritoryStateDtos = this.provinceTerritoryStateDtoMapper.mapProvinceTerritoryStateDtosToProvinceTerritoryStateLocalizedDtos(provinceTerritoryStateDtos, locale);
     const sortedLocalizedProvinceTerritoryStateDtos = this.sortLocalizedProvinceTerritoryStateDtos(localizedProvinceTerritoryStateDtos, locale);
     this.log.trace('Returning localized and sorted province territory states: [%j]', sortedLocalizedProvinceTerritoryStateDtos);
     return sortedLocalizedProvinceTerritoryStateDtos;
   }
 
-  getLocalizedProvinceTerritoryStateById(id: string, locale: AppLocale): ProvinceTerritoryStateLocalizedDto {
+  async getLocalizedProvinceTerritoryStateById(id: string, locale: AppLocale): Promise<ProvinceTerritoryStateLocalizedDto> {
     this.log.debug('Get localized province territory state with id: [%s] and locale: [%s]', id, locale);
-    const provinceTerritoryStateDto = this.getProvinceTerritoryStateById(id);
+    const provinceTerritoryStateDto = await this.getProvinceTerritoryStateById(id);
     const localizedProvinceTerritoryStateDto = this.provinceTerritoryStateDtoMapper.mapProvinceTerritoryStateDtoToProvinceTerritoryStateLocalizedDto(provinceTerritoryStateDto, locale);
     this.log.trace('Returning localized province territory state: [%j]', localizedProvinceTerritoryStateDto);
     return localizedProvinceTerritoryStateDto;
   }
 
-  getLocalizedProvinceTerritoryStateByCode(code: string, locale: AppLocale): ProvinceTerritoryStateLocalizedDto {
+  async getLocalizedProvinceTerritoryStateByCode(code: string, locale: AppLocale): Promise<ProvinceTerritoryStateLocalizedDto> {
     this.log.debug('Get localized province territory state with code: [%s] and locale: [%s]', code, locale);
-    const provinceTerritoryStateDto = this.getProvinceTerritoryStateByCode(code);
+    const provinceTerritoryStateDto = await this.getProvinceTerritoryStateByCode(code);
     const localizedProvinceTerritoryStateDto = this.provinceTerritoryStateDtoMapper.mapProvinceTerritoryStateDtoToProvinceTerritoryStateLocalizedDto(provinceTerritoryStateDto, locale);
     this.log.trace('Returning localized province territory state with code [%s]: [%j]', code, localizedProvinceTerritoryStateDto);
     return localizedProvinceTerritoryStateDto;
   }
-
   /**
    * Sort the localized province territory states by name.
    */

--- a/frontend/app/.server/resources/power-platform/province-territory-state.json
+++ b/frontend/app/.server/resources/power-platform/province-territory-state.json
@@ -1,557 +1,573 @@
 {
-  "@odata.context": "https://canadadental-uat.crm3.dynamics.com/api/data/v9.2/$metadata#esdc_provinceterritorystates(esdc_provinceterritorystateid,_esdc_countryid_value,esdc_nameenglish,esdc_namefrench,esdc_internationalalphacode)",
+  "@odata.context": "https://canadadental-sandbox.crm3.dynamics.com/api/data/v9.2/$metadata#esdc_countries(esdc_groupkey,esdc_ProvinceTerritoryState_Countryid_esd(esdc_provinceterritorystateid,esdc_nameenglish,esdc_namefrench,esdc_internationalalphacode))",
   "value": [
     {
-      "@odata.etag": "W/\"1398952923\"",
-      "esdc_provinceterritorystateid": "701091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Alabama",
-      "esdc_namefrench": "Alabama",
-      "esdc_internationalalphacode": "AL"
-    },
-    {
-      "@odata.etag": "W/\"1398952930\"",
-      "esdc_provinceterritorystateid": "721091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Alaska",
-      "esdc_namefrench": "Alaska",
-      "esdc_internationalalphacode": "AK"
-    },
-    {
-      "@odata.etag": "W/\"1398952936\"",
-      "esdc_provinceterritorystateid": "741091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Arizona",
-      "esdc_namefrench": "Arizona",
-      "esdc_internationalalphacode": "AZ"
-    },
-    {
-      "@odata.etag": "W/\"1398952942\"",
-      "esdc_provinceterritorystateid": "761091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Arkansas",
-      "esdc_namefrench": "Arkansas",
-      "esdc_internationalalphacode": "AR"
-    },
-    {
-      "@odata.etag": "W/\"1398952948\"",
-      "esdc_provinceterritorystateid": "781091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "California",
-      "esdc_namefrench": "Californie",
-      "esdc_internationalalphacode": "CA"
-    },
-    {
-      "@odata.etag": "W/\"1398952954\"",
-      "esdc_provinceterritorystateid": "7a1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Colorado",
-      "esdc_namefrench": "Colorado",
-      "esdc_internationalalphacode": "CO"
-    },
-    {
-      "@odata.etag": "W/\"1398952961\"",
-      "esdc_provinceterritorystateid": "7c1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Connecticut",
-      "esdc_namefrench": "Connecticut",
-      "esdc_internationalalphacode": "CT"
-    },
-    {
-      "@odata.etag": "W/\"1398952967\"",
-      "esdc_provinceterritorystateid": "7e1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Delaware",
-      "esdc_namefrench": "Delaware",
-      "esdc_internationalalphacode": "DE"
-    },
-    {
-      "@odata.etag": "W/\"1398952973\"",
-      "esdc_provinceterritorystateid": "801091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Florida",
-      "esdc_namefrench": "Floride",
-      "esdc_internationalalphacode": "FL"
-    },
-    {
-      "@odata.etag": "W/\"1398952979\"",
-      "esdc_provinceterritorystateid": "821091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Georgia",
-      "esdc_namefrench": "Géorgie",
-      "esdc_internationalalphacode": "GA"
-    },
-    {
-      "@odata.etag": "W/\"1398952985\"",
-      "esdc_provinceterritorystateid": "841091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Hawaii",
-      "esdc_namefrench": "Hawaï",
-      "esdc_internationalalphacode": "HI"
-    },
-    {
-      "@odata.etag": "W/\"1398952991\"",
-      "esdc_provinceterritorystateid": "861091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Idaho",
-      "esdc_namefrench": "Idaho",
-      "esdc_internationalalphacode": "ID"
-    },
-    {
-      "@odata.etag": "W/\"1398952997\"",
-      "esdc_provinceterritorystateid": "881091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Illinois",
-      "esdc_namefrench": "Illinois",
-      "esdc_internationalalphacode": "IL"
-    },
-    {
-      "@odata.etag": "W/\"1398953003\"",
-      "esdc_provinceterritorystateid": "8a1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Indiana",
-      "esdc_namefrench": "Indiana",
-      "esdc_internationalalphacode": "IN"
-    },
-    {
-      "@odata.etag": "W/\"1398953009\"",
-      "esdc_provinceterritorystateid": "8c1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Iowa",
-      "esdc_namefrench": "Iowa",
-      "esdc_internationalalphacode": "IA"
-    },
-    {
-      "@odata.etag": "W/\"1398953015\"",
-      "esdc_provinceterritorystateid": "8e1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Kansas",
-      "esdc_namefrench": "Kansas",
-      "esdc_internationalalphacode": "KS"
-    },
-    {
-      "@odata.etag": "W/\"1398953021\"",
-      "esdc_provinceterritorystateid": "901091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Kentucky",
-      "esdc_namefrench": "Kentucky",
-      "esdc_internationalalphacode": "KY"
-    },
-    {
-      "@odata.etag": "W/\"1398953027\"",
-      "esdc_provinceterritorystateid": "921091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Louisiana",
-      "esdc_namefrench": "Louisiane",
-      "esdc_internationalalphacode": "LA"
-    },
-    {
-      "@odata.etag": "W/\"1398953033\"",
-      "esdc_provinceterritorystateid": "941091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Maine",
-      "esdc_namefrench": "Maine",
-      "esdc_internationalalphacode": "ME"
-    },
-    {
-      "@odata.etag": "W/\"1398953039\"",
-      "esdc_provinceterritorystateid": "961091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Maryland",
-      "esdc_namefrench": "Maryland",
-      "esdc_internationalalphacode": "MD"
-    },
-    {
-      "@odata.etag": "W/\"1398953045\"",
-      "esdc_provinceterritorystateid": "981091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Massachusetts",
-      "esdc_namefrench": "Massachusetts",
-      "esdc_internationalalphacode": "MA"
-    },
-    {
-      "@odata.etag": "W/\"1398953051\"",
-      "esdc_provinceterritorystateid": "9a1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Michigan",
-      "esdc_namefrench": "Michigan",
-      "esdc_internationalalphacode": "MI"
-    },
-    {
-      "@odata.etag": "W/\"1398953057\"",
-      "esdc_provinceterritorystateid": "9c1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Minnesota",
-      "esdc_namefrench": "Minnesota",
-      "esdc_internationalalphacode": "MN"
-    },
-    {
-      "@odata.etag": "W/\"1398953063\"",
-      "esdc_provinceterritorystateid": "9e1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Mississippi",
-      "esdc_namefrench": "Mississippi",
-      "esdc_internationalalphacode": "MS"
-    },
-    {
-      "@odata.etag": "W/\"1398953069\"",
-      "esdc_provinceterritorystateid": "a01091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Missouri",
-      "esdc_namefrench": "Missouri",
-      "esdc_internationalalphacode": "MO"
-    },
-    {
-      "@odata.etag": "W/\"1398953075\"",
-      "esdc_provinceterritorystateid": "a21091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Montana",
-      "esdc_namefrench": "Montana",
-      "esdc_internationalalphacode": "MT"
-    },
-    {
-      "@odata.etag": "W/\"1398953081\"",
-      "esdc_provinceterritorystateid": "a41091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Nebraska",
-      "esdc_namefrench": "Nebraska",
-      "esdc_internationalalphacode": "NE"
-    },
-    {
-      "@odata.etag": "W/\"1398953087\"",
-      "esdc_provinceterritorystateid": "a61091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Nevada",
-      "esdc_namefrench": "Nevada",
-      "esdc_internationalalphacode": "NV"
-    },
-    {
-      "@odata.etag": "W/\"1398953093\"",
-      "esdc_provinceterritorystateid": "a81091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "New Hampshire",
-      "esdc_namefrench": "New Hampshire",
-      "esdc_internationalalphacode": "NH"
-    },
-    {
-      "@odata.etag": "W/\"1398953099\"",
-      "esdc_provinceterritorystateid": "aa1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "New Jersey",
-      "esdc_namefrench": "New Jersey",
-      "esdc_internationalalphacode": "NJ"
-    },
-    {
-      "@odata.etag": "W/\"1398953105\"",
-      "esdc_provinceterritorystateid": "ac1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "New Mexico",
-      "esdc_namefrench": "Nouveau-Mexique",
-      "esdc_internationalalphacode": "NM"
-    },
-    {
-      "@odata.etag": "W/\"1398953111\"",
-      "esdc_provinceterritorystateid": "ae1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "New York",
-      "esdc_namefrench": "État de New York",
-      "esdc_internationalalphacode": "NY"
-    },
-    {
-      "@odata.etag": "W/\"1398953117\"",
-      "esdc_provinceterritorystateid": "b01091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "North Carolina",
-      "esdc_namefrench": "Caroline du Nord",
-      "esdc_internationalalphacode": "NC"
-    },
-    {
-      "@odata.etag": "W/\"1398953123\"",
-      "esdc_provinceterritorystateid": "b21091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "North Dakota",
-      "esdc_namefrench": "Dakota du Nord",
-      "esdc_internationalalphacode": "ND"
-    },
-    {
-      "@odata.etag": "W/\"1398953129\"",
-      "esdc_provinceterritorystateid": "b41091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Ohio",
-      "esdc_namefrench": "Ohio",
-      "esdc_internationalalphacode": "OH"
-    },
-    {
-      "@odata.etag": "W/\"1398953135\"",
-      "esdc_provinceterritorystateid": "b61091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Oklahoma",
-      "esdc_namefrench": "Oklahoma",
-      "esdc_internationalalphacode": "OK"
-    },
-    {
-      "@odata.etag": "W/\"1398953141\"",
-      "esdc_provinceterritorystateid": "b81091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Oregon",
-      "esdc_namefrench": "Oregon",
-      "esdc_internationalalphacode": "OR"
-    },
-    {
-      "@odata.etag": "W/\"1398953147\"",
-      "esdc_provinceterritorystateid": "ba1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Pennsylvania",
-      "esdc_namefrench": "Pennsylvanie",
-      "esdc_internationalalphacode": "PA"
-    },
-    {
-      "@odata.etag": "W/\"1398953153\"",
-      "esdc_provinceterritorystateid": "bc1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Rhode Island",
-      "esdc_namefrench": "Rhode Island",
-      "esdc_internationalalphacode": "RI"
-    },
-    {
-      "@odata.etag": "W/\"1398953159\"",
-      "esdc_provinceterritorystateid": "c01091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "South Carolina",
-      "esdc_namefrench": "Caroline du Sud",
-      "esdc_internationalalphacode": "SC"
-    },
-    {
-      "@odata.etag": "W/\"1398953165\"",
-      "esdc_provinceterritorystateid": "c21091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "South Dakota",
-      "esdc_namefrench": "Dakota du Sud",
-      "esdc_internationalalphacode": "SD"
-    },
-    {
-      "@odata.etag": "W/\"1398953171\"",
-      "esdc_provinceterritorystateid": "c41091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Tennessee",
-      "esdc_namefrench": "Tennessee",
-      "esdc_internationalalphacode": "TN"
-    },
-    {
-      "@odata.etag": "W/\"1398953177\"",
-      "esdc_provinceterritorystateid": "c61091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Texas",
-      "esdc_namefrench": "Texas",
-      "esdc_internationalalphacode": "TX"
-    },
-    {
-      "@odata.etag": "W/\"1398953183\"",
-      "esdc_provinceterritorystateid": "c81091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Utah",
-      "esdc_namefrench": "Utah",
-      "esdc_internationalalphacode": "UT"
-    },
-    {
-      "@odata.etag": "W/\"1398953189\"",
-      "esdc_provinceterritorystateid": "ca1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Vermont",
-      "esdc_namefrench": "Vermont",
-      "esdc_internationalalphacode": "VT"
-    },
-    {
-      "@odata.etag": "W/\"1398953195\"",
-      "esdc_provinceterritorystateid": "cc1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Virginia",
-      "esdc_namefrench": "Virginie",
-      "esdc_internationalalphacode": "VA"
-    },
-    {
-      "@odata.etag": "W/\"1398953201\"",
-      "esdc_provinceterritorystateid": "ce1091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Washington",
-      "esdc_namefrench": "État de Washington",
-      "esdc_internationalalphacode": "WA"
-    },
-    {
-      "@odata.etag": "W/\"1398953207\"",
-      "esdc_provinceterritorystateid": "d01091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "West Virginia",
-      "esdc_namefrench": "Virginie-Occidentale",
-      "esdc_internationalalphacode": "WV"
-    },
-    {
-      "@odata.etag": "W/\"1398953213\"",
-      "esdc_provinceterritorystateid": "d21091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Wisconsin",
-      "esdc_namefrench": "Wisconsin",
-      "esdc_internationalalphacode": "WI"
-    },
-    {
-      "@odata.etag": "W/\"1398953219\"",
-      "esdc_provinceterritorystateid": "d41091c1-03b4-eb11-8236-0022486d8555",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Wyoming",
-      "esdc_namefrench": "Wyoming",
-      "esdc_internationalalphacode": "WY"
-    },
-    {
-      "@odata.etag": "W/\"1398953225\"",
-      "esdc_provinceterritorystateid": "3b17d494-35b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Alberta",
-      "esdc_namefrench": "Alberta",
-      "esdc_internationalalphacode": "AB"
-    },
-    {
-      "@odata.etag": "W/\"1415001203\"",
-      "esdc_provinceterritorystateid": "9c440baa-35b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "British Columbia",
-      "esdc_namefrench": "Colombie-Britannique",
-      "esdc_internationalalphacode": "BC"
-    },
-    {
-      "@odata.etag": "W/\"1398953232\"",
-      "esdc_provinceterritorystateid": "6d861c55-36b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Manitoba",
-      "esdc_namefrench": "Manitoba",
-      "esdc_internationalalphacode": "MB"
-    },
-    {
-      "@odata.etag": "W/\"1398953238\"",
-      "esdc_provinceterritorystateid": "23dc27a2-36b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "New Brunswick",
-      "esdc_namefrench": "Nouveau-Brunswick",
-      "esdc_internationalalphacode": "NB"
-    },
-    {
-      "@odata.etag": "W/\"1398953244\"",
-      "esdc_provinceterritorystateid": "fc2243c9-36b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Nova Scotia",
-      "esdc_namefrench": "Nouvelle-Écosse",
-      "esdc_internationalalphacode": "NS"
-    },
-    {
-      "@odata.etag": "W/\"1398953250\"",
-      "esdc_provinceterritorystateid": "daf4d05b-37b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Ontario",
-      "esdc_namefrench": "Ontario",
-      "esdc_internationalalphacode": "ON"
-    },
-    {
-      "@odata.etag": "W/\"1398953256\"",
-      "esdc_provinceterritorystateid": "39449f70-37b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Quebec",
-      "esdc_namefrench": "Québec",
-      "esdc_internationalalphacode": "QC"
-    },
-    {
-      "@odata.etag": "W/\"1398953262\"",
-      "esdc_provinceterritorystateid": "5bc09caf-38b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Saskatchewan",
-      "esdc_namefrench": "Saskatchewan",
-      "esdc_internationalalphacode": "SK"
-    },
-    {
-      "@odata.etag": "W/\"1398953268\"",
-      "esdc_provinceterritorystateid": "5abc28c9-38b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Newfoundland and Labrador",
-      "esdc_namefrench": "Terre-Neuve-et-Labrador",
-      "esdc_internationalalphacode": "NL"
-    },
-    {
-      "@odata.etag": "W/\"1398953274\"",
-      "esdc_provinceterritorystateid": "3b8110df-38b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Prince Edward Island",
-      "esdc_namefrench": "Île-du-Prince-Édouard",
-      "esdc_internationalalphacode": "PE"
-    },
-    {
-      "@odata.etag": "W/\"1398953280\"",
-      "esdc_provinceterritorystateid": "9936c08e-39b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Nunavut",
-      "esdc_namefrench": "Nunavut",
-      "esdc_internationalalphacode": "NU"
-    },
-    {
-      "@odata.etag": "W/\"1398953286\"",
-      "esdc_provinceterritorystateid": "6026aca2-39b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Northwest Territories",
-      "esdc_namefrench": "Territoires du Nord-Ouest",
-      "esdc_internationalalphacode": "NT"
-    },
-    {
-      "@odata.etag": "W/\"1398953292\"",
-      "esdc_provinceterritorystateid": "8fef32b7-39b3-eb11-8236-0022486d8d5f",
-      "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Yukon",
-      "esdc_namefrench": "Yukon",
-      "esdc_internationalalphacode": "YT"
-    },
-    {
-      "@odata.etag": "W/\"1398953298\"",
-      "esdc_provinceterritorystateid": "21341235-1ae4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "District of Columbia",
-      "esdc_namefrench": "District de Colombie",
-      "esdc_internationalalphacode": "DC"
-    },
-    {
-      "@odata.etag": "W/\"1398953304\"",
-      "esdc_provinceterritorystateid": "18c5680b-1be4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "American Samoa",
-      "esdc_namefrench": "Samoa américaines",
-      "esdc_internationalalphacode": "AS"
-    },
-    {
-      "@odata.etag": "W/\"1398953310\"",
-      "esdc_provinceterritorystateid": "18dd6b1d-1be4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Guam",
-      "esdc_namefrench": "Guam",
-      "esdc_internationalalphacode": "GU"
-    },
-    {
-      "@odata.etag": "W/\"1398953316\"",
-      "esdc_provinceterritorystateid": "90f46e2f-1be4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Northern Mariana Islands",
-      "esdc_namefrench": "Îles Mariannes du Nord",
-      "esdc_internationalalphacode": "MP"
-    },
-    {
-      "@odata.etag": "W/\"1398953322\"",
-      "esdc_provinceterritorystateid": "06ca9e47-1be4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "Puerto Rico",
-      "esdc_namefrench": "Porto Rico",
-      "esdc_internationalalphacode": "PR"
-    },
-    {
-      "@odata.etag": "W/\"1398953328\"",
-      "esdc_provinceterritorystateid": "cf6c8c59-1be4-eb11-bacb-0022486d8f50",
-      "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
-      "esdc_nameenglish": "U.S. Virgin Islands",
-      "esdc_namefrench": "Îles Vierges américaines",
-      "esdc_internationalalphacode": "VI"
+      "@odata.etag": "W/\"55360838\"",
+      "esdc_countryid": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+      "esdc_groupkey": "common",
+      "esdc_ProvinceTerritoryState_Countryid_esd": [
+        {
+          "@odata.etag": "W/\"44809698\"",
+          "esdc_nameenglish": "Alberta",
+          "esdc_internationalalphacode": "AB",
+          "esdc_namefrench": "Alberta",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "3b17d494-35b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809700\"",
+          "esdc_nameenglish": "British Columbia",
+          "esdc_internationalalphacode": "BC",
+          "esdc_namefrench": "Colombie-Britannique",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "9c440baa-35b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809701\"",
+          "esdc_nameenglish": "Manitoba",
+          "esdc_internationalalphacode": "MB",
+          "esdc_namefrench": "Manitoba",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "6d861c55-36b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809702\"",
+          "esdc_nameenglish": "New Brunswick",
+          "esdc_internationalalphacode": "NB",
+          "esdc_namefrench": "Nouveau-Brunswick",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "23dc27a2-36b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809705\"",
+          "esdc_nameenglish": "Nova Scotia",
+          "esdc_internationalalphacode": "NS",
+          "esdc_namefrench": "Nouvelle-Écosse",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "fc2243c9-36b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809707\"",
+          "esdc_nameenglish": "Ontario",
+          "esdc_internationalalphacode": "ON",
+          "esdc_namefrench": "Ontario",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "daf4d05b-37b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809709\"",
+          "esdc_nameenglish": "Quebec",
+          "esdc_internationalalphacode": "QC",
+          "esdc_namefrench": "Québec",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "39449f70-37b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809710\"",
+          "esdc_nameenglish": "Saskatchewan",
+          "esdc_internationalalphacode": "SK",
+          "esdc_namefrench": "Saskatchewan",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "5bc09caf-38b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809703\"",
+          "esdc_nameenglish": "Newfoundland and Labrador",
+          "esdc_internationalalphacode": "NL",
+          "esdc_namefrench": "Terre-Neuve-et-Labrador",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "5abc28c9-38b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809708\"",
+          "esdc_nameenglish": "Prince Edward Island",
+          "esdc_internationalalphacode": "PE",
+          "esdc_namefrench": "Île-du-Prince-Édouard",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "3b8110df-38b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809706\"",
+          "esdc_nameenglish": "Nunavut",
+          "esdc_internationalalphacode": "NU",
+          "esdc_namefrench": "Nunavut",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "9936c08e-39b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"44809704\"",
+          "esdc_nameenglish": "Northwest Territories",
+          "esdc_internationalalphacode": "NT",
+          "esdc_namefrench": "Territoires du Nord-Ouest",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "6026aca2-39b3-eb11-8236-0022486d8d5f"
+        },
+        {
+          "@odata.etag": "W/\"156185745\"",
+          "esdc_nameenglish": "Yukon",
+          "esdc_internationalalphacode": "YT",
+          "esdc_namefrench": "Yukon",
+          "_esdc_countryid_value": "0cf5389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "8fef32b7-39b3-eb11-8236-0022486d8d5f"
+        }
+      ],
+      "esdc_ProvinceTerritoryState_Countryid_esd@odata.nextLink": "https://canadadental-sandbox.crm3.dynamics.com/api/data/v9.2/esdc_countries(0cf5389e-97ae-eb11-8236-000d3af4bfc3)/esdc_ProvinceTerritoryState_Countryid_esd?$select=esdc_provinceterritorystateid,esdc_nameenglish,esdc_namefrench,esdc_internationalalphacode&$filter=statecode%20eq%200%20and%20esdc_enabledentalapplicationportal%20eq%20true"
+    },
+    {
+      "@odata.etag": "W/\"155914146\"",
+      "esdc_countryid": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+      "esdc_groupkey": "common",
+      "esdc_ProvinceTerritoryState_Countryid_esd": [
+        {
+          "@odata.etag": "W/\"44809712\"",
+          "esdc_nameenglish": "Alabama",
+          "esdc_internationalalphacode": "AL",
+          "esdc_namefrench": "Alabama",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "701091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809713\"",
+          "esdc_nameenglish": "Alaska",
+          "esdc_internationalalphacode": "AK",
+          "esdc_namefrench": "Alaska",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "721091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809716\"",
+          "esdc_nameenglish": "Arizona",
+          "esdc_internationalalphacode": "AZ",
+          "esdc_namefrench": "Arizona",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "741091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809717\"",
+          "esdc_nameenglish": "Arkansas",
+          "esdc_internationalalphacode": "AR",
+          "esdc_namefrench": "Arkansas",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "761091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809718\"",
+          "esdc_nameenglish": "California",
+          "esdc_internationalalphacode": "CA",
+          "esdc_namefrench": "Californie",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "781091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809719\"",
+          "esdc_nameenglish": "Colorado",
+          "esdc_internationalalphacode": "CO",
+          "esdc_namefrench": "Colorado",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "7a1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809834\"",
+          "esdc_nameenglish": "Connecticut",
+          "esdc_internationalalphacode": "CT",
+          "esdc_namefrench": "Connecticut",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "7c1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809835\"",
+          "esdc_nameenglish": "Delaware",
+          "esdc_internationalalphacode": "DE",
+          "esdc_namefrench": "Delaware",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "7e1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809838\"",
+          "esdc_nameenglish": "Florida",
+          "esdc_internationalalphacode": "FL",
+          "esdc_namefrench": "Floride",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "801091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809839\"",
+          "esdc_nameenglish": "Georgia",
+          "esdc_internationalalphacode": "GA",
+          "esdc_namefrench": "Géorgie",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "821091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809841\"",
+          "esdc_nameenglish": "Hawaii",
+          "esdc_internationalalphacode": "HI",
+          "esdc_namefrench": "Hawaï",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "841091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809842\"",
+          "esdc_nameenglish": "Idaho",
+          "esdc_internationalalphacode": "ID",
+          "esdc_namefrench": "Idaho",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "861091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809843\"",
+          "esdc_nameenglish": "Illinois",
+          "esdc_internationalalphacode": "IL",
+          "esdc_namefrench": "Illinois",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "881091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809844\"",
+          "esdc_nameenglish": "Indiana",
+          "esdc_internationalalphacode": "IN",
+          "esdc_namefrench": "Indiana",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "8a1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809845\"",
+          "esdc_nameenglish": "Iowa",
+          "esdc_internationalalphacode": "IA",
+          "esdc_namefrench": "Iowa",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "8c1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809846\"",
+          "esdc_nameenglish": "Kansas",
+          "esdc_internationalalphacode": "KS",
+          "esdc_namefrench": "Kansas",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "8e1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809847\"",
+          "esdc_nameenglish": "Kentucky",
+          "esdc_internationalalphacode": "KY",
+          "esdc_namefrench": "Kentucky",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "901091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809848\"",
+          "esdc_nameenglish": "Louisiana",
+          "esdc_internationalalphacode": "LA",
+          "esdc_namefrench": "Louisiane",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "921091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809849\"",
+          "esdc_nameenglish": "Maine",
+          "esdc_internationalalphacode": "ME",
+          "esdc_namefrench": "Maine",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "941091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809850\"",
+          "esdc_nameenglish": "Maryland",
+          "esdc_internationalalphacode": "MD",
+          "esdc_namefrench": "Maryland",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "961091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809851\"",
+          "esdc_nameenglish": "Massachusetts",
+          "esdc_internationalalphacode": "MA",
+          "esdc_namefrench": "Massachusetts",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "981091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809852\"",
+          "esdc_nameenglish": "Michigan",
+          "esdc_internationalalphacode": "MI",
+          "esdc_namefrench": "Michigan",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "9a1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809853\"",
+          "esdc_nameenglish": "Minnesota",
+          "esdc_internationalalphacode": "MN",
+          "esdc_namefrench": "Minnesota",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "9c1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809854\"",
+          "esdc_nameenglish": "Mississippi",
+          "esdc_internationalalphacode": "MS",
+          "esdc_namefrench": "Mississippi",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "9e1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809856\"",
+          "esdc_nameenglish": "Missouri",
+          "esdc_internationalalphacode": "MO",
+          "esdc_namefrench": "Missouri",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "a01091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809857\"",
+          "esdc_nameenglish": "Montana",
+          "esdc_internationalalphacode": "MT",
+          "esdc_namefrench": "Montana",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "a21091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809858\"",
+          "esdc_nameenglish": "Nebraska",
+          "esdc_internationalalphacode": "NE",
+          "esdc_namefrench": "Nebraska",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "a41091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809859\"",
+          "esdc_nameenglish": "Nevada",
+          "esdc_internationalalphacode": "NV",
+          "esdc_namefrench": "Nevada",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "a61091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809860\"",
+          "esdc_nameenglish": "New Hampshire",
+          "esdc_internationalalphacode": "NH",
+          "esdc_namefrench": "New Hampshire",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "a81091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809861\"",
+          "esdc_nameenglish": "New Jersey",
+          "esdc_internationalalphacode": "NJ",
+          "esdc_namefrench": "New Jersey",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "aa1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809862\"",
+          "esdc_nameenglish": "New Mexico",
+          "esdc_internationalalphacode": "NM",
+          "esdc_namefrench": "Nouveau-Mexique",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "ac1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809863\"",
+          "esdc_nameenglish": "New York",
+          "esdc_internationalalphacode": "NY",
+          "esdc_namefrench": "État de New York",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "ae1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809864\"",
+          "esdc_nameenglish": "North Carolina",
+          "esdc_internationalalphacode": "NC",
+          "esdc_namefrench": "Caroline du Nord",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "b01091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809865\"",
+          "esdc_nameenglish": "North Dakota",
+          "esdc_internationalalphacode": "ND",
+          "esdc_namefrench": "Dakota du Nord",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "b21091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809867\"",
+          "esdc_nameenglish": "Ohio",
+          "esdc_internationalalphacode": "OH",
+          "esdc_namefrench": "Ohio",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "b41091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809868\"",
+          "esdc_nameenglish": "Oklahoma",
+          "esdc_internationalalphacode": "OK",
+          "esdc_namefrench": "Oklahoma",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "b61091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809869\"",
+          "esdc_nameenglish": "Oregon",
+          "esdc_internationalalphacode": "OR",
+          "esdc_namefrench": "Oregon",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "b81091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809870\"",
+          "esdc_nameenglish": "Pennsylvania",
+          "esdc_internationalalphacode": "PA",
+          "esdc_namefrench": "Pennsylvanie",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "ba1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809872\"",
+          "esdc_nameenglish": "Rhode Island",
+          "esdc_internationalalphacode": "RI",
+          "esdc_namefrench": "Rhode Island",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "bc1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809873\"",
+          "esdc_nameenglish": "South Carolina",
+          "esdc_internationalalphacode": "SC",
+          "esdc_namefrench": "Caroline du Sud",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "c01091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809874\"",
+          "esdc_nameenglish": "South Dakota",
+          "esdc_internationalalphacode": "SD",
+          "esdc_namefrench": "Dakota du Sud",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "c21091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809875\"",
+          "esdc_nameenglish": "Tennessee",
+          "esdc_internationalalphacode": "TN",
+          "esdc_namefrench": "Tennessee",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "c41091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809877\"",
+          "esdc_nameenglish": "Texas",
+          "esdc_internationalalphacode": "TX",
+          "esdc_namefrench": "Texas",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "c61091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809879\"",
+          "esdc_nameenglish": "Utah",
+          "esdc_internationalalphacode": "UT",
+          "esdc_namefrench": "Utah",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "c81091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809880\"",
+          "esdc_nameenglish": "Vermont",
+          "esdc_internationalalphacode": "VT",
+          "esdc_namefrench": "Vermont",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "ca1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809881\"",
+          "esdc_nameenglish": "Virginia",
+          "esdc_internationalalphacode": "VA",
+          "esdc_namefrench": "Virginie",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "cc1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809882\"",
+          "esdc_nameenglish": "Washington",
+          "esdc_internationalalphacode": "WA",
+          "esdc_namefrench": "État de Washington",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "ce1091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809883\"",
+          "esdc_nameenglish": "West Virginia",
+          "esdc_internationalalphacode": "WV",
+          "esdc_namefrench": "Virginie-Occidentale",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "d01091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809884\"",
+          "esdc_nameenglish": "Wisconsin",
+          "esdc_internationalalphacode": "WI",
+          "esdc_namefrench": "Wisconsin",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "d21091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809885\"",
+          "esdc_nameenglish": "Wyoming",
+          "esdc_internationalalphacode": "WY",
+          "esdc_namefrench": "Wyoming",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "d41091c1-03b4-eb11-8236-0022486d8555"
+        },
+        {
+          "@odata.etag": "W/\"44809836\"",
+          "esdc_nameenglish": "District of Columbia",
+          "esdc_internationalalphacode": "DC",
+          "esdc_namefrench": "District de Colombie",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "21341235-1ae4-eb11-bacb-0022486d8f50"
+        },
+        {
+          "@odata.etag": "W/\"44809715\"",
+          "esdc_nameenglish": "American Samoa",
+          "esdc_internationalalphacode": "AS",
+          "esdc_namefrench": "Samoa américaines",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "18c5680b-1be4-eb11-bacb-0022486d8f50"
+        },
+        {
+          "@odata.etag": "W/\"44809840\"",
+          "esdc_nameenglish": "Guam",
+          "esdc_internationalalphacode": "GU",
+          "esdc_namefrench": "Guam",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "18dd6b1d-1be4-eb11-bacb-0022486d8f50"
+        },
+        {
+          "@odata.etag": "W/\"44809866\"",
+          "esdc_nameenglish": "Northern Mariana Islands",
+          "esdc_internationalalphacode": "MP",
+          "esdc_namefrench": "Îles Mariannes du Nord",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "90f46e2f-1be4-eb11-bacb-0022486d8f50"
+        },
+        {
+          "@odata.etag": "W/\"44809871\"",
+          "esdc_nameenglish": "Puerto Rico",
+          "esdc_internationalalphacode": "PR",
+          "esdc_namefrench": "Porto Rico",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "06ca9e47-1be4-eb11-bacb-0022486d8f50"
+        },
+        {
+          "@odata.etag": "W/\"44809878\"",
+          "esdc_nameenglish": "U.S. Virgin Islands",
+          "esdc_internationalalphacode": "VI",
+          "esdc_namefrench": "Îles Vierges américaines",
+          "_esdc_countryid_value": "fcf7389e-97ae-eb11-8236-000d3af4bfc3",
+          "esdc_provinceterritorystateid": "cf6c8c59-1be4-eb11-bacb-0022486d8f50"
+        }
+      ],
+      "esdc_ProvinceTerritoryState_Countryid_esd@odata.nextLink": "https://canadadental-sandbox.crm3.dynamics.com/api/data/v9.2/esdc_countries(fcf7389e-97ae-eb11-8236-000d3af4bfc3)/esdc_ProvinceTerritoryState_Countryid_esd?$select=esdc_provinceterritorystateid,esdc_nameenglish,esdc_namefrench,esdc_internationalalphacode&$filter=statecode%20eq%200%20and%20esdc_enabledentalapplicationportal%20eq%20true"
     }
   ]
 }

--- a/frontend/app/routes/protected/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -71,7 +71,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const childNumber = t('protected-apply-adult-child:children.child-number', { childNumber: state.childNumber });

--- a/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
@@ -70,8 +70,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -100,7 +100,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -108,7 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -70,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const allRegions = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const allRegions = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
   const regions = allRegions.filter(({ countryId }) => countryId === CANADA_COUNTRY_ID);
 

--- a/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/home-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult-child:address.home-address.page-title') }) };
 
@@ -141,6 +141,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -150,7 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -169,7 +170,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/mailing-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult-child:address.mailing-address.page-title') }) };
 
@@ -154,6 +154,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -163,7 +164,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -182,7 +183,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/review-adult-information.tsx
@@ -69,8 +69,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -100,7 +100,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -108,7 +108,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
@@ -71,8 +71,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -101,7 +101,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -109,7 +109,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -70,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:dental-benefits.title') }) };

--- a/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/home-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:address.home-address.page-title') }) };
 
@@ -141,6 +141,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -150,7 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -169,7 +170,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/mailing-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-adult:address.mailing-address.page-title') }) };
 
@@ -155,6 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -164,7 +165,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -183,7 +184,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/review-information.tsx
@@ -76,8 +76,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -107,7 +107,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -115,7 +115,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -70,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const allRegions = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const allRegions = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
   const regions = allRegions.filter(({ countryId }) => countryId === CANADA_COUNTRY_ID);
 

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -62,8 +62,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -92,7 +92,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -100,7 +100,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/home-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.home-address.page-title') }) };
 
@@ -141,6 +141,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -150,7 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -169,7 +170,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/mailing-address.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-apply-child:address.mailing-address.page-title') }) };
 
@@ -155,6 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -164,7 +165,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -183,7 +184,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/review-adult-information.tsx
@@ -71,8 +71,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
@@ -102,7 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -110,7 +110,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/$childId/confirm-federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const childName = state.isNew ? childNumber : (state.information?.firstName ?? childNumber);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = {

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -72,7 +72,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-dental-benefits.title') }) };

--- a/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-home-address.tsx
@@ -68,7 +68,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.home-address.page-title') }) };
 
@@ -139,6 +139,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -148,7 +149,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -167,7 +168,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-mailing-address.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-address.mailing-address.page-title') }) };
 
@@ -146,6 +146,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -155,7 +156,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -174,7 +175,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
+++ b/frontend/app/routes/protected/renew/$id/review-adult-information.tsx
@@ -90,13 +90,13 @@ export async function loader({ context: { appContainer, session }, params, reque
   const communicationPreferredLanguageId = state.preferredLanguage ?? state.clientApplication.communicationPreferences.preferredLanguage;
   const communicationPreferredLanguageName = preferredLanguageService.getLocalizedPreferredLanguageById(communicationPreferredLanguageId, locale).name;
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? provinceTerritoryStateService.getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await provinceTerritoryStateService.getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
   const clientApplicationMailingProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.mailingProvince
-    ? provinceTerritoryStateService.getProvinceTerritoryStateById(state.clientApplication.contactInformation.mailingProvince).abbr
+    ? await provinceTerritoryStateService.getProvinceTerritoryStateById(state.clientApplication.contactInformation.mailingProvince)
     : undefined;
 
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? provinceTerritoryStateService.getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
-  const clientApplicationHomeProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.homeProvince ? provinceTerritoryStateService.getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince).abbr : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await provinceTerritoryStateService.getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
+  const clientApplicationHomeProvinceTerritoryStateAbbr = state.clientApplication.contactInformation.homeProvince ? await provinceTerritoryStateService.getProvinceTerritoryStateById(state.clientApplication.contactInformation.homeProvince) : undefined;
 
   const mailingCountryId = state.mailingAddress?.country ?? state.clientApplication.contactInformation.mailingCountry;
   const mailingCountryName = await countryService.getLocalizedCountryById(mailingCountryId, locale);
@@ -135,14 +135,14 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: mailingCountryName.name,
       }
     : {
         address: state.clientApplication.contactInformation.mailingAddress,
         city: state.clientApplication.contactInformation.mailingCity,
-        province: clientApplicationHomeProvinceTerritoryStateAbbr,
+        province: clientApplicationHomeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.clientApplication.contactInformation.mailingPostalCode,
         country: mailingCountryName.name,
         apartment: state.clientApplication.contactInformation.mailingApartment,
@@ -154,7 +154,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     homeAddressInfo = {
       address: state.homeAddress.address,
       city: state.homeAddress.city,
-      provinceState: homeProvinceTerritoryStateAbbr,
+      provinceState: homeProvinceTerritoryStateAbbr?.abbr,
       postalZipCode: state.homeAddress.postalCode,
       country: homeCountryName.name,
     };
@@ -165,7 +165,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     homeAddressInfo = {
       address: state.clientApplication.contactInformation.homeAddress,
       city: state.clientApplication.contactInformation.homeCity,
-      provinceState: clientApplicationMailingProvinceTerritoryStateAbbr,
+      provinceState: clientApplicationMailingProvinceTerritoryStateAbbr?.abbr,
       postalZipCode: state.clientApplication.contactInformation.homePostalCode,
       country: homeCountryName.name,
       apartment: state.clientApplication.contactInformation.homeApartment,

--- a/frontend/app/routes/public/address-validation/review.tsx
+++ b/frontend/app/routes/public/address-validation/review.tsx
@@ -43,12 +43,13 @@ export async function loader({ context: { appContainer, session }, request }: Ro
 
   const validatedMailingAddress = validationResult.data;
   const country = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(validatedMailingAddress.countryId, locale);
+  const provinceTerritoryState = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getLocalizedProvinceTerritoryStateById(validatedMailingAddress.provinceStateId ?? '', locale);
   const formattedMailingAddress = {
     address: validatedMailingAddress.address,
     city: validatedMailingAddress.city,
     country: country.name,
     postalZipCode: validatedMailingAddress.postalZipCode,
-    provinceState: validatedMailingAddress.provinceStateId && appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getLocalizedProvinceTerritoryStateById(validatedMailingAddress.provinceStateId, locale).abbr,
+    provinceState: validatedMailingAddress.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const { CANADA_COUNTRY_ID } = appContainer.get(TYPES.configs.ClientConfig);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const childNumber = t('apply-adult-child:children.child-number', { childNumber: state.childNumber });

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -97,7 +97,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -105,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const allRegions = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const allRegions = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
   const regions = allRegions.filter(({ countryId }) => countryId === CANADA_COUNTRY_ID);
 

--- a/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.home-address.page-title') }) };
 
@@ -131,6 +131,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -140,7 +141,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -159,7 +160,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult-child:address.mailing-address.page-title') }) };
 
@@ -143,6 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -152,7 +153,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -171,7 +172,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/review-adult-information.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -96,7 +96,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -104,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -68,8 +68,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -98,7 +98,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -106,7 +106,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:dental-benefits.title') }) };

--- a/frontend/app/routes/public/apply/$id/adult/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.home-address.page-title') }) };
 
@@ -130,6 +130,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -139,7 +140,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -158,7 +159,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-adult:address.mailing-address.page-title') }) };
 
@@ -143,6 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -152,7 +153,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -171,7 +172,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/adult/review-information.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/review-information.tsx
@@ -72,8 +72,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -103,7 +103,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -111,7 +111,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/$childId/federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const allRegions = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const allRegions = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
   const regions = allRegions.filter(({ countryId }) => countryId === CANADA_COUNTRY_ID);
 

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -59,8 +59,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const preferredLanguage = appContainer.get(TYPES.domain.services.PreferredLanguageService).getLocalizedPreferredLanguageById(state.communicationPreferences.preferredLanguage, locale);
@@ -89,7 +89,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -97,7 +97,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/apply/$id/child/home-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.home-address.page-title') }) };
 
@@ -131,6 +131,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -140,7 +141,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -159,7 +160,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
+++ b/frontend/app/routes/public/apply/$id/child/mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('apply-child:address.mailing-address.page-title') }) };
 
@@ -143,6 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -152,7 +153,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -171,7 +172,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/apply/$id/child/review-adult-information.tsx
@@ -67,8 +67,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale);
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : undefined;
@@ -98,7 +98,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const mailingAddressInfo = {
     address: state.mailingAddress.address,
     city: state.mailingAddress.city,
-    province: mailingProvinceTerritoryStateAbbr,
+    province: mailingProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.mailingAddress.postalCode,
     country: countryMailing,
   };
@@ -106,7 +106,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const homeAddressInfo = {
     address: state.homeAddress?.address,
     city: state.homeAddress?.city,
-    province: homeProvinceTerritoryStateAbbr,
+    province: homeProvinceTerritoryStateAbbr?.abbr,
     postalCode: state.homeAddress?.postalCode,
     country: countryHome?.name,
   };

--- a/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -70,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const childName = state.isNew ? childNumber : (state.information?.firstName ?? childNumber);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = {

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -64,8 +64,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -90,7 +90,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
       }
@@ -100,7 +100,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress.address,
         city: state.homeAddress.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
       }

--- a/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/review-adult-information.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -94,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress?.address,
         city: state.mailingAddress?.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress?.postalCode,
         country: countryMailing,
       }
@@ -104,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress?.address,
         city: state.homeAddress?.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress?.postalCode,
         country: countryHome,
       }

--- a/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-dental-benefits.title') }) };

--- a/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.home-address.page-title') }) };
 
@@ -137,6 +137,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -146,7 +147,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -165,7 +166,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/update-mailing-address.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult-child:update-address.mailing-address.page-title') }) };
 
@@ -152,6 +152,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -161,7 +162,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -180,7 +181,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -63,8 +63,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const selectedProvincialBenefits = state.dentalBenefits?.provincialTerritorialSocialProgram
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -89,7 +89,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
       }
@@ -99,7 +99,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress.address,
         city: state.homeAddress.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
       }

--- a/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/review-adult-information.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -94,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress?.address,
         city: state.mailingAddress?.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress?.postalCode,
         country: countryMailing,
       }
@@ -104,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress?.address,
         city: state.homeAddress?.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress?.postalCode,
         country: countryHome,
       }

--- a/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-federal-provincial-territorial-benefits.tsx
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-dental-benefits.title') }) };

--- a/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.home-address.page-title') }) };
 
@@ -138,6 +138,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -147,7 +148,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -166,7 +167,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/update-mailing-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-adult:update-address.mailing-address.page-title') }) };
 
@@ -151,6 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -160,7 +161,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -179,7 +180,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/$childId/update-federal-provincial-territorial-benefits.tsx
@@ -70,7 +70,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const childName = state.information?.firstName ?? childNumber;
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = {

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -57,8 +57,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -83,7 +83,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
       }
@@ -93,7 +93,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress.address,
         city: state.homeAddress.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
       }

--- a/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
+++ b/frontend/app/routes/public/renew/$id/child/review-adult-information.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = state.maritalStatus ? appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale) : undefined;
@@ -94,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress?.address,
         city: state.mailingAddress?.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress?.postalCode,
         country: countryMailing,
       }
@@ -104,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress?.address,
         city: state.homeAddress?.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress?.postalCode,
         country: countryHome,
       }

--- a/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.home-address.page-title') }) };
 
@@ -138,6 +138,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -147,7 +148,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -166,7 +167,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/update-mailing-address.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-child:update-address.mailing-address.page-title') }) };
 
@@ -151,6 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -160,7 +161,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -179,7 +180,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -68,8 +68,8 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).getLocalizedProvincialGovernmentInsurancePlanById(state.dentalBenefits.provincialTerritorialSocialProgram, locale)
     : undefined;
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
@@ -97,7 +97,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing?.name ?? '',
       }
@@ -107,7 +107,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress.address,
         city: state.homeAddress.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome?.name ?? '',
       }

--- a/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/federal-provincial-territorial-benefits.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const federalSocialPrograms = appContainer.get(TYPES.domain.services.FederalGovernmentInsurancePlanService).listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
-  const provinceTerritoryStates = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
+  const provinceTerritoryStates = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStatesByCountryId(CANADA_COUNTRY_ID, locale);
   const provincialTerritorialSocialPrograms = appContainer.get(TYPES.domain.services.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:dental-benefits.title') }) };

--- a/frontend/app/routes/public/renew/$id/ita/review-information.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/review-information.tsx
@@ -65,8 +65,8 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
 
-  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province).abbr : undefined;
-  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province).abbr : undefined;
+  const mailingProvinceTerritoryStateAbbr = state.mailingAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
+  const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
   const countryMailing = state.mailingAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.mailingAddress.country, locale) : undefined;
   const countryHome = state.homeAddress?.country ? await appContainer.get(TYPES.domain.services.CountryService).getLocalizedCountryById(state.homeAddress.country, locale) : undefined;
   const maritalStatus = appContainer.get(TYPES.domain.services.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale);
@@ -94,7 +94,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.mailingAddress.address,
         city: state.mailingAddress.city,
-        province: mailingProvinceTerritoryStateAbbr,
+        province: mailingProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.mailingAddress.postalCode,
         country: countryMailing,
       }
@@ -104,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     ? {
         address: state.homeAddress.address,
         city: state.homeAddress.city,
-        province: homeProvinceTerritoryStateAbbr,
+        province: homeProvinceTerritoryStateAbbr?.abbr,
         postalCode: state.homeAddress.postalCode,
         country: countryHome,
       }

--- a/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-home-address.tsx
@@ -60,7 +60,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.home-address.page-title') }) };
 
@@ -138,6 +138,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(parsedDataResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(parsedDataResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedHomeAddress: CanadianAddress = {
@@ -147,7 +148,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: parsedDataResult.data.postalZipCode,
     provinceStateId: parsedDataResult.data.provinceStateId,
-    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(parsedDataResult.data.provinceStateId, locale).abbr,
+    provinceState: parsedDataResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -166,7 +167,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedHomeAddress,
       status: 'address-suggestion',

--- a/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/update-mailing-address.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const locale = getLocale(request);
 
   const countryList = await appContainer.get(TYPES.domain.services.CountryService).listAndSortLocalizedCountries(locale);
-  const regionList = appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
+  const regionList = await appContainer.get(TYPES.domain.services.ProvinceTerritoryStateService).listAndSortLocalizedProvinceTerritoryStates(locale);
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('renew-ita:update-address.mailing-address.page-title') }) };
 
@@ -151,6 +151,7 @@ export async function action({ context: { appContainer, session }, params, reque
   invariant(validatedResult.data.provinceStateId, 'Province state is required for Canadian addresses');
 
   const country = await countryService.getLocalizedCountryById(validatedResult.data.countryId, locale);
+  const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale);
 
   // Build the address object using validated data, transforming unique identifiers
   const formattedMailingAddress: CanadianAddress = {
@@ -160,7 +161,7 @@ export async function action({ context: { appContainer, session }, params, reque
     country: country.name,
     postalZipCode: validatedResult.data.postalZipCode,
     provinceStateId: validatedResult.data.provinceStateId,
-    provinceState: validatedResult.data.provinceStateId && provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById(validatedResult.data.provinceStateId, locale).abbr,
+    provinceState: validatedResult.data.provinceStateId && provinceTerritoryState.abbr,
   };
 
   const addressCorrectionResult = await addressValidationService.getAddressCorrectionResult({
@@ -179,7 +180,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   if (addressCorrectionResult.status === 'corrected') {
-    const provinceTerritoryState = provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
+    const provinceTerritoryState = await provinceTerritoryStateService.getLocalizedProvinceTerritoryStateByCode(addressCorrectionResult.provinceCode, locale);
     return {
       enteredAddress: formattedMailingAddress,
       status: 'address-suggestion',


### PR DESCRIPTION
### Description
Follows the same pattern as previous PRs

We have to re-use the call to the `esdc_countries` endpoint since there isn't a dedicated provice/territory/state endpoint, but we can filter the results returned (and hence data sent over the wire) by only selecting `group_key != null` in the search params.  I've opted to keep separate services for countries and prov/terr/state.

### Related Azure Boards Work Items
AB#6170

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`