### PR TITLE
AB#6504 -- Added survey link to confirmation pages

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -460,3 +460,9 @@ APPLY_ELIGIBILITY_RULES='[{"minAge":18,"maxAge":34,"startDate":"2025-05-15T04:00
 # Application killswitch TTL -- used to disable the application submissions when an HTTP429 is encountered
 # (optional; default: 300 seconds ... 5 minutes)
 APPLICATION_KILLSWITCH_TTL_SECONDS=300
+
+#
+# CDCP Survey URLs
+#
+CDCP_SURVEY_LINK_EN=https://canada-preview.adobecqms.net/en/services/benefits/dental/dental-care-plan/questionnaire-after-application.html
+CDCP_SURVEY_LINK_FR=https://canada-preview.adobecqms.net/fr/services/prestations/dentaire/regime-soins-dentaires/questionnaire-apres-processus-demande.html

--- a/frontend/__tests__/components/client-env.test.tsx
+++ b/frontend/__tests__/components/client-env.test.tsx
@@ -36,6 +36,8 @@ describe('<ClientEnv>', () => {
       SESSION_TIMEOUT_SECONDS: 120,
       USA_COUNTRY_ID: 'USA',
       INVALID_LETTER_TYPE_IDS: ['101010'],
+      CDCP_SURVEY_LINK_EN: 'https://canada-preview.adobecqms.net/en/services/benefits/dental/dental-care-plan/questionnaire-after-application.html',
+      CDCP_SURVEY_LINK_FR: 'https://canada-preview.adobecqms.net/fr/services/prestations/dentaire/regime-soins-dentaires/questionnaire-apres-processus-demande.html',
     };
 
     const { container } = render(<ClientEnvComponent env={env} nonce={nonce} />);

--- a/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/confirmation.tsx
@@ -12,7 +12,7 @@ import { clearProtectedApplyState, getChildrenState } from '~/.server/routes/hel
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -58,6 +58,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     getChildrenState(state).length === 0) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
@@ -159,6 +162,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -187,7 +191,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, surveyLink } = loaderData;
 
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} className="external-link" newTabIndicator target="_blank" />;
   const cdcpLink = <InlineLink to={t('protected-apply-adult-child:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
@@ -224,6 +228,26 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
           {t('confirm.print-btn')}
         </Button>
       </section>
+
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Adult_Child:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>

--- a/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/confirmation.tsx
@@ -12,7 +12,7 @@ import { clearProtectedApplyState } from '~/.server/routes/helpers/protected-app
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -57,6 +57,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     state.typeOfApplication === undefined) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.federalSocialProgram
     ? await appContainer.get(TYPES.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
@@ -125,6 +128,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -151,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ProtectedApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, surveyLink } = loaderData;
 
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} className="external-link" newTabIndicator target="_blank" />;
   const cdcpLink = <InlineLink to={t('protected-apply-adult:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
@@ -188,6 +192,26 @@ export default function ProtectedApplyFlowConfirm({ loaderData, params }: Route.
           {t('confirm.print-btn')}
         </Button>
       </section>
+
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Adult:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>

--- a/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/confirmation.tsx
@@ -12,7 +12,7 @@ import { clearProtectedApplyState, getChildrenState } from '~/.server/routes/hel
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -56,6 +56,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     getChildrenState(state).length === 0) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
@@ -147,6 +150,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -174,7 +178,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo } = loaderData;
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo, surveyLink } = loaderData;
 
   const dentalContactUsLink = <InlineLink to={t('confirm.dental-link')} className="external-link" newTabIndicator target="_blank" />;
   const cdcpLink = <InlineLink to={t('protected-apply-child:confirm.status-checker-link')} className="external-link" newTabIndicator target="_blank" />;
@@ -207,6 +211,25 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
           {t('confirm.print-btn')}
         </Button>
       </section>
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Child:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
         <p className="mt-4">{t('confirm.begin-process')}</p>
@@ -409,7 +432,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
             </fetcher.Form>
           </DialogFooter>
         </DialogContent>
-      </Dialog>{' '}
+      </Dialog>
     </div>
   );
 }

--- a/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/confirmation.tsx
@@ -11,7 +11,7 @@ import { loadApplyAdultChildState } from '~/.server/routes/helpers/apply-adult-c
 import { clearApplyState, getChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -54,6 +54,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     getChildrenState(state).length === 0) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
@@ -152,6 +155,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -172,7 +176,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, surveyLink } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -211,6 +215,26 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
           {t('confirm.print-btn')}
         </Button>
       </section>
+
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult_Child:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>

--- a/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/confirmation.tsx
@@ -11,7 +11,7 @@ import { loadApplyAdultState } from '~/.server/routes/helpers/apply-adult-route-
 import { clearApplyState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -53,6 +53,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     state.typeOfApplication === undefined) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.federalSocialProgram
     ? await appContainer.get(TYPES.FederalGovernmentInsurancePlanService).getLocalizedFederalGovernmentInsurancePlanById(state.dentalBenefits.federalSocialProgram, locale)
@@ -118,6 +121,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -139,7 +143,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo } = loaderData;
+  const { userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, dentalInsurance, submissionInfo, surveyLink } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -178,6 +182,26 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
           {t('confirm.print-btn')}
         </Button>
       </section>
+
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>

--- a/frontend/app/routes/public/apply/$id/child/confirmation.tsx
+++ b/frontend/app/routes/public/apply/$id/child/confirmation.tsx
@@ -11,7 +11,7 @@ import { loadApplyChildState } from '~/.server/routes/helpers/apply-child-route-
 import { clearApplyState, getChildrenState } from '~/.server/routes/helpers/apply-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
-import { Button } from '~/components/buttons';
+import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DescriptionListItem } from '~/components/description-list-item';
@@ -52,6 +52,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     getChildrenState(state).length === 0) {
     throw new Error(`Incomplete application "${state.id}" state!`);
   }
+
+  const env = appContainer.get(TYPES.ClientConfig);
+  const surveyLink = locale === 'en' ? env.CDCP_SURVEY_LINK_EN : env.CDCP_SURVEY_LINK_FR;
 
   const mailingProvinceTerritoryStateAbbr = state.mailingAddress.province ? await appContainer.get(TYPES.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.mailingAddress.province) : undefined;
   const homeProvinceTerritoryStateAbbr = state.homeAddress?.province ? await appContainer.get(TYPES.ProvinceTerritoryStateService).getProvinceTerritoryStateById(state.homeAddress.province) : undefined;
@@ -140,6 +143,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     spouseInfo,
     submissionInfo: state.submissionInfo,
+    surveyLink,
     userInfo,
   };
 }
@@ -160,7 +164,7 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplyFlowConfirm({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const fetcher = useFetcher<typeof action>();
-  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo } = loaderData;
+  const { children, userInfo, spouseInfo, homeAddressInfo, mailingAddressInfo, submissionInfo, surveyLink } = loaderData;
 
   const mscaLinkAccount = <InlineLink to={t('confirm.msca-link-account')} className="external-link" newTabIndicator target="_blank" />;
   const mscaLinkChecker = <InlineLink to={t('confirm.msca-link-checker')} className="external-link" newTabIndicator target="_blank" />;
@@ -195,6 +199,25 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
           {t('confirm.print-btn')}
         </Button>
       </section>
+      <ContextualAlert type="comment">
+        <div className="space-y-4">
+          <p className="text-2xl">
+            <strong>{t('confirm.survey.title')}</strong>
+          </p>
+          <p>{t('confirm.survey.info')}</p>
+          <ButtonLink
+            id="survey-button"
+            to={surveyLink}
+            className="external-link"
+            newTabIndicator
+            target="_blank"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Child:Confirmation survey button - Take the survey click"
+            variant="primary"
+          >
+            {t('confirm.survey.button')}
+          </ButtonLink>
+        </div>
+      </ContextualAlert>
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
         <p className="mt-4">{t('confirm.begin-process')}</p>
@@ -409,7 +432,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
             </fetcher.Form>
           </DialogFooter>
         </DialogContent>
-      </Dialog>{' '}
+      </Dialog>
     </div>
   );
 }

--- a/frontend/app/utils/env-utils.ts
+++ b/frontend/app/utils/env-utils.ts
@@ -58,7 +58,11 @@ export const clientEnvSchema = z.object({
   COMMUNICATION_METHOD_GC_MAIL_ID: z.string().trim().min(1).default('775170002'),
   CLIENT_STATUS_SUCCESS_ID: z.string().trim().min(1).default('51af5170-614e-ee11-be6f-000d3a09d640'),
   INVALID_CLIENT_FRIENDLY_STATUS: z.string().trim().min(1).default('504fba6e-604e-ee11-be6f-000d3a09d640'),
-  INVALID_LETTER_TYPE_IDS: z.string().trim().transform(csvToArray).default(['775170000'])
+  INVALID_LETTER_TYPE_IDS: z.string().trim().transform(csvToArray).default(['775170000']),
+
+  // CDCP Survey URLs
+  CDCP_SURVEY_LINK_EN: z.url().default('https://canada-preview.adobecqms.net/en/services/benefits/dental/dental-care-plan/questionnaire-after-application.html'),
+  CDCP_SURVEY_LINK_FR: z.url().default('https://canada-preview.adobecqms.net/fr/services/prestations/dentaire/regime-soins-dentaires/questionnaire-apres-processus-demande.html')
 });
 
 export type ClientEnv = z.infer<typeof clientEnvSchema>;

--- a/frontend/public/locales/en/apply-adult-child.json
+++ b/frontend/public/locales/en/apply-adult-child.json
@@ -450,6 +450,11 @@
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back",
       "close-btn": "Close application"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/en/apply-adult.json
+++ b/frontend/public/locales/en/apply-adult.json
@@ -201,6 +201,11 @@
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back",
       "close-btn": "Close application"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/en/apply-child.json
+++ b/frontend/public/locales/en/apply-child.json
@@ -450,6 +450,11 @@
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back",
       "close-btn": "Close application"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "contact-apply-child": {

--- a/frontend/public/locales/en/protected-apply-adult-child.json
+++ b/frontend/public/locales/en/protected-apply-adult-child.json
@@ -440,6 +440,11 @@
       "info": "By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/en/protected-apply-adult.json
+++ b/frontend/public/locales/en/protected-apply-adult.json
@@ -191,6 +191,11 @@
       "info": "By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/en/protected-apply-child.json
+++ b/frontend/public/locales/en/protected-apply-child.json
@@ -438,6 +438,11 @@
       "info": "By closing the application, you will end your session and any information entered will be cleared from your browser. Make sure you printed or save a copy of your application code.",
       "are-you-sure": "Are you sure you want to close the application?",
       "back-btn": "Back"
+    },
+    "survey": {
+      "title": "Give us feedback on your application experience",
+      "info": "You can help us improve the Canada Dental Care Plan with a short survey. This will take just 3 to 5 minutes of your time. The survey will open in a new window.",
+      "button": "Take the survey"
     }
   },
   "contact-apply-child": {

--- a/frontend/public/locales/fr/apply-adult-child.json
+++ b/frontend/public/locales/fr/apply-adult-child.json
@@ -450,6 +450,11 @@
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour",
       "close-btn": "Fermer la demande"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/fr/apply-adult.json
+++ b/frontend/public/locales/fr/apply-adult.json
@@ -201,6 +201,11 @@
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour",
       "close-btn": "Fermer la demande"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/fr/apply-child.json
+++ b/frontend/public/locales/fr/apply-child.json
@@ -450,6 +450,11 @@
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour",
       "close-btn": "Fermer la demande"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "contact-apply-child": {

--- a/frontend/public/locales/fr/protected-apply-adult-child.json
+++ b/frontend/public/locales/fr/protected-apply-adult-child.json
@@ -440,6 +440,11 @@
       "info": "En fermant cette demande, vous mettrez fin à votre session et les informations saisies seront effacées de votre navigateur. Assurez-vous d'avoir une copie de votre code de demande.",
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/fr/protected-apply-adult.json
+++ b/frontend/public/locales/fr/protected-apply-adult.json
@@ -191,6 +191,11 @@
       "info": "En fermant cette demande, vous mettrez fin à votre session et les informations saisies seront effacées de votre navigateur. Assurez-vous d'avoir une copie de votre code de demande.",
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "confirm-dental-benefits": {

--- a/frontend/public/locales/fr/protected-apply-child.json
+++ b/frontend/public/locales/fr/protected-apply-child.json
@@ -438,6 +438,11 @@
       "info": "En fermant cette demande, vous mettrez fin à votre session et les informations saisies seront effacées de votre navigateur. Assurez-vous d'avoir une copie de votre code de demande.",
       "are-you-sure": "Êtes-vous sûr de vouloir fermer la demande?",
       "back-btn": "Retour"
+    },
+    "survey": {
+      "title": "Faites-nous part de vos commentaires sur votre expérience concernant votre demande",
+      "info": "Vous pouvez nous aider à améliorer le Régime canadien de soins dentaires en participant à un court sondage. Cela ne vous prendra que 3 à 5 minutes. Le sondage s'ouvrira dans une nouvelle fenêtre.",
+      "button": "Participez au court sondage"
     }
   },
   "contact-apply-child": {


### PR DESCRIPTION
### Description
 Added a survey section/link to confirmation pages for /apply and /protected routes.

Added prod/non-prod survey link env vars to gitops configs.

### Related Azure Boards Work Items
[AB#6504](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/6504)

### Screenshots (if applicable)
<img width="616" height="260" alt="image" src="https://github.com/user-attachments/assets/a0a9afd3-c392-448f-bbb7-ef3f5038ecb0" />

<img width="604" height="258" alt="image" src="https://github.com/user-attachments/assets/9e6914a6-8cb8-4496-a581-4b67af887db9" />
