### PR TITLE
fix(frontend) display prepopulated fpt benefits

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -80,10 +80,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-renew:update-dental-benefits.title') }) };
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits.reduce(async (benefits, id) => {
+  const clientDentalBenefits = (await state.clientApplication.dentalBenefits.reduce(async (benefits, id) => {
     const federalProgram = await federalGovernmentInsurancePlanService.findFederalGovernmentInsurancePlanById(id);
     if (federalProgram) {
-      return {
+      return await {
         ...benefits,
         hasFederalBenefits: true,
         federalSocialProgram: id,
@@ -92,7 +92,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
     const provincialProgram = await provincialGovernmentInsurancePlanService.findProvincialGovernmentInsurancePlanById(id);
     if (provincialProgram) {
-      return {
+      return await {
         ...benefits,
         hasProvincialTerritorialBenefits: true,
         provincialTerritorialSocialProgram: id,
@@ -100,8 +100,8 @@ export async function loader({ context: { appContainer, session }, params, reque
       };
     }
 
-    return benefits;
-  }, {}) as ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
+    return await benefits;
+  }, Promise.resolve({}))) as ProtectedDentalFederalBenefitsState & ProtectedDentalProvincialTerritorialBenefitsState;
 
   const dentalBenefits = isInvitationToApplyClient(state.clientApplication) ? state.dentalBenefits : clientDentalBenefits;
 


### PR DESCRIPTION
### Description
resolves some async/await issues in order to display prepoulated FPT benefits in the msca renew app

### Related Azure Boards Work Items
AB#6338

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`