### PR TITLE
fix(frontend): Express session issue

### DIFF
--- a/frontend/__tests__/.server/web/session.test.ts
+++ b/frontend/__tests__/.server/web/session.test.ts
@@ -101,14 +101,12 @@ describe('Session', () => {
         const session = new ExpressSession(mockRequestSession);
         session.set('key' as SessionKey, 'value');
         expect(mockRequestSession.key).toBe('value');
-        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
 
       it('should sanitize the key', () => {
         const session = new ExpressSession(mockRequestSession);
         session.set(' sanitized key!@#$%^' as SessionKey, 'value');
         expect(mockRequestSession['_sanitized_key___$__']).toBe('value');
-        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
     });
 
@@ -118,7 +116,6 @@ describe('Session', () => {
         const session = new ExpressSession(mockRequestSession);
         expect(session.unset('key' as SessionKey)).toBe(true);
         expect(mockRequestSession.key).toBeUndefined();
-        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
 
       it('should return false if key does not exist', () => {
@@ -132,7 +129,6 @@ describe('Session', () => {
         const session = new ExpressSession(mockRequestSession);
         expect(session.unset(' sanitized key!@#$%^' as SessionKey)).toBe(true);
         expect(mockRequestSession['_sanitized_key___$__']).toBeUndefined();
-        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
     });
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fix Express session issue where calling `save` was preventing new sessions from being persisted correctly. When users accessed `/en/apply` directly, they were redirected to the T\&C page with a new apply flow ID, but the state was not stored in Redis. This problem only occurred with Redis Sentinel. The fix removes explicit `save` calls on session `set` and `unset`, since the session is already saved before the response is sent. Verified locally with Redis Sentinel.

[Session.save(callback)](https://github.com/expressjs/session?tab=readme-ov-file#sessionsavecallback)

> This method is automatically called at the end of the HTTP response if the session data has been altered (though this behavior can be altered with various options in the middleware constructor). Because of this, typically this method does not need to be called.

#### How to reproduce the issue

Open new Incognito window and open this URL: https://cdcp-int1.dev-dp-internal.dts-stn.com/en/apply . You should be redirected to Canada CDCP Website. The fix can be tested after this PR is merged and deployed in INT1.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->