### PR TITLE
fix(frontend): preserve existing partner information during renewal w…

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
-import { getAgeCategoryFromAge, getAgeCategoryFromDateString, getAgeCategoryReferenceDate, getAllowedTypeOfApplication, getEligibilityStatus, isChildClientNumberValid, isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
+import {
+  getAgeCategoryFromAge,
+  getAgeCategoryFromDateString,
+  getAgeCategoryReferenceDate,
+  getAllowedTypeOfApplication,
+  getEligibilityStatus,
+  isChildClientNumberValid,
+  isChildOrYouth,
+  maritalStatusHasPartner,
+} from '~/.server/routes/helpers/base-application-route-helpers';
 
 vi.mock('~/.server/utils/env.utils', () => ({
   getEnv: vi.fn(() => ({
     ELIGIBILITY_STATUS_CODE_ELIGIBLE: 'ELIGIBLE',
+    MARITAL_STATUS_CODE_COMMON_LAW: 'COMMON_LAW',
+    MARITAL_STATUS_CODE_MARRIED: 'MARRIED',
   })),
 }));
 
@@ -382,6 +393,30 @@ describe('getAllowedTypeOfApplication', () => {
           },
         }),
       ).toEqual(['children']);
+    });
+  });
+
+  describe('maritalStatusHasPartner', () => {
+    it('returns true when marital status is MARITAL_STATUS_CODE_MARRIED', () => {
+      expect(maritalStatusHasPartner('MARRIED')).toBe(true);
+    });
+
+    it('returns true when marital status is MARITAL_STATUS_CODE_COMMON_LAW', () => {
+      expect(maritalStatusHasPartner('COMMON_LAW')).toBe(true);
+    });
+
+    it('returns false when marital status is undefined', () => {
+      expect(maritalStatusHasPartner(undefined)).toBe(false);
+    });
+
+    it('returns false when marital status is empty string', () => {
+      expect(maritalStatusHasPartner('')).toBe(false);
+    });
+
+    it('returns false when marital status is a value other than married or common law', () => {
+      expect(maritalStatusHasPartner('SINGLE')).toBe(false);
+      expect(maritalStatusHasPartner('DIVORCED')).toBe(false);
+      expect(maritalStatusHasPartner('WIDOWED')).toBe(false);
     });
   });
 });

--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -1,6 +1,7 @@
 import type { PickDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
+import { getEnv } from '~/.server/utils/env.utils';
 import type { EligibilityType } from '~/components/eligibility';
 import { getAgeFromDateString } from '~/utils/date-utils';
 
@@ -176,4 +177,16 @@ export function getAllowedTypeOfApplication({
   // If the primary applicant is not eligible for renewal but at least one child is eligible for renewal, we allow
   // 'children' applications to enable the user to submit an application on behalf of their eligible child(ren).
   return ['children'];
+}
+
+/**
+ * Determines whether a marital status indicates that a person has a partner.
+ *
+ * @param maritalStatus - The marital status code to check. If undefined or empty, returns false.
+ * @returns `true` if the marital status is either common law or married, `false` otherwise.
+ */
+export function maritalStatusHasPartner(maritalStatus?: string) {
+  if (!maritalStatus) return false;
+  const { MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
+  return [MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED].includes(maritalStatus);
 }

--- a/frontend/app/.server/routes/helpers/protected-application-intake-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-adult-route-helpers.ts
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { applicantInformationStateHasPartner, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -135,11 +135,11 @@ export function validateProtectedApplicationIntakeAdultStateForReview({ params, 
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-adult/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-adult/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -133,11 +133,11 @@ export function validateProtectedApplicationIntakeChildStateForReview({ params, 
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-children/parent-or-guardian', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication } from '~/.server/routes/helpers/base-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -133,11 +133,11 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-family/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('protected/application/$id/intake-family/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
@@ -3,9 +3,9 @@ import { redirect } from 'react-router';
 import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -142,11 +142,11 @@ export function validateProtectedApplicationRenewalChildStateForReview({ params,
     throw redirect(getPathById('protected/application/$id/renew', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('protected/application/$id/renewal-children/parent-or-guardian', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('protected/application/$id/renewal-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
@@ -3,8 +3,8 @@ import { redirect } from 'react-router';
 import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -142,11 +142,11 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/renew', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('protected/application/$id/renewal-family/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('protected/application/$id/renewal-family/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -358,12 +358,6 @@ export function getChildrenState<TState extends Pick<ProtectedApplicationState, 
     : state.children.filter((child) => isNewChildState(child) === false);
 }
 
-export function applicantInformationStateHasPartner(maritalStatus?: string) {
-  if (!maritalStatus) return false;
-  const { MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
-  return [MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED].includes(maritalStatus);
-}
-
 /**
  * Extracts the input model and type of application from a combined string.
  *

--- a/frontend/app/.server/routes/helpers/public-application-full-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-adult-route-helpers.ts
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { applicantInformationStateHasPartner, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -140,11 +140,11 @@ export function validatePublicApplicationFullAdultStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-adult/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-adult/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -139,11 +139,11 @@ export function validatePublicApplicationFullChildStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-children/parent-or-guardian', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -139,11 +139,11 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-family/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('public/application/$id/full-family/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -340,12 +340,6 @@ export function getChildrenState<TState extends Pick<PublicApplicationState, 'ch
     : state.children.filter((child) => isNewChildState(child) === false);
 }
 
-export function applicantInformationStateHasPartner(maritalStatus?: string) {
-  if (!maritalStatus) return false;
-  const { MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
-  return [MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED].includes(maritalStatus);
-}
-
 /**
  * Extracts the input model and type of application from a combined string.
  *

--- a/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
@@ -3,9 +3,9 @@ import { redirect } from 'react-router';
 import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -143,11 +143,11 @@ export function validatePublicApplicationSimplifiedChildStateForReview({ params,
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('public/application/$id/simplified-children/parent-or-guardian', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('public/application/$id/simplified-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
@@ -3,8 +3,8 @@ import { redirect } from 'react-router';
 import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
-import { getAllowedTypeOfApplication, isChildClientNumberValid } from '~/.server/routes/helpers/base-application-route-helpers';
-import { applicantInformationStateHasPartner, getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -143,11 +143,11 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
     throw redirect(getPathById('protected/application/$id/your-application', params));
   }
 
-  if (applicantInformationStateHasPartner(maritalStatus) && !partnerInformation) {
+  if (maritalStatusHasPartner(maritalStatus) && !partnerInformation) {
     throw redirect(getPathById('public/application/$id/simplified-family/marital-status', params));
   }
 
-  if (!applicantInformationStateHasPartner(maritalStatus) && partnerInformation) {
+  if (!maritalStatusHasPartner(maritalStatus) && partnerInformation) {
     throw redirect(getPathById('public/application/$id/simplified-family/marital-status', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
@@ -1,4 +1,4 @@
-import type { PickDeep } from 'node_modules/type-fest/source/pick-deep';
+import type { PickDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { isChildClientNumberValid, isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -17,6 +17,7 @@ import type {
   RenewalContactInformationDto,
   RenewalPartnerInformationDto,
 } from '~/.server/domain/dtos';
+import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type {
   ApplicationYearState,
   ChildState,
@@ -137,6 +138,7 @@ interface ToMailingAddressArgs {
 }
 
 interface ToPartnerInformationArgs {
+  effectiveMaritalStatus?: string;
   existingPartnerInformation?: ReadonlyDeep<ClientPartnerInformationDto>;
   renewedPartnerInformation?: PartnerInformationState;
 }
@@ -200,6 +202,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       dentalInsurance,
       partnerInformation: this.toPartnerInformation({
+        effectiveMaritalStatus: maritalStatus ?? clientApplication.applicantInformation.maritalStatus,
         existingPartnerInformation: clientApplication.partnerInformation,
         renewedPartnerInformation: partnerInformation,
       }),
@@ -276,6 +279,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       dentalInsurance,
       partnerInformation: this.toPartnerInformation({
+        effectiveMaritalStatus: maritalStatus ?? clientApplication.applicantInformation.maritalStatus,
         existingPartnerInformation: clientApplication.partnerInformation,
         renewedPartnerInformation: partnerInformation,
       }),
@@ -346,6 +350,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       dentalBenefits: [],
       dentalInsurance: undefined,
       partnerInformation: this.toPartnerInformation({
+        effectiveMaritalStatus: maritalStatus ?? clientApplication.applicantInformation.maritalStatus,
         existingPartnerInformation: clientApplication.partnerInformation,
         renewedPartnerInformation: partnerInformation,
       }),
@@ -576,7 +581,21 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return dentalBenefits;
   }
 
-  private toPartnerInformation({ existingPartnerInformation, renewedPartnerInformation }: ToPartnerInformationArgs): RenewalPartnerInformationDto | undefined {
-    return renewedPartnerInformation;
+  private toPartnerInformation({ effectiveMaritalStatus, existingPartnerInformation, renewedPartnerInformation }: ToPartnerInformationArgs): RenewalPartnerInformationDto | undefined {
+    if (!maritalStatusHasPartner(effectiveMaritalStatus)) {
+      return undefined;
+    }
+
+    if (renewedPartnerInformation) {
+      return renewedPartnerInformation;
+    }
+
+    return existingPartnerInformation
+      ? {
+          confirm: existingPartnerInformation.confirm,
+          socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber ?? '',
+          yearOfBirth: existingPartnerInformation.yearOfBirth,
+        }
+      : undefined;
   }
 }

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -9,8 +9,9 @@ import { z } from 'zod';
 import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
+import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationFlow, PartnerInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { applicantInformationStateHasPartner, getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -135,12 +136,12 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
   const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
 
-  if (!parsedMaritalStatus.success || (applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
+  if (!parsedMaritalStatus.success || (maritalStatusHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
     return data(
       {
         errors: {
           ...(parsedMaritalStatus.error ? transformFlattenedError(z.flattenError(parsedMaritalStatus.error)) : {}),
-          ...(parsedMaritalStatus.success && applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(z.flattenError(parsedPartnerInformation.error)) : {}),
+          ...(parsedMaritalStatus.success && maritalStatusHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(z.flattenError(parsedPartnerInformation.error)) : {}),
         },
       },
       { status: 400 },

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -9,8 +9,9 @@ import { z } from 'zod';
 import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
+import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationFlow, PartnerInformationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { applicantInformationStateHasPartner, getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -128,12 +129,12 @@ export async function action({ context: { appContainer, session }, params, reque
   const parsedMaritalStatus = maritalStatusSchema.safeParse(maritalStatusData);
   const parsedPartnerInformation = partnerInformationSchema.safeParse(partnerInformationData);
 
-  if (!parsedMaritalStatus.success || (applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
+  if (!parsedMaritalStatus.success || (maritalStatusHasPartner(parsedMaritalStatus.data.maritalStatus) && !parsedPartnerInformation.success)) {
     return data(
       {
         errors: {
           ...(parsedMaritalStatus.error ? transformFlattenedError(z.flattenError(parsedMaritalStatus.error)) : {}),
-          ...(parsedMaritalStatus.success && applicantInformationStateHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(z.flattenError(parsedPartnerInformation.error)) : {}),
+          ...(parsedMaritalStatus.success && maritalStatusHasPartner(parsedMaritalStatus.data.maritalStatus) && parsedPartnerInformation.error ? transformFlattenedError(z.flattenError(parsedPartnerInformation.error)) : {}),
         },
       },
       { status: 400 },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,6 @@
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
     "paths": {
-      "*": ["./*"],
       "~/*": ["./app/*"]
     },
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the logic for mapping partner information during the benefit renewal process. The main change ensures that if renewed partner information is not available, the system now falls back to using existing partner information, constructing a new object with default values where necessary.

Benefit renewal mapping improvements:

* Updated the `toPartnerInformation` method in `benefit-renewal.state.mapper.ts` to return a constructed object based on `existingPartnerInformation` if `renewedPartnerInformation` is not present, ensuring fields like `socialInsuranceNumber` default to an empty string when undefined.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

ESDCCM/CDCP Work item: `40166`