### PR TITLE
fix(frontend) redirect incomplete marital status

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -435,5 +435,7 @@ export function validateProtectedChildrenStateForReview(childrenState: Protected
 }
 
 export function isInvitationToApplyClient(clientApplication: ProtectedClientApplicationState) {
-  return clientApplication.isInvitationToApplyClient || clientApplication.applicantInformation.maritalStatus === undefined;
+  return (
+    clientApplication.isInvitationToApplyClient || clientApplication.applicantInformation.maritalStatus === undefined || (renewStateHasPartner(clientApplication.applicantInformation.maritalStatus) && clientApplication.partnerInformation === undefined)
+  );
 }

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { Route } from './+types/type-renewal';
 
 import { TYPES } from '~/.server/constants';
+import { renewStateHasPartner } from '~/.server/routes/helpers/protected-renew-route-helpers';
 import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -89,7 +90,10 @@ export async function action({ context: { appContainer, session }, params, reque
   });
 
   invariant(state.clientApplication, 'Expected state.clientApplication to be defined');
-  const isInvitationToApplyClient = state.clientApplication.isInvitationToApplyClient || state.clientApplication.applicantInformation.maritalStatus === undefined;
+  const isInvitationToApplyClient =
+    state.clientApplication.isInvitationToApplyClient ||
+    state.clientApplication.applicantInformation.maritalStatus === undefined ||
+    (renewStateHasPartner(state.clientApplication.applicantInformation.maritalStatus) && state.clientApplication.partnerInformation === undefined);
 
   if (parsedDataResult.data.typeOfRenewal === RENEWAL_TYPE.adult) {
     if (isInvitationToApplyClient) {


### PR DESCRIPTION
### Description
redirects renewal applications with incomplete marital status to ITA flow.  AFAIK it doesn't need to be any deeper than thsi conditional, but feel free to correct me if I'm wrong.

### Related Azure Boards Work Items
AB#6335

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`