### PR TITLE
refactor(frontend) use Option in applicant dto mapper and service

### DIFF
--- a/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
@@ -1,10 +1,11 @@
 import { injectable } from 'inversify';
+import { Option } from 'oxide.ts';
 
 import type { ApplicantRequestEntity, ApplicantResponseEntity } from '~/.server/domain/entities';
 
 export interface ApplicantDtoMapper {
   mapSinToApplicantRequestEntity(sin: string): ApplicantRequestEntity;
-  mapApplicantResponseEntityToClientNumber(applicantResponseEntity: ApplicantResponseEntity): string | null;
+  mapApplicantResponseEntityToClientNumber(applicantResponseEntity: ApplicantResponseEntity): Option<string>;
 }
 
 @injectable()
@@ -19,8 +20,7 @@ export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
     };
   }
 
-  mapApplicantResponseEntityToClientNumber(applicantResponseEntity: ApplicantResponseEntity): string | null {
-    const clientNumber = applicantResponseEntity.BenefitApplication?.Applicant?.ClientIdentification?.find(({ IdentificationCategoryText }) => IdentificationCategoryText === 'Client Number')?.IdentificationID;
-    return clientNumber ?? null;
+  mapApplicantResponseEntityToClientNumber(applicantResponseEntity: ApplicantResponseEntity): Option<string> {
+    return Option.from(applicantResponseEntity.BenefitApplication?.Applicant?.ClientIdentification?.find(({ IdentificationCategoryText }) => IdentificationCategoryText === 'Client Number')?.IdentificationID);
   }
 }

--- a/frontend/app/.server/domain/services/applicant.service.ts
+++ b/frontend/app/.server/domain/services/applicant.service.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import { None, Option, Some } from 'oxide.ts';
+import { None, Option } from 'oxide.ts';
 
 import { TYPES } from '~/.server/constants';
 import type { ApplicantRequestDto } from '~/.server/domain/dtos';
@@ -58,8 +58,7 @@ export class DefaultApplicantService implements ApplicantService {
     }
 
     const clientNumber = this.applicantDtoMapper.mapApplicantResponseEntityToClientNumber(applicantResponseEntity.unwrap());
-    this.log.trace('Returning client number [%s] for sin [%s]', clientNumber, sin);
-
-    return clientNumber ? Some(clientNumber) : None;
+    this.log.trace('Returning client number [%s] for sin [%s]', clientNumber.unwrapUnchecked(), sin);
+    return clientNumber;
   }
 }


### PR DESCRIPTION
### Description
Expands coverage of the Option type to the applicant dto mapper and subsequently modifies the service.

### Related Azure Boards Work Items
AB#6375


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`