### PR TITLE
feat(frontend) add '/profile/contact/email-address/verify'

### DIFF
--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -118,6 +118,7 @@ export const pageIds = {
       phoneNumber: 'CDCP-PROT-PROF-0005',
       contactInformation: 'CDCP-PROT-PROF-0006',
       email: 'CDCP-PROT-PROF-0007',
+      verifyEmail: 'CDCP-PROT-PROF-0008',
     },
   },
   public: {

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -96,7 +96,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   //TODO: handle send verification code
 
-  return redirect(getPathById('protected/profile/contact/verify-email', params));
+  return redirect(getPathById('protected/profile/contact/email-address/verify', params));
 }
 
 export default function ProtectedProfileEmailAddress({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from 'react';
+
+import { data, redirect, useFetcher } from 'react-router';
+
+import { invariant } from '@dts-stn/invariant';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import type { Route } from './+types/verify-email';
+
+import { TYPES } from '~/.server/constants';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { Button, ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
+import { useErrorAlert } from '~/components/error-alert';
+import { useErrorSummary } from '~/components/error-summary';
+import { InlineLink } from '~/components/inline-link';
+import { InputField } from '~/components/input-field';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { getCurrentDateString } from '~/utils/date-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { extractDigits } from '~/utils/string-utils';
+
+const FORM_ACTION = {
+  request: 'request',
+  submit: 'submit',
+} as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('protected-profile', 'gcweb'),
+  pageIdentifier: pageIds.protected.profile.verifyEmail,
+  pageTitleI18nKey: 'protected-profile:verify-email.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:verify-email.page-title') }) };
+
+  const userInfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.ApplicationYearService);
+  const applicationYear = applicationYearService.getRenewalApplicationYear(currentDate);
+
+  const clientApplicationService = appContainer.get(TYPES.ClientApplicationService);
+  const clientApplicationResult = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.applicationYearId, userId: userInfoToken.sub });
+
+  if (clientApplicationResult.isNone()) {
+    throw redirect(getPathById('protected/data-unavailable', params));
+  }
+
+  const clientApplication = clientApplicationResult.unwrap();
+
+  return {
+    meta,
+    email: clientApplication.contactInformation.email,
+  };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const idToken: IdToken = session.get('idToken');
+  const t = await getFixedT(request, handle.i18nNamespaces);
+  const locale = getLocale(request);
+  const { ENGLISH_LANGUAGE_CODE } = appContainer.get(TYPES.ServerConfig);
+
+  const userInfoToken = session.get('userInfoToken');
+  invariant(userInfoToken.sin, 'Expected userInfoToken.sin to be defined');
+
+  const currentDate = getCurrentDateString(locale);
+  const applicationYearService = appContainer.get(TYPES.ApplicationYearService);
+  const applicationYear = applicationYearService.getRenewalApplicationYear(currentDate);
+
+  const clientApplicationService = appContainer.get(TYPES.ClientApplicationService);
+  const clientApplicationResult = await clientApplicationService.findClientApplicationBySin({ sin: userInfoToken.sin, applicationYearId: applicationYear.applicationYearId, userId: userInfoToken.sub });
+
+  if (clientApplicationResult.isNone()) {
+    throw redirect(getPathById('protected/data-unavailable', params));
+  }
+
+  const clientApplication = clientApplicationResult.unwrap();
+
+  // TODO: handle verification logic without the use of state (code below is left in to prevent breaking the UI)
+
+  // Fetch verification code service
+  const verificationCodeService = appContainer.get(TYPES.VerificationCodeService);
+
+  const formAction = z.enum(FORM_ACTION).parse(formData.get('_action'));
+
+  if (formAction === FORM_ACTION.request) {
+    // Create a new verification code and store the code in session
+    const verificationCode = verificationCodeService.createVerificationCode(idToken.sub);
+    await verificationCodeService.sendVerificationCodeEmail({
+      email: clientApplication.contactInformation.email ?? '',
+      verificationCode: verificationCode,
+      preferredLanguage: clientApplication.communicationPreferences.preferredLanguage === ENGLISH_LANGUAGE_CODE.toString() ? 'en' : 'fr',
+      userId: idToken.sub,
+    });
+    return { status: 'verification-code-sent' } as const;
+  }
+
+  const verificationCodeSchema = z.object({
+    verificationCode: z.string().trim().min(1, t('protected-profile:verify-email.error-message.verification-code-required')).transform(extractDigits),
+  });
+
+  const parsedDataResult = verificationCodeSchema.safeParse({
+    verificationCode: formData.get('verificationCode') ?? '',
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
+  }
+
+  // Check if the verification code matches
+  if (clientApplication.contactInformation.email && parsedDataResult.data.verificationCode !== '12345') {
+    return { status: 'verification-code-mismatch' } as const;
+  }
+
+  return redirect(getPathById('protected/profile/contact-information', params));
+}
+
+export default function ProtectedProfileVerifyEmail({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { email } = loaderData;
+  const [showDialog, setShowDialog] = useState(false);
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const fetcherStatus = typeof fetcher.data === 'object' && 'status' in fetcher.data ? fetcher.data.status : undefined;
+  const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+  const errorSummary = useErrorSummary(errors, { verificationCode: 'verification-code' });
+  const { ErrorAlert } = useErrorAlert(fetcherStatus === 'verification-code-mismatch');
+
+  const communicationLink = <InlineLink routeId="protected/profile/communication-preferences" params={params} />;
+
+  useEffect(() => {
+    if (fetcherStatus === 'verification-code-sent') {
+      setShowDialog(true);
+    }
+  }, [fetcherStatus, fetcher.data]);
+
+  return (
+    <div className="max-w-prose">
+      <ErrorAlert>
+        <h2 className="mb-2 font-bold">{t('protected-profile:verify-email.verification-code-alert.heading')}</h2>
+        <p className="mb-2">{t('protected-profile:verify-email.verification-code-alert.detail')}</p>
+      </ErrorAlert>
+      <errorSummary.ErrorSummary />
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <fieldset className="mb-6">
+          <p className="mb-4">{t('protected-profile:verify-email.verification-code', { email })}</p>
+          <p className="mb-4">{t('protected-profile:verify-email.request-new')}</p>
+          <p className="mb-8">
+            <Trans ns={handle.i18nNamespaces} i18nKey="protected-profile:verify-email.unable-to-verify" components={{ communicationLink }} />
+          </p>
+          <p className="mb-4 italic">{t('protected-profile:required-label')}</p>
+          <div className="grid items-end gap-6 md:grid-cols-2">
+            <InputField
+              id="verification-code"
+              name="verificationCode"
+              className="w-full"
+              errorMessage={errors?.verificationCode}
+              label={t('protected-profile:verify-email.verification-code-label')}
+              aria-describedby="verification-code"
+              inputMode="numeric"
+              required
+            />
+          </div>
+          <LoadingButton
+            id="request-button"
+            type="button"
+            name="_action"
+            variant="link"
+            className="no-underline hover:underline"
+            loading={isSubmitting}
+            value={FORM_ACTION.request}
+            onClick={async () => {
+              const formData = new FormData();
+              formData.append('_action', FORM_ACTION.request);
+
+              const csrfTokenInput = document.querySelector('input[name="_csrf"]') as HTMLInputElement;
+              formData.append('_csrf', csrfTokenInput.value);
+
+              await fetcher.submit(formData, { method: 'post' });
+            }}
+          >
+            {t('protected-profile:verify-email.request-new-code')}
+          </LoadingButton>
+        </fieldset>
+        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <LoadingButton variant="primary" id="continue-button" name="_action" value={FORM_ACTION.submit} loading={isSubmitting}>
+            {t('protected-profile:verify-email.continue')}
+          </LoadingButton>
+          <ButtonLink id="back-button" routeId="protected/profile/contact/email-address" params={params} disabled={isSubmitting}>
+            {t('protected-profile:verify-email.back')}
+          </ButtonLink>
+        </div>
+      </fetcher.Form>
+      <Dialog open={showDialog} onOpenChange={setShowDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('protected-profile:verify-email.code-sent.heading')}</DialogTitle>
+          </DialogHeader>
+          <DialogDescription>{t('protected-profile:verify-email.code-sent.detail', { email })}</DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm">
+                {t('protected-profile:verify-email.continue')}
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -65,9 +65,14 @@ export const routes = [
         paths: { en: '/:lang/protected/profile/contact-information', fr: '/:lang/protege/profil/contact-information' },
       },
       {
-        id: 'protected/profile/contact/email',
+        id: 'protected/profile/contact/email-address',
         file: 'routes/protected/profile/email.tsx',
         paths: { en: '/:lang/protected/profile/contact/email-address', fr: '/:lang/protege/profil/cordonnees/adresse-courriel' },
+      },
+      {
+        id: 'protected/profile/contact/email-address/verify',
+        file: 'routes/protected/profile/verify-email.tsx',
+        paths: { en: '/:lang/protected/profile/contact/email-address/verify', fr: '/:lang/protege/profil/cordonnees/adresse-courriel/verifier' },
       },
       {
         file: 'routes/protected/apply/layout.tsx',

--- a/frontend/public/locales/en/protected-profile.json
+++ b/frontend/public/locales/en/protected-profile.json
@@ -88,5 +88,29 @@
       "email-required": "Enter email address, for example name@example.com",
       "email-valid": "Enter an email address in the correct format, such as name@example.com"
     }
+  },
+  "verify-email": {
+    "page-title": "Verify your email address",
+    "verification-code": "An email with a verification code has been sent to {{email}}. Please enter the 5-digit verification code and select \"Continue\".",
+    "request-new": "It may take up to 60 seconds for the email to arrive. If you don't see it, check your junk or spam folder. If you still don't have the code, you can request a new one.",
+    "unable-to-verify": "If you are not able to verify your email, select “Back” to update the email address  or <communicationLink>modify your communication preference</communicationLink>.",
+    "verification-code-label": "Verification code",
+    "request-new-code": "Request new verification code",
+    "back": "Back",
+    "continue": "Continue",
+    "cancel-btn": "Cancel",
+    "save-btn": "Save",
+    "error-message": {
+      "verification-code-required": "Enter 5-digit verification code",
+      "verification-code-max-attempts": "You have entered an incorrect verification code more than 5 times. You must request a new code using the \"Request new verification code\" link below."
+    },
+    "verification-code-alert": {
+      "heading": "The verification code entered does not match the code that was sent to the email address provided, or the code has expired.",
+      "detail": "Please check the code and try again. If the issue continues, you can request a new code using the \"Request new verification code\" link below."
+    },
+    "code-sent": {
+      "heading": "New verification code",
+      "detail": "A new verification code has been sent to {{email}}."
+    }
   }
 }

--- a/frontend/public/locales/fr/protected-profile.json
+++ b/frontend/public/locales/fr/protected-profile.json
@@ -88,5 +88,29 @@
       "email-required": "Entrez l'adresse courriel, par exemple nom@exemple.com",
       "email-valid": "Entrez l'adresse courriel dans le bon format, par exemple nom@exemple.com"
     }
+  },
+  "verify-email": {
+    "page-title": "Confirmation de votre adresse courriel",
+    "verification-code": "Un courriel contenant un code de vérification a été envoyé à {{email}}. Veuillez saisir le code à 5 chiffres ci-dessous et cliquer sur «\u00a0Continuer\u00a0».",
+    "request-new": "Le courriel peut prendre jusqu'à 60 secondes avant d'arriver. Si vous ne le voyez pas, vérifiez votre dossier de courrier indésirable. Si le code ne s'y trouve pas non plus, vous pouvez en demander un nouveau.",
+    "unable-to-verify": "Si vous n'êtes pas en mesure de confirmer votre courriel, cliquez sur «\u00a0Retour\u00a0» pour mettre à jour votre adresse courriel ou <communicationLink>modifier vos préférences de communication</communicationLink>.",
+    "verification-code-label": "Code de vérification",
+    "request-new-code": "Demander un nouveau code",
+    "back": "Retour",
+    "continue": "Continuer",
+    "cancel-btn": "Annuler",
+    "save-btn": "Enregistrer",
+    "error-message": {
+      "verification-code-required": "Entrez le code de vérification de 5 chiffres",
+      "verification-code-max-attempts": "Vous avez saisi un code de vérification incorrect plus de 5 fois. Vous devez demander un nouveau code à l'aide du lien «\u00a0Demander un nouveau code de vérification\u00a0» ci-dessous."
+    },
+    "verification-code-alert": {
+      "heading": "Le code de vérification saisi ne correspond pas au code envoyé à l'adresse électronique fournie, ou le code a expiré.",
+      "detail": "Veuillez vérifier le code et essayer de nouveau. Si le problème persiste, vous pouvez demander un nouveau code à l'aide du lien «\u00a0Demander un nouveau code de vérification\u00a0» ci-dessous."
+    },
+    "code-sent": {
+      "heading": "Nouveau code",
+      "detail": "Un nouveau code de vérification a été envoyé à {{email}}."
+    }
   }
 }


### PR DESCRIPTION
### Description
Adds `/profile/contact/email-address/verify`.  This PR adds the UI.  There are outstanding `todo`s, specifically for handling the page action since we aren't using application state.  

### Related Azure Boards Work Items
[AB#7016](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7016)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`