### PR TITLE
refactor(frontend): refactor contact information handling and clean up parameters

### DIFF
--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -99,7 +99,6 @@ interface ToApplicantInformationArgs {
 interface ToChildrenArgs {
   existingChildren: readonly ReadonlyDeep<ClientChildDto>[];
   renewedChildren: ChildState[];
-  isProtectedRenewal?: boolean;
 }
 
 interface ToCommunicationPreferencesArgs {
@@ -400,7 +399,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toChildren({ existingChildren, renewedChildren, isProtectedRenewal }: ToChildrenArgs): RenewalChildDto[] {
+  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs): RenewalChildDto[] {
     return renewedChildren.map((renewedChild) => {
       const existingChild = existingChildren.find((existingChild) => existingChild.information.clientNumber === renewedChild.information?.memberId);
       invariant(existingChild, 'Expected existingChild to be defined');

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -111,12 +111,12 @@ interface ToCommunicationPreferencesArgs {
 
 interface ToContactInformationArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
-  hasEmailChanged: boolean;
-  isHomeAddressSameAsMailingAddress?: boolean;
-  renewedContactInformation?: DeclaredChangePhoneNumberState;
-  renewedHomeAddress?: DeclaredChangeHomeAddressState;
-  renewedMailingAddress?: DeclaredChangeMailingAddressState;
-  renewedEmail?: string;
+  isHomeAddressSameAsMailingAddress: boolean | undefined;
+  renewedContactInformation: DeclaredChangePhoneNumberState | undefined;
+  renewedHomeAddress: DeclaredChangeHomeAddressState | undefined;
+  renewedMailingAddress: DeclaredChangeMailingAddressState | undefined;
+  renewedEmailVerified: boolean | undefined;
+  renewedEmail: string | undefined;
 }
 
 interface ToDentalBenefitsArgs {
@@ -141,6 +141,12 @@ interface ToPartnerInformationArgs {
   effectiveMaritalStatus?: string;
   existingPartnerInformation?: ReadonlyDeep<ClientPartnerInformationDto>;
   renewedPartnerInformation?: PartnerInformationState;
+}
+
+interface HasEmailChangedArgs {
+  emailVerified: boolean | undefined;
+  email: string | undefined;
+  existingEmail: string | undefined;
 }
 
 @injectable()
@@ -172,6 +178,12 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       throw new Error('Expected clientApplication to be defined');
     }
 
+    const hasEmailChanged = this.hasEmailChanged({
+      emailVerified,
+      email,
+      existingEmail: clientApplication.contactInformation.email,
+    });
+
     return {
       ...clientApplication,
       applicantInformation: this.toApplicantInformation({
@@ -188,11 +200,11 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
-        hasEmailChanged: !!email,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmailVerified: emailVerified,
         renewedEmail: email,
       }),
       dentalBenefits: this.toDentalBenefits({
@@ -213,7 +225,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged: emailVerified && email !== clientApplication.contactInformation.email,
+        hasEmailChanged,
       },
     };
   }
@@ -265,11 +277,11 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
-        hasEmailChanged: !!email,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmailVerified: emailVerified,
         renewedEmail: email,
       }),
       dentalBenefits: this.toDentalBenefits({
@@ -290,7 +302,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged: emailVerified && email !== clientApplication.contactInformation.email,
+        hasEmailChanged: this.hasEmailChanged({ emailVerified, email, existingEmail: clientApplication.contactInformation.email }),
       },
     };
   }
@@ -340,11 +352,11 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
-        hasEmailChanged: !!email,
         isHomeAddressSameAsMailingAddress,
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
+        renewedEmailVerified: emailVerified,
         renewedEmail: email,
       }),
       dentalBenefits: [],
@@ -361,9 +373,20 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged: emailVerified && email !== clientApplication.contactInformation.email,
+        hasEmailChanged: this.hasEmailChanged({ emailVerified, email, existingEmail: clientApplication.contactInformation.email }),
       },
     };
+  }
+
+  /**
+   * Determines if the email has changed based on the emailVerified flag, the new email value, and the existing email
+   * value. The email is considered changed if it is verified, not empty, and different from the existing email.
+   *
+   * @param param0 - An object containing the emailVerified flag, the new email value, and the existing email value.
+   * @returns A boolean indicating whether the email has changed.
+   */
+  private hasEmailChanged({ emailVerified, email, existingEmail }: HasEmailChangedArgs): boolean {
+    return emailVerified === true && email !== undefined && email.trim().length > 0 && email !== existingEmail;
   }
 
   private toApplicantInformation({ existingApplicantInformation, renewedMaritalStatus }: ToApplicantInformationArgs): RenewalApplicantInformationDto {
@@ -407,27 +430,38 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     });
   }
 
-  private toContactInformation({ existingContactInformation, hasEmailChanged, isHomeAddressSameAsMailingAddress, renewedContactInformation, renewedHomeAddress, renewedMailingAddress, renewedEmail }: ToContactInformationArgs): RenewalContactInformationDto {
+  private toContactInformation({
+    existingContactInformation,
+    isHomeAddressSameAsMailingAddress,
+    renewedContactInformation,
+    renewedHomeAddress,
+    renewedMailingAddress,
+    renewedEmailVerified,
+    renewedEmail,
+  }: ToContactInformationArgs): RenewalContactInformationDto {
+    // If the phone number has changed, use the new phone number values. Otherwise, use the existing phone number values.
+    const phoneNumbers = renewedContactInformation?.hasChanged
+      ? {
+          phoneNumber: renewedContactInformation.value.primary,
+          phoneNumberAlt: renewedContactInformation.value.alternate,
+        }
+      : {
+          phoneNumber: existingContactInformation.phoneNumber,
+          phoneNumberAlt: existingContactInformation.phoneNumberAlt,
+        };
+
+    const hasEmailChanged = this.hasEmailChanged({
+      emailVerified: renewedEmailVerified,
+      email: renewedEmail,
+      existingEmail: existingContactInformation.email,
+    });
+
     return {
+      email: hasEmailChanged && renewedEmail ? renewedEmail : existingContactInformation.email,
       copyMailingAddress: !!isHomeAddressSameAsMailingAddress,
       ...this.toHomeAddress({ existingContactInformation, isHomeAddressSameAsMailingAddress, homeAddress: renewedHomeAddress, mailingAddress: renewedMailingAddress }),
       ...this.toMailingAddress({ existingContactInformation, mailingAddress: renewedMailingAddress }),
-      ...(renewedContactInformation?.hasChanged
-        ? {
-            phoneNumber: renewedContactInformation.value.primary,
-            phoneNumberAlt: renewedContactInformation.value.alternate,
-          }
-        : {
-            phoneNumber: existingContactInformation.phoneNumber,
-            phoneNumberAlt: existingContactInformation.phoneNumberAlt,
-          }),
-      ...(hasEmailChanged
-        ? {
-            email: renewedEmail,
-          }
-        : {
-            email: existingContactInformation.email,
-          }),
+      ...phoneNumbers,
     };
   }
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors how email changes are detected and handled in the `DefaultBenefitRenewalStateMapper` class and related interfaces. The main focus is to centralize and clarify the logic for determining if an email has changed, and to update the interfaces and method signatures to reflect these improvements.

**Email change detection and handling:**

* Introduced a new private method `hasEmailChanged` that encapsulates the logic for determining if an email has changed, based on verification status, presence, and difference from the existing email. This method is now used throughout the class to ensure consistent behavior. [[1]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L364-R390) [[2]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3R145-R150)
* Updated the `ToContactInformationArgs` interface to remove the `hasEmailChanged` boolean and instead pass `renewedEmailVerified` and `renewedEmail`, allowing the method to compute email changes internally.
* Refactored the `toContactInformation` method to use the new `hasEmailChanged` logic, ensuring that the correct email is set based on the computed change.
* Replaced direct boolean logic for `hasEmailChanged` in return objects with calls to the new method, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L216-R227) [[2]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L293-R304) [[3]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L364-R390) [[4]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3R180-R185) [[5]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L191-R206) [[6]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L268-R283) [[7]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L343-R358)

**Interface and method signature updates:**

* Removed unused or unnecessary arguments from interfaces, such as `isProtectedRenewal` from `ToChildrenArgs`, and updated method signatures accordingly for cleaner code. [[1]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L102) [[2]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L380-R402)

These changes make the codebase more robust, easier to maintain, and reduce the risk of inconsistencies in how email changes are detected and handled.