### PR TITLE
feat(frontend) add protected/profile/communication-preferences

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -110,6 +110,7 @@ export const pageIds = {
     profile: {
       applicantInformation: 'CDCP-PROT-PROF-0001',
       governmentDentalBenefits: 'CDCP-PROT-PROF-0002',
+      communicationPreferences: 'CDCP-PROT-PROF-0003',
     },
   },
   public: {

--- a/frontend/app/routes/protected/profile/communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/communication-preferences.tsx
@@ -1,0 +1,98 @@
+import { redirect } from 'react-router';
+
+import { invariant } from '@dts-stn/invariant';
+import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/communication-preferences';
+
+import { TYPES } from '~/.server/constants';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { ButtonLink } from '~/components/buttons';
+import { DescriptionListItem } from '~/components/description-list-item';
+import { InlineLink } from '~/components/inline-link';
+import { pageIds } from '~/page-ids';
+import { getCurrentDateString } from '~/utils/date-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const PREFERRED_SUN_LIFE_METHOD = { email: 'email', mail: 'mail' } as const;
+export const PREFERRED_NOTIFICATION_METHOD = { msca: 'msca', mail: 'mail' } as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-profile', 'gcweb'),
+  pageIdentifier: pageIds.protected.profile.communicationPreferences,
+  pageTitleI18nKey: 'protected-profile:communication-preferences.page-title',
+};
+
+export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const userInfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.ApplicationYearService);
+  const applicationYear = applicationYearService.getRenewalApplicationYear(currentDate);
+
+  const clientApplicationService = appContainer.get(TYPES.ClientApplicationService);
+  const clientApplicationResult = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.applicationYearId, userId: userInfoToken.sub });
+
+  if (clientApplicationResult.isNone()) {
+    throw redirect(getPathById('protected/data-unavailable', params));
+  }
+
+  const clientApplication = clientApplicationResult.unwrap();
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:communication-preferences.page-title') }) };
+
+  const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
+  const { ENGLISH_LANGUAGE_CODE } = appContainer.get(TYPES.ServerConfig);
+
+  // TODO update with correct values
+  return {
+    meta,
+    languagePreference: clientApplication.communicationPreferences.preferredLanguage,
+    sunlifeComminicationPreference: 'email',
+    gocComminicationPreference: 'msca',
+    SCCH_BASE_URI,
+    ENGLISH_LANGUAGE_CODE,
+  };
+}
+
+export default function ViewCommunicationPreferences({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { languagePreference, sunlifeComminicationPreference, gocComminicationPreference, SCCH_BASE_URI, ENGLISH_LANGUAGE_CODE } = loaderData;
+
+  return (
+    <div className="max-w-prose">
+      <dl>
+        <DescriptionListItem term={t('protected-profile:communication-preferences.language-preference')}>
+          <p>{languagePreference === ENGLISH_LANGUAGE_CODE.toString() ? t('protected-profile:communication-preferences.english') : 'protected-profile:communication-preferences.french'}</p>
+        </DescriptionListItem>
+        <DescriptionListItem term={t('protected-profile:communication-preferences.sunlife-communication-preference')}>
+          <p>{sunlifeComminicationPreference === PREFERRED_SUN_LIFE_METHOD.email ? t('protected-profile:communication-preferences.by-email') : t('protected-profile:communication-preferences.by-mail')}</p>
+        </DescriptionListItem>
+        <DescriptionListItem term={t('protected-profile:communication-preferences.goc-communication-preference')}>
+          <p>{gocComminicationPreference === PREFERRED_NOTIFICATION_METHOD.msca ? t('protected-profile:communication-preferences.online') : t('protected-profile:communication-preferences.by-mail')}</p>
+        </DescriptionListItem>
+      </dl>
+      {/*TODO: Update routeId*/}
+      <InlineLink id="update-communication-preferences" routeId="protected/profile/communication-preferences" params={params}>
+        {t('protected-profile:communication-preferences.update-link-text')}
+      </InlineLink>
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <ButtonLink variant="primary" id="back-button" to={t('gcweb:header.menu-dashboard.href', { baseUri: SCCH_BASE_URI })}>
+          {t('protected-profile:communication-preferences.return-button')}
+        </ButtonLink>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -40,6 +40,11 @@ export const routes = [
         paths: { en: '/:lang/protected/profile/government-dental-benefits', fr: '/:lang/protege/profil/government-dental-benefits' }, //TODO: update French path
       },
       {
+        id: 'protected/profile/communication-preferences',
+        file: 'routes/protected/profile/communication-preferences.tsx',
+        paths: { en: '/:lang/protected/profile/communication-preferences', fr: '/:lang/protege/profil/preferences-communication' },
+      },
+      {
         file: 'routes/protected/apply/layout.tsx',
         children: [
           { id: 'protected/apply/index', file: 'routes/protected/apply/index.tsx', paths: { en: '/:lang/protected/apply', fr: '/:lang/protege/demander' } },

--- a/frontend/public/locales/en/protected-profile.json
+++ b/frontend/public/locales/en/protected-profile.json
@@ -14,5 +14,18 @@
     "no": "No",
     "update-link-text": "Change access to other government dental benefits",
     "return-button": "Return to dashboard"
+  },
+  "communication-preferences": {
+    "page-title": "My communication preferences",
+    "language-preference": "Language preference",
+    "english": "English",
+    "french": "French",
+    "by-email": "By email",
+    "by-mail": "By mail",
+    "online": "Online through My Service Canada Account",
+    "sunlife-communication-preference": "Sun Life communication preference",
+    "goc-communication-preference": "Government of Canada communication preference",
+    "update-link-text": "Change communication preferences",
+    "return-button": "Return to dashboard"
   }
 }

--- a/frontend/public/locales/fr/protected-profile.json
+++ b/frontend/public/locales/fr/protected-profile.json
@@ -14,5 +14,18 @@
     "no": "Non",
     "update-link-text": "Modifier la réponse à «\u00a0Accès à des prestations dentaires gouvernementales\u00a0»",
     "return-button": "Retour au tableau de bord"
+  },
+  "communication-preferences": {
+    "page-title": "Mes préférences de communication",
+    "language-preference": "Langue de préférence",
+    "english": "Anglais",
+    "french": "Français",
+    "by-email": "Par courriel",
+    "by-mail": "Par la poste",
+    "online": "En ligne, sur Mon dossier Service Canada (MDSC)",
+    "sunlife-communication-preference": "Préférence de communication avec la Sun Life",
+    "goc-communication-preference": "Préférence de communication du gouvernement du Canada",
+    "update-link-text": "Modifier la préférences de communication",
+    "return-button": "Retour au tableau de bord"
   }
 }


### PR DESCRIPTION
### Description
Adds the summary screen `/protected/profile/communication-preferences`

### Related Azure Boards Work Items
[AB#7019](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7019)


### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`