### PR TITLE
refactor(frontend): Remove federal/provincial find/list of government insurance plans from repository

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/government-insurance-plan.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/government-insurance-plan.repository.test.ts
@@ -55,7 +55,7 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('should fetch all federal government insurance plans', async () => {
+  it('should fetch all government insurance plans', async () => {
     const responseDataMock = {
       value: [
         {
@@ -63,6 +63,12 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
           esdc_nameenglish: 'name english',
           esdc_namefrench: 'name french',
           _esdc_provinceterritorystateid_value: null,
+        },
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'name english',
+          esdc_namefrench: 'name french',
+          _esdc_provinceterritorystateid_value: '0',
         },
       ],
     };
@@ -72,7 +78,7 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
 
     // act
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
-    const actual = await repository.listAllFederalGovernmentInsurancePlans();
+    const actual = await repository.listAllGovernmentInsurancePlans();
 
     expect(actual).toEqual(responseDataMock.value);
 
@@ -96,7 +102,7 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
     );
   });
 
-  it('should fetch federal government insurance plan by id', async () => {
+  it('should fetch government insurance plan by id', async () => {
     const responseDataMock = {
       value: [
         {
@@ -105,46 +111,11 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
           esdc_namefrench: 'name french',
           _esdc_provinceterritorystateid_value: null,
         },
-      ],
-    };
-
-    const httpClientMock = mock<HttpClient>();
-    httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
-
-    // act
-    const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
-    const actual = await repository.findFederalGovernmentInsurancePlanById('0');
-
-    expect(actual).toEqual(responseDataMock.value[0]);
-
-    expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
-      'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
-      {
-        proxyUrl: serverConfigMock.HTTP_PROXY_URL,
-        method: 'GET',
-        headers: {
-          'Ocp-Apim-Subscription-Key': serverConfigMock.INTEROP_API_SUBSCRIPTION_KEY,
-        },
-        retryOptions: {
-          backoffMs: 3,
-          retries: 10,
-          retryConditions: {
-            '502': [],
-          },
-        },
-      },
-    );
-  });
-
-  it('should fetch all provincial government insurance plans', async () => {
-    const responseDataMock = {
-      value: [
         {
-          esdc_governmentinsuranceplanid: '0',
+          esdc_governmentinsuranceplanid: '1',
           esdc_nameenglish: 'name english',
           esdc_namefrench: 'name french',
-          _esdc_provinceterritorystateid_value: '0',
+          _esdc_provinceterritorystateid_value: '1',
         },
       ],
     };
@@ -154,48 +125,7 @@ describe('DefaultGovernmentInsurancePlanRepository', () => {
 
     // act
     const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
-    const actual = await repository.listAllProvincialGovernmentInsurancePlans();
-
-    expect(actual).toEqual(responseDataMock.value);
-
-    expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
-      'http.client.interop-api.government-insurance-plans.gets',
-      new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_governmentinsuranceplans?%24select=esdc_governmentinsuranceplanid%2Cesdc_nameenglish%2Cesdc_namefrench%2C_esdc_provinceterritorystateid_value&%24filter=statecode+eq+0'),
-      {
-        proxyUrl: serverConfigMock.HTTP_PROXY_URL,
-        method: 'GET',
-        headers: {
-          'Ocp-Apim-Subscription-Key': serverConfigMock.INTEROP_API_SUBSCRIPTION_KEY,
-        },
-        retryOptions: {
-          backoffMs: 3,
-          retries: 10,
-          retryConditions: {
-            '502': [],
-          },
-        },
-      },
-    );
-  });
-
-  it('should fetch provincial government insurance plan by id', async () => {
-    const responseDataMock = {
-      value: [
-        {
-          esdc_governmentinsuranceplanid: '0',
-          esdc_nameenglish: 'name english',
-          esdc_namefrench: 'name french',
-          _esdc_provinceterritorystateid_value: '0',
-        },
-      ],
-    };
-
-    const httpClientMock = mock<HttpClient>();
-    httpClientMock.instrumentedFetch.mockResolvedValue(Response.json(responseDataMock));
-
-    // act
-    const repository = new DefaultGovernmentInsurancePlanRepository(serverConfigMock, httpClientMock);
-    const actual = await repository.findProvincialGovernmentInsurancePlanById('0');
+    const actual = await repository.findGovernmentInsurancePlanById('0');
 
     expect(actual).toEqual(responseDataMock.value[0]);
 
@@ -226,12 +156,24 @@ describe('MockGovernmentInsurancePlanRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('should get all federal government insurance plans', async () => {
+  it('should get all government insurance plans', async () => {
     const repository = new MockGovernmentInsurancePlanRepository();
 
-    const federalGovernmentInsurancePlans = await repository.listAllFederalGovernmentInsurancePlans();
+    const governmentInsurancePlans = await repository.listAllGovernmentInsurancePlans();
 
-    expect(federalGovernmentInsurancePlans).toEqual([
+    expect(governmentInsurancePlans).toEqual([
+      {
+        esdc_governmentinsuranceplanid: '1',
+        esdc_nameenglish: 'First Provincial Insurance Plan',
+        esdc_namefrench: "Premier plan d'assurance provincial",
+        _esdc_provinceterritorystateid_value: '10',
+      },
+      {
+        esdc_governmentinsuranceplanid: '2',
+        esdc_nameenglish: 'Second Provincial Insurance Plan',
+        esdc_namefrench: "Deuxième plan d'assurance provincial",
+        _esdc_provinceterritorystateid_value: '20',
+      },
       {
         esdc_governmentinsuranceplanid: '3',
         esdc_nameenglish: 'First Insurance Plan Federal',
@@ -247,22 +189,22 @@ describe('MockGovernmentInsurancePlanRepository', () => {
     ]);
   });
 
-  it('should handle empty federal government insurance plans data', async () => {
+  it('should handle empty government insurance plans data', async () => {
     vi.spyOn(dataSource, 'default', 'get').mockReturnValueOnce({ value: [] });
 
     const repository = new MockGovernmentInsurancePlanRepository();
 
-    const federalGovernmentInsurancePlans = await repository.listAllFederalGovernmentInsurancePlans();
+    const governmentInsurancePlans = await repository.listAllGovernmentInsurancePlans();
 
-    expect(federalGovernmentInsurancePlans).toEqual([]);
+    expect(governmentInsurancePlans).toEqual([]);
   });
 
-  it('should get a federal government insurance plan by id', async () => {
+  it('should get a government insurance plan by id', async () => {
     const repository = new MockGovernmentInsurancePlanRepository();
 
-    const federalGovernmentInsurancePlan = await repository.findFederalGovernmentInsurancePlanById('3');
+    const governmentInsurancePlan = await repository.findGovernmentInsurancePlanById('3');
 
-    expect(federalGovernmentInsurancePlan).toEqual({
+    expect(governmentInsurancePlan).toEqual({
       esdc_governmentinsuranceplanid: '3',
       esdc_nameenglish: 'First Insurance Plan Federal',
       esdc_namefrench: "Premier plan d'assurance fédéral",
@@ -270,63 +212,11 @@ describe('MockGovernmentInsurancePlanRepository', () => {
     });
   });
 
-  it('should return null for non-existent federal government insurance plan id', async () => {
+  it('should return null for non-existent government insurance plan id', async () => {
     const repository = new MockGovernmentInsurancePlanRepository();
 
-    const federalGovernmentInsurancePlan = await repository.findFederalGovernmentInsurancePlanById('non-existent-id');
+    const governmentInsurancePlan = await repository.findGovernmentInsurancePlanById('non-existent-id');
 
-    expect(federalGovernmentInsurancePlan).toBeNull();
-  });
-
-  it('should get all provincial government insurance plans', async () => {
-    const repository = new MockGovernmentInsurancePlanRepository();
-
-    const provincialGovernmentInsurancePlans = await repository.listAllProvincialGovernmentInsurancePlans();
-
-    expect(provincialGovernmentInsurancePlans).toEqual([
-      {
-        esdc_governmentinsuranceplanid: '1',
-        esdc_nameenglish: 'First Provincial Insurance Plan',
-        esdc_namefrench: "Premier plan d'assurance provincial",
-        _esdc_provinceterritorystateid_value: '10',
-      },
-      {
-        esdc_governmentinsuranceplanid: '2',
-        esdc_nameenglish: 'Second Provincial Insurance Plan',
-        esdc_namefrench: "Deuxième plan d'assurance provincial",
-        _esdc_provinceterritorystateid_value: '20',
-      },
-    ]);
-  });
-
-  it('should handle empty provincial government insurance plans data', async () => {
-    vi.spyOn(dataSource, 'default', 'get').mockReturnValueOnce({ value: [] });
-
-    const repository = new MockGovernmentInsurancePlanRepository();
-
-    const provincialGovernmentInsurancePlans = await repository.listAllProvincialGovernmentInsurancePlans();
-
-    expect(provincialGovernmentInsurancePlans).toEqual([]);
-  });
-
-  it('should get a provincial government insurance plan by id', async () => {
-    const repository = new MockGovernmentInsurancePlanRepository();
-
-    const provincialGovernmentInsurancePlans = await repository.findProvincialGovernmentInsurancePlanById('1');
-
-    expect(provincialGovernmentInsurancePlans).toEqual({
-      esdc_governmentinsuranceplanid: '1',
-      esdc_nameenglish: 'First Provincial Insurance Plan',
-      esdc_namefrench: "Premier plan d'assurance provincial",
-      _esdc_provinceterritorystateid_value: '10',
-    });
-  });
-
-  it('should return null for non-existent provincial government insurance plan id', async () => {
-    const repository = new MockGovernmentInsurancePlanRepository();
-
-    const provincialGovernmentInsurancePlans = await repository.findProvincialGovernmentInsurancePlanById('non-existent-id');
-
-    expect(provincialGovernmentInsurancePlans).toBeNull();
+    expect(governmentInsurancePlan).toBeNull();
   });
 });

--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -32,7 +32,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
   describe('listFederalGovernmentInsurancePlans', () => {
     it('fetches all federal government insurance plans', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.listAllFederalGovernmentInsurancePlans.mockResolvedValueOnce([
+      mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans.mockResolvedValueOnce([
         {
           esdc_governmentinsuranceplanid: '1',
           esdc_nameenglish: 'First Insurance Plan',
@@ -68,7 +68,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dtos = await service.listFederalGovernmentInsurancePlans();
 
       expect(dtos).toEqual(mockDtos);
-      expect(mockGovernmentInsurancePlanRepository.listAllFederalGovernmentInsurancePlans).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
     });
   });
@@ -77,7 +77,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches federal government insurance plan by id', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -98,14 +98,14 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.findFederalGovernmentInsurancePlanById(id);
 
       expect(dto).toEqual(mockDto);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
     });
 
     it('fetches federal government insurance plan by id and returns null if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
 
@@ -114,7 +114,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.findFederalGovernmentInsurancePlanById(id);
 
       expect(dto).toBeNull();
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
   });
@@ -123,7 +123,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches federal government insurance plan by id', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -144,21 +144,21 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.getFederalGovernmentInsurancePlanById(id);
 
       expect(dto).toEqual(mockDto);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
     });
 
     it('fetches federal government insurance plan by id and throws exception if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
 
       const service = new DefaultFederalGovernmentInsurancePlanService(mockFederalGovernmentInsurancePlanDtoMapper, mockGovernmentInsurancePlanRepository, mockServerConfig);
 
       await expect(async () => await service.getFederalGovernmentInsurancePlanById(id)).rejects.toThrow(FederalGovernmentInsurancePlanNotFoundException);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
   });
@@ -166,7 +166,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
   describe('listAndSortLocalizedFederalGovernmentInsurancePlans', () => {
     it('fetches and sorts localized countries with Canada first', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.listAllFederalGovernmentInsurancePlans.mockResolvedValueOnce([
+      mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans.mockResolvedValueOnce([
         {
           esdc_governmentinsuranceplanid: '1',
           esdc_nameenglish: 'First Insurance Plan',
@@ -200,7 +200,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dtos = await service.listAndSortLocalizedFederalGovernmentInsurancePlans('en');
 
       expect(dtos).toStrictEqual(expectedFederalGovernmentInsurancePlanLocalizedDtos);
-      expect(mockGovernmentInsurancePlanRepository.listAllFederalGovernmentInsurancePlans).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtosToFederalGovernmentInsurancePlanLocalizedDtos).toHaveBeenCalledOnce();
     });
@@ -210,7 +210,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches federal government insurance plan by id and locale', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -237,7 +237,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.findLocalizedFederalGovernmentInsurancePlanById(id, 'en');
 
       expect(dto).toEqual(mockLocalizedDto);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
     });
@@ -245,7 +245,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches federal government insurance plan by id and locale and returns null if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
 
@@ -254,7 +254,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.findLocalizedFederalGovernmentInsurancePlanById(id, 'en');
 
       expect(dto).toBeNull();
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).not.toHaveBeenCalled();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).not.toHaveBeenCalled();
     });
@@ -264,7 +264,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches localized federal government insurance plan by id', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -283,7 +283,7 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
       const dto = await service.getLocalizedFederalGovernmentInsurancePlanById(id, 'en');
 
       expect(dto).toEqual(mockLocalizedDto);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToFederalGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
     });
@@ -291,14 +291,14 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
     it('fetches localized federal government insurance plan by id throws not found exception', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockFederalGovernmentInsurancePlanDtoMapper = mock<FederalGovernmentInsurancePlanDtoMapper>();
 
       const service = new DefaultFederalGovernmentInsurancePlanService(mockFederalGovernmentInsurancePlanDtoMapper, mockGovernmentInsurancePlanRepository, mockServerConfig);
 
       await expect(async () => await service.getLocalizedFederalGovernmentInsurancePlanById(id, 'en')).rejects.toThrow(FederalGovernmentInsurancePlanNotFoundException);
-      expect(mockGovernmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).not.toHaveBeenCalled();
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtoToFederalGovernmentInsurancePlanLocalizedDto).not.toHaveBeenCalled();
     });

--- a/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
@@ -32,7 +32,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
   describe('listProvincialGovernmentInsurancePlans', () => {
     it('fetches all provincial government insurance plans', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.listAllProvincialGovernmentInsurancePlans.mockResolvedValueOnce([
+      mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans.mockResolvedValueOnce([
         {
           esdc_governmentinsuranceplanid: '1',
           esdc_nameenglish: 'First Insurance Plan',
@@ -70,7 +70,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dtos = await service.listProvincialGovernmentInsurancePlans();
 
       expect(dtos).toEqual(mockDtos);
-      expect(mockGovernmentInsurancePlanRepository.listAllProvincialGovernmentInsurancePlans).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
     });
   });
@@ -79,7 +79,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     it('fetches provincial government insurance plan by id', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -101,21 +101,21 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dto = await service.getProvincialGovernmentInsurancePlanById(id);
 
       expect(dto).toEqual(mockDto);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
     });
 
     it('fetches provincial government insurance plan by id and throws exception if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
 
       const service = new DefaultProvincialGovernmentInsurancePlanService(mockProvincialGovernmentInsurancePlanDtoMapper, mockGovernmentInsurancePlanRepository, mockServerConfig);
 
       await expect(async () => await service.getProvincialGovernmentInsurancePlanById(id)).rejects.toThrow(ProvincialGovernmentInsurancePlanNotFoundException);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
   });
@@ -124,7 +124,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     it('fetches provincial government insurance plan by id', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -146,14 +146,14 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dto = await service.findProvincialGovernmentInsurancePlanById(id);
 
       expect(dto).toEqual(mockDto);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
     });
 
     it('fetches provincial government insurance plan by id and returns null if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
 
@@ -162,7 +162,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dto = await service.findProvincialGovernmentInsurancePlanById(id);
 
       expect(dto).toBeNull();
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
   });
@@ -170,7 +170,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
   describe('listAndSortLocalizedProvincialGovernmentInsurancePlans', () => {
     it('should return a list of localized provincial government insurance plans', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.listAllProvincialGovernmentInsurancePlans.mockResolvedValueOnce([
+      mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans.mockResolvedValueOnce([
         {
           esdc_governmentinsuranceplanid: '1',
           esdc_nameenglish: 'First Insurance Plan',
@@ -204,7 +204,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dtos = await service.listAndSortLocalizedProvincialGovernmentInsurancePlans('en');
 
       expect(dtos).toEqual(mockLocalizedDtos);
-      expect(mockGovernmentInsurancePlanRepository.listAllProvincialGovernmentInsurancePlans).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtosToProvincialGovernmentInsurancePlanLocalizedDtos).toHaveBeenCalledOnce();
     });
@@ -214,7 +214,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     it('fetches provincial government insurance plan by id and locale', async () => {
       const id = '1';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -243,7 +243,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dto = await service.findLocalizedProvincialGovernmentInsurancePlanById(id, 'en');
 
       expect(dto).toEqual(mockLocalizedDto);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtoToProvincialGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
     });
@@ -251,7 +251,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
     it('fetches provincial government insurance plan by id and locale and returns null if not found', async () => {
       const id = '1033';
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
 
@@ -260,7 +260,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dto = await service.findLocalizedProvincialGovernmentInsurancePlanById(id, 'en');
 
       expect(dto).toBeNull();
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
@@ -269,7 +269,7 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
   describe('getLocalizedProvincialGovernmentInsurancePlanById', () => {
     it('should return a localized provincial government insurance plan by id', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce({
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce({
         esdc_governmentinsuranceplanid: '1',
         esdc_nameenglish: 'First Insurance Plan',
         esdc_namefrench: "Premier plan d'assurance",
@@ -289,21 +289,21 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
       const dtos = await service.getLocalizedProvincialGovernmentInsurancePlanById('1', 'en');
 
       expect(dtos).toEqual(mockLocalizedDto);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtoToProvincialGovernmentInsurancePlanLocalizedDto).toHaveBeenCalledOnce();
     });
 
     it('should throw an error if no provincial government insurance plan is found', async () => {
       const mockGovernmentInsurancePlanRepository = mock<GovernmentInsurancePlanRepository>();
-      mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById.mockResolvedValueOnce(null);
+      mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById.mockResolvedValueOnce(null);
 
       const mockProvincialGovernmentInsurancePlanDtoMapper = mock<ProvincialGovernmentInsurancePlanDtoMapper>();
 
       const service = new DefaultProvincialGovernmentInsurancePlanService(mockProvincialGovernmentInsurancePlanDtoMapper, mockGovernmentInsurancePlanRepository, mockServerConfig);
 
       await expect(async () => await service.getLocalizedProvincialGovernmentInsurancePlanById('1', 'en')).rejects.toThrow(ProvincialGovernmentInsurancePlanNotFoundException);
-      expect(mockGovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById).toHaveBeenCalledOnce();
+      expect(mockGovernmentInsurancePlanRepository.findGovernmentInsurancePlanById).toHaveBeenCalledOnce();
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntityToProvincialGovernmentInsurancePlanDto).not.toHaveBeenCalled();
     });
   });

--- a/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
@@ -115,7 +115,7 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
 
   async listFederalGovernmentInsurancePlans(): Promise<ReadonlyArray<FederalGovernmentInsurancePlanDto>> {
     this.log.debug('Get all federal government insurance plans');
-    const federalGovernmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllFederalGovernmentInsurancePlans();
+    const federalGovernmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
     const federalGovernmentInsurancePlanDtos = this.federalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(federalGovernmentInsurancePlanEntities);
     this.log.trace('Returning federal government insurance plans: [%j]', federalGovernmentInsurancePlanDtos);
     return federalGovernmentInsurancePlanDtos;
@@ -123,7 +123,7 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
 
   async findFederalGovernmentInsurancePlanById(id: string): Promise<FederalGovernmentInsurancePlanDto | null> {
     this.log.debug('Finding federal government insurance plan with id: [%s]', id);
-    const federalGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById(id);
+    const federalGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findGovernmentInsurancePlanById(id);
 
     if (!federalGovernmentInsurancePlanEntity) {
       this.log.trace('Federal government insurance plan with id: [%s] not found. Returning null', id);
@@ -137,7 +137,7 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
 
   async getFederalGovernmentInsurancePlanById(id: string): Promise<FederalGovernmentInsurancePlanDto> {
     this.log.debug('Get federal government insurance plan with id: [%s]', id);
-    const federalGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findFederalGovernmentInsurancePlanById(id);
+    const federalGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findGovernmentInsurancePlanById(id);
 
     if (!federalGovernmentInsurancePlanEntity) {
       this.log.error('Federal government insurance plan with id: [%s] not found', id);

--- a/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
@@ -23,17 +23,17 @@ export interface ProvincialGovernmentInsurancePlanService {
 export class DefaultProvincialGovernmentInsurancePlanService implements ProvincialGovernmentInsurancePlanService {
   private readonly log: Logger;
   private readonly provincialGovernmentInsurancePlanDtoMapper: ProvincialGovernmentInsurancePlanDtoMapper;
-  private readonly GovernmentInsurancePlanRepository: GovernmentInsurancePlanRepository;
+  private readonly governmentInsurancePlanRepository: GovernmentInsurancePlanRepository;
   private readonly serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_PROVINCIAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS'>;
 
   constructor(
     @inject(TYPES.domain.mappers.ProvincialGovernmentInsurancePlanDtoMapper) provincialGovernmentInsurancePlanDtoMapper: ProvincialGovernmentInsurancePlanDtoMapper,
-    @inject(TYPES.domain.repositories.GovernmentInsurancePlanRepository) GovernmentInsurancePlanRepository: GovernmentInsurancePlanRepository,
+    @inject(TYPES.domain.repositories.GovernmentInsurancePlanRepository) governmentInsurancePlanRepository: GovernmentInsurancePlanRepository,
     @inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'LOOKUP_SVC_ALL_PROVINCIAL_GOVERNMENT_INSURANCE_PLANS_CACHE_TTL_SECONDS' | 'LOOKUP_SVC_PROVINCIAL_GOVERNMENT_INSURANCE_PLAN_CACHE_TTL_SECONDS'>,
   ) {
     this.log = createLogger('DefaultProvincialGovernmentInsurancePlanService');
     this.provincialGovernmentInsurancePlanDtoMapper = provincialGovernmentInsurancePlanDtoMapper;
-    this.GovernmentInsurancePlanRepository = GovernmentInsurancePlanRepository;
+    this.governmentInsurancePlanRepository = governmentInsurancePlanRepository;
     this.serverConfig = serverConfig;
     this.init();
   }
@@ -66,7 +66,7 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
 
   async listProvincialGovernmentInsurancePlans(): Promise<ReadonlyArray<ProvincialGovernmentInsurancePlanDto>> {
     this.log.debug('Get all provincial government insurance plans');
-    const provincialGovernmentInsurancePlanEntities = await this.GovernmentInsurancePlanRepository.listAllProvincialGovernmentInsurancePlans();
+    const provincialGovernmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
     const provincialGovernmentInsurancePlanDtos = this.provincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanEntities);
     this.log.trace('Returning provincial government insurance plans: [%j]', provincialGovernmentInsurancePlanDtos);
     return provincialGovernmentInsurancePlanDtos;
@@ -74,7 +74,7 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
 
   async findProvincialGovernmentInsurancePlanById(id: string): Promise<ProvincialGovernmentInsurancePlanDto | null> {
     this.log.debug('Finding provincial government insurance plan with id: [%s]', id);
-    const provincialGovernmentInsurancePlanEntity = await this.GovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById(id);
+    const provincialGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findGovernmentInsurancePlanById(id);
 
     if (!provincialGovernmentInsurancePlanEntity) {
       this.log.trace('Provincial government insurance plan with id: [%s] not found. Returning null', id);
@@ -88,7 +88,7 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
 
   async getProvincialGovernmentInsurancePlanById(id: string): Promise<ProvincialGovernmentInsurancePlanDto> {
     this.log.debug('Get provincial government insurance plan with id: [%s]', id);
-    const provincialGovernmentInsurancePlanEntity = await this.GovernmentInsurancePlanRepository.findProvincialGovernmentInsurancePlanById(id);
+    const provincialGovernmentInsurancePlanEntity = await this.governmentInsurancePlanRepository.findGovernmentInsurancePlanById(id);
 
     if (!provincialGovernmentInsurancePlanEntity) throw new ProvincialGovernmentInsurancePlanNotFoundException(`Provincial government insurance plan with id: [${id}] not found`);
 


### PR DESCRIPTION
### Description
This PR is part of an incremental refactor to move the responsibility for filtering all government insurance plans to federal or provincial/territorial from the repository layer to the service layer.

As a first step, province/federal-specific list/find methods in the repository have been removed in favour of a generic list/find methods. Filtering will be applied at the service level in a future PR.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`