### PR TITLE
Bum uats

### DIFF
--- a/gitops/overlays/otto/patches/deployments.yaml
+++ b/gitops/overlays/otto/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-7bb1f3e1
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat1/kustomization.yaml
+++ b/gitops/overlays/uat1/kustomization.yaml
@@ -24,8 +24,8 @@ resources:
   #   1. comment ./ingresses.yaml
   #   2. uncomment ./ingresses-maintenance.yaml
   #
-  - ./ingresses.yaml
-  # - ./ingresses-maintenance.yaml
+  # - ./ingresses.yaml
+  - ./ingresses-maintenance.yaml
   # Uncomment if we want to enable letters maintenance
   # - ./ingresses-letters-maintenance.yaml
 patches:

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-7bb1f3e1
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat2/kustomization.yaml
+++ b/gitops/overlays/uat2/kustomization.yaml
@@ -24,8 +24,8 @@ resources:
   #   1. comment ./ingresses.yaml
   #   2. uncomment ./ingresses-maintenance.yaml
   #
-  - ./ingresses.yaml
-  # - ./ingresses-maintenance.yaml
+  # - ./ingresses.yaml
+  - ./ingresses-maintenance.yaml
 patches:
   - path: ./patches/deployments.yaml
   - path: ./patches/deployments-maintenance.yaml

--- a/gitops/overlays/uat2/patches/deployments.yaml
+++ b/gitops/overlays/uat2/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:0.0.0-7bb1f3e1
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the UAT1 and UAT2 GitOps overlays to switch both environments into maintenance mode and deploy a new frontend image version. The changes ensure that the maintenance ingress is used and that the latest release candidate of the frontend is deployed.

Deployment updates:

* Updated the frontend container image for `canada-dental-care-plan-frontend` to version `7.0.0-RC241` in both UAT1 and UAT2 deployments.

Maintenance mode configuration:

* Switched the ingress resource from `ingresses.yaml` to `ingresses-maintenance.yaml` in both `gitops/overlays/uat1/kustomization.yaml` and `gitops/overlays/uat2/kustomization.yaml`, enabling maintenance mode for both environments. [[1]](diffhunk://#diff-812fd7df51a5e76a8476145c886abcc5e99ddae37ee9896c291dc541378270a0L27-R28) [[2]](diffhunk://#diff-c51ad311dfc503425d976c2bef59b269c1b00930a6c9fe47505dc4194fbbf508L27-R28)