### PR TITLE
feat(frontend) add profile/contact/email-address

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -117,6 +117,7 @@ export const pageIds = {
       editCommunicationPreferences: 'CDCP-PROT-PROF-0004',
       phoneNumber: 'CDCP-PROT-PROF-0005',
       contactInformation: 'CDCP-PROT-PROF-0006',
+      email: 'CDCP-PROT-PROF-0007',
     },
   },
   public: {

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -1,0 +1,135 @@
+import { data, redirect, useFetcher } from 'react-router';
+
+import { invariant } from '@dts-stn/invariant';
+import { useTranslation } from 'react-i18next';
+import validator from 'validator';
+import { z } from 'zod';
+
+import type { Route } from './+types/email';
+
+import { TYPES } from '~/.server/constants';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { useErrorSummary } from '~/components/error-summary';
+import { InputField } from '~/components/input-field';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getCurrentDateString } from '~/utils/date-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-profile', 'gcweb'),
+  pageIdentifier: pageIds.protected.profile.email,
+  pageTitleI18nKey: 'protected-profile:email.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:email.page-title') }) };
+
+  const userInfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.ApplicationYearService);
+  const applicationYear = applicationYearService.getRenewalApplicationYear(currentDate);
+
+  const clientApplicationService = appContainer.get(TYPES.ClientApplicationService);
+  const clientApplicationResult = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.applicationYearId, userId: userInfoToken.sub });
+
+  if (clientApplicationResult.isNone()) {
+    throw redirect(getPathById('protected/data-unavailable', params));
+  }
+
+  const clientApplication = clientApplicationResult.unwrap();
+
+  return {
+    meta,
+    defaultState: clientApplication.contactInformation.email,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const emailSchema = z
+    .object({
+      email: z
+        .string({ error: t('protected-profile:email.error-message.email-required') })
+        .trim()
+        .min(1)
+        .max(64),
+    })
+
+    .superRefine((val, ctx) => {
+      if (!validator.isEmail(val.email)) {
+        ctx.addIssue({ code: 'custom', message: t('protected-profile:email.error-message.email-valid'), path: ['email'] });
+      }
+    });
+
+  const parsedDataResult = emailSchema.safeParse({
+    email: formData.get('email') ? String(formData.get('email') ?? '') : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
+  }
+
+  //TODO: handle send verification code
+
+  return redirect(getPathById('protected/profile/contact/verify-email', params));
+}
+
+export default function ProtectedProfileEmailAddress({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState } = loaderData;
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const errors = fetcher.data?.errors;
+  const errorSummary = useErrorSummary(errors, { email: 'email' });
+
+  return (
+    <div className="max-w-prose">
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <p className="mb-4">{t('protected-profile:email.provide-email')}</p>
+        <p className="mb-8">{t('protected-profile:email.verify-email')}</p>
+        <p className="mb-4 italic">{t('protected-profile:required-label')}</p>
+        <div className="mb-6 grid items-end gap-6 md:grid-cols-2">
+          <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t('protected-profile:email.email-legend')} maxLength={64} required />
+        </div>
+
+        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <LoadingButton variant="primary" id="save-button" loading={isSubmitting}>
+            {t('protected-profile:email.save-btn')}
+          </LoadingButton>
+          <ButtonLink id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting}>
+            {t('protected-profile:email.back')}
+          </ButtonLink>
+        </div>
+      </fetcher.Form>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -65,6 +65,11 @@ export const routes = [
         paths: { en: '/:lang/protected/profile/contact-information', fr: '/:lang/protege/profil/contact-information' },
       },
       {
+        id: 'protected/profile/contact/email',
+        file: 'routes/protected/profile/email.tsx',
+        paths: { en: '/:lang/protected/profile/contact/email-address', fr: '/:lang/protege/profil/cordonnees/adresse-courriel' },
+      },
+      {
         file: 'routes/protected/apply/layout.tsx',
         children: [
           { id: 'protected/apply/index', file: 'routes/protected/apply/index.tsx', paths: { en: '/:lang/protected/apply', fr: '/:lang/protege/demander' } },

--- a/frontend/public/locales/en/protected-profile.json
+++ b/frontend/public/locales/en/protected-profile.json
@@ -76,5 +76,17 @@
     "update-mailing-address-link-text": "Change mailing address",
     "update-home-address-link-text": "Change home address",
     "return-button": "Return to dashboard"
+  },
+  "email": {
+    "page-title": "Email address",
+    "provide-email": "Provide the email address you'd like the Government of Canada and/or Sun Life to use to contact you about your Canadian Dental Care Plan coverage.",
+    "verify-email": "We will need to verify your email address.",
+    "email-legend": "Email address",
+    "back": "Back",
+    "save-btn": "Save",
+    "error-message": {
+      "email-required": "Enter email address, for example name@example.com",
+      "email-valid": "Enter an email address in the correct format, such as name@example.com"
+    }
   }
 }

--- a/frontend/public/locales/fr/protected-profile.json
+++ b/frontend/public/locales/fr/protected-profile.json
@@ -76,5 +76,17 @@
     "update-mailing-address-link-text": "Modifier l'adresse postale",
     "update-home-address-link-text": "Modifier l'adresse du domicile",
     "return-button": "Retour au tableau de bord"
+  },
+  "email": {
+    "page-title": "Adresse courriel",
+    "provide-email": "Indiquez l'adresse électronique à laquelle vous souhaitez recevoir l'information au sujet de votre couverture au titre du Régime de soins dentaires du Canada que vous communiquera le gouvernement du Canada ou la Sun Life.",
+    "verify-email": "Nous confirmerons votre adresse électronique.",
+    "email-legend": "Adresse courriel",
+    "back": "Retour",
+    "save-btn": "Sauvegarder",
+    "error-message": {
+      "email-required": "Entrez l'adresse courriel, par exemple nom@exemple.com",
+      "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com"
+    }
   }
 }


### PR DESCRIPTION
### Description
Breaking out email/verify-email into several smaller PRs.  This PR adds `/profile/contact/email-address`.  

### Related Azure Boards Work Items
[AB#7016](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7016)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`