### PR TITLE
fix(frontend) fix marital status form submit

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -6,10 +6,27 @@ import type { ClientApplicationEntity, ClientApplicationSinRequestEntity } from 
 import { DefaultClientApplicationDtoMapper } from '~/.server/domain/mappers';
 
 describe('DefaultClientApplicationDtoMapper', () => {
-  const mockServerConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'> = {
+  const mockServerConfig: Pick<
+    ServerConfig,
+    | 'APPLICANT_CATEGORY_CODE_INDIVIDUAL'
+    | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'
+    | 'ENGLISH_LANGUAGE_CODE'
+    | 'MARITAL_STATUS_CODE_SINGLE'
+    | 'MARITAL_STATUS_CODE_MARRIED'
+    | 'MARITAL_STATUS_CODE_COMMON_LAW'
+    | 'MARITAL_STATUS_CODE_DIVORCED'
+    | 'MARITAL_STATUS_CODE_WIDOWED'
+    | 'MARITAL_STATUS_CODE_SEPARATED'
+  > = {
     APPLICANT_CATEGORY_CODE_INDIVIDUAL: '111111111',
     APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY: '222222222',
     ENGLISH_LANGUAGE_CODE: 1,
+    MARITAL_STATUS_CODE_SINGLE: 'single',
+    MARITAL_STATUS_CODE_MARRIED: 'married',
+    MARITAL_STATUS_CODE_COMMON_LAW: 'commonlaw',
+    MARITAL_STATUS_CODE_DIVORCED: 'divorced',
+    MARITAL_STATUS_CODE_WIDOWED: 'widowed',
+    MARITAL_STATUS_CODE_SEPARATED: 'separated',
   };
   const mapper = new DefaultClientApplicationDtoMapper(mockServerConfig);
 
@@ -99,7 +116,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
             ],
             PersonMaritalStatus: {
               StatusCode: {
-                ReferenceDataID: 'MARRIED',
+                ReferenceDataID: 'married',
               },
             },
             PersonName: [
@@ -191,7 +208,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
         applicantInformation: {
           firstName: 'John',
           lastName: 'Doe',
-          maritalStatus: 'MARRIED',
+          maritalStatus: 'married',
           socialInsuranceNumber: '80000002',
           clientId: '00000000-0000-0000-0000-000000000000',
           clientNumber: '00000000000',

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -14,9 +14,34 @@ export interface ClientApplicationDtoMapper {
 
 @injectable()
 export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMapper {
-  private readonly serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'>;
+  private readonly serverConfig: Pick<
+    ServerConfig,
+    | 'APPLICANT_CATEGORY_CODE_INDIVIDUAL'
+    | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'
+    | 'ENGLISH_LANGUAGE_CODE'
+    | 'MARITAL_STATUS_CODE_SINGLE'
+    | 'MARITAL_STATUS_CODE_MARRIED'
+    | 'MARITAL_STATUS_CODE_COMMON_LAW'
+    | 'MARITAL_STATUS_CODE_DIVORCED'
+    | 'MARITAL_STATUS_CODE_WIDOWED'
+    | 'MARITAL_STATUS_CODE_SEPARATED'
+  >;
 
-  constructor(@inject(TYPES.configs.ServerConfig) serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'ENGLISH_LANGUAGE_CODE'>) {
+  constructor(
+    @inject(TYPES.configs.ServerConfig)
+    serverConfig: Pick<
+      ServerConfig,
+      | 'APPLICANT_CATEGORY_CODE_INDIVIDUAL'
+      | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY'
+      | 'ENGLISH_LANGUAGE_CODE'
+      | 'MARITAL_STATUS_CODE_SINGLE'
+      | 'MARITAL_STATUS_CODE_MARRIED'
+      | 'MARITAL_STATUS_CODE_COMMON_LAW'
+      | 'MARITAL_STATUS_CODE_DIVORCED'
+      | 'MARITAL_STATUS_CODE_WIDOWED'
+      | 'MARITAL_STATUS_CODE_SEPARATED'
+    >,
+  ) {
     this.serverConfig = serverConfig;
   }
 
@@ -63,7 +88,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
     const applicantInformation = {
       firstName: applicant.PersonName[0].PersonGivenName[0],
       lastName: applicant.PersonName[0].PersonSurName,
-      maritalStatus: applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID,
+      maritalStatus: this.toMaritalStatusCode(applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID),
       clientId:
         applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID ??
         (() => {
@@ -188,5 +213,18 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
     if (typeOfApplication === APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY) return 'child';
     if (typeOfApplication === APPLICANT_CATEGORY_CODE_INDIVIDUAL) return 'adult';
     return 'adult-child';
+  }
+
+  private toMaritalStatusCode(powerPlatformMaritalStatusCode: string | undefined): string | undefined {
+    const { MARITAL_STATUS_CODE_SINGLE, MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_WIDOWED, MARITAL_STATUS_CODE_DIVORCED, MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_SEPARATED } = this.serverConfig;
+    const MARITAL_STATUS_CODE_MAP: Record<string, string> = {
+      [MARITAL_STATUS_CODE_SINGLE]: 'single',
+      [MARITAL_STATUS_CODE_MARRIED]: 'married',
+      [MARITAL_STATUS_CODE_COMMON_LAW]: 'commonlaw',
+      [MARITAL_STATUS_CODE_SEPARATED]: 'separated',
+      [MARITAL_STATUS_CODE_DIVORCED]: 'divorced',
+      [MARITAL_STATUS_CODE_WIDOWED]: 'widowed',
+    };
+    return powerPlatformMaritalStatusCode ? MARITAL_STATUS_CODE_MAP[powerPlatformMaritalStatusCode] : undefined;
   }
 }

--- a/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-renew-route-helpers.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 
 import type { ClientApplicationDto } from '~/.server/domain/dtos';
 import { createLogger } from '~/.server/logging';
-import { getEnv } from '~/.server/utils/env.utils';
 import { isRedirectResponse } from '~/.server/utils/response.utils';
 import type { Session } from '~/.server/web/session';
 import { getAgeFromDateString } from '~/utils/date-utils';
@@ -288,8 +287,7 @@ export function startProtectedRenewState({ applicationYear, clientApplication, i
 
 export function renewStateHasPartner(maritalStatus?: string) {
   if (!maritalStatus) return false;
-  const { MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW } = getEnv();
-  return [MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW].includes(Number(maritalStatus));
+  return ['married', 'commonlaw'].includes(maritalStatus);
 }
 
 export function isNewChildState(child: ProtectedChildState) {

--- a/frontend/app/.server/routes/helpers/renew-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/renew-route-helpers.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 
 import type { ClientApplicationDto } from '~/.server/domain/dtos';
 import { createLogger } from '~/.server/logging';
-import { getEnv } from '~/.server/utils/env.utils';
 import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteRenewUrl } from '~/.server/utils/url.utils';
 import type { Session } from '~/.server/web/session';
@@ -283,8 +282,7 @@ export function startRenewState({ applicationYear, id, session }: StartArgs) {
 }
 
 export function renewStateHasPartner(maritalStatus: string) {
-  const { MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW } = getEnv();
-  return [MARITAL_STATUS_CODE_MARRIED, MARITAL_STATUS_CODE_COMMONLAW].includes(Number(maritalStatus));
+  return ['married', 'commonlaw'].includes(maritalStatus);
 }
 
 export function isNewChildState(child: ChildState) {

--- a/frontend/app/routes/public/renew/$id/type-renewal.tsx
+++ b/frontend/app/routes/public/renew/$id/type-renewal.tsx
@@ -8,8 +8,7 @@ import { z } from 'zod';
 import type { Route } from './+types/type-renewal';
 
 import { TYPES } from '~/.server/constants';
-import { renewStateHasPartner } from '~/.server/routes/helpers/protected-renew-route-helpers';
-import { loadRenewState, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
+import { loadRenewState, renewStateHasPartner, saveRenewState } from '~/.server/routes/helpers/renew-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';


### PR DESCRIPTION
### Description
Users are able to move to the next screen without filling in their spouses information.  I'm assuming the same issue happens in the apply app(s).  If this PR is approved, I'll fix the apply app in a separate PR if it is an issue. 

### Related Azure Boards Work Items
AB#6342

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`