### PR TITLE
refactor(frontend) add preferredMethodGovernmentOfCanada to ClientApplicationDto

### DIFF
--- a/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
+++ b/frontend/__tests__/.server/domain/mappers/client-application.dto.mapper.test.ts
@@ -217,6 +217,7 @@ describe('DefaultClientApplicationDtoMapper', () => {
           email: 'email@example.com',
           preferredLanguage: '1',
           preferredMethod: 'EMAIL',
+          preferredMethodGovernmentOfCanada: 'EMAIL',
         },
         contactInformation: {
           copyMailingAddress: true,

--- a/frontend/__tests__/.server/domain/services/client-application.service.test.ts
+++ b/frontend/__tests__/.server/domain/services/client-application.service.test.ts
@@ -169,6 +169,7 @@ describe('DefaultClientApplicationService', () => {
     communicationPreferences: {
       preferredLanguage: 'ENG',
       preferredMethod: 'EMAIL',
+      preferredMethodGovernmentOfCanada: 'EMAIL',
     },
     contactInformation: {
       copyMailingAddress: true,

--- a/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
+++ b/frontend/__tests__/.server/routes/mappers/benefit-renewal.state.mapper.test.ts
@@ -72,6 +72,7 @@ describe('DefaultBenefitRenewalStateMapper', () => {
     communicationPreferences: {
       preferredLanguage: 'English',
       preferredMethod: 'Mail',
+      preferredMethodGovernmentOfCanada: 'Email',
     },
     contactInformation: {
       copyMailingAddress: false,

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -42,6 +42,7 @@ export type ClientCommunicationPreferencesDto = ReadonlyDeep<{
   email?: string;
   preferredLanguage: string;
   preferredMethod: string;
+  preferredMethodGovernmentOfCanada: string;
 }>;
 
 export type ClientContactInformationDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -132,6 +132,7 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
       email: applicant.PersonContactInformation[0].EmailAddress?.at(0)?.EmailAddressID,
       preferredLanguage: applicant.PersonLanguage[0].CommunicationCategoryCode.ReferenceDataID,
       preferredMethod: applicant.PreferredMethodCommunicationCode.ReferenceDataID,
+      preferredMethodGovernmentOfCanada: applicant.PreferredMethodCommunicationCode.ReferenceDataID, //TODO update with correct value once Interop sends the value in the payload
     };
 
     const homeAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');


### PR DESCRIPTION
### Description
adds `preferredMethodGovernmentOfCanada`  to `ClientCommunicationPreferencesDto` which is used to compose `ClientApplicationDto`.  This attribute will _eventually_ be exposed by Interop for us to use.