### PR TITLE
fix(frontend) remove underline from button link

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/verify-email.tsx
@@ -253,6 +253,7 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Adult_Child:Request new verification code - Verify email click"

--- a/frontend/app/routes/protected/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/verify-email.tsx
@@ -253,6 +253,7 @@ export default function ProtectedApplyFlowVerifyEmail({ loaderData, params }: Ro
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Adult:Request new verification code - Verify email click"

--- a/frontend/app/routes/protected/renew/$id/verify-email.tsx
+++ b/frontend/app/routes/protected/renew/$id/verify-email.tsx
@@ -255,6 +255,7 @@ export default function ProtectedRenewVerifyEmail({ loaderData, params }: Route.
             type="button"
             name="_action"
             variant="link"
+            className="no-underline hover:underline"
             loading={isSubmitting}
             value={FORM_ACTION.request}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Protected:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/verify-email.tsx
@@ -242,6 +242,7 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/verify-email.tsx
@@ -242,6 +242,7 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/apply/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/apply/$id/child/verify-email.tsx
@@ -243,6 +243,7 @@ export default function ApplyFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/verify-email.tsx
@@ -242,6 +242,7 @@ export default function RenewFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult_Child:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/verify-email.tsx
@@ -242,6 +242,7 @@ export default function RenewFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Adult:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/renew/$id/child/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/child/verify-email.tsx
@@ -242,6 +242,7 @@ export default function RenewFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-Child:Request new verification code - Verify email click"

--- a/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/verify-email.tsx
@@ -242,6 +242,7 @@ export default function RenewFlowVerifyEmail({ loaderData, params }: Route.Compo
               type="button"
               name="_action"
               variant="link"
+              className="no-underline hover:underline"
               loading={isSubmitting}
               value={FORM_ACTION.request}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Renew Application Form-ITA:Request new verification code - Verify email click"


### PR DESCRIPTION
### Description
ITAO is reporting that buttons styled as links, particularly using underlines is a failure because it can confuse users who expect links to navigate to a new page.  This PR overrides the style to remove the underline and add a hover state with an outline (the visible focus indicator still exists when the element receives focus via keyboard). 