### PR TITLE
feat(frontend): add functions to compare home and mailing addresses for equality

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
@@ -9,6 +9,8 @@ import {
   getEligibilityStatus,
   isChildClientNumberValid,
   isChildOrYouth,
+  isClientApplicationHomeAddressSameAsMailingAddress,
+  isHomeAddressSameAsMailingAddress,
   maritalStatusHasPartner,
 } from '~/.server/routes/helpers/base-application-route-helpers';
 
@@ -418,5 +420,205 @@ describe('getAllowedTypeOfApplication', () => {
       expect(maritalStatusHasPartner('DIVORCED')).toBe(false);
       expect(maritalStatusHasPartner('WIDOWED')).toBe(false);
     });
+  });
+});
+
+describe('isHomeAddressSameAsMailingAddress', () => {
+  it('returns false when homeAddress is undefined', () => {
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: undefined, mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } } })).toBe(false);
+  });
+
+  it('returns false when mailingAddress is undefined', () => {
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } }, mailingAddress: undefined })).toBe(false);
+  });
+
+  it('returns false when both addresses are undefined', () => {
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: undefined, mailingAddress: undefined })).toBe(false);
+  });
+
+  it('returns false when homeAddress.hasChanged is false', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: false },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when mailingAddress.hasChanged is false', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+        mailingAddress: { hasChanged: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when both addresses have hasChanged false', () => {
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: { hasChanged: false }, mailingAddress: { hasChanged: false } })).toBe(false);
+  });
+
+  it('returns true when both addresses have changed and all fields are equal', () => {
+    const value = { address: '123 Main St', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' };
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: { hasChanged: true, value }, mailingAddress: { hasChanged: true, value } })).toBe(true);
+  });
+
+  it('returns true when both addresses are equal with optional fields omitted', () => {
+    const value = { address: '123 Main St', city: 'Ottawa', country: 'CA' };
+    expect(isHomeAddressSameAsMailingAddress({ homeAddress: { hasChanged: true, value }, mailingAddress: { hasChanged: true, value } })).toBe(true);
+  });
+
+  it('returns false when addresses differ by street address', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+        mailingAddress: { hasChanged: true, value: { address: '456 Elm St', city: 'Ottawa', country: 'CA' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by city', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Toronto', country: 'CA' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by country', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'US' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by postalCode', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6' } },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA', postalCode: 'K2B 1B7' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by province', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA', province: 'ON' } },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA', province: 'QC' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when one address has postalCode and the other does not', () => {
+    expect(
+      isHomeAddressSameAsMailingAddress({
+        homeAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6' } },
+        mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Ottawa', country: 'CA' } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isClientApplicationHomeAddressSameAsMailingAddress', () => {
+  it('returns false when homeAddress is undefined', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: undefined,
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when all fields are identical', () => {
+    const address = { address: '123 Main St', apartment: '4B', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' };
+    expect(isClientApplicationHomeAddressSameAsMailingAddress({ contactInformation: { homeAddress: address, mailingAddress: address } })).toBe(true);
+  });
+
+  it('returns true when all fields are equal with undefined optional fields', () => {
+    const address = { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: undefined, province: undefined };
+    expect(isClientApplicationHomeAddressSameAsMailingAddress({ contactInformation: { homeAddress: address, mailingAddress: address } })).toBe(true);
+  });
+
+  it('returns false when addresses differ by street address', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '456 Elm St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by apartment', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: '4B', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: '5C', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when one address has an apartment and the other does not', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: '4B', city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by city', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Toronto', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by country', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'US', postalCode: 'K1A 0A6', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by postalCode', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K2B 1B7', province: 'ON' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when addresses differ by province', () => {
+    expect(
+      isClientApplicationHomeAddressSameAsMailingAddress({
+        contactInformation: {
+          homeAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'ON' },
+          mailingAddress: { address: '123 Main St', apartment: undefined, city: 'Ottawa', country: 'CA', postalCode: 'K1A 0A6', province: 'QC' },
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -1,9 +1,19 @@
+import { isDeepStrictEqual } from 'node:util';
 import type { PickDeep } from 'type-fest';
 
-import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
+import type { ClientApplicationDto, ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
+import type { DeclaredChange } from '~/.server/routes/helpers/declared-change-type';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { EligibilityType } from '~/components/eligibility';
 import { getAgeFromDateString } from '~/utils/date-utils';
+
+type DeclaredChangeAddress = DeclaredChange<{
+  address: string;
+  city: string;
+  country: string;
+  postalCode?: string;
+  province?: string;
+}>;
 
 /**
  * Age categories based on the age of the individual.
@@ -189,4 +199,74 @@ export function maritalStatusHasPartner(maritalStatus?: string) {
   if (!maritalStatus) return false;
   const { MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
   return [MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED].includes(maritalStatus);
+}
+
+/**
+ * Determines if the home address is the same as the mailing address by performing a deep equality check on the relevant address fields.
+ * Both addresses must be defined and have changes for the function to compare them; otherwise, it returns false.
+ *
+ * @param state - An object containing the home and mailing addresses, each of which may have changed.
+ * @returns `true` if both addresses are defined, have changes, and all relevant fields are deeply equal, `false` otherwise.
+ */
+export function isHomeAddressSameAsMailingAddress(state: { homeAddress?: DeclaredChangeAddress; mailingAddress?: DeclaredChangeAddress }): boolean {
+  const { homeAddress, mailingAddress } = state;
+
+  if (homeAddress?.hasChanged !== true || mailingAddress?.hasChanged !== true) {
+    // both addresses must be defined and have changes to be able to compare them, otherwise we cannot determine if
+    // they are the same or not, so we return false.
+    return false;
+  }
+
+  return isDeepStrictEqual(
+    {
+      address: homeAddress.value.address,
+      city: homeAddress.value.city,
+      country: homeAddress.value.country,
+      postalCode: homeAddress.value.postalCode,
+      province: homeAddress.value.province,
+    },
+    {
+      address: mailingAddress.value.address,
+      city: mailingAddress.value.city,
+      country: mailingAddress.value.country,
+      postalCode: mailingAddress.value.postalCode,
+      province: mailingAddress.value.province,
+    },
+  );
+}
+
+/**
+ * Determines if the client's home address is the same as their mailing address by performing a deep equality check on
+ * the relevant address fields.
+ *
+ * @param clientApplication - An object containing the client's application data, specifically the home and mailing addresses.
+ * @returns `true` if both addresses are defined and all relevant fields are deeply equal, `false` otherwise.
+ */
+export function isClientApplicationHomeAddressSameAsMailingAddress(clientApplication: PickDeep<ClientApplicationDto, 'contactInformation.homeAddress' | 'contactInformation.mailingAddress'>): boolean {
+  const { homeAddress, mailingAddress } = clientApplication.contactInformation;
+
+  if (!homeAddress) {
+    // both addresses must be defined to be able to compare them, otherwise we cannot determine if
+    // they are the same or not, so we return false.
+    return false;
+  }
+
+  return isDeepStrictEqual(
+    {
+      address: homeAddress.address,
+      apartment: homeAddress.apartment,
+      city: homeAddress.city,
+      country: homeAddress.country,
+      postalCode: homeAddress.postalCode,
+      province: homeAddress.province,
+    },
+    {
+      address: mailingAddress.address,
+      apartment: mailingAddress.apartment,
+      city: mailingAddress.city,
+      country: mailingAddress.country,
+      postalCode: mailingAddress.postalCode,
+      province: mailingAddress.province,
+    },
+  );
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request introduces two new helper functions for comparing home and mailing addresses, along with comprehensive unit tests to ensure their correctness. These changes enhance the ability to determine if two address objects are equivalent, both in general state and within a client application context.

Address comparison helpers:

* Added `isHomeAddressSameAsMailingAddress`, which checks if two declared-change address objects (with possible changes) are deeply equal, considering all relevant fields. The function returns `false` if either address is missing or has not changed. (`frontend/app/.server/routes/helpers/base-application-route-helpers.ts`, [frontend/app/.server/routes/helpers/base-application-route-helpers.tsR203-R272](diffhunk://#diff-eb43f28b1ee5921daea586c6779f22458adcd9d0bf2593eafd7d88ac451b9cc2R203-R272))
* Added `isClientApplicationHomeAddressSameAsMailingAddress`, which compares the home and mailing addresses in a `ClientApplicationDto` for deep equality, including optional fields like `apartment`. (`frontend/app/.server/routes/helpers/base-application-route-helpers.ts`, [frontend/app/.server/routes/helpers/base-application-route-helpers.tsR203-R272](diffhunk://#diff-eb43f28b1ee5921daea586c6779f22458adcd9d0bf2593eafd7d88ac451b9cc2R203-R272))

Testing improvements:

* Added extensive unit tests for both new helper functions, covering scenarios where addresses are undefined, have differing fields, or are equal, to ensure robust and predictable behavior. (`frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts`, [frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.tsR425-R624](diffhunk://#diff-eab7ad367238a0f27b5b9adb778d3679e542dce2768a1994eae67f8ae43d7364R425-R624))
* Updated imports in the test file to include the new helper functions. (`frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts`, [frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.tsR12-R13](diffhunk://#diff-eab7ad367238a0f27b5b9adb778d3679e542dce2768a1994eae67f8ae43d7364R12-R13))

Type and utility updates:

* Defined a `DeclaredChangeAddress` type for improved type safety in address comparison logic. (`frontend/app/.server/routes/helpers/base-application-route-helpers.ts`, [frontend/app/.server/routes/helpers/base-application-route-helpers.tsR1-R17](diffhunk://#diff-eb43f28b1ee5921daea586c6779f22458adcd9d0bf2593eafd7d88ac451b9cc2R1-R17))