### PR TITLE
refactor(frontend) option type inclusion

### DIFF
--- a/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/client-friendly-status.repository.test.ts
@@ -60,7 +60,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.listAllClientFriendlyStatuses();
 
-    expect(actual.ok().unwrap()).toEqual(responseDataMock.value);
+    expect(actual).toEqual(responseDataMock.value);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
@@ -99,7 +99,7 @@ describe('DefaultClientFriendlyStatusRepository', () => {
     const repository = new DefaultClientFriendlyStatusRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findClientFriendlyStatusById('1');
 
-    expect(actual.unwrap().unwrap()).toEqual(responseDataMock.value[0]);
+    expect(actual.unwrap()).toEqual(responseDataMock.value[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.client-friendly-statuses.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_clientfriendlystatuses?%24select=esdc_clientfriendlystatusid%2Cesdc_descriptionenglish%2Cesdc_descriptionfrench&%24filter=statecode+eq+0'),
@@ -132,7 +132,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatuses = await repository.listAllClientFriendlyStatuses();
 
-    expect(clientFriendlyStatuses.unwrap()).toEqual([
+    expect(clientFriendlyStatuses).toEqual([
       {
         esdc_clientfriendlystatusid: '1',
         esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
@@ -153,7 +153,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatuses = await repository.listAllClientFriendlyStatuses();
 
-    expect(clientFriendlyStatuses.unwrap()).toEqual([]);
+    expect(clientFriendlyStatuses).toEqual([]);
   });
 
   it('should get a client friendly status by id', async () => {
@@ -161,7 +161,7 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatus = await repository.findClientFriendlyStatusById('1');
 
-    expect(clientFriendlyStatus.unwrap().unwrap()).toEqual({
+    expect(clientFriendlyStatus.unwrap()).toEqual({
       esdc_clientfriendlystatusid: '1',
       esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
       esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
@@ -173,6 +173,6 @@ describe('MockClientFriendlyStatusRepository', () => {
 
     const clientFriendlyStatus = await repository.findClientFriendlyStatusById('non-existent-id');
 
-    expect(clientFriendlyStatus.unwrap()).toBe(None);
+    expect(clientFriendlyStatus).toBe(None);
   });
 });

--- a/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
+++ b/frontend/__tests__/.server/domain/repositories/country.repository.test.ts
@@ -1,3 +1,4 @@
+import { None } from 'oxide.ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -108,7 +109,7 @@ describe('DefaultCountryRepository', () => {
     const repository = new DefaultCountryRepository(serverConfigMock, httpClientMock);
     const actual = await repository.findCountryById('1');
 
-    expect(actual).toEqual(responseDataMock.value[0]);
+    expect(actual.unwrap()).toEqual(responseDataMock.value[0]);
     expect(httpClientMock.instrumentedFetch).toHaveBeenCalledExactlyOnceWith(
       'http.client.interop-api.countries.gets',
       new URL('https://api.example.com/dental-care/code-list/pp/v1/esdc_countries?%24select=esdc_countryid%2Cesdc_nameenglish%2Cesdc_namefrench%2Cesdc_countrycodealpha3&%24filter=statecode+eq+0+and+esdc_enabledentalapplicationportal+eq+true'),
@@ -172,7 +173,7 @@ describe('MockCountryRepository', () => {
 
     const country = await repository.findCountryById('1');
 
-    expect(country).toEqual({
+    expect(country.unwrap()).toEqual({
       esdc_countryid: '1',
       esdc_nameenglish: 'Canada English',
       esdc_namefrench: 'Canada Français',
@@ -185,6 +186,6 @@ describe('MockCountryRepository', () => {
 
     const country = await repository.findCountryById('non-existent-id');
 
-    expect(country).toBeNull();
+    expect(country).toBe(None);
   });
 });

--- a/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-friendly-status.service.test.ts
@@ -1,5 +1,5 @@
 import type { Moized } from 'moize';
-import { None, Ok, Some } from 'oxide.ts';
+import { None, Some } from 'oxide.ts';
 import { describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -33,13 +33,11 @@ describe('DefaultClientFriendlyStatusService', () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
       mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(
-        Ok(
-          Some({
-            esdc_clientfriendlystatusid: '1',
-            esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
-            esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
-          }),
-        ),
+        Some({
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        }),
       );
 
       const mockDto: ClientFriendlyStatusDto = {
@@ -55,7 +53,7 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const dto = await service.getClientFriendlyStatusById(id);
 
-      expect(dto.unwrap()).toEqual(mockDto);
+      expect(dto).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).toHaveBeenCalledOnce();
     });
@@ -63,14 +61,13 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(Ok(None));
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(None);
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      const result = await service.getClientFriendlyStatusById(id);
-      expect(result.unwrapErr()).toBeInstanceOf(ClientFriendlyStatusNotFoundException);
+      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusEntityToClientFriendlyStatusDto).not.toHaveBeenCalled();
     });
@@ -81,13 +78,11 @@ describe('DefaultClientFriendlyStatusService', () => {
       const id = '1';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
       mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(
-        Ok(
-          Some({
-            esdc_clientfriendlystatusid: '1',
-            esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
-            esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
-          }),
-        ),
+        Some({
+          esdc_clientfriendlystatusid: '1',
+          esdc_descriptionenglish: 'You have qualified for the Canadian Dental Care Plan.',
+          esdc_descriptionfrench: 'Vous êtes admissible au Régime canadien de soins dentaires.',
+        }),
       );
 
       const mockDto: ClientFriendlyStatusLocalizedDto = { id: '1', name: 'You have qualified for the Canadian Dental Care Plan.' };
@@ -99,7 +94,7 @@ describe('DefaultClientFriendlyStatusService', () => {
 
       const dto = await service.getLocalizedClientFriendlyStatusById(id, 'en');
 
-      expect(dto.unwrap()).toEqual(mockDto);
+      expect(dto).toEqual(mockDto);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).toHaveBeenCalledOnce();
     });
@@ -107,14 +102,13 @@ describe('DefaultClientFriendlyStatusService', () => {
     it('fetches localized client friendly status by id throws not found exception', async () => {
       const id = '1033';
       const mockClientFriendlyStatusRepository = mock<ClientFriendlyStatusRepository>();
-      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(Ok(None));
+      mockClientFriendlyStatusRepository.findClientFriendlyStatusById.mockResolvedValueOnce(None);
 
       const mockClientFriendlyStatusDtoMapper = mock<ClientFriendlyStatusDtoMapper>();
 
       const service = new DefaultClientFriendlyStatusService(mockClientFriendlyStatusDtoMapper, mockClientFriendlyStatusRepository, mockServerConfig);
 
-      const result = await service.getClientFriendlyStatusById(id);
-      expect(result.unwrapErr()).toBeInstanceOf(ClientFriendlyStatusNotFoundException);
+      await expect(async () => await service.getClientFriendlyStatusById(id)).rejects.toThrow(ClientFriendlyStatusNotFoundException);
       expect(mockClientFriendlyStatusRepository.findClientFriendlyStatusById).toHaveBeenCalledOnce();
       expect(mockClientFriendlyStatusDtoMapper.mapClientFriendlyStatusDtoToClientFriendlyStatusLocalizedDto).not.toHaveBeenCalled();
     });

--- a/frontend/__tests__/.server/domain/services/country.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/country.service.test.ts
@@ -1,4 +1,5 @@
 import type { Moized } from 'moize';
+import { None, Some } from 'oxide.ts';
 import { describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -70,12 +71,14 @@ describe('DefaultCountryService', () => {
     it('fetches country by id', async () => {
       const id = '1';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockResolvedValueOnce({
-        esdc_countryid: '1',
-        esdc_nameenglish: 'Canada English',
-        esdc_namefrench: 'Canada Français',
-        esdc_countrycodealpha3: 'CAN',
-      });
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(
+        Some({
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+          esdc_countrycodealpha3: 'CAN',
+        }),
+      );
 
       const mockDto: CountryDto = { id: '1', nameEn: 'Canada English', nameFr: 'Canada Français' };
 
@@ -94,7 +97,7 @@ describe('DefaultCountryService', () => {
     it('fetches country by id throws not found exception', async () => {
       const id = '1033';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockResolvedValueOnce(null);
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(None);
 
       const mockCountryDtoMapper = mock<CountryDtoMapper>();
 
@@ -159,12 +162,14 @@ describe('DefaultCountryService', () => {
     it('fetches localized country by id', async () => {
       const id = '1';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockResolvedValueOnce({
-        esdc_countryid: '1',
-        esdc_nameenglish: 'Canada English',
-        esdc_namefrench: 'Canada Français',
-        esdc_countrycodealpha3: 'CAN',
-      });
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(
+        Some({
+          esdc_countryid: '1',
+          esdc_nameenglish: 'Canada English',
+          esdc_namefrench: 'Canada Français',
+          esdc_countrycodealpha3: 'CAN',
+        }),
+      );
 
       const mockDto: CountryLocalizedDto = { id: '1', name: 'Canada English' };
 
@@ -183,7 +188,7 @@ describe('DefaultCountryService', () => {
     it('fetches localized country by id throws not found exception', async () => {
       const id = '1033';
       const mockCountryRepository = mock<CountryRepository>();
-      mockCountryRepository.findCountryById.mockResolvedValueOnce(null);
+      mockCountryRepository.findCountryById.mockResolvedValueOnce(None);
 
       const mockCountryDtoMapper = mock<CountryDtoMapper>();
 

--- a/frontend/app/.server/domain/repositories/country.repository.ts
+++ b/frontend/app/.server/domain/repositories/country.repository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import { None, Option, Some } from 'oxide.ts';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
@@ -21,7 +22,7 @@ export interface CountryRepository {
    * @param id The id of the country entity.
    * @returns The country entity or null if not found.
    */
-  findCountryById(id: string): Promise<CountryEntity | null>;
+  findCountryById(id: string): Promise<Option<CountryEntity>>;
 
   /**
    * Retrieves metadata associated with the country repository.
@@ -93,7 +94,7 @@ export class DefaultCountryRepository implements CountryRepository {
     return countryEntities;
   }
 
-  async findCountryById(id: string): Promise<CountryEntity | null> {
+  async findCountryById(id: string): Promise<Option<CountryEntity>> {
     this.log.debug('Fetching country with id: [%s]', id);
 
     const countryEntities = await this.listAllCountries();
@@ -101,11 +102,11 @@ export class DefaultCountryRepository implements CountryRepository {
 
     if (!countryEntity) {
       this.log.warn('Country not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
     this.log.trace('Returning country: [%j]', countryEntity);
-    return countryEntity;
+    return Some(countryEntity);
   }
 
   getMetadata(): Record<string, string> {
@@ -140,7 +141,7 @@ export class MockCountryRepository implements CountryRepository {
     return await Promise.resolve(countryEntities);
   }
 
-  async findCountryById(id: string): Promise<CountryEntity | null> {
+  async findCountryById(id: string): Promise<Option<CountryEntity>> {
     this.log.debug('Fetching country with id: [%s]', id);
 
     const countryEntities = countryJsonDataSource.value;
@@ -148,10 +149,10 @@ export class MockCountryRepository implements CountryRepository {
 
     if (!countryEntity) {
       this.log.warn('Country not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return await Promise.resolve(countryEntity);
+    return await Promise.resolve(Some(countryEntity));
   }
 
   getMetadata(): Record<string, string> {

--- a/frontend/app/.server/domain/services/country.service.ts
+++ b/frontend/app/.server/domain/services/country.service.ts
@@ -136,12 +136,12 @@ export class DefaultCountryService implements CountryService {
     this.log.debug('Get country with id: [%s]', id);
     const countryEntity = await this.countryRepository.findCountryById(id);
 
-    if (!countryEntity) {
+    if (countryEntity.isNone()) {
       this.log.error('Country with id: [%s] not found', id);
       throw new CountryNotFoundException(`Country with id: [${id}] not found`);
     }
 
-    const countryDto = this.countryDtoMapper.mapCountryEntityToCountryDto(countryEntity);
+    const countryDto = this.countryDtoMapper.mapCountryEntityToCountryDto(countryEntity.unwrap());
     this.log.trace('Returning country: [%j]', countryDto);
     return countryDto;
   }

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -54,7 +54,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const clientFriendlyStatus = statusId ? await appContainer.get(TYPES.domain.services.ClientFriendlyStatusService).getLocalizedClientFriendlyStatusById(statusId, locale) : null;
 
   return {
-    statusResult: { alertType, clientFriendlyStatus: clientFriendlyStatus?.unwrap() },
+    statusResult: { alertType, clientFriendlyStatus },
     meta,
   };
 }


### PR DESCRIPTION
### Description
Before I left for vacation we discussed using the `Option` type for `findBy*` repository methods to make it clear that these methods can return `Some(T)` or `None`.  This PR reverts some of the changes in #3919, and updates the country service/repository to use the `Option` type.  Future PRs to come to add Option to the other services/repositories.

### Related Azure Boards Work Items
AB#6375