### PR TITLE
fix(frontend): Prevent session loss after destroy during login

### DIFF
--- a/frontend/__tests__/.server/web/session.test.ts
+++ b/frontend/__tests__/.server/web/session.test.ts
@@ -133,10 +133,18 @@ describe('Session', () => {
     });
 
     describe('destroy', () => {
-      it('should destroy the session and call save', () => {
+      it('should destroy the session', () => {
         const session = new ExpressSession(mockRequestSession);
         session.destroy();
         expect(mockRequestSession.destroy).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe('save', () => {
+      it('should save the session', () => {
+        const session = new ExpressSession(mockRequestSession);
+        session.save();
+        expect(mockRequestSession.save).toHaveBeenCalledOnce();
       });
     });
 
@@ -205,6 +213,10 @@ describe('Session', () => {
 
     it('should not throw error on destroy', () => {
       expect(() => session.destroy()).not.toThrowError();
+    });
+
+    it('should not throw error on save', () => {
+      expect(() => session.save()).not.toThrowError();
     });
   });
 });

--- a/frontend/app/.server/web/session.ts
+++ b/frontend/app/.server/web/session.ts
@@ -127,6 +127,17 @@ export interface Session {
    * @returns {void} This method does not return any value.
    */
   destroy(): void;
+
+  /**
+   * Saves the current session back to the store.
+   *
+   * This method will Save the session back to the store, replacing the contents on the store with
+   * the contents in memory (though a store may do something else--consult the store's documentation
+   * for exact behavior).
+   *
+   * @returns {void} This method does not return any value.
+   */
+  save(): void;
 }
 
 /**
@@ -211,6 +222,16 @@ export class ExpressSession implements Session {
     });
   }
 
+  save(): void {
+    this.session.save((err) => {
+      if (err) {
+        this.log.error('Failed to save session %s: %s', this.id, err.message);
+      } else {
+        this.log.info('Session %s saved successfully', this.id);
+      }
+    });
+  }
+
   protected sanitizeKey(key: string): string {
     assert.ok(!validator.isEmpty(key, { ignore_whitespace: true }), 'Session key cannot be empty');
     let sanitized = key.replaceAll(/[^a-zA-Z0-9_$]/g, '_');
@@ -269,5 +290,10 @@ export class NoopSession implements Session {
   destroy(): void {
     this.log.warn('Called "destroy" on NoopSession. No operation is performed.');
     // No operation; no session to destroy in a stateless context.
+  }
+
+  save(): void {
+    this.log.warn('Called "save" on NoopSession. No operation is performed.');
+    // No operation; no session to save in a stateless context.
   }
 }

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -118,6 +118,11 @@ async function handleRaoidcLoginRequest({ context: { appContainer, session }, re
   session.set('authReturnUrl', returnUrl ?? '/');
   session.set('authState', state);
 
+  // Note: In this particular situation, calling session.save() here is necessary because save is
+  // automatically called at the end of the HTTP response, but if session.destroy() was called before,
+  // previous set operations would not be persisted.
+  session.save();
+
   log.debug('Redirecting to RAOIDC signin URL [%s]', authUrl.href);
   return redirectDocument(authUrl.href);
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Ensure session persistence during login by saving it to the store after `destroy` is invoked.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->