### PR TITLE
fix(frontend): add route handling for renewal-children application flow

### DIFF
--- a/frontend/app/routes/protected/application/spokes/email.tsx
+++ b/frontend/app/routes/protected/application/spokes/email.tsx
@@ -30,6 +30,9 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
     case 'intake-children': {
       return `protected/application/$id/${applicationFlow}/parent-or-guardian`;
     }
+    case 'renewal-children': {
+      return `protected/application/$id/${applicationFlow}/parent-or-guardian`;
+    }
     default: {
       return `protected/application/$id/${applicationFlow}/contact-information`;
     }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the application routing logic to handle a new flow type. Specifically, it ensures that the `'renewal-children'` application flow is routed in the same way as `'intake-children'`.

Routing logic update:

* Added a case for `'renewal-children'` in the `getRouteFromApplicationFlow` function in `email.tsx`, so it now routes to the `parent-or-guardian` step, matching the behavior for `'intake-children'`.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

Fixes [AB#8654](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8654)