### PR TITLE
AB#6213 add missing text and communication link to verify-email

### DIFF
--- a/frontend/public/locales/en/protected-renew.json
+++ b/frontend/public/locales/en/protected-renew.json
@@ -605,7 +605,7 @@
     "page-title": "Verify your email address",
     "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
     "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
-    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
     "verification-code-label": "Verification code",
     "request-new-code": "Request new verification code",
     "back": "Back",

--- a/frontend/public/locales/en/renew-adult-child.json
+++ b/frontend/public/locales/en/renew-adult-child.json
@@ -103,7 +103,7 @@
     "page-title": "Verify your email address",
     "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
     "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
-    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
     "verification-code-label": "Verification code",
     "request-new-code": "Request new verification code",
     "back": "Back",

--- a/frontend/public/locales/en/renew-adult.json
+++ b/frontend/public/locales/en/renew-adult.json
@@ -103,7 +103,7 @@
     "page-title": "Verify your email address",
     "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
     "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
-    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
     "verification-code-label": "Verification code",
     "request-new-code": "Request new verification code",
     "back": "Back",

--- a/frontend/public/locales/en/renew-child.json
+++ b/frontend/public/locales/en/renew-child.json
@@ -255,7 +255,7 @@
     "page-title": "Verify your email address",
     "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
     "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
-    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
     "verification-code-label": "Verification code",
     "request-new-code": "Request new verification code",
     "back": "Back",

--- a/frontend/public/locales/en/renew-ita.json
+++ b/frontend/public/locales/en/renew-ita.json
@@ -83,7 +83,7 @@
     "page-title": "Verify your email address",
     "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
     "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
-    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
     "verification-code-label": "Verification code",
     "request-new-code": "Request new verification code",
     "back": "Back",

--- a/frontend/public/locales/fr/protected-renew.json
+++ b/frontend/public/locales/fr/protected-renew.json
@@ -605,7 +605,7 @@
     "page-title": "Confirmation de votre adresse courriel",
     "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}, veuillez saisir le code ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
     "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
-    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
     "verification-code-label": "Code de vérification",
     "request-new-code": "Demander un nouveau code",
     "back": "Retour",

--- a/frontend/public/locales/fr/renew-adult-child.json
+++ b/frontend/public/locales/fr/renew-adult-child.json
@@ -103,7 +103,7 @@
     "page-title": "Confirmation de votre adresse courriel",
     "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}, veuillez saisir le code ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
     "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
-    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
     "verification-code-label": "Code de vérification",
     "request-new-code": "Demander un nouveau code",
     "back": "Retour",

--- a/frontend/public/locales/fr/renew-adult.json
+++ b/frontend/public/locales/fr/renew-adult.json
@@ -103,7 +103,7 @@
     "page-title": "Confirmation de votre adresse courriel",
     "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}, veuillez saisir le code ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
     "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
-    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
     "verification-code-label": "Code de vérification",
     "request-new-code": "Demander un nouveau code",
     "back": "Retour",

--- a/frontend/public/locales/fr/renew-child.json
+++ b/frontend/public/locales/fr/renew-child.json
@@ -256,7 +256,7 @@
     "page-title": "Confirmation de votre adresse courriel",
     "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}, veuillez saisir le code ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
     "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
-    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
     "verification-code-label": "Code de vérification",
     "request-new-code": "Demander un nouveau code",
     "back": "Retour",

--- a/frontend/public/locales/fr/renew-ita.json
+++ b/frontend/public/locales/fr/renew-ita.json
@@ -83,7 +83,7 @@
     "page-title": "Confirmation de votre adresse courriel",
     "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}, veuillez saisir le code ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
     "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
-    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
     "verification-code-label": "Code de vérification",
     "request-new-code": "Demander un nouveau code",
     "back": "Retour",


### PR DESCRIPTION
### Description
Add missing text and communication link to renew flow verify-email page

### Related Azure Boards Work Items
AB#6213

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->