### PR TITLE
fix(frontend) prepopulate email behind msca

### DIFF
--- a/frontend/app/routes/protected/renew/$id/confirm-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-email.tsx
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: state.email,
+    defaultState: state.email ?? state.clientApplication.contactInformation.email,
     editMode: state.editMode,
   };
 }


### PR DESCRIPTION
### Description
uses `clientApplication` as a fallback for the email to display to the user.  The user still needs to verify their email however.  Unsure if that is the intended behaviour.

### Related Azure Boards Work Items
AB#6339
