### PR TITLE
refactor(frontend) include oxide.ts in project

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
@@ -1,3 +1,4 @@
+import { None } from 'oxide.ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -59,7 +60,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllClientFriendlyStatuses();
 
-    expect(actual).toEqual(responseDataMock.value);
+    expect(actual.ok().unwrap()).toEqual(responseDataMock.value);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
@@ -98,7 +99,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findClientFriendlyStatusById('1');
 
-    expect(actual).toEqual(responseDataMock.value[0]);
+    expect(actual.unwrap().unwrap()).toEqual(responseDataMock.value[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
@@ -131,7 +132,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatuses = await repository.listAllClientFriendlyStatuses();
 
-    expect(clientFriendlyStatuses).toEqual([
+    expect(clientFriendlyStatuses.unwrap()).toEqual([
       {
         esdc_clientfriendlystatusid: '1',
         esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
@@ -152,7 +153,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatuses = await repository.listAllClientFriendlyStatuses();
 
-    expect(clientFriendlyStatuses).toEqual([]);
+    expect(clientFriendlyStatuses.unwrap()).toEqual([]);
   });
 
   it('should get a client friendly status by id', async () => {
@@ -160,7 +161,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatus = await repository.findClientFriendlyStatusById('1');
 
-    expect(clientFriendlyStatus).toEqual({
+    expect(clientFriendlyStatus.unwrap().unwrap()).toEqual({
       esdc_clientfriendlystatusid: '1',
       esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
       esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
@@ -172,6 +173,6 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatus = await repository.findClientFriendlyStatusById('non-existent-id');
 
-    expect(clientFriendlyStatus).toBeNull();
+    expect(clientFriendlyStatus.unwrap()).toBe(None);
   });
 });

--- a/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
@@ -1,4 +1,5 @@
 import type { Moized } from 'moize';
+import { None, Ok, Some } from 'oxide.ts';
 import { describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -31,11 +32,15 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches client friendly status by id', async () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce({
-        esdc_clientfriendlystatusid: '1',
-        esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
-        esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
-      });
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(
+        Ok(
+          Some({
+            esdc_clientfriendlystatusid: '1',
+            esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+            esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+          }),
+        ),
+      );
 
       const mockDto: ClientFriendlyStatusDto = {
         id: '1',
@@ -50,7 +55,7 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const dto = await service.getClientFriendlyStatusById(id);
 
-      expect(dto).toEqual(mockDto);
+      expect(dto.unwrap()).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).toHaveBeenCalledOnce();
     });
@@ -58,13 +63,14 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(null);
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(Ok(None));
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
+      const result = await service.getClientFriendlyStatusById(id);
+      expect(result.unwrapErr()).toBeInstanceOf(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).not.toHaveBeenCalled();
     });
@@ -74,11 +80,15 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches localized client friendly status by id', async () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce({
-        esdc_clientfriendlystatusid: '1',
-        esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
-        esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
-      });
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(
+        Ok(
+          Some({
+            esdc_clientfriendlystatusid: '1',
+            esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+            esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+          }),
+        ),
+      );
 
       const mockDto: ClientFriendlyStatusLocalizedDto = { id: '1', name: 'You have qualified for the Canadian Dental Care Plan.' };
 
@@ -89,7 +99,7 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const dto = await service.getLocalizedClientFriendlyStatusById(id, 'en');
 
-      expect(dto).toEqual(mockDto);
+      expect(dto.unwrap()).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).toHaveBeenCalledOnce();
     });
@@ -97,13 +107,14 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches localized client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(null);
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(Ok(None));
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
+      const result = await service.getClientFriendlyStatusById(id);
+      expect(result.unwrapErr()).toBeInstanceOf(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).not.toHaveBeenCalled();
     });

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const clientFriendlyStatus = statusId ? await appContainer.get(TYPES.domain.services.ClientFriendlyStatusService).getLocalizedClientFriendlyStatusById(statusId, locale) : null;
 
   return {
-    statusResult: { alertType, clientFriendlyStatus },
+    statusResult: { alertType, clientFriendlyStatus: clientFriendlyStatus?.unwrap() },
     meta,
   };
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "moderndash": "^4.0.0",
         "moize": "^6.1.6",
         "morgan": "^1.10.0",
+        "oxide.ts": "^1.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-i18next": "^15.5.3",
@@ -12673,6 +12674,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oxide.ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/oxide.ts/-/oxide.ts-1.1.0.tgz",
+      "integrity": "sha512-+MkqFRQVHEe/x4/cJ6KuYz2m2VpnoBi7aKLbttGYTxmpNZalQ2RbKH2HxyfsTqXJhjh9DYxulPWfQV/hWMmzCg=="
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "moderndash": "^4.0.0",
     "moize": "^6.1.6",
     "morgan": "^1.10.0",
+    "oxide.ts": "^1.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.5.3",


### PR DESCRIPTION
### Description
Initial commit to bring `oxide.ts` into CDCP.  This package allows us to use established functional programming types `Option` and `Result` which opens up a world of stronger typing and error handling capabilities.  This initial PR includes it in `package.json` and subsequently updates the `client-friendly-status` service/repository to use it as a reference implementation.  Future PRs to follow for the other services/repositories.  Not all `oxide.ts` features are leveraged in this PR simply to limit the scope.

### Related Azure Boards Work Items
AB#6375

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`