### PR TITLE
chore(gitops): bump non-prod to v7.0.0

### DIFF
--- a/gitops/overlays/int2/patches/deployments.yaml
+++ b/gitops/overlays/int2/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/otto/patches/deployments.yaml
+++ b/gitops/overlays/otto/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/perf/patches/deployments.yaml
+++ b/gitops/overlays/perf/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/staging/patches/deployments.yaml
+++ b/gitops/overlays/staging/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/training/patches/deployments.yaml
+++ b/gitops/overlays/training/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:6.0.0
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/uat1/patches/deployments.yaml
+++ b/gitops/overlays/uat1/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/gitops/overlays/uat2/patches/deployments.yaml
+++ b/gitops/overlays/uat2/patches/deployments.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0-RC241
+          image: dtsrhpdevscedacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.0.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the `canada-dental-care-plan-frontend` container image version across multiple environment overlays to use the new `7.0.0` release, replacing previous versions and release candidates. This ensures all specified environments are now deploying the latest stable frontend image.

**Container image version updates:**

* Updated the `canada-dental-care-plan-frontend` image to version `7.0.0` (from `6.0.0` or `7.0.0-RC241`) in the following overlays:
  - `int2` (`gitops/overlays/int2/patches/deployments.yaml`)
  - `otto` (`gitops/overlays/otto/patches/deployments.yaml`)
  - `perf` (`gitops/overlays/perf/patches/deployments.yaml`)
  - `staging` (`gitops/overlays/staging/patches/deployments.yaml`)
  - `training` (`gitops/overlays/training/patches/deployments.yaml`)
  - `uat1` (`gitops/overlays/uat1/patches/deployments.yaml`)
  - `uat2` (`gitops/overlays/uat2/patches/deployments.yaml`)