### PR TITLE
fix(frontend): home address assignment logic in mailing address action

### DIFF
--- a/frontend/app/routes/protected/profile/mailing-address.tsx
+++ b/frontend/app/routes/protected/profile/mailing-address.tsx
@@ -134,15 +134,7 @@ export async function action({ context: { appContainer, session }, params, reque
       {
         clientId: clientApplication.applicantInformation.clientId,
         mailingAddress,
-        homeAddress: isCopyMailingToHome
-          ? mailingAddress
-          : {
-              address: clientApplication.contactInformation.homeAddress?.address ?? '',
-              city: clientApplication.contactInformation.homeAddress?.city ?? '',
-              countryId: clientApplication.contactInformation.homeAddress?.country ?? '',
-              postalZipCode: clientApplication.contactInformation.homeAddress?.postalCode ?? '',
-              provinceStateId: clientApplication.contactInformation.homeAddress?.province ?? '',
-            },
+        homeAddress: resolveHomeAddress(isCopyMailingToHome, mailingAddress, clientApplication.contactInformation.homeAddress),
       },
       idToken.sub,
     );
@@ -203,15 +195,7 @@ export async function action({ context: { appContainer, session }, params, reque
     {
       clientId: clientApplication.applicantInformation.clientId,
       mailingAddress,
-      homeAddress: isCopyMailingToHome
-        ? mailingAddress
-        : {
-            address: clientApplication.contactInformation.homeAddress?.address ?? '',
-            city: clientApplication.contactInformation.homeAddress?.city ?? '',
-            countryId: clientApplication.contactInformation.homeAddress?.country ?? '',
-            postalZipCode: clientApplication.contactInformation.homeAddress?.postalCode ?? '',
-            provinceStateId: clientApplication.contactInformation.homeAddress?.province ?? '',
-          },
+      homeAddress: resolveHomeAddress(isCopyMailingToHome, mailingAddress, clientApplication.contactInformation.homeAddress),
     },
     idToken.sub,
   );
@@ -221,6 +205,28 @@ export async function action({ context: { appContainer, session }, params, reque
 
 function isAddressResponse(data: unknown): data is AddressResponse {
   return typeof data === 'object' && data !== null && 'status' in data && typeof data.status === 'string';
+}
+
+/**
+ * Resolves the home address to send to the external service. If the user has chosen to copy the mailing address
+ * to home, or if there is no existing home address on file, uses the mailing address. Otherwise, preserves the
+ * existing home address. The external service requires both addresses to be sent in the same request.
+ */
+function resolveHomeAddress(
+  isCopyMailingToHome: boolean,
+  mailingAddress: { address: string; city: string; countryId: string; postalZipCode?: string; provinceStateId?: string },
+  existingHomeAddress: { address: string; city: string; country: string; postalCode?: string; province?: string } | null | undefined,
+) {
+  if (isCopyMailingToHome || !existingHomeAddress) {
+    return mailingAddress;
+  }
+  return {
+    address: existingHomeAddress.address,
+    city: existingHomeAddress.city,
+    countryId: existingHomeAddress.country,
+    postalZipCode: existingHomeAddress.postalCode,
+    provinceStateId: existingHomeAddress.province,
+  };
 }
 
 export default function EditMailingAddress({ loaderData, params }: Route.ComponentProps) {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors how the home address is determined and sent when updating addresses in the user profile. The logic now ensures that if the user chooses to copy their mailing address to their home address, or if there is no existing home address, the mailing address is used for both fields. Otherwise, the existing home address is preserved and sent as-is. This change helps ensure both addresses are always sent to the external service as required.

**Address update logic improvements:**

* Refactored the logic for determining `homeAddress` so that if the user opts to copy the mailing address or if no home address exists, the mailing address is used; otherwise, the existing home address is sent. This ensures both addresses are always provided to the external service, even if the home address is unchanged. [[1]](diffhunk://#diff-ec327ca4447305920d6637007b079ff14d599cd9ab25ac64088115b1b81eeab1R203-R221) [[2]](diffhunk://#diff-ec327ca4447305920d6637007b079ff14d599cd9ab25ac64088115b1b81eeab1L137-R145)