### PR TITLE
feat(frontend) add profileEmailVerificationState to session

### DIFF
--- a/frontend/app/.server/web/session.ts
+++ b/frontend/app/.server/web/session.ts
@@ -42,6 +42,12 @@ type SessionTypeMap = {
   lastAccessTime: string;
   letters: ReadonlyArray<LetterDto>;
   userInfoToken: UserinfoToken;
+  profileEmailVerificationState: {
+    pendingEmail: string;
+    verificationCode: string;
+    verificationAttempts: number;
+    createdAt: string;
+  };
 };
 
 /**


### PR DESCRIPTION
### Description
adds `profileEmailVerificationState` to the session so we can persist state across redirects in the protected-profile email/verify email routes.  This prevents needing to create a route-helper for the protect-profile flow as we really only need to keep state on these two routes.

### Related Azure Boards Work Items
[AB#7016](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7016)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`