### PR TITLE
chore(gitops): deploy v7.0.0 to production with maintenance mode

### DIFF
--- a/gitops/overlays/prod/ingresses-apply-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-apply-maintenance.yaml
@@ -14,6 +14,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `wildcardservicecanadaca` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - srv024.service.canada.ca
   rules:
     - host: srv024.service.canada.ca
       http:
@@ -47,6 +54,13 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `proddpinternaldtsstncom` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - canada-dental-care-plan.prod-dp-internal.dts-stn.com
   rules:
     - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/prod/ingresses-letters-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-letters-maintenance.yaml
@@ -14,6 +14,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `wildcardservicecanadaca` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - srv024.service.canada.ca
   rules:
     - host: srv024.service.canada.ca
       http:
@@ -47,6 +54,13 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `proddpinternaldtsstncom` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - canada-dental-care-plan.prod-dp-internal.dts-stn.com
   rules:
     - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/prod/ingresses-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-maintenance.yaml
@@ -11,6 +11,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `wildcardservicecanadaca` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - srv024.service.canada.ca
   rules:
     - host: srv024.service.canada.ca
       http:
@@ -36,6 +43,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k # required for OAuth proxy
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `proddpinternaldtsstncom` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - canada-dental-care-plan.prod-dp-internal.dts-stn.com
   rules:
     - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/prod/ingresses-renew-error-404.yaml
+++ b/gitops/overlays/prod/ingresses-renew-error-404.yaml
@@ -17,6 +17,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `wildcardservicecanadaca` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - srv024.service.canada.ca
   rules:
     - host: srv024.service.canada.ca
       http:
@@ -53,6 +60,13 @@ metadata:
       rewrite ^/fr/lettres(.*)$ /fr/protege/lettres$1 redirect;
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `proddpinternaldtsstncom` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - canada-dental-care-plan.prod-dp-internal.dts-stn.com
   rules:
     - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/prod/ingresses.yaml
+++ b/gitops/overlays/prod/ingresses.yaml
@@ -6,6 +6,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `wildcardservicecanadaca` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - srv024.service.canada.ca
   rules:
     - host: srv024.service.canada.ca
       http:
@@ -28,6 +35,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `proddpinternaldtsstncom` is provisioned out-of-band by the prod
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - canada-dental-care-plan.prod-dp-internal.dts-stn.com
   rules:
     - host: canada-dental-care-plan.prod-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  - ./ingresses.yaml
-  # - ./ingresses-maintenance.yaml
+  # - ./ingresses.yaml
+  - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
## Description

Deploy frontend v7.0.0 to production with maintenance mode enabled.

### Changes
- Bumped frontend image from `6.0.0` to `7.0.0`
- Enabled maintenance ingress (ingresses-maintenance.yaml)

### Maintenance Window
- **Start:** April 14, 2026, at 8:00 p.m. (EST)
- **End:** April 15, 2026, at 8:00 a.m. (EST)

---

> ⚠️ **WARNING: DO NOT MERGE this PR before April 14, 2026, at 8:00 p.m. (EST)** ⚠️
>
> Merging this PR will activate the maintenance page and deploy v7.0.0 to production.