### PR TITLE
refactor(frontend) use Option is demographic survey

### DIFF
--- a/frontend/app/.server/domain/repositories/demographic-survey.repository.ts
+++ b/frontend/app/.server/domain/repositories/demographic-survey.repository.ts
@@ -1,4 +1,5 @@
 import { injectable } from 'inversify';
+import { None, Option, Some } from 'oxide.ts';
 
 import type { DisabilityStatusEntity, EthnicGroupEntity, FirstNationsEntity, GenderStatusEntity, IndigenousStatusEntity, LocationBornStatusEntity } from '~/.server/domain/entities';
 import { createLogger } from '~/.server/logging';
@@ -22,7 +23,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the indigenous status entity.
    * @returns The indigenous status entity or null if not found.
    */
-  findIndigenousStatusById(id: string): IndigenousStatusEntity | null;
+  findIndigenousStatusById(id: string): Option<IndigenousStatusEntity>;
 
   /**
    * Fetch all First Nations entities.
@@ -35,7 +36,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the First Nations entity.
    * @returns The First Nations entity or null if not found.
    */
-  findFirstNationsById(id: string): FirstNationsEntity | null;
+  findFirstNationsById(id: string): Option<FirstNationsEntity>;
 
   /**
    * Fetch all disability status entities.
@@ -48,7 +49,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the disability status entity.
    * @returns The disability status entity or null if not found.
    */
-  findDisabilityStatusById(id: string): DisabilityStatusEntity | null;
+  findDisabilityStatusById(id: string): Option<DisabilityStatusEntity>;
 
   /**
    * Fetch all location born status entities.
@@ -61,7 +62,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the location born status entity.
    * @returns The location born status entity or null if not found.
    */
-  findEthnicGroupById(id: string): EthnicGroupEntity | null;
+  findEthnicGroupById(id: string): Option<EthnicGroupEntity>;
 
   /**
    * Fetch all location born status entities.
@@ -74,7 +75,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the location born status entity.
    * @returns The location born status entity or null if not found.
    */
-  findLocationBornStatusById(id: string): LocationBornStatusEntity | null;
+  findLocationBornStatusById(id: string): Option<LocationBornStatusEntity>;
 
   /**
    * Fetch all gender status entities.
@@ -87,7 +88,7 @@ export interface DemographicSurveyRepository {
    * @param id The id of the gender status entity.
    * @returns The gender status entity or null if not found.
    */
-  findGenderStatusById(id: string): GenderStatusEntity | null;
+  findGenderStatusById(id: string): Option<GenderStatusEntity>;
 }
 
 @injectable()
@@ -111,7 +112,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return indigenousStatusEntities;
   }
 
-  findIndigenousStatusById(id: string): IndigenousStatusEntity | null {
+  findIndigenousStatusById(id: string): Option<IndigenousStatusEntity> {
     this.log.debug('Fetching indigenous status with id: [%s]', id);
 
     const indigenousStatusEntities = IndigenousStatusJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -119,10 +120,10 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!indigenousStatusEntity) {
       this.log.warn('indigenous status not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return indigenousStatusEntity;
+    return Some(indigenousStatusEntity);
   }
 
   listAllFirstNations(): FirstNationsEntity[] {
@@ -138,7 +139,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return firstNationsEntities;
   }
 
-  findFirstNationsById(id: string): FirstNationsEntity | null {
+  findFirstNationsById(id: string): Option<FirstNationsEntity> {
     this.log.debug('Fetching First Nations with id: [%s]', id);
 
     const firstNationsEntities = FirstNationsJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -146,10 +147,10 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!firstNationsEntity) {
       this.log.warn('First Nations not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return firstNationsEntity;
+    return Some(firstNationsEntity);
   }
 
   listAllDisabilityStatuses(): DisabilityStatusEntity[] {
@@ -165,7 +166,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return disabilityStatusEntities;
   }
 
-  findDisabilityStatusById(id: string): DisabilityStatusEntity | null {
+  findDisabilityStatusById(id: string): Option<DisabilityStatusEntity> {
     this.log.debug('Fetching disability status with id: [%s]', id);
 
     const disabilityStatusEntities = DisabilityStatusJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -173,10 +174,10 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!disabilityStatusEntity) {
       this.log.warn('disability status not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return disabilityStatusEntity;
+    return Some(disabilityStatusEntity);
   }
 
   listAllEthnicGroups(): EthnicGroupEntity[] {
@@ -192,7 +193,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return ethnicGroupEntities;
   }
 
-  findEthnicGroupById(id: string): EthnicGroupEntity | null {
+  findEthnicGroupById(id: string): Option<EthnicGroupEntity> {
     this.log.debug('Fetching location born status with id: [%s]', id);
 
     const ethnicGroupEntities = EthnicGroupJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -200,10 +201,10 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!ethnicGroupEntity) {
       this.log.warn('location born status not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return ethnicGroupEntity;
+    return Some(ethnicGroupEntity);
   }
 
   listAllLocationBornStatuses(): LocationBornStatusEntity[] {
@@ -219,7 +220,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return locationBornStatusEntities;
   }
 
-  findLocationBornStatusById(id: string): LocationBornStatusEntity | null {
+  findLocationBornStatusById(id: string): Option<LocationBornStatusEntity> {
     this.log.debug('Fetching location born status with id: [%s]', id);
 
     const locationBornStatusEntities = LocationBornStatusJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -227,10 +228,10 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!locationBornStatusEntity) {
       this.log.warn('location born status not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return locationBornStatusEntity;
+    return Some(locationBornStatusEntity);
   }
 
   listAllGenderStatuses(): GenderStatusEntity[] {
@@ -246,7 +247,7 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
     return genderStatusEntities;
   }
 
-  findGenderStatusById(id: string): GenderStatusEntity | null {
+  findGenderStatusById(id: string): Option<GenderStatusEntity> {
     this.log.debug('Fetching gender status with id: [%s]', id);
 
     const genderStatusEntities = GenderStatusJsonDataSource.value.at(0)?.OptionSet.Options;
@@ -254,9 +255,9 @@ export class DefaultDemographicSurveyRepository implements DemographicSurveyRepo
 
     if (!genderStatusEntity) {
       this.log.warn('gender status not found; id: [%s]', id);
-      return null;
+      return None;
     }
 
-    return genderStatusEntity;
+    return Some(genderStatusEntity);
   }
 }

--- a/frontend/app/.server/domain/services/demographic-survey.service.ts
+++ b/frontend/app/.server/domain/services/demographic-survey.service.ts
@@ -347,12 +347,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get inidigenous status with id: [%s]', id);
     const indigenousStatusEntity = this.DemographicSurveyRepository.findIndigenousStatusById(id);
 
-    if (!indigenousStatusEntity) {
+    if (indigenousStatusEntity.isNone()) {
       this.log.error('inidigenous status with id: [%s] not found', id);
       throw new IndigenousStatusNotFoundException(`inidigenous status with id: [${id}] not found`);
     }
 
-    const indigenousStatusDto = this.DemographicSurveyDtoMapper.mapIndigenousStatusEntityToIndigenousStatusDto(indigenousStatusEntity);
+    const indigenousStatusDto = this.DemographicSurveyDtoMapper.mapIndigenousStatusEntityToIndigenousStatusDto(indigenousStatusEntity.unwrap());
     this.log.trace('Returning inidigenous status: [%j]', indigenousStatusDto);
     return indigenousStatusDto;
   }
@@ -386,12 +386,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get First Nation with id: [%s]', id);
     const firstNationsEntity = this.DemographicSurveyRepository.findFirstNationsById(id);
 
-    if (!firstNationsEntity) {
+    if (firstNationsEntity.isNone()) {
       this.log.error('First Nation with id: [%s] not found', id);
       throw new FirstNationsNotFoundException(`First Nation with id: [${id}] not found`);
     }
 
-    const firstNationsDto = this.DemographicSurveyDtoMapper.mapFirstNationsEntityToFirstNationsDto(firstNationsEntity);
+    const firstNationsDto = this.DemographicSurveyDtoMapper.mapFirstNationsEntityToFirstNationsDto(firstNationsEntity.unwrap());
     this.log.trace('Returning First Nation: [%j]', firstNationsDto);
     return firstNationsDto;
   }
@@ -425,12 +425,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get disability status with id: [%s]', id);
     const disabilityStatusEntity = this.DemographicSurveyRepository.findDisabilityStatusById(id);
 
-    if (!disabilityStatusEntity) {
+    if (disabilityStatusEntity.isNone()) {
       this.log.error('disability status with id: [%s] not found', id);
       throw new DisabilityStatusNotFoundException(`disability status with id: [${id}] not found`);
     }
 
-    const disabilityStatusDto = this.DemographicSurveyDtoMapper.mapDisabilityStatusEntityToDisabilityStatusDto(disabilityStatusEntity);
+    const disabilityStatusDto = this.DemographicSurveyDtoMapper.mapDisabilityStatusEntityToDisabilityStatusDto(disabilityStatusEntity.unwrap());
     this.log.trace('Returning disability status: [%j]', disabilityStatusDto);
     return disabilityStatusDto;
   }
@@ -464,12 +464,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get ethnic group with id: [%s]', id);
     const ethnicGroupEntity = this.DemographicSurveyRepository.findEthnicGroupById(id);
 
-    if (!ethnicGroupEntity) {
+    if (ethnicGroupEntity.isNone()) {
       this.log.error('ethnic group with id: [%s] not found', id);
       throw new EthnicGroupNotFoundException(`ethnic group with id: [${id}] not found`);
     }
 
-    const ethnicGroupDto = this.DemographicSurveyDtoMapper.mapEthnicGroupEntityToEthnicGroupDto(ethnicGroupEntity);
+    const ethnicGroupDto = this.DemographicSurveyDtoMapper.mapEthnicGroupEntityToEthnicGroupDto(ethnicGroupEntity.unwrap());
     this.log.trace('Returning ethnic group: [%j]', ethnicGroupDto);
     return ethnicGroupDto;
   }
@@ -503,12 +503,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get location born status with id: [%s]', id);
     const locationBornStatusEntity = this.DemographicSurveyRepository.findLocationBornStatusById(id);
 
-    if (!locationBornStatusEntity) {
+    if (locationBornStatusEntity.isNone()) {
       this.log.error('location born status with id: [%s] not found', id);
       throw new LocationBornStatusNotFoundException(`location born status with id: [${id}] not found`);
     }
 
-    const locationBornStatusDto = this.DemographicSurveyDtoMapper.mapLocationBornStatusEntityToLocationBornStatusDto(locationBornStatusEntity);
+    const locationBornStatusDto = this.DemographicSurveyDtoMapper.mapLocationBornStatusEntityToLocationBornStatusDto(locationBornStatusEntity.unwrap());
     this.log.trace('Returning location born status: [%j]', locationBornStatusDto);
     return locationBornStatusDto;
   }
@@ -542,12 +542,12 @@ export class DefaultDemographicSurveyServiceService implements DemographicSurvey
     this.log.debug('Get gender status with id: [%s]', id);
     const genderStatusEntity = this.DemographicSurveyRepository.findGenderStatusById(id);
 
-    if (!genderStatusEntity) {
+    if (genderStatusEntity.isNone()) {
       this.log.error('gender status with id: [%s] not found', id);
       throw new GenderStatusNotFoundException(`gender status with id: [${id}] not found`);
     }
 
-    const genderStatusDto = this.DemographicSurveyDtoMapper.mapGenderStatusEntityToGenderStatusDto(genderStatusEntity);
+    const genderStatusDto = this.DemographicSurveyDtoMapper.mapGenderStatusEntityToGenderStatusDto(genderStatusEntity.unwrap());
     this.log.trace('Returning gender status: [%j]', genderStatusDto);
     return genderStatusDto;
   }


### PR DESCRIPTION
### Description
Completely unnecessary PR since demographic survey isn't used, but this updates the method signatures to use `Option` just in case.

### Related Azure Boards Work Items
AB#6375


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`