### PR TITLE
refactor(frontend) add updatePhoneNumber to profile-service

### DIFF
--- a/frontend/app/.server/domain/dtos/profile.dto.ts
+++ b/frontend/app/.server/domain/dtos/profile.dto.ts
@@ -1,5 +1,10 @@
-export type CommunicationPreferenceDto = Readonly<{
+export type CommunicationPreferenceRequestDto = Readonly<{
   preferredLanguage: string;
   preferredMethod: string;
   preferredMethodGovernmentOfCanada: string;
+}>;
+
+export type PhoneNumberRequestDto = Readonly<{
+  phoneNumber?: string;
+  phoneNumberAlt?: string;
 }>;

--- a/frontend/app/.server/domain/repositories/profile.repository.ts
+++ b/frontend/app/.server/domain/repositories/profile.repository.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'inversify';
 
-import type { CommunicationPreferenceDto } from '~/.server/domain/dtos';
+import type { CommunicationPreferenceRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
 import type { Logger } from '~/.server/logging';
 import { createLogger } from '~/.server/logging';
 
@@ -11,7 +11,15 @@ export interface ProfileRepository {
    * @param communicationPreferenceDto The communication preference dto.
    * @returns A Promise that resolves when the update is complete.
    */
-  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void>;
+  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceRequestDto): Promise<void>;
+
+  /**
+   * Updates phone numbers for a user.
+   *
+   * @param PhoneNumberDto The phone number dto.
+   * @returns A Promise that resolves when the update is complete.
+   */
+  updatePhoneNumbers(PhoneNumberDto: PhoneNumberRequestDto): Promise<void>;
 
   /**
    * Retrieves metadata associated with the letter repository.
@@ -37,10 +45,17 @@ export class MockProfileRepository implements ProfileRepository {
     this.log = createLogger('MockProfileRepository');
   }
 
-  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void> {
+  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceRequestDto): Promise<void> {
     this.log.debug('Mock updating communication preferences for request [%j]', communicationPreferenceDto);
 
     this.log.debug('Successfully mock updated communication preferences');
+    return await Promise.resolve();
+  }
+
+  async updatePhoneNumbers(phoneNumberDto: PhoneNumberRequestDto): Promise<void> {
+    this.log.debug('Mock updating phone numbers for request [%j]', phoneNumberDto);
+
+    this.log.debug('Successfully mock updated phone numbers');
     return await Promise.resolve();
   }
 

--- a/frontend/app/.server/domain/services/profile.service.ts
+++ b/frontend/app/.server/domain/services/profile.service.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 
 import { TYPES } from '~/.server/constants';
-import type { CommunicationPreferenceDto } from '~/.server/domain/dtos';
+import type { CommunicationPreferenceRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
 import type { ProfileRepository } from '~/.server/domain/repositories';
 import type { AuditService } from '~/.server/domain/services';
 import type { Logger } from '~/.server/logging';
@@ -14,7 +14,15 @@ export interface ProfileService {
    * @param communicationPreferenceDto The communication preference dto
    * @returns A Promise that resolves when the update is complete
    */
-  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void>;
+  updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceRequestDto): Promise<void>;
+
+  /**
+   * Updates phone numbers for a user in the protected route.
+   *
+   * @param phoneNumberDto The phone number dto
+   * @returns A Promise that resolves when the update is complete
+   */
+  updatePhoneNumbers(phoneNumberDto: PhoneNumberRequestDto): Promise<void>;
 }
 
 @injectable()
@@ -32,11 +40,19 @@ export class DefaultProfileService implements ProfileService {
     this.log.debug('DefaultProfileService initiated.');
   }
 
-  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceDto): Promise<void> {
+  async updateCommunicationPreferences(communicationPreferenceDto: CommunicationPreferenceRequestDto): Promise<void> {
     this.log.trace('Updating communication preferences for request [%j]', communicationPreferenceDto);
 
     await this.profileRepository.updateCommunicationPreferences(communicationPreferenceDto);
 
     this.log.trace('Successfully updated communication preferences');
+  }
+
+  async updatePhoneNumbers(phoneNumberDto: PhoneNumberRequestDto): Promise<void> {
+    this.log.trace('Updating phone numbers for request [%j]', phoneNumberDto);
+
+    await this.profileRepository.updatePhoneNumbers(phoneNumberDto);
+
+    this.log.trace('Successfully updated phone numbers');
   }
 }

--- a/frontend/app/routes/protected/profile/phone-number.tsx
+++ b/frontend/app/routes/protected/profile/phone-number.tsx
@@ -94,7 +94,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
   }
 
-  //TODO: call profile-service
+  await appContainer.get(TYPES.ProfileService).updatePhoneNumbers(parsedDataResult.data);
 
   return redirect(getPathById('protected/profile/contact-information', params));
 }


### PR DESCRIPTION
### Description
Adds mock `updatePhoneNumbers` to profile service.  

### Related Azure Boards Work Items
[AB#7185](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7185)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`