### PR TITLE
chore(gitops): Bump non-prod environments to v5.6.0

### DIFF
--- a/gitops/overlays/int2/patches/deployments.yaml
+++ b/gitops/overlays/int2/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.5.0-RC180
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/otto/patches/deployments.yaml
+++ b/gitops/overlays/otto/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0-RC182
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.5.0-RC180
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.5.0-RC180
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.5.0-RC180
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0-RC182
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat2/patches/deployments.yaml
+++ b/gitops/overlays/uat2/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.5.0-RC180
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:5.6.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

Bump non-prod environments to v5.6.0.

The environments are `INT2`, `OTTO`, `PERF`, `STAGING`, `TRAINING`, `UAT1` and `UAT2`.