### PR TITLE
chore(gitops): Enabling `verification-code mock` in otto

### DIFF
--- a/gitops/overlays/otto/configs/frontend/config.conf
+++ b/gitops/overlays/otto/configs/frontend/config.conf
@@ -7,6 +7,8 @@ AUTH_RASCL_LOGOUT_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/
 
 ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application,killswitch-api
 
+ENABLED_MOCKS=verification-code
+
 HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb
 
 INTEROP_API_BASE_URI=https://services-nonprd-api.dev.service.gc.ca/uat/stream1


### PR DESCRIPTION
### Description
Configures the `otto` environment to generate and email a consistent dummy verification code enabling reliable full E2E testing.