### PR TITLE
chore(frontend) cleanup FORM_ACTION constants

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/children/index.tsx
@@ -36,8 +36,6 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = {
   add: 'add',
   continue: 'continue',
-  cancel: 'cancel',
-  save: 'save',
   remove: 'remove',
   back: 'back',
 } as const;

--- a/frontend/app/routes/protected/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/phone-number.tsx
@@ -27,7 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/phone-number.tsx
@@ -27,7 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/children/index.tsx
@@ -33,7 +33,7 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-const FORM_ACTION = { add: 'add', continue: 'continue', cancel: 'cancel', save: 'save', remove: 'remove' } as const;
+const FORM_ACTION = { add: 'add', continue: 'continue', remove: 'remove' } as const;
 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protected-apply-child', 'apply', 'gcweb'),

--- a/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/phone-number.tsx
@@ -27,7 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/confirm-address.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-address.tsx
@@ -24,7 +24,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatAddressLine } from '~/utils/string-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-federal-provincial-territorial-benefits.tsx
@@ -28,8 +28,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-marital-status.tsx
@@ -33,7 +33,6 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirm-phone.tsx
@@ -23,7 +23,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/confirmation.tsx
+++ b/frontend/app/routes/protected/renew/$id/confirmation.tsx
@@ -20,7 +20,6 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
   close: 'close',
 } as const;
 

--- a/frontend/app/routes/protected/renew/$id/member-selection.tsx
+++ b/frontend/app/routes/protected/renew/$id/member-selection.tsx
@@ -28,9 +28,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
-  save: 'save',
-  back: 'back',
 } as const;
 
 export const handle = {

--- a/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/children/index.tsx
@@ -35,8 +35,6 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = {
   add: 'add',
   continue: 'continue',
-  cancel: 'cancel',
-  save: 'save',
   remove: 'remove',
   back: 'back',
 } as const;

--- a/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/phone-number.tsx
@@ -26,7 +26,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/phone-number.tsx
@@ -26,7 +26,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/apply/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/apply/$id/child/children/index.tsx
@@ -32,7 +32,7 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
-const FORM_ACTION = { add: 'add', continue: 'continue', cancel: 'cancel', save: 'save', remove: 'remove' } as const;
+const FORM_ACTION = { add: 'add', continue: 'continue', remove: 'remove' } as const;
 
 export const handle = { i18nNamespaces: getTypedI18nNamespaces('apply-child', 'apply', 'gcweb'), pageIdentifier: pageIds.public.apply.child.childSummary, pageTitleI18nKey: 'apply-child:children.index.page-title' } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/apply/$id/child/phone-number.tsx
+++ b/frontend/app/routes/public/apply/$id/child/phone-number.tsx
@@ -26,7 +26,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/children/index.tsx
@@ -33,8 +33,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const FORM_ACTION = {
   add: 'add',
   continue: 'continue',
-  cancel: 'cancel',
-  save: 'save',
   remove: 'remove',
   back: 'back',
 } as const;

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-address.tsx
@@ -27,8 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirm-phone.tsx
@@ -30,7 +30,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/confirmation.tsx
@@ -25,7 +25,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
   close: 'close',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/dental-insurance.tsx
@@ -26,7 +26,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   back: 'back',
   save: 'save',
 } as const;

--- a/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-address.tsx
@@ -27,8 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirm-phone.tsx
@@ -30,7 +30,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/confirmation.tsx
@@ -25,7 +25,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
   close: 'close',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/dental-insurance.tsx
@@ -26,7 +26,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   back: 'back',
   save: 'save',
 } as const;

--- a/frontend/app/routes/public/renew/$id/child/children/index.tsx
+++ b/frontend/app/routes/public/renew/$id/child/children/index.tsx
@@ -33,8 +33,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const FORM_ACTION = {
   add: 'add',
   continue: 'continue',
-  cancel: 'cancel',
-  save: 'save',
   remove: 'remove',
   back: 'back',
 } as const;

--- a/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-address.tsx
@@ -27,8 +27,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirm-phone.tsx
@@ -30,7 +30,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/child/confirmation.tsx
@@ -25,7 +25,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
   close: 'close',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-address.tsx
@@ -29,8 +29,6 @@ import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
-  continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirm-phone.tsx
@@ -27,7 +27,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/confirmation.tsx
@@ -25,7 +25,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 const FORM_ACTION = {
-  submit: 'submit',
   close: 'close',
 } as const;
 

--- a/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/dental-insurance.tsx
@@ -26,7 +26,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   back: 'back',
   save: 'save',
 } as const;

--- a/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/marital-status.tsx
@@ -34,7 +34,6 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 
 const FORM_ACTION = {
   continue: 'continue',
-  cancel: 'cancel',
   save: 'save',
 } as const;
 


### PR DESCRIPTION
### Description
removes unused properties in `FORM_ACTION` constants.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`