### PR TITLE
fix(frontend) force email verification modal open when email request sent

### DIFF
--- a/frontend/app/routes/protected/renew/$id/verify-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/verify-email.tsx
@@ -105,9 +105,16 @@ export async function action({ context: { appContainer, session }, params, reque
 
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
+        verificationCode: verificationCode,
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+        userId: idToken.sub,
+      });
+      return { status: 'verification-code-sent' } as const;
+    } else if (state.email) {
+      await verificationCodeService.sendVerificationCodeEmail({
+        email: state.email,
         verificationCode: verificationCode,
         preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: idToken.sub,

--- a/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
@@ -96,12 +96,19 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
 
+    invariant(state.clientApplication, 'Expected clientApplication to be defined');
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
-      invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
+        verificationCode: verificationCode,
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+        userId: 'anonymous',
+      });
+      return { status: 'verification-code-sent' } as const;
+    } else if (state.email) {
+      await verificationCodeService.sendVerificationCodeEmail({
+        email: state.email,
         verificationCode: verificationCode,
         preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -96,12 +96,19 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
 
+    invariant(state.clientApplication, 'Expected clientApplication to be defined');
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
-      invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
+        verificationCode: verificationCode,
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+        userId: 'anonymous',
+      });
+      return { status: 'verification-code-sent' } as const;
+    } else if (state.email) {
+      await verificationCodeService.sendVerificationCodeEmail({
+        email: state.email,
         verificationCode: verificationCode,
         preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',

--- a/frontend/app/routes/public/renew/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/verify-email.tsx
@@ -96,12 +96,19 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
 
+    invariant(state.clientApplication, 'Expected clientApplication to be defined');
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
-      invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
+        verificationCode: verificationCode,
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+        userId: 'anonymous',
+      });
+      return { status: 'verification-code-sent' } as const;
+    } else if (state.email) {
+      await verificationCodeService.sendVerificationCodeEmail({
+        email: state.email,
         verificationCode: verificationCode,
         preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',

--- a/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
@@ -96,12 +96,19 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     });
 
+    invariant(state.clientApplication, 'Expected clientApplication to be defined');
     if (state.editMode) {
       invariant(state.editModeEmail, 'Expected editModeEmail to be defined');
-      invariant(state.editModeCommunicationPreferences, 'Expected editModeCommunicationPreferences to be defined');
-      invariant(state.clientApplication, 'Expected clientApplication to be defined');
       await verificationCodeService.sendVerificationCodeEmail({
         email: state.editModeEmail,
+        verificationCode: verificationCode,
+        preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+        userId: 'anonymous',
+      });
+      return { status: 'verification-code-sent' } as const;
+    } else if (state.email) {
+      await verificationCodeService.sendVerificationCodeEmail({
+        email: state.email,
         verificationCode: verificationCode,
         preferredLanguage: state.clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
         userId: 'anonymous',


### PR DESCRIPTION
### Description
The modal was only showing in `editMode` because the status of `verification-code-sent` was only inside of that block.  This PR moves the return out one level when the request link is clicked.

### Related Azure Boards Work Items
AB#6212

