### PR TITLE
refactor(frontend) add updateEmailAddress to mock service

### DIFF
--- a/frontend/app/.server/domain/dtos/profile.dto.ts
+++ b/frontend/app/.server/domain/dtos/profile.dto.ts
@@ -16,3 +16,7 @@ export type DentalBenefitsRequestDto = Readonly<{
   provincialTerritorialSocialProgram?: string;
   province?: string;
 }>;
+
+export type EmailAddressRequestDto = Readonly<{
+  email: string;
+}>;

--- a/frontend/app/.server/domain/repositories/profile.repository.ts
+++ b/frontend/app/.server/domain/repositories/profile.repository.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'inversify';
 
-import type { CommunicationPreferenceRequestDto, DentalBenefitsRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
+import type { CommunicationPreferenceRequestDto, DentalBenefitsRequestDto, EmailAddressRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
 import type { Logger } from '~/.server/logging';
 import { createLogger } from '~/.server/logging';
 
@@ -20,6 +20,14 @@ export interface ProfileRepository {
    * @returns A Promise that resolves when the update is complete.
    */
   updatePhoneNumbers(PhoneNumberDto: PhoneNumberRequestDto): Promise<void>;
+
+  /**
+   * Updates email address for a user.
+   *
+   * @param emailAddressDto The email address dto.
+   * @returns A Promise that resolves when the update is complete.
+   */
+  updateEmailAddress(emailAddressDto: EmailAddressRequestDto): Promise<void>;
 
   /**
    * Updates dental benefits for a user.
@@ -71,6 +79,13 @@ export class MockProfileRepository implements ProfileRepository {
     this.log.debug('Mock updating dental benefits for request [%j]', dentalBenefitsDto);
 
     this.log.debug('Successfully mock updated dental benefits');
+    return await Promise.resolve();
+  }
+
+  async updateEmailAddress(emailAddressDto: EmailAddressRequestDto): Promise<void> {
+    this.log.debug('Mock updating email address for request [%j]', emailAddressDto);
+
+    this.log.debug('Successfully mock updated email address');
     return await Promise.resolve();
   }
 

--- a/frontend/app/.server/domain/services/profile.service.ts
+++ b/frontend/app/.server/domain/services/profile.service.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 
 import { TYPES } from '~/.server/constants';
-import type { CommunicationPreferenceRequestDto, DentalBenefitsRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
+import type { CommunicationPreferenceRequestDto, DentalBenefitsRequestDto, EmailAddressRequestDto, PhoneNumberRequestDto } from '~/.server/domain/dtos';
 import type { ProfileRepository } from '~/.server/domain/repositories';
 import type { AuditService } from '~/.server/domain/services';
 import type { Logger } from '~/.server/logging';
@@ -31,6 +31,14 @@ export interface ProfileService {
    * @returns A Promise that resolves when the update is complete
    */
   updateDentalBenefits(dentalBenefitsDto: DentalBenefitsRequestDto): Promise<void>;
+
+  /**
+   * Updates email address for a user in the protected route.
+   *
+   * @param emailAddressDto The email address dto
+   * @returns A Promise that resolves when the update is complete
+   */
+  updateEmailAddress(emailAddressDto: EmailAddressRequestDto): Promise<void>;
 }
 
 @injectable()
@@ -70,5 +78,13 @@ export class DefaultProfileService implements ProfileService {
     await this.profileRepository.updateDentalBenefits(dentalBenefitsDto);
 
     this.log.trace('Successfully updated dental benefits');
+  }
+
+  async updateEmailAddress(emailAddressDto: EmailAddressRequestDto): Promise<void> {
+    this.log.trace('Updating email address for request [%j]', emailAddressDto);
+
+    await this.profileRepository.updateEmailAddress(emailAddressDto);
+
+    this.log.trace('Successfully updated email address');
   }
 }

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -172,7 +172,7 @@ export async function action({ context: { appContainer, session }, params, reque
     return { status: 'verification-code-mismatch' } as const;
   }
 
-  // TODO: call profile-service to update email
+  await appContainer.get(TYPES.ProfileService).updateEmailAddress({ email: verificationState.pendingEmail });
 
   session.unset('profileEmailVerificationState');
 


### PR DESCRIPTION
### Description
Adds `updateEmailAddress` to mock profile-service.  The default implementation will be added once we know what PP expects in our request payload.

### Related Azure Boards Work Items
[AB#7185](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7185)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`