### PR TITLE
refactor(frontend) update validation for edit-communication-preferences

### DIFF
--- a/frontend/public/locales/en/protected-profile.json
+++ b/frontend/public/locales/en/protected-profile.json
@@ -82,7 +82,9 @@
     "error-message": {
       "preferred-language-required": "Select preferred language of communication",
       "preferred-method-required": "Select preferred method of communication for Sun Life",
-      "preferred-notification-method-required": "Select preferred method of communication for the Government of Canada"
+      "preferred-notification-method-required": "Select preferred method of communication for the Government of Canada",
+      "preferred-method-email-verified": "A verified email address is required to receive communications from Sun Life digitally.",
+      "preferred-notification-method-email-verified": "A verified email address is required to receive communications from the Government of Canada digitally."
     }
   },
   "phone-number": {

--- a/frontend/public/locales/fr/protected-profile.json
+++ b/frontend/public/locales/fr/protected-profile.json
@@ -82,7 +82,9 @@
     "error-message": {
       "preferred-language-required": "Sélectionnez la langue de communication préférée",
       "preferred-method-required": "Sélectionnez votre moyen de communication préféré avec la Sun Life",
-      "preferred-notification-method-required": "Sélectionnez votre moyen de communication préféré avec le gouvernement du Canada"
+      "preferred-notification-method-required": "Sélectionnez votre moyen de communication préféré avec le gouvernement du Canada",
+      "preferred-method-email-verified": "Une adresse courriel vérifiée est requise pour recevoir les communications de Sun Life par voie numérique.",
+      "preferred-notification-method-email-verified": "Une adresse courriel vérifiée est requise pour recevoir les communications du gouvernement du Canada par voie numérique."
     }
   },
   "phone-number": {


### PR DESCRIPTION
### Description

If the user has selected they prefer email communication, but they don't have a verified email, we should display an error.  For now, since PP doesn't send us whether an email is verified, we can just check whether the email is `undefined`.  A todo has been added for when PP updates their payload.

<img width="769" height="804" alt="image" src="https://github.com/user-attachments/assets/f83567d8-7e03-49f2-ac48-919dc47de3d9" />


### Related Azure Boards Work Items
[AB#7020](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7020)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`