### PR TITLE
fix(frontend): Update Canadian Postal Code validation regex

### DIFF
--- a/frontend/__tests__/.server/utils/postal-zip-code.utils.test.ts
+++ b/frontend/__tests__/.server/utils/postal-zip-code.utils.test.ts
@@ -30,11 +30,11 @@ describe('~/.server/utils/postal-zip-code.utils.ts', () => {
   describe('isValidPostalCode()', () => {
     // Canadian Postal Codes
     it('should return true for Canadian postal code without space', () => {
-      expect(isValidPostalCode('CA', 'H0H0H0')).toEqual(true);
+      expect(isValidPostalCode('CA', 'H0H0W0')).toEqual(true);
     });
 
     it('should return true Canadian postal code with space', () => {
-      expect(isValidPostalCode('CA', 'H0H 0H0')).toEqual(true);
+      expect(isValidPostalCode('CA', 'H0H 0Z0')).toEqual(true);
     });
 
     it('should return false for Canadian postal code with too many spaces', () => {
@@ -43,6 +43,14 @@ describe('~/.server/utils/postal-zip-code.utils.ts', () => {
 
     it('should return false for Canadian postal code of invalid format', () => {
       expect(isValidPostalCode('CA', 'H0H0')).toEqual(false);
+    });
+
+    it.each([...'DFIOQUdfioqu'].map((ch) => [ch]))('should return false when Canadian postal code contains invalid character "%s"', (ch) => {
+      expect(isValidPostalCode('CA', `H0${ch} 0W0`)).toEqual(false);
+    });
+
+    it.each([...'WZwz'].map((ch) => [ch]))('should return false when Canadian postal code starts with invalid character "%s"', (ch) => {
+      expect(isValidPostalCode('CA', `${ch}0H 0H0`)).toEqual(false);
     });
 
     // American Zip Code

--- a/frontend/app/.server/utils/postal-zip-code.utils.ts
+++ b/frontend/app/.server/utils/postal-zip-code.utils.ts
@@ -1,6 +1,6 @@
 import { getEnv } from '~/.server/utils/env.utils';
 
-export const postalCodeRegex = /^[ABCEGHJKLMNPRSTVXY]\d[A-Z]\s?\d[A-Z]\d$/i;
+export const postalCodeRegex = /^(?!.*[DFIOQUdfioqu])[A-VXYa-vxy][0-9][A-Za-z] ?[0-9][A-Za-z][0-9]$/i;
 export const zipCodeRegex = /^\d{5}$|^\d{5}-?\d{4}$/;
 
 export const isValidPostalCode = (countryCode: string, postalCode: string) => {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Fixes the Canadian Postal Code validation regex to match the official rules.

https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

Fixes [AB#6808](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/6808)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->