### PR TITLE
build(frontend): Bump container node to 22.17.1-bookworm-slim

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -24,7 +24,7 @@
 
 
 # Base image used for all future stages
-ARG BASE_IMAGE=docker.io/node:22.17.0-bookworm-slim
+ARG BASE_IMAGE=docker.io/node:22.17.1-bookworm-slim
 FROM $BASE_IMAGE AS base
 ENV NODE_ENV production
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

[Node v22.17.1 (LTS)](https://nodejs.org/en/blog/release/v22.17.1)