### PR TITLE
feat(frontend): Set communication method to "digital" by default

### DIFF
--- a/frontend/app/routes/protected/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult-child/communication-preference.tsx
@@ -57,7 +57,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   return {
     meta,
     defaultState: {
-      ...state.communicationPreferences,
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
     },
     editMode: state.editMode,
     languages,

--- a/frontend/app/routes/protected/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/adult/communication-preference.tsx
@@ -56,7 +56,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
     languages,
   };

--- a/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/protected/apply/$id/child/communication-preference.tsx
@@ -56,7 +56,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
     languages,
   };

--- a/frontend/app/routes/protected/renew/$id/communication-preference.tsx
+++ b/frontend/app/routes/protected/renew/$id/communication-preference.tsx
@@ -45,7 +45,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     isInvitationToApplyClient: isInvitationToApplyClient(state.clientApplication),
     isHomeAddressSameAsMailingAddress: state.isHomeAddressSameAsMailingAddress,
     editMode: state.editMode,

--- a/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult-child/communication-preference.tsx
@@ -49,7 +49,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
     languages,
   };

--- a/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/adult/communication-preference.tsx
@@ -49,7 +49,11 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
     languages,
   };

--- a/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/apply/$id/child/communication-preference.tsx
@@ -50,7 +50,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   return {
     meta,
     defaultState: {
-      ...state.communicationPreferences,
+      preferredLanguage: state.communicationPreferences?.preferredLanguage,
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
     },
     editMode: state.editMode,
     languages,

--- a/frontend/app/routes/public/renew/$id/adult-child/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/adult-child/communication-preference.tsx
@@ -47,7 +47,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
   };
 }

--- a/frontend/app/routes/public/renew/$id/adult/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/adult/communication-preference.tsx
@@ -45,7 +45,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
   };
 }

--- a/frontend/app/routes/public/renew/$id/child/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/child/communication-preference.tsx
@@ -47,7 +47,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
   };
 }

--- a/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
+++ b/frontend/app/routes/public/renew/$id/ita/communication-preference.tsx
@@ -45,7 +45,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   return {
     meta,
-    defaultState: { ...state.communicationPreferences },
+    defaultState: {
+      preferredMethod: state.communicationPreferences?.preferredMethod ?? PREFERRED_SUN_LIFE_METHOD.email,
+      preferredNotificationMethod: state.communicationPreferences?.preferredNotificationMethod ?? PREFERRED_NOTIFICATION_METHOD.msca,
+    },
     editMode: state.editMode,
   };
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The client created a change request to set communication method to "digital" by default. This pull request set communication method to "digital" by default for all apply and renewal flows. (Even though renewal is deactivated since v5.5.0)

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#6890](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/6890)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have updated the documentation if necessary
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have checked that my code follows the project's coding style by running `npm run format:check`
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [x] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->