### PR TITLE
feat(frontend): enhance toLocaleDateString for timeZone support and add documentation

### DIFF
--- a/frontend/__tests__/utils/date-utils.test.ts
+++ b/frontend/__tests__/utils/date-utils.test.ts
@@ -240,6 +240,26 @@ describe('useMonths', () => {
     it('should throw an error for an invalid Canadian locale', () => {
       expect(() => toLocaleDateString(new UTCDate(2000, 0, 1), 'xy')).toThrowError();
     });
+
+    it('should format date in UTC when timeZone is explicitly set to UTC', () => {
+      // 2024-01-15 23:00 UTC is still Jan 15 in UTC
+      expect(toLocaleDateString(new UTCDate('2024-01-15T23:00:00.000Z'), 'en', { timeZone: 'UTC' })).toEqual('January 15, 2024');
+    });
+
+    it('should format date adjusted to the specified timeZone', () => {
+      // 2024-01-15 23:00 UTC is Jan 16 in Asia/Tokyo (UTC+9)
+      expect(toLocaleDateString(new UTCDate('2024-01-15T23:00:00.000Z'), 'en', { timeZone: 'Asia/Tokyo' })).toEqual('January 16, 2024');
+    });
+
+    it('should format date in a negative offset timeZone', () => {
+      // 2024-01-16 03:00 UTC is still Jan 15 in America/Vancouver (UTC-8)
+      expect(toLocaleDateString(new UTCDate('2024-01-16T03:00:00.000Z'), 'en', { timeZone: 'America/Vancouver' })).toEqual('January 15, 2024');
+    });
+
+    it('should format date in French with a timeZone option', () => {
+      // 2024-01-15 23:00 UTC is Jan 16 in Asia/Tokyo (UTC+9)
+      expect(toLocaleDateString(new UTCDate('2024-01-15T23:00:00.000Z'), 'fr', { timeZone: 'Asia/Tokyo' })).toEqual('16 janvier 2024');
+    });
   });
 });
 

--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -212,9 +212,20 @@ export function parseDateTimeString(dateTime: string) {
   return new UTCDate(dateTime);
 }
 
-export function toLocaleDateString(date: UTCDate, locale: string) {
+/**
+ * Converts a UTC date to a localized date string using Canadian locale formats.
+ * @param date - The UTC date to convert
+ * @param locale - The language locale ('en' or 'fr' for English or French)
+ * @param options - Optional Intl.DateTimeFormatOptions, specifically for timeZone configuration
+ * @returns A localized date string formatted as "Month Day, Year" (e.g., "January 15, 2024" for English or "15 janvier 2024" for French)
+ * @throws {Error} If the provided locale is not 'en' or 'fr' (case-insensitive)
+ * @example
+ * const date = new Date('2024-01-15').toUTCDate();
+ * const result = toLocaleDateString(date, 'en'); // "January 15, 2024"
+ */
+export function toLocaleDateString(date: UTCDate, locale: string, options?: Pick<Intl.DateTimeFormatOptions, 'timeZone'>) {
   invariant(/^(en|fr)$/i.test(locale), `Canadian locale is invalid [${locale}]`);
-  return date.toLocaleDateString(`${locale}-CA`, { year: 'numeric', month: 'long', day: 'numeric' });
+  return date.toLocaleDateString(`${locale}-CA`, { ...options, dateStyle: 'long' });
 }
 
 /**


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request enhances the `toLocaleDateString` utility function by allowing callers to specify a time zone for date formatting, and updates its documentation. Comprehensive tests have been added to verify correct formatting across different locales and time zones.

Enhancements to date formatting:

* Updated the `toLocaleDateString` function in `date-utils.ts` to accept an optional `options` parameter, enabling the specification of a `timeZone` for accurate localized date formatting. The function now merges these options with the default formatting.
* Improved the function's documentation with a detailed docstring, including usage examples and error conditions.

Testing improvements:

* Added several test cases in `date-utils.test.ts` to verify that `toLocaleDateString` correctly formats dates for different time zones (e.g., UTC, Asia/Tokyo, America/Vancouver) and locales (`en`, `fr`).