### PR TITLE
feat(frontend) boilerplate for profile-service

### DIFF
--- a/frontend/app/.server/constants/types.constant.ts
+++ b/frontend/app/.server/constants/types.constant.ts
@@ -40,6 +40,7 @@ import type {
   GovernmentInsurancePlanRepository,
   LetterRepository,
   LetterTypeRepository,
+  ProfileRepository,
   ProvinceTerritoryStateRepository,
   VerificationCodeRepository,
 } from '~/.server/domain/repositories';
@@ -60,6 +61,7 @@ import type {
   LanguageService,
   LetterService,
   LetterTypeService,
+  ProfileService,
   ProvinceTerritoryStateService,
   ProvincialGovernmentInsurancePlanService,
   VerificationCodeService,
@@ -211,4 +213,6 @@ export const TYPES = assignServiceIdentifiers({
   VerificationCodeDtoMapper: serviceId<VerificationCodeDtoMapper>(),
   VerificationCodeRepository: serviceId<VerificationCodeRepository>(),
   VerificationCodeService: serviceId<VerificationCodeService>(),
+  ProfileService: serviceId<ProfileService>(),
+  ProfileRepository: serviceId<ProfileRepository>(),
 } as const satisfies ServiceTypesMap);

--- a/frontend/app/.server/container-modules/repositories.container-module.ts
+++ b/frontend/app/.server/container-modules/repositories.container-module.ts
@@ -33,6 +33,7 @@ import {
   MockGovernmentInsurancePlanRepository,
   MockLetterRepository,
   MockLetterTypeRepository,
+  MockProfileRepository,
   MockProvinceTerritoryStateRepository,
   MockVerificationCodeRepository,
 } from '~/.server/domain/repositories';
@@ -117,5 +118,7 @@ export function createRepositoriesContainerModule(serverConfig: Pick<ServerConfi
 
     options.bind(TYPES.DynatraceRepository).to(DefaultDynatraceRepository);
     options.bind(TYPES.HCaptchaRepository).to(DefaultHCaptchaRepository);
+
+    options.bind(TYPES.ProfileRepository).to(MockProfileRepository);
   });
 }

--- a/frontend/app/.server/container-modules/services.container-module.ts
+++ b/frontend/app/.server/container-modules/services.container-module.ts
@@ -23,6 +23,7 @@ import {
   DefaultLanguageService,
   DefaultLetterService,
   DefaultLetterTypeService,
+  DefaultProfileService,
   DefaultProvinceTerritoryStateService,
   DefaultProvincialGovernmentInsurancePlanService,
   DefaultVerificationCodeService,
@@ -73,6 +74,7 @@ export function createServicesContainerModule(serverConfig: Pick<ServerConfig, '
     options.bind(TYPES.LanguageService).to(DefaultLanguageService);
     options.bind(TYPES.LetterService).to(DefaultLetterService);
     options.bind(TYPES.LetterTypeService).to(DefaultLetterTypeService);
+    options.bind(TYPES.ProfileService).to(DefaultProfileService);
     options.bind(TYPES.ProvinceTerritoryStateService).to(DefaultProvinceTerritoryStateService);
     options.bind(TYPES.ProvincialGovernmentInsurancePlanService).to(DefaultProvincialGovernmentInsurancePlanService);
     options.bind(TYPES.RaoidcService).to(DefaultRaoidcService);

--- a/frontend/app/.server/domain/dtos/index.ts
+++ b/frontend/app/.server/domain/dtos/index.ts
@@ -17,3 +17,4 @@ export type * from './letter.dto';
 export type * from './province-territory-state.dto';
 export type * from './provincial-government-insurance-plan.dto';
 export type * from './verification-code.dto';
+export type * from './profile.dto';

--- a/frontend/app/.server/domain/dtos/profile.dto.ts
+++ b/frontend/app/.server/domain/dtos/profile.dto.ts
@@ -1,0 +1,5 @@
+export type CommunicationPreferenceDto = Readonly<{
+  preferredLanguage: string;
+  preferredMethod: string;
+  preferredMethodGovernmentOfCanada: string;
+}>;

--- a/frontend/app/.server/domain/repositories/index.ts
+++ b/frontend/app/.server/domain/repositories/index.ts
@@ -14,3 +14,4 @@ export * from './letter.repository';
 export * from './province-territory-state.repository';
 export * from './government-insurance-plan.repository';
 export * from './verification-code.repository';
+export * from './profile.repository';

--- a/frontend/app/.server/domain/repositories/profile.repository.ts
+++ b/frontend/app/.server/domain/repositories/profile.repository.ts
@@ -1,0 +1,56 @@
+import { injectable } from 'inversify';
+
+import type { CommunicationPreferenceDto } from '~/.server/domain/dtos';
+import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+
+export interface ProfileRepository {
+  /**
+   * Updates communication preferences for a user.
+   *
+   * @param communicationPreferenceDto The communication preference dto.
+   * @returns A Promise that resolves when the update is complete.
+   */
+  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void>;
+
+  /**
+   * Retrieves metadata associated with the letter repository.
+   *
+   * @returns A record where the keys and values are strings representing metadata information.
+   */
+  getMetadata(): Record<string, string>;
+
+  /**
+   * Performs a health check to ensure that the letter repository is operational.
+   *
+   * @throws An error if the health check fails or the repository is unavailable.
+   * @returns A promise that resolves when the health check completes successfully.
+   */
+  checkHealth(): Promise<void>;
+}
+
+@injectable()
+export class MockProfileRepository implements ProfileRepository {
+  private readonly log: Logger;
+
+  constructor() {
+    this.log = createLogger('MockProfileRepository');
+  }
+
+  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void> {
+    this.log.debug('Mock updating communication preferences for request [%j]', communicationPreferenceDto);
+
+    this.log.debug('Successfully mock updated communication preferences');
+    return await Promise.resolve();
+  }
+
+  getMetadata(): Record<string, string> {
+    return {
+      mockEnabled: 'true',
+    };
+  }
+
+  async checkHealth(): Promise<void> {
+    return await Promise.resolve();
+  }
+}

--- a/frontend/app/.server/domain/services/index.ts
+++ b/frontend/app/.server/domain/services/index.ts
@@ -17,6 +17,7 @@ export * from './letter.service';
 export * from './province-territory-state.service';
 export * from './provincial-government-insurance-plan.service';
 export * from './verification-code.service';
+export * from './profile.service';
 
 /**
  * Key that holds the killswitch boolean value in redis.

--- a/frontend/app/.server/domain/services/profile.service.ts
+++ b/frontend/app/.server/domain/services/profile.service.ts
@@ -1,0 +1,42 @@
+import { inject, injectable } from 'inversify';
+
+import { TYPES } from '~/.server/constants';
+import type { CommunicationPreferenceDto } from '~/.server/domain/dtos';
+import type { ProfileRepository } from '~/.server/domain/repositories';
+import type { AuditService } from '~/.server/domain/services';
+import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
+
+export interface ProfileService {
+  /**
+   * Updates communication preferences for a user in the protected route.
+   *
+   * @param communicationPreferenceDto The communication preference dto
+   * @returns A Promise that resolves when the update is complete
+   */
+  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void>;
+}
+
+@injectable()
+export class DefaultProfileService implements ProfileService {
+  private readonly log: Logger;
+  private readonly profileRepository: ProfileRepository;
+
+  constructor(@inject(TYPES.ProfileRepository) profileRepository: ProfileRepository, @inject(TYPES.AuditService) auditService: AuditService) {
+    this.log = createLogger('DefaultProfileService');
+    this.profileRepository = profileRepository;
+    this.init();
+  }
+
+  private init(): void {
+    this.log.debug('DefaultProfileService initiated.');
+  }
+
+  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void> {
+    this.log.trace('Updating communication preferences for request [%j]', communicationPreferenceDto);
+
+    await this.profileRepository.updateCommunicationPreferences(communicationPreferenceDto);
+
+    this.log.trace('Successfully updated communication preferences');
+  }
+}

--- a/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
@@ -67,7 +67,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     defaultState: {
       preferredLanguage: clientApplication.communicationPreferences.preferredLanguage,
       preferredMethod: clientApplication.communicationPreferences.preferredMethod,
-      preferredNotificationMethod: clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada,
+      preferredMethodGovernmentOfCanada: clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada,
     },
     languages,
   };
@@ -85,20 +85,20 @@ export async function action({ context: { appContainer, session }, params, reque
   const formSchema = z.object({
     preferredLanguage: z.string().trim().min(1, t('protected-profile:edit-communication-preferences.error-message.preferred-language-required')),
     preferredMethod: z.string().trim().min(1, t('protected-profile:edit-communication-preferences.error-message.preferred-method-required')),
-    preferredNotificationMethod: z.string().trim().min(1, t('protected-profile:edit-communication-preferences.error-message.preferred-notification-method-required')),
+    preferredMethodGovernmentOfCanada: z.string().trim().min(1, t('protected-profile:edit-communication-preferences.error-message.preferred-notification-method-required')),
   });
 
   const parsedDataResult = formSchema.safeParse({
     preferredLanguage: String(formData.get('preferredLanguage') ?? ''),
     preferredMethod: String(formData.get('preferredMethod') ?? ''),
-    preferredNotificationMethod: String(formData.get('preferredNotificationMethod') ?? ''),
+    preferredMethodGovernmentOfCanada: String(formData.get('preferredMethodGovernmentOfCanada   ') ?? ''),
   });
 
   if (!parsedDataResult.success) {
     return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
   }
 
-  // TODO send updated values in service call
+  await appContainer.get(TYPES.ProfileService).updateCommunicationPreferences(parsedDataResult.data);
 
   return redirect(getPathById('protected/profile/communication-preferences', params));
 }
@@ -114,7 +114,7 @@ export default function EditCommunicationPreferences({ loaderData, params }: Rou
   const errorSummary = useErrorSummary(errors, {
     preferredLanguage: 'input-radio-preferred-language-option-0',
     preferredMethod: 'input-radio-preferred-methods-option-0',
-    preferredNotificationMethod: 'input-radio-preferred-notification-method-option-0',
+    preferredMethodGovernmentOfCanada: 'input-radio-preferred-notification-method-option-0',
   });
 
   const preferredLanguageOptions: InputRadiosProps['options'] = languages.map((language) => ({
@@ -153,22 +153,22 @@ export default function EditCommunicationPreferences({ loaderData, params }: Rou
 
           <InputRadios
             id="preferred-notification-method"
-            name="preferredNotificationMethod"
+            name="preferredMethodGovernmentOfCanada   "
             legend={t('protected-profile:edit-communication-preferences.preferred-notification-method')}
             options={[
               {
                 value: PREFERRED_NOTIFICATION_METHOD.msca,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-profile:edit-communication-preferences.preferred-notification-method-msca" components={{ span: <span className="font-semibold" /> }} />,
-                defaultChecked: defaultState.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.msca,
+                defaultChecked: defaultState.preferredMethodGovernmentOfCanada === PREFERRED_NOTIFICATION_METHOD.msca,
               },
               {
                 value: PREFERRED_NOTIFICATION_METHOD.mail,
                 children: <Trans ns={handle.i18nNamespaces} i18nKey="protected-profile:edit-communication-preferences.preferred-notification-method-mail" components={{ span: <span className="font-semibold" /> }} />,
-                defaultChecked: defaultState.preferredNotificationMethod === PREFERRED_NOTIFICATION_METHOD.mail,
+                defaultChecked: defaultState.preferredMethodGovernmentOfCanada === PREFERRED_NOTIFICATION_METHOD.mail,
               },
             ]}
             required
-            errorMessage={errors?.preferredNotificationMethod}
+            errorMessage={errors?.preferredMethodGovernmentOfCanada}
           />
         </div>
         <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">


### PR DESCRIPTION
### Description
Adds boilerplate `profile-service` which will be used to update the client's profile data.  We don't currently have the interop endpoints, so mocking is the goal here.  This PR adds the `updateCommunicationPreferences` method which is called in `/communication-preferences/edit`.  More methods will follow in subsequent PRs.

### Related Azure Boards Work Items
[AB#7185](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7185)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`
- [x] I have checked that all unit tests pass by running `npm run test:unit -- run`