### PR TITLE
fix(frontend): Add `value` field to code table entities and update endpoints for letter type and government insurance plan repositories

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
@@ -42,13 +42,15 @@ describe('DefaultClientFriendlyStatusRepository', () => {
   });
 
   it('should fetch all client friendly statuses', async () => {
-    const responseDataMock = [
-      {
-        esdc_clientfriendlystatusid: '1',
-        esdc_descriptionenglish: 'english',
-        esdc_descriptionfrench: 'french',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'english',
+          esdc_descriptionfrench: 'french',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -57,7 +59,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllClientFriendlyStatuses();
 
-    expect(actual).toEqual(responseDataMock);
+    expect(actual).toEqual(responseDataMock.value);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
@@ -79,13 +81,15 @@ describe('DefaultClientFriendlyStatusRepository', () => {
   });
 
   it('should fetch client friendly status by id', async () => {
-    const responseDataMock = [
-      {
-        esdc_clientfriendlystatusid: '1',
-        esdc_descriptionenglish: 'english',
-        esdc_descriptionfrench: 'french',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'english',
+          esdc_descriptionfrench: 'french',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -94,7 +98,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findClientFriendlyStatusById('1');
 
-    expect(actual).toEqual(responseDataMock[0]);
+    expect(actual).toEqual(responseDataMock.value[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),

--- a/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
@@ -44,20 +44,22 @@ describe('DefaultCountryRepository', () => {
   });
 
   it('should return results for listAllCountries call', async () => {
-    const responseDataMock = [
-      {
-        esdc_countrycodealpha3: 'CAN',
-        esdc_countryid: '1',
-        esdc_nameenglish: 'Canada English',
-        esdc_namefrench: 'Canada Français',
-      },
-      {
-        esdc_countrycodealpha3: 'USA',
-        esdc_countryid: '2',
-        esdc_nameenglish: 'United States English',
-        esdc_namefrench: 'États-Unis Français',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_countrycodealpha3: 'CAN',
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+        },
+        {
+          esdc_countrycodealpha3: 'USA',
+          esdc_countryid: '2',
+          esdc_nameenglish: 'United States English',
+          esdc_namefrench: 'États-Unis Français',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -66,7 +68,7 @@ describe('DefaultCountryRepository', () => {
     const repository = new DefaultCountryRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllCountries();
 
-    expect(actual).toEqual(responseDataMock);
+    expect(actual).toEqual(responseDataMock.value);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.countries.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_countries?%24select=esdc_countryid%2Cesdc_nameenglish%2Cesdc_namefrench%2Cesdc_countrycodealpha3&%24filter=statecode+eq+0+and+esdc_enabledentalapplicationportal+eq+true'),
@@ -88,14 +90,16 @@ describe('DefaultCountryRepository', () => {
   });
 
   it('should return singular result for findCountryById call', async () => {
-    const responseDataMock = [
-      {
-        esdc_countrycodealpha3: 'CAN',
-        esdc_countryid: '1',
-        esdc_nameenglish: 'Canada English',
-        esdc_namefrench: 'Canada Français',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_countrycodealpha3: 'CAN',
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -104,7 +108,7 @@ describe('DefaultCountryRepository', () => {
     const repository = new DefaultCountryRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findCountryById('1');
 
-    expect(actual).toEqual(responseDataMock[0]);
+    expect(actual).toEqual(responseDataMock.value[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.countries.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_countries?%24select=esdc_countryid%2Cesdc_nameenglish%2Cesdc_namefrench%2Cesdc_countrycodealpha3&%24filter=statecode+eq+0+and+esdc_enabledentalapplicationportal+eq+true'),

--- a/frontend/__tests__/.server/domain/repositories/government-insurance-plan.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/government-insurance-plan.repository.test.ts
@@ -56,14 +56,16 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
   });
 
   it('should fetch all federal government insurance plans', async () => {
-    const responseDataMock = [
-      {
-        esdc_governmentinsuranceplanid: '0',
-        esdc_nameenglish: 'name english',
-        esdc_namefrench: 'name french',
-        _esdc_provinceterritorystateid_value: null,
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_governmentinsuranceplanid: '0',
+          esdc_nameenglish: 'name english',
+          esdc_namefrench: 'name french',
+          _esdc_provinceterritorystateid_value: null,
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -72,11 +74,11 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllFederalGovernmentInsurancePlans();
 
-    expect(actual).toEqual(responseDataMock);
+    expect(actual).toEqual(responseDataMock.value);
 
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/governmentinsuranceplans?%24select=+esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',
@@ -95,14 +97,16 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
   });
 
   it('should fetch federal government insurance plan by id', async () => {
-    const responseDataMock = [
-      {
-        esdc_governmentinsuranceplanid: '0',
-        esdc_nameenglish: 'name english',
-        esdc_namefrench: 'name french',
-        _esdc_provinceterritorystateid_value: null,
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_governmentinsuranceplanid: '0',
+          esdc_nameenglish: 'name english',
+          esdc_namefrench: 'name french',
+          _esdc_provinceterritorystateid_value: null,
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -111,11 +115,11 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findFederalGovernmentInsurancePlanById('0');
 
-    expect(actual).toEqual(responseDataMock[0]);
+    expect(actual).toEqual(responseDataMock.value[0]);
 
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/governmentinsuranceplans?%24select=+esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',
@@ -134,14 +138,16 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
   });
 
   it('should fetch all provincial government insurance plans', async () => {
-    const responseDataMock = [
-      {
-        esdc_governmentinsuranceplanid: '0',
-        esdc_nameenglish: 'name english',
-        esdc_namefrench: 'name french',
-        _esdc_provinceterritorystateid_value: '0',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_governmentinsuranceplanid: '0',
+          esdc_nameenglish: 'name english',
+          esdc_namefrench: 'name french',
+          _esdc_provinceterritorystateid_value: '0',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -150,11 +156,11 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllProvincialGovernmentInsurancePlans();
 
-    expect(actual).toEqual(responseDataMock);
+    expect(actual).toEqual(responseDataMock.value);
 
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/governmentinsuranceplans?%24select=+esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',
@@ -173,14 +179,16 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
   });
 
   it('should fetch provincial government insurance plan by id', async () => {
-    const responseDataMock = [
-      {
-        esdc_governmentinsuranceplanid: '0',
-        esdc_nameenglish: 'name english',
-        esdc_namefrench: 'name french',
-        _esdc_provinceterritorystateid_value: '0',
-      },
-    ];
+    const responseDataMock = {
+      value: [
+        {
+          esdc_governmentinsuranceplanid: '0',
+          esdc_nameenglish: 'name english',
+          esdc_namefrench: 'name french',
+          _esdc_provinceterritorystateid_value: '0',
+        },
+      ],
+    };
 
     const httpClientMock = mock<HttpClient>();
     httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
@@ -189,11 +197,11 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findProvincialGovernmentInsurancePlanById('0');
 
-    expect(actual).toEqual(responseDataMock[0]);
+    expect(actual).toEqual(responseDataMock.value[0]);
 
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/governmentinsuranceplans?%24select=+esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
+      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
       {
         proxyUrl: serverConfigMock.HTTP_PROXY_URL,
         method: 'GET',

--- a/frontend/app/.server/domain/entities/client-friendly-status.entity.ts
+++ b/frontend/app/.server/domain/entities/client-friendly-status.entity.ts
@@ -1,3 +1,7 @@
+export type ClientFriendlyStatusResponseEntity = Readonly<{
+  value: ReadonlyArray<ClientFriendlyStatusEntity>;
+}>;
+
 export type ClientFriendlyStatusEntity = Readonly<{
   esdc_clientfriendlystatusid: string;
   esdc_descriptionenglish: string;

--- a/frontend/app/.server/domain/entities/country.entity.ts
+++ b/frontend/app/.server/domain/entities/country.entity.ts
@@ -1,3 +1,7 @@
+export type CountryResponseEntity = Readonly<{
+  value: ReadonlyArray<CountryEntity>;
+}>;
+
 export type CountryEntity = Readonly<{
   esdc_countryid: string;
   esdc_nameenglish: string;

--- a/frontend/app/.server/domain/entities/government-insurance-plan.entity.ts
+++ b/frontend/app/.server/domain/entities/government-insurance-plan.entity.ts
@@ -1,3 +1,7 @@
+export type GovernmentInsurancePlanResponseEntity = Readonly<{
+  value: ReadonlyArray<GovernmentInsurancePlanEntity>;
+}>;
+
 export type GovernmentInsurancePlanEntity = Readonly<{
   esdc_governmentinsuranceplanid: string;
   esdc_nameenglish: string;

--- a/frontend/app/.server/domain/entities/letter-type.entity.ts
+++ b/frontend/app/.server/domain/entities/letter-type.entity.ts
@@ -1,5 +1,9 @@
 import type { ReadonlyDeep } from 'type-fest';
 
+export type LetterTypeResponseEntity = ReadonlyDeep<{
+  value: LetterTypeEntity[];
+}>;
+
 export type LetterTypeEntity = ReadonlyDeep<{
   esdc_value: string;
   esdc_cctlettertypeid: string;

--- a/frontend/app/.server/domain/repositories/client-friendly-status.repository.ts
+++ b/frontend/app/.server/domain/repositories/client-friendly-status.repository.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { ClientFriendlyStatusEntity } from '~/.server/domain/entities';
+import type { ClientFriendlyStatusEntity, ClientFriendlyStatusResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
@@ -14,7 +14,7 @@ export interface ClientFriendlyStatusRepository {
    * Fetch all client-friendly status entities.
    * @returns All client-friendly status entities.
    */
-  listAllClientFriendlyStatuses(): Promise<ClientFriendlyStatusEntity[]>;
+  listAllClientFriendlyStatuses(): Promise<ReadonlyArray<ClientFriendlyStatusEntity>>;
 
   /**
    * Fetch a client-friendly status entity by its id.
@@ -55,7 +55,7 @@ export class DefaultClientFriendlyStatusRepository implements ClientFriendlyStat
     this.baseUrl = `${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/code-list/pp/v1`;
   }
 
-  async listAllClientFriendlyStatuses(): Promise<ClientFriendlyStatusEntity[]> {
+  async listAllClientFriendlyStatuses(): Promise<ReadonlyArray<ClientFriendlyStatusEntity>> {
     this.log.trace('Fetching all client friendly statuses');
 
     const url = new URL(`${this.baseUrl}/esdc_clientfriendlystatuses`);
@@ -86,9 +86,10 @@ export class DefaultClientFriendlyStatusRepository implements ClientFriendlyStat
       throw new Error(`Failed to fetch client friendly statuses. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    const clientFriendlyStatusEntities: ClientFriendlyStatusEntity[] = await response.json();
-    this.log.trace('Client friendly statuses: [%j]', clientFriendlyStatusEntities);
+    const clientFriendlyStatusResponseEntity: ClientFriendlyStatusResponseEntity = await response.json();
+    const clientFriendlyStatusEntities = clientFriendlyStatusResponseEntity.value;
 
+    this.log.trace('Client friendly statuses: [%j]', clientFriendlyStatusEntities);
     return clientFriendlyStatusEntities;
   }
 

--- a/frontend/app/.server/domain/repositories/country.repository.ts
+++ b/frontend/app/.server/domain/repositories/country.repository.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { CountryEntity } from '~/.server/domain/entities';
+import type { CountryEntity, CountryResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
@@ -86,9 +86,10 @@ export class DefaultCountryRepository implements CountryRepository {
       throw new Error(`Failed to fetch countries. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    const countryEntities: CountryEntity[] = await response.json();
-    this.log.trace('Countries: [%j]', countryEntities);
+    const countryResponseEntity: CountryResponseEntity = await response.json();
+    const countryEntities = countryResponseEntity.value;
 
+    this.log.trace('Countries: [%j]', countryEntities);
     return countryEntities;
   }
 

--- a/frontend/app/.server/domain/repositories/letter-type.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter-type.repository.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'inversify';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { LetterTypeEntity } from '~/.server/domain/entities';
+import type { LetterTypeEntity, LetterTypeResponseEntity } from '~/.server/domain/entities';
 import type { HttpClient } from '~/.server/http';
 import { createLogger } from '~/.server/logging';
 import type { Logger } from '~/.server/logging';
@@ -61,7 +61,7 @@ export class DefaultLetterTypeRepository implements LetterTypeRepository {
     const url = new URL(`${this.baseUrl}/esdc_cctlettertypes`);
     url.searchParams.set('$select', 'esdc_portalnameenglish,esdc_portalnamefrench,_esdc_parentid_value,esdc_value');
     url.searchParams.set('$filter', 'esdc_displayonportal eq 1 and statecode eq 0');
-    url.searchParams.set('$expand', 'esdc_ParentId($select=esdc_portalnameenglish,esdc_portalnamefrench');
+    url.searchParams.set('$expand', 'esdc_ParentId($select=esdc_portalnameenglish,esdc_portalnamefrench)');
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.letter-types.gets', url, {
       method: 'GET',
       headers: {
@@ -87,9 +87,10 @@ export class DefaultLetterTypeRepository implements LetterTypeRepository {
       throw new Error(`Failed to fetch letter types. Status: ${response.status}, Status Text: ${response.statusText}`);
     }
 
-    const letterTypeEntities: LetterTypeEntity[] = await response.json();
-    this.log.trace('Letter types: [%j]', letterTypeEntities);
+    const letterTypeResponseEntity: LetterTypeResponseEntity = await response.json();
+    const letterTypeEntities = letterTypeResponseEntity.value;
 
+    this.log.trace('Letter types: [%j]', letterTypeEntities);
     return letterTypeEntities;
   }
 


### PR DESCRIPTION
### Description
This PR resolves two issues encountered while testing with `int1`:
- Adds a new code table response entity type that includes the missing `value` field returned by Interop/Power Platform.
- Updates the letter type and government insurance plan endpoints, which were previously returning 400 and 404 errors respectively.

### Related Azure Boards Work Items
AB#6170

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`