### PR TITLE
chore(gitops): Bumping uat1 to `0.0.0-b045aff6` with `code-tables` mock enabled

### DIFF
--- a/gitops/overlays/uat1/configs/frontend/config.conf
+++ b/gitops/overlays/uat1/configs/frontend/config.conf
@@ -5,6 +5,8 @@ AUTH_RAOIDC_BASE_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/raoidc_ii/
 AUTH_RAOIDC_CLIENT_ID=CDCP
 AUTH_RASCL_LOGOUT_URL=https://srv241-s2.sade.hrdc-drhc.gc.ca/ecas-seca/rascl_ii/Support/GlobalLogout.aspx
 
+ENABLED_MOCKS=code-tables
+
 ENABLED_FEATURES=hcaptcha,status,view-letters,view-letters-online-application,killswitch-api
 
 HCAPTCHA_SITE_KEY=269265df-c45d-4deb-bd74-a229344e5cdb

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.3.0-RC168
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-b045aff6
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
As per title.