### PR TITLE
refactor(frontend) add auditing to protected profile loaders/actions

### DIFF
--- a/frontend/app/routes/protected/profile/applicant-information.tsx
+++ b/frontend/app/routes/protected/profile/applicant-information.tsx
@@ -45,6 +45,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     sin: child.information.socialInsuranceNumber,
   }));
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.applicant-information', { userId: idToken.sub });
+
   return {
     meta,
     SCCH_BASE_URI,

--- a/frontend/app/routes/protected/profile/communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/communication-preferences.tsx
@@ -33,6 +33,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:communication-preferences.page-title') }) };
   const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.communication-preferences', { userId: idToken.sub });
+
   return {
     meta,
     preferredLanguage: appContainer.get(TYPES.LanguageService).getLocalizedLanguageById(clientApplication.communicationPreferences.preferredLanguage, locale),

--- a/frontend/app/routes/protected/profile/contact-information.tsx
+++ b/frontend/app/routes/protected/profile/contact-information.tsx
@@ -29,6 +29,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:contact-information.page-title') }) };
   const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.contact-information', { userId: idToken.sub });
+
   return {
     meta,
     phoneNumber: clientApplication.contactInformation.phoneNumber,

--- a/frontend/app/routes/protected/profile/dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/dental-benefits.tsx
@@ -62,6 +62,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.dental-benefits', { userId: idToken.sub });
+
   return { meta, clientApplication, clientDentalBenefits, children, SCCH_BASE_URI };
 }
 

--- a/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
@@ -93,6 +93,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-profile:edit-child-dental-benefits.title', { childName }) }),
   };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.edit-child-dental-benefits', { userId: idToken.sub });
+
   return {
     federalProgram,
     provincialTerritorialProgram,
@@ -189,6 +192,10 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   await appContainer.get(TYPES.ProfileService).updateDentalBenefits({ ...parsedFederalBenefitsResult.data, ...parsedProvincialTerritorialBenefitsResult.data });
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.edit-child-dental-benefits', { userId: idToken.sub });
+
   return redirect(getPathById('protected/profile/dental-benefits', params));
 }
 

--- a/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
@@ -44,7 +44,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const languages = appContainer.get(TYPES.LanguageService).listAndSortLocalizedLanguages(locale);
 
-  // TODO update with correct values
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.edit-communication-preferences', { userId: idToken.sub });
+
   return {
     meta,
     defaultState: {
@@ -101,6 +103,9 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   await appContainer.get(TYPES.ProfileService).updateCommunicationPreferences(parsedDataResult.data);
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.edit-communication-preferences', { userId: idToken.sub });
 
   return redirect(getPathById('protected/profile/communication-preferences', params));
 }

--- a/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
@@ -83,6 +83,9 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t('gcweb:meta.title.template', { title: t('protected-profile:edit-dental-benefits.title', { applicantName }) }),
   };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.edit-dental-benefits', { userId: idToken.sub });
+
   return {
     federalProgram,
     provincialTerritorialProgram,
@@ -173,6 +176,10 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   await appContainer.get(TYPES.ProfileService).updateDentalBenefits({ ...parsedFederalBenefitsResult.data, ...parsedProvincialTerritorialBenefitsResult.data });
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.edit-dental-benefits', { userId: idToken.sub });
+
   return redirect(getPathById('protected/profile/dental-benefits', params));
 }
 

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -38,6 +38,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:email.page-title') }) };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.email-address', { userId: idToken.sub });
+
   return {
     meta,
     defaultState: clientApplication.contactInformation.email,
@@ -80,6 +83,8 @@ export async function action({ context: { appContainer, session }, params, reque
   if (!parsedDataResult.success) {
     return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
   }
+
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.email-address', { userId: idToken.sub });
 
   // TODO: check if existing email is verified otherwise we must verify it
   const isNewEmail = clientApplication.contactInformation.email !== parsedDataResult.data.email;

--- a/frontend/app/routes/protected/profile/home-address.tsx
+++ b/frontend/app/routes/protected/profile/home-address.tsx
@@ -44,6 +44,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:home-address.page-title') }) };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.home-address', { userId: idToken.sub });
+
   return {
     meta,
     defaultState: {
@@ -60,6 +63,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   //TODO: update action for address verification
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.home-address', { userId: idToken.sub });
+
   return redirect(getPathById('protected/profile/contact-information', params));
 }
 

--- a/frontend/app/routes/protected/profile/mailing-address.tsx
+++ b/frontend/app/routes/protected/profile/mailing-address.tsx
@@ -45,6 +45,9 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:mailing-address.page-title') }) };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.mailing-address', { userId: idToken.sub });
+
   return {
     meta,
     defaultState: {
@@ -62,6 +65,10 @@ export async function loader({ context: { appContainer, session }, params, reque
 
 export function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
   //TODO: update action for address verification
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.mailing-address', { userId: idToken.sub });
+
   return redirect(getPathById('protected/profile/contact-information', params));
 }
 

--- a/frontend/app/routes/protected/profile/phone-number.tsx
+++ b/frontend/app/routes/protected/profile/phone-number.tsx
@@ -37,6 +37,9 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-profile:phone-number.page-title') }) };
 
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.phone-number', { userId: idToken.sub });
+
   return {
     meta,
     defaultState: {
@@ -77,6 +80,9 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   await appContainer.get(TYPES.ProfileService).updatePhoneNumbers(parsedDataResult.data);
+
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.phone-number', { userId: idToken.sub });
 
   return redirect(getPathById('protected/profile/contact-information', params));
 }

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -54,11 +54,12 @@ export async function loader({ context: { appContainer, session }, params, reque
     throw redirect(getPathById('protected/profile/contact/email-address', params));
   }
 
-  const verificationState = session.get('profileEmailVerificationState');
+  const idToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.profile.verify-email', { userId: idToken.sub });
 
   return {
     meta,
-    email: verificationState.pendingEmail,
+    email: session.get('profileEmailVerificationState').pendingEmail,
   };
 }
 
@@ -86,6 +87,8 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const verificationCodeService = appContainer.get(TYPES.VerificationCodeService);
   const formAction = z.enum(FORM_ACTION).parse(formData.get('_action'));
+
+  appContainer.get(TYPES.AuditService).createAudit('update-data.profile.verify-email', { userId: idToken.sub });
 
   if (formAction === FORM_ACTION.request) {
     const newVerificationCode = verificationCodeService.createVerificationCode(idToken.sub);


### PR DESCRIPTION
### Description
Similar to the protected renew/apply flows, we should add auditing to the protected profile flow.

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [x] I have checked that my code contains no linting errors by running `npm run lint`
- [x] I have checked that my code contains no type errors by running `npm run typecheck`