### PR TITLE
fix(frontend): fix datetime formatting using time zone config

### DIFF
--- a/frontend/app/routes/protected/documents/index.tsx
+++ b/frontend/app/routes/protected/documents/index.tsx
@@ -9,6 +9,7 @@ import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/table';
 import { pageIds } from '~/page-ids';
+import { parseDateTimeString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -44,14 +45,13 @@ export async function loader({ context: { appContainer, session }, params, reque
   appContainer.get(TYPES.AuditService).createAudit('page-view.documents', { userId: idToken.sub });
 
   const { TIME_ZONE } = appContainer.get(TYPES.ClientConfig);
-  const dateFormatter = new Intl.DateTimeFormat(`${locale}-CA`, { timeZone: TIME_ZONE, dateStyle: 'long' });
 
   return {
     meta,
     documents: evidentiaryDocuments.map((document) => {
       return {
         ...document,
-        mscaUploadDateFormatted: dateFormatter.format(new Date(document.mscaUploadDate)),
+        mscaUploadDateFormatted: toLocaleDateString(parseDateTimeString(document.mscaUploadDate), locale, { timeZone: TIME_ZONE }),
       };
     }),
     SCCH_BASE_URI,

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -1,7 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
-import { addDays } from 'date-fns';
+import { addMinutes } from 'date-fns';
 import { Trans, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
@@ -26,7 +26,7 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
-import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, toLocaleDateString } from '~/utils/date-utils';
+import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateTimeString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -64,7 +64,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const state = getPublicApplicationState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
-  const { RENEWAL_PERIOD_END_DATE } = appContainer.get(TYPES.ServerConfig);
+  const { RENEWAL_PERIOD_END_DATE, TIME_ZONE } = appContainer.get(TYPES.ServerConfig);
 
   const applicantInformationSchema = z
     .object({
@@ -173,7 +173,10 @@ export async function action({ context: { appContainer, session }, params, reque
     }
 
     if (clientApplicationRenewalEligibilityResult.result !== 'ELIGIBLE') {
-      const startDate = toLocaleDateString(addDays(RENEWAL_PERIOD_END_DATE, 1), locale);
+      const renewalPeriodEndDate = parseDateTimeString(RENEWAL_PERIOD_END_DATE);
+      // Add one minute to ensure the intake start date is after the renewal period end date
+      const intakeStartDate = addMinutes(renewalPeriodEndDate, 1);
+      const startDate = toLocaleDateString(intakeStartDate, locale, { timeZone: TIME_ZONE });
       return { status: 'client-not-found', startDate } as const;
     }
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors date handling in two frontend routes to improve consistency and accuracy, especially with respect to time zones. It replaces direct `Date` and `Intl.DateTimeFormat` usage with utility functions that handle parsing and formatting, and ensures time zone awareness when generating user-facing dates.

**Date parsing and formatting improvements:**

* Replaces direct use of `Intl.DateTimeFormat` and `Date` in `documents/index.tsx` with the `parseDateTimeString` and `toLocaleDateString` utility functions, ensuring consistent and locale-aware date formatting that respects the configured time zone. [[1]](diffhunk://#diff-a5afd3578b93da915686d3ff29444eb0822675b8d406eddd57381db85eab9183R2) [[2]](diffhunk://#diff-a5afd3578b93da915686d3ff29444eb0822675b8d406eddd57381db85eab9183L47-R54)
* Updates imports in both `documents/index.tsx` and `personal-information.tsx` to use the new date utility functions for parsing and formatting. [[1]](diffhunk://#diff-a5afd3578b93da915686d3ff29444eb0822675b8d406eddd57381db85eab9183R2) [[2]](diffhunk://#diff-271f40f21671491b3b50d567b42b68187597a5547d18ecc2b9d35d16d75c9a8dL29-R29)

**Time zone handling and date calculation:**

* In `personal-information.tsx`, retrieves `TIME_ZONE` from server config and passes it to date formatting utilities, ensuring displayed dates are accurate for the user's configured time zone. [[1]](diffhunk://#diff-271f40f21671491b3b50d567b42b68187597a5547d18ecc2b9d35d16d75c9a8dL67-R67) [[2]](diffhunk://#diff-271f40f21671491b3b50d567b42b68187597a5547d18ecc2b9d35d16d75c9a8dL176-R179)
* Changes the calculation of the intake start date for ineligible renewals to add one minute (using `addMinutes`) to the renewal period end date, instead of one day, for greater precision. [[1]](diffhunk://#diff-271f40f21671491b3b50d567b42b68187597a5547d18ecc2b9d35d16d75c9a8dL4-R4) [[2]](diffhunk://#diff-271f40f21671491b3b50d567b42b68187597a5547d18ecc2b9d35d16d75c9a8dL176-R179)

AB#40142