### PR TITLE
refactor(frontend) preferredLanguage communication-preferences

### DIFF
--- a/frontend/app/routes/protected/profile/communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/communication-preferences.tsx
@@ -54,28 +54,25 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:communication-preferences.page-title') }) };
 
   const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
-  const { ENGLISH_LANGUAGE_CODE } = appContainer.get(TYPES.ServerConfig);
 
-  // TODO update with correct values
   return {
     meta,
-    languagePreference: clientApplication.communicationPreferences.preferredLanguage,
-    sunlifeComminicationPreference: 'email',
-    gocComminicationPreference: 'msca',
+    preferredLanguage: appContainer.get(TYPES.LanguageService).getLocalizedLanguageById(clientApplication.communicationPreferences.preferredLanguage, locale),
+    sunlifeComminicationPreference: clientApplication.communicationPreferences.preferredMethod,
+    gocComminicationPreference: clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada,
     SCCH_BASE_URI,
-    ENGLISH_LANGUAGE_CODE,
   };
 }
 
 export default function ViewCommunicationPreferences({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { languagePreference, sunlifeComminicationPreference, gocComminicationPreference, SCCH_BASE_URI, ENGLISH_LANGUAGE_CODE } = loaderData;
+  const { preferredLanguage, sunlifeComminicationPreference, gocComminicationPreference, SCCH_BASE_URI } = loaderData;
 
   return (
     <div className="max-w-prose">
       <dl>
         <DescriptionListItem term={t('protected-profile:communication-preferences.language-preference')}>
-          <p>{languagePreference === ENGLISH_LANGUAGE_CODE.toString() ? t('protected-profile:communication-preferences.english') : 'protected-profile:communication-preferences.french'}</p>
+          <p>{preferredLanguage.name}</p>
         </DescriptionListItem>
         <DescriptionListItem term={t('protected-profile:communication-preferences.sunlife-communication-preference')}>
           <p>{sunlifeComminicationPreference === PREFERRED_SUN_LIFE_METHOD.email ? t('protected-profile:communication-preferences.by-email') : t('protected-profile:communication-preferences.by-mail')}</p>

--- a/frontend/public/locales/en/protected-profile.json
+++ b/frontend/public/locales/en/protected-profile.json
@@ -19,8 +19,6 @@
   "communication-preferences": {
     "page-title": "My communication preferences",
     "language-preference": "Language preference",
-    "english": "English",
-    "french": "French",
     "by-email": "By email",
     "by-mail": "By mail",
     "online": "Online through My Service Canada Account",

--- a/frontend/public/locales/fr/protected-profile.json
+++ b/frontend/public/locales/fr/protected-profile.json
@@ -19,8 +19,6 @@
   "communication-preferences": {
     "page-title": "Mes préférences de communication",
     "language-preference": "Langue de préférence",
-    "english": "Anglais",
-    "french": "Français",
     "by-email": "Par courriel",
     "by-mail": "Par la poste",
     "online": "En ligne, sur Mon dossier Service Canada (MDSC)",


### PR DESCRIPTION
### Description
Totally forgot about the cdcp specific idioms we use.  This PR makes use of the language service to get a localized version of the client's preferred language, and also defaults the values of the other inputs to whatever is fetched in the `clientApplication` which would be the correct approach