### PR TITLE
refactor(frontend) preferred communication code tables

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -6,7 +6,11 @@ import type { ClientApplicationEntity, ClientApplicationSinRequestEntity } from 
 import { DefaultClientApplicationDtoMapper } from '~/.server/domain/mappers';
 
 describe('DefaultClientApplicationDtoMapper', () => {
-  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'> = { APPLICANT_CATEGORY_CODE_INDIVIDUAL: '111111111', APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: '222222222' };
+  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'> = {
+    APPLICANT_CATEGORY_CODE_INDIVIDUAL: '111111111',
+    APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: '222222222',
+    ENGLISH_LANGUAGE_CODE: 1,
+  };
   const mapper = new DefaultClientApplicationDtoMapper(mockServerConfig);
 
   describe('mapClientApplicationEntityToClientApplicationDto', () => {
@@ -88,7 +92,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
             PersonLanguage: [
               {
                 CommunicationCategoryCode: {
-                  ReferenceDataID: 'ENG',
+                  ReferenceDataID: '1',
                 },
                 PreferredIndicator: true,
               },
@@ -195,7 +199,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
         children: [],
         communicationPreferences: {
           email: 'email@example.com',
-          preferredLanguage: 'ENG',
+          preferredLanguage: 'english',
           preferredMethod: 'EMAIL',
         },
         contactInformation: {

--- a/frontend/__tests__/.server/domain/mappers/preferred-language.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/preferred-language.dto.mapper.test.ts
@@ -16,7 +16,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
   describe('mapPreferredLanguageEntityToPreferredLanguageDto', () => {
     it('maps a PreferredLanguageEntity with both English and French labels to a PreferredLanguageDto', () => {
       const mockEntity: PreferredLanguageEntity = {
-        Value: 1033,
+        Value: 'english',
         Label: {
           LocalizedLabels: [
             { Label: 'English', LanguageCode: 1033 },
@@ -25,7 +25,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
         },
       };
 
-      const expectedDto: PreferredLanguageDto = { id: '1033', nameEn: 'English', nameFr: 'Anglais' };
+      const expectedDto: PreferredLanguageDto = { id: 'english', nameEn: 'English', nameFr: 'Anglais' };
 
       const mapper = new DefaultPreferredLanguageDtoMapper(mockServerConfig);
 
@@ -36,7 +36,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
 
     it('throws an error if the PreferredLanguageEntity is missing the English label', () => {
       const mockEntity: PreferredLanguageEntity = {
-        Value: 1033,
+        Value: 'invalidId',
         Label: {
           LocalizedLabels: [{ Label: 'Anglais', LanguageCode: 1036 }],
         },
@@ -44,12 +44,12 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
 
       const mapper = new DefaultPreferredLanguageDtoMapper(mockServerConfig);
 
-      expect(() => mapper.mapPreferredLanguageEntityToPreferredLanguageDto(mockEntity)).toThrowError(`Preferred language missing English or French name; id: [1033]`);
+      expect(() => mapper.mapPreferredLanguageEntityToPreferredLanguageDto(mockEntity)).toThrowError(`Preferred language missing English or French name; id: [invalidId]`);
     });
 
     it('throws an error if the PreferredLanguageEntity is missing the French label', () => {
       const mockEntity: PreferredLanguageEntity = {
-        Value: 1033,
+        Value: 'invalidId',
         Label: {
           LocalizedLabels: [{ Label: 'English', LanguageCode: 1033 }],
         },
@@ -57,7 +57,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
 
       const mapper = new DefaultPreferredLanguageDtoMapper(mockServerConfig);
 
-      expect(() => mapper.mapPreferredLanguageEntityToPreferredLanguageDto(mockEntity)).toThrowError(`Preferred language missing English or French name; id: [1033]`);
+      expect(() => mapper.mapPreferredLanguageEntityToPreferredLanguageDto(mockEntity)).toThrowError(`Preferred language missing English or French name; id: [invalidId]`);
     });
   });
 
@@ -65,7 +65,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
     it('maps an array of PreferredLanguageEntities to an array of PreferredLanguageDtos', () => {
       const mockEntities: PreferredLanguageEntity[] = [
         {
-          Value: 1033,
+          Value: 'english',
           Label: {
             LocalizedLabels: [
               { Label: 'English', LanguageCode: 1033 },
@@ -74,7 +74,7 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
           },
         },
         {
-          Value: 1036,
+          Value: 'french',
           Label: {
             LocalizedLabels: [
               { Label: 'French', LanguageCode: 1033 },
@@ -85,8 +85,8 @@ describe('DefaultPreferredLanguageDtoMapper', () => {
       ];
 
       const expectedDtos: PreferredLanguageDto[] = [
-        { id: '1033', nameEn: 'English', nameFr: 'Anglais' },
-        { id: '1036', nameEn: 'French', nameFr: 'Français' },
+        { id: 'english', nameEn: 'English', nameFr: 'Anglais' },
+        { id: 'french', nameEn: 'French', nameFr: 'Français' },
       ];
 
       const mapper = new DefaultPreferredLanguageDtoMapper(mockServerConfig);

--- a/frontend/__tests__/.server/domain/services/preferred-language.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/preferred-language.service.test.ts
@@ -37,7 +37,7 @@ describe('DefaultPreferredLanguageService', () => {
       const mockPreferredLanguageRepository = mock<PreferredLanguageRepository>();
       mockPreferredLanguageRepository.listAllPreferredLanguages.mockReturnValueOnce([
         {
-          Value: 1033,
+          Value: 'english',
           Label: {
             LocalizedLabels: [
               { Label: 'English', LanguageCode: 1033 },
@@ -46,7 +46,7 @@ describe('DefaultPreferredLanguageService', () => {
           },
         },
         {
-          Value: 1036,
+          Value: 'french',
           Label: {
             LocalizedLabels: [
               { Label: 'French', LanguageCode: 1033 },
@@ -79,7 +79,7 @@ describe('DefaultPreferredLanguageService', () => {
       const id = '1033';
       const mockPreferredLanguageRepository = mock<PreferredLanguageRepository>();
       mockPreferredLanguageRepository.findPreferredLanguageById.mockReturnValueOnce({
-        Value: 1033,
+        Value: 'english',
         Label: {
           LocalizedLabels: [
             { Label: 'English', LanguageCode: 1033 },
@@ -123,7 +123,7 @@ describe('DefaultPreferredLanguageService', () => {
       const mockPreferredLanguageRepository = mock<PreferredLanguageRepository>();
       mockPreferredLanguageRepository.listAllPreferredLanguages.mockReturnValueOnce([
         {
-          Value: 1036,
+          Value: 'french',
           Label: {
             LocalizedLabels: [
               { Label: 'French', LanguageCode: 1033 },
@@ -132,7 +132,7 @@ describe('DefaultPreferredLanguageService', () => {
           },
         },
         {
-          Value: 1033,
+          Value: 'english',
           Label: {
             LocalizedLabels: [
               { Label: 'English', LanguageCode: 1033 },
@@ -173,7 +173,7 @@ describe('DefaultPreferredLanguageService', () => {
       const locale = 'en';
       const mockPreferredLanguageRepository = mock<PreferredLanguageRepository>();
       mockPreferredLanguageRepository.findPreferredLanguageById.mockReturnValueOnce({
-        Value: 1033,
+        Value: 'english',
         Label: {
           LocalizedLabels: [
             { Label: 'English', LanguageCode: 1033 },

--- a/frontend/app/.server/domain/entities/preferred-language.entity.ts
+++ b/frontend/app/.server/domain/entities/preferred-language.entity.ts
@@ -1,7 +1,7 @@
 import type { ReadonlyDeep } from 'type-fest';
 
 export type PreferredLanguageEntity = ReadonlyDeep<{
-  Value: number;
+  Value: string;
   Label: {
     LocalizedLabels: {
       LanguageCode: number;

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -39,6 +39,8 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     | 'COMMUNICATION_METHOD_GC_DIGITAL_ID'
     | 'COMMUNICATION_METHOD_MAIL_ID'
     | 'COMMUNICATION_METHOD_EMAIL_ID'
+    | 'ENGLISH_LANGUAGE_CODE'
+    | 'FRENCH_LANGUAGE_CODE'
     | 'BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC'
     | 'BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED'
   >;
@@ -53,6 +55,8 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
       | 'COMMUNICATION_METHOD_GC_DIGITAL_ID'
       | 'COMMUNICATION_METHOD_MAIL_ID'
       | 'COMMUNICATION_METHOD_EMAIL_ID'
+      | 'ENGLISH_LANGUAGE_CODE'
+      | 'FRENCH_LANGUAGE_CODE'
       | 'BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC'
       | 'BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED'
     >,
@@ -72,7 +76,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     const { applicantInformation, applicationYearId, children, communicationPreferences, contactInformation, dateOfBirth, dentalBenefits, dentalInsurance, livingIndependently, partnerInformation, termsAndConditions, typeOfApplication } =
       benefitApplication;
 
-    const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC } = this.serverConfig;
+    const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC, ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = this.serverConfig;
     return {
       BenefitApplication: {
         Applicant: {
@@ -97,7 +101,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
           PersonLanguage: [
             {
               CommunicationCategoryCode: {
-                ReferenceDataID: communicationPreferences.preferredLanguage,
+                ReferenceDataID: (communicationPreferences.preferredLanguage === 'english' ? ENGLISH_LANGUAGE_CODE : FRENCH_LANGUAGE_CODE).toString(),
               },
               PreferredIndicator: true,
             },

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -84,6 +84,8 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     | 'COMMUNICATION_METHOD_MAIL_ID'
     | 'COMMUNICATION_METHOD_EMAIL_ID'
     | 'COMMUNICATION_METHOD_GC_DIGITAL_ID'
+    | 'ENGLISH_LANGUAGE_CODE'
+    | 'FRENCH_LANGUAGE_CODE'
   >;
 
   constructor(
@@ -98,6 +100,8 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       | 'COMMUNICATION_METHOD_MAIL_ID'
       | 'COMMUNICATION_METHOD_EMAIL_ID'
       | 'COMMUNICATION_METHOD_GC_DIGITAL_ID'
+      | 'ENGLISH_LANGUAGE_CODE'
+      | 'FRENCH_LANGUAGE_CODE'
     >,
   ) {
     this.serverConfig = serverConfig;
@@ -142,7 +146,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     }: ToBenefitRenewalRequestEntityArgs,
     isProtectedRoute: boolean,
   ): BenefitRenewalRequestEntity {
-    const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC } = this.serverConfig;
+    const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC, ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = this.serverConfig;
     return {
       BenefitApplication: {
         Applicant: {
@@ -179,7 +183,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
           PersonLanguage: [
             {
               CommunicationCategoryCode: {
-                ReferenceDataID: communicationPreferences.preferredLanguage,
+                ReferenceDataID: (communicationPreferences.preferredLanguage === 'english' ? ENGLISH_LANGUAGE_CODE : FRENCH_LANGUAGE_CODE).toString(),
               },
               PreferredIndicator: true,
             },

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -14,9 +14,9 @@ export interface ClientApplicationDtoMapper {
 
 @injectable()
 export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMapper {
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>;
+  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'>;
 
-  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'>) {
+  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'>) {
     this.serverConfig = serverConfig;
   }
 
@@ -57,6 +57,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
   }
 
   mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto {
+    const { ENGLISH_LANGUAGE_CODE } = this.serverConfig;
     const applicant = clientApplicationEntity.BenefitApplication.Applicant;
 
     const applicantInformation = {
@@ -105,7 +106,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
     const communicationPreferences = {
       email: applicant.PersonContactInformation[0].EmailAddress?.at(0)?.EmailAddressID,
-      preferredLanguage: applicant.PersonLanguage[0].CommunicationCategoryCode.ReferenceDataID,
+      preferredLanguage: applicant.PersonLanguage[0].CommunicationCategoryCode.ReferenceDataID === ENGLISH_LANGUAGE_CODE.toString() ? 'english' : 'french',
       preferredMethod: applicant.PreferredMethodCommunicationCode.ReferenceDataID,
     };
 

--- a/frontend/app/.server/domain/mappers/preferred-language.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/preferred-language.dto.mapper.ts
@@ -35,7 +35,7 @@ export class DefaultPreferredLanguageDtoMapper implements PreferredLanguageDtoMa
   mapPreferredLanguageEntityToPreferredLanguageDto(preferredLanguageEntity: PreferredLanguageEntity): PreferredLanguageDto {
     const { ENGLISH_LANGUAGE_CODE, FRENCH_LANGUAGE_CODE } = this.serverConfig;
 
-    const id = preferredLanguageEntity.Value.toString();
+    const id = preferredLanguageEntity.Value;
     const nameEn = preferredLanguageEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === ENGLISH_LANGUAGE_CODE)?.Label;
     const nameFr = preferredLanguageEntity.Label.LocalizedLabels.find((label) => label.LanguageCode === FRENCH_LANGUAGE_CODE)?.Label;
 

--- a/frontend/app/.server/resources/power-platform/preferred-language.json
+++ b/frontend/app/.server/resources/power-platform/preferred-language.json
@@ -8,7 +8,7 @@
         "MetadataId": "d27aef54-eaff-ed11-8f6d-000d3a09d640",
         "Options": [
           {
-            "Value": 1033,
+            "Value": "english",
             "Color": null,
             "IsManaged": false,
             "ExternalValue": "",
@@ -62,7 +62,7 @@
             }
           },
           {
-            "Value": 1036,
+            "Value": "french",
             "Color": null,
             "IsManaged": false,
             "ExternalValue": "",


### PR DESCRIPTION
### Description
refactors our code table to use an internal id and then maps to the PP specific identifiers upon the final request.

### Related Azure Boards Work Items
AB#6319

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`