### PR TITLE
chore(gitops): add TLS ingress configuration for all non-prod overlays

### DIFF
--- a/gitops/overlays/dev/ingresses.yaml
+++ b/gitops/overlays/dev/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-dev.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-dev.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-dev.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/int1/ingresses.yaml
+++ b/gitops/overlays/int1/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-int1.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-int1.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-int1.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/int2/ingresses.yaml
+++ b/gitops/overlays/int2/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-int2.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-int2.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-int2.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/otto/ingresses.yaml
+++ b/gitops/overlays/otto/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-otto
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-otto.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-otto.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-otto.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/perf/ingresses.yaml
+++ b/gitops/overlays/perf/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-perf.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-perf.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-perf.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/prototype/ingresses.yaml
+++ b/gitops/overlays/prototype/ingresses.yaml
@@ -6,6 +6,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-prototype.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-prototype.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-prototype.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/staging/ingresses-renew-error-404.yaml
+++ b/gitops/overlays/staging/ingresses-renew-error-404.yaml
@@ -10,6 +10,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-staging.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-staging.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-staging.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/staging/ingresses.yaml
+++ b/gitops/overlays/staging/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-staging.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-staging.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-staging.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/training/ingresses.yaml
+++ b/gitops/overlays/training/ingresses.yaml
@@ -6,6 +6,13 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpinternaldtsstncom` is provisioned out-of-band by the dev
+    # cluster platform (e.g., shared certificate management) and is not managed
+    # in this repo.
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-training.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-training.dev-dp-internal.dts-stn.com
       http:

--- a/gitops/overlays/uat1/ingresses-letters-maintenance.yaml
+++ b/gitops/overlays/uat1/ingresses-letters-maintenance.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-uat1.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/uat1/ingresses-maintenance.yaml
+++ b/gitops/overlays/uat1/ingresses-maintenance.yaml
@@ -11,6 +11,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-uat1.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/uat1/ingresses.yaml
+++ b/gitops/overlays/uat1/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-uat1.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-uat1.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/uat2/ingresses-maintenance.yaml
+++ b/gitops/overlays/uat2/ingresses-maintenance.yaml
@@ -11,6 +11,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-uat2.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-uat2.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-uat2.dev-dp.dts-stn.com
       http:

--- a/gitops/overlays/uat2/ingresses.yaml
+++ b/gitops/overlays/uat2/ingresses.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/name: frontend
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret `devdpdtsstncom` and `devdpinternaldtsstncom` are provisioned
+    # out-of-band by the dev cluster platform (e.g., shared certificate management)
+    # and are not managed in this repo.
+    - secretName: devdpdtsstncom
+      hosts:
+        - cdcp-uat2.dev-dp.dts-stn.com
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - cdcp-uat2.dev-dp-internal.dts-stn.com
   rules:
     - host: cdcp-uat2.dev-dp.dts-stn.com
       http:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the Kubernetes ingress configurations for multiple environments to explicitly define TLS settings for frontend services. The changes ensure that the relevant hostnames are associated with pre-provisioned TLS secrets, which are managed outside of this repository by the cluster platform. This improves clarity and compliance with secure connection requirements across all environments.