### PR TITLE
chore(gitops): Bump UAT1 and OTTO to v5.6.0-RC182

### DIFF
--- a/gitops/overlays/otto/patches/deployments.yaml
+++ b/gitops/overlays/otto/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-951fc35f
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0-RC182
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-951fc35f
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0-RC182
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Bump UAT1 and OTTO to v5.6.0-RC182

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

<img width="369" height="150" alt="image" src="https://github.com/user-attachments/assets/349b6143-ef2e-49d8-af81-9a9a2effe2dc" />