### PR TITLE
refactor(frontend): Add federal and provincial/territorial filtering of government insurance plans to service layer

### DIFF
--- a/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/federal-government-insurance-plan.service.test.ts
@@ -45,6 +45,12 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
           esdc_namefrench: "Deuxième plan d'assurance",
           _esdc_provinceterritorystateid_value: null,
         },
+        {
+          esdc_governmentinsuranceplanid: '3',
+          esdc_nameenglish: 'Third Insurance Plan',
+          esdc_namefrench: "Troisième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '3', // Provincial plan - should be filtered out
+        },
       ]);
 
       const mockDtos: FederalGovernmentInsurancePlanDto[] = [
@@ -69,7 +75,20 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
 
       expect(dtos).toEqual(mockDtos);
       expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
-      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledExactlyOnceWith([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: null,
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: null,
+        },
+      ]);
     });
   });
 
@@ -179,6 +198,12 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
           esdc_namefrench: "Deuxième plan d'assurance",
           _esdc_provinceterritorystateid_value: null,
         },
+        {
+          esdc_governmentinsuranceplanid: '3',
+          esdc_nameenglish: 'Third Insurance Plan',
+          esdc_namefrench: "Troisième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '3', // Provincial plan - should be filtered out
+        },
       ]);
 
       const mockMappedFederalGovernmentInsurancePlanDtos: FederalGovernmentInsurancePlanDto[] = [
@@ -201,7 +226,20 @@ describe('DefaultFederalGovernmentInsurancePlanService', () => {
 
       expect(dtos).toStrictEqual(expectedFederalGovernmentInsurancePlanLocalizedDtos);
       expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
-      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
+      expect(mockFederalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos).toHaveBeenCalledExactlyOnceWith([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: null,
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: null,
+        },
+      ]);
       expect(mockFederalGovernmentInsurancePlanDtoMapper.mapFederalGovernmentInsurancePlanDtosToFederalGovernmentInsurancePlanLocalizedDtos).toHaveBeenCalledOnce();
     });
   });

--- a/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/provincial-government-insurance-plan.service.test.ts
@@ -45,6 +45,12 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
           esdc_namefrench: "Deuxième plan d'assurance",
           _esdc_provinceterritorystateid_value: '20',
         },
+        {
+          esdc_governmentinsuranceplanid: '3',
+          esdc_nameenglish: 'Third Insurance Plan',
+          esdc_namefrench: "Troisième plan d'assurance",
+          _esdc_provinceterritorystateid_value: null, // Federal plan - should be filtered out
+        },
       ]);
 
       const mockDtos: ProvincialGovernmentInsurancePlanDto[] = [
@@ -71,7 +77,20 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
 
       expect(dtos).toEqual(mockDtos);
       expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
-      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledExactlyOnceWith([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: '10',
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '20',
+        },
+      ]);
     });
   });
 
@@ -183,6 +202,12 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
           esdc_namefrench: "Deuxième plan d'assurance",
           _esdc_provinceterritorystateid_value: '20',
         },
+        {
+          esdc_governmentinsuranceplanid: '3',
+          esdc_nameenglish: 'Third Insurance Plan',
+          esdc_namefrench: "Troisième plan d'assurance",
+          _esdc_provinceterritorystateid_value: null, // Federal plan - should be filtered out
+        },
       ]);
 
       const mockDtos: ProvincialGovernmentInsurancePlanDto[] = [
@@ -205,7 +230,20 @@ describe('DefaultProvincialGovernmentInsurancePlanService', () => {
 
       expect(dtos).toEqual(mockLocalizedDtos);
       expect(mockGovernmentInsurancePlanRepository.listAllGovernmentInsurancePlans).toHaveBeenCalledOnce();
-      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledOnce();
+      expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos).toHaveBeenCalledExactlyOnceWith([
+        {
+          esdc_governmentinsuranceplanid: '1',
+          esdc_nameenglish: 'First Insurance Plan',
+          esdc_namefrench: "Premier plan d'assurance",
+          _esdc_provinceterritorystateid_value: '10',
+        },
+        {
+          esdc_governmentinsuranceplanid: '2',
+          esdc_nameenglish: 'Second Insurance Plan',
+          esdc_namefrench: "Deuxième plan d'assurance",
+          _esdc_provinceterritorystateid_value: '20',
+        },
+      ]);
       expect(mockProvincialGovernmentInsurancePlanDtoMapper.mapProvincialGovernmentInsurancePlanDtosToProvincialGovernmentInsurancePlanLocalizedDtos).toHaveBeenCalledOnce();
     });
   });

--- a/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/federal-government-insurance-plan.service.ts
@@ -115,7 +115,8 @@ export class DefaultFederalGovernmentInsurancePlanService implements FederalGove
 
   async listFederalGovernmentInsurancePlans(): Promise<ReadonlyArray<FederalGovernmentInsurancePlanDto>> {
     this.log.debug('Get all federal government insurance plans');
-    const federalGovernmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
+    const governmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
+    const federalGovernmentInsurancePlanEntities = governmentInsurancePlanEntities.filter((entity) => entity._esdc_provinceterritorystateid_value === null);
     const federalGovernmentInsurancePlanDtos = this.federalGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToFederalGovernmentInsurancePlanDtos(federalGovernmentInsurancePlanEntities);
     this.log.trace('Returning federal government insurance plans: [%j]', federalGovernmentInsurancePlanDtos);
     return federalGovernmentInsurancePlanDtos;

--- a/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
+++ b/frontend/app/.server/domain/services/provincial-government-insurance-plan.service.ts
@@ -66,7 +66,8 @@ export class DefaultProvincialGovernmentInsurancePlanService implements Provinci
 
   async listProvincialGovernmentInsurancePlans(): Promise<ReadonlyArray<ProvincialGovernmentInsurancePlanDto>> {
     this.log.debug('Get all provincial government insurance plans');
-    const provincialGovernmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
+    const governmentInsurancePlanEntities = await this.governmentInsurancePlanRepository.listAllGovernmentInsurancePlans();
+    const provincialGovernmentInsurancePlanEntities = governmentInsurancePlanEntities.filter((entity) => entity._esdc_provinceterritorystateid_value !== null);
     const provincialGovernmentInsurancePlanDtos = this.provincialGovernmentInsurancePlanDtoMapper.mapGovernmentInsurancePlanEntitiesToProvincialGovernmentInsurancePlanDtos(provincialGovernmentInsurancePlanEntities);
     this.log.trace('Returning provincial government insurance plans: [%j]', provincialGovernmentInsurancePlanDtos);
     return provincialGovernmentInsurancePlanDtos;


### PR DESCRIPTION
### Description
This PR completes the filtering logic for government insurance plans (started in #3852) by moving it to the service layer.

### Checklist
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
Ensure that the `/federal-provincial-territorial-benefits` page renders correctly in English and French.