### PR TITLE
refactor(frontend) remove code verification expiration check

### DIFF
--- a/frontend/app/.server/web/session.ts
+++ b/frontend/app/.server/web/session.ts
@@ -46,7 +46,6 @@ type SessionTypeMap = {
     pendingEmail: string;
     verificationCode: string;
     verificationAttempts: number;
-    createdAt: string;
   };
 };
 

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -92,7 +92,6 @@ export async function action({ context: { appContainer, session }, params, reque
       pendingEmail: parsedDataResult.data.email,
       verificationCode,
       verificationAttempts: 0,
-      createdAt: new Date().toISOString(),
     });
 
     await verificationCodeService.sendVerificationCodeEmail({

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -56,14 +56,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const verificationState = session.get('profileEmailVerificationState');
 
-  const createdAt = new Date(verificationState.createdAt);
-  const now = new Date();
-  // invalidate state if verification code is older than 30 minutes
-  if (now.getTime() - createdAt.getTime() > 30 * 60 * 1000) {
-    session.unset('profileEmailVerificationState');
-    throw redirect(getPathById('protected/profile/contact/email-address', params));
-  }
-
   return {
     meta,
     email: verificationState.pendingEmail,
@@ -83,13 +75,6 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   const verificationState = session.get('profileEmailVerificationState');
-  const createdAt = new Date(verificationState.createdAt);
-  const now = new Date();
-  // invalidate state if verification code is older than 30 minutes
-  if (now.getTime() - createdAt.getTime() > 30 * 60 * 1000) {
-    session.unset('profileEmailVerificationState');
-    throw redirect(getPathById('protected/profile/contact/email-address', params));
-  }
 
   const userInfoToken = session.get('userInfoToken');
   invariant(userInfoToken.sub, 'Expected userInfoToken.sub to be defined');
@@ -109,7 +94,6 @@ export async function action({ context: { appContainer, session }, params, reque
       ...verificationState,
       verificationCode: newVerificationCode,
       verificationAttempts: 0,
-      createdAt: new Date().toISOString(),
     });
 
     await verificationCodeService.sendVerificationCodeEmail({


### PR DESCRIPTION
### Description
To keep the protected-profile space consistent with the protect/public apply/renew spaces, we should remove any checks related to email verification code expiration.  The aforementioned spaces don't track time of initial code verification creation either, so this can removed from the session.

### Related Azure Boards Work Items
[AB#7016](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/7016)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have tested the changes locally
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`