### PR TITLE
chore(gitops): bump UAT1 frontend to 6.0.0-RC169

### DIFF
--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-fecf0e06
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0-RC169
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

As per title.

<img width="874" height="154" alt="image" src="https://github.com/user-attachments/assets/f11bfa89-aa85-4f84-b490-c8583280ac70" />
