### PR TITLE
chore(gitops): toggle ingresses configuration for maintenance mode

### DIFF
--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  # - ./ingresses.yaml
-  - ./ingresses-maintenance.yaml
+  - ./ingresses.yaml
+  # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -66,11 +66,6 @@ configMapGenerator:
     #                the project as a reference for future, similar deployments
     # files:
     #   - ./configs/maintenance/503.html
-    literals:
-      - startTimeEn=April 14, 2026, at 8:00 p.m.
-      - startTimeFr=14 avril 2026 à 20 h 00
-      - endTimeEn=April 15, 2026, at 8:00 a.m. (EST)
-      - endTimeFr=15 avril 2026 à 08 h 00 (HNE)
 secretGenerator:
   - name: frontend
     behavior: replace


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the ingress configuration for the production environment by switching from the maintenance ingress to the standard ingress. This change will direct traffic back to the normal application routes and remove the maintenance page for users.

Ingress configuration update:

* Enabled the standard ingress by uncommenting `./ingresses.yaml` and disabled the maintenance ingress by commenting out `./ingresses-maintenance.yaml` in `gitops/overlays/prod/kustomization.yaml`.