### PR TITLE
refactor(mappers): add logging for home address validation in applicant mappers

### DIFF
--- a/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
@@ -3,6 +3,8 @@ import { injectable } from 'inversify';
 
 import type { ApplicantDto, FindApplicantByBasicInfoDto, FindApplicantBySinRequestDto } from '~/.server/domain/dtos';
 import type { ApplicantResponseEntity, FindApplicantByBasicInfoRequestEntity, FindApplicantBySinRequestEntity } from '~/.server/domain/entities';
+import type { Logger } from '~/.server/logging';
+import { createLogger } from '~/.server/logging';
 import { expectDefined } from '~/utils/assert-utils';
 
 export interface ApplicantDtoMapper {
@@ -13,6 +15,12 @@ export interface ApplicantDtoMapper {
 
 @injectable()
 export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
+  private readonly log: Logger;
+
+  constructor() {
+    this.log = createLogger('DefaultApplicantDtoMapper');
+  }
+
   mapFindApplicantByBasicInfoRequestDtoToFindApplicantByBasicInfoRequestEntity(request: OmitStrict<FindApplicantByBasicInfoDto, 'userId'>): FindApplicantByBasicInfoRequestEntity {
     return {
       Applicant: {
@@ -45,14 +53,27 @@ export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
 
   mapApplicantResponseEntityToApplicantDto(applicantResponseEntity: ApplicantResponseEntity): ApplicantDto {
     const applicant = applicantResponseEntity.BenefitApplication.Applicant;
+    const clientId = expectDefined(applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID, 'Expected clientId to be defined');
     const personContactInformation = applicant.PersonContactInformation.at(0);
     const primaryPhone = personContactInformation?.TelephoneNumber.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Primary');
     const alternatePhone = personContactInformation?.TelephoneNumber.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Alternate');
     const emailAddress = personContactInformation?.EmailAddress.at(0);
 
     const homeAddress = personContactInformation?.Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');
+
+    // Check if all required home address fields are present before including the home address in the response
+    const hasHomeAddressFields =
+      homeAddress !== undefined && //
+      !!homeAddress.AddressStreet.StreetName &&
+      !!homeAddress.AddressCityName &&
+      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID;
+
+    if (!hasHomeAddressFields) {
+      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response.`);
+    }
+
     const mailingAddress = personContactInformation?.Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
-    invariant(mailingAddress, 'Expected mailing address to be defined'); // Mailing address is required for mapping to ApplicantDto
+    invariant(mailingAddress, `Expected mailing address to be defined for client: ${clientId}`);
 
     return {
       clientId: expectDefined(applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID, 'Expected clientId to be defined'),
@@ -63,18 +84,16 @@ export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
       socialInsuranceNumber: applicant.PersonSINIdentification?.IdentificationID,
       maritalStatus: applicant.PersonMaritalStatus?.StatusCode?.ReferenceDataID,
       contactInformation: {
-        homeAddress:
-          // Only map home address if all required fields are present to ensure we don't return partial/invalid address data
-          homeAddress?.AddressStreet.StreetName && homeAddress.AddressCityName && homeAddress.AddressCountry.CountryCode.ReferenceDataID
-            ? {
-                address: homeAddress.AddressStreet.StreetName,
-                apartment: homeAddress.AddressSecondaryUnitText,
-                city: homeAddress.AddressCityName,
-                country: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
-                postalCode: homeAddress.AddressPostalCode,
-                province: homeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
-              }
-            : undefined,
+        homeAddress: hasHomeAddressFields
+          ? {
+              address: homeAddress.AddressStreet.StreetName,
+              apartment: homeAddress.AddressSecondaryUnitText,
+              city: homeAddress.AddressCityName,
+              country: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
+              postalCode: homeAddress.AddressPostalCode,
+              province: homeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
+            }
+          : undefined,
         mailingAddress: {
           address: expectDefined(mailingAddress.AddressStreet.StreetName, 'Expected mailingAddress.AddressStreet to be defined'),
           apartment: mailingAddress.AddressSecondaryUnitText,

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -5,6 +5,8 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type { ApplicantDto, ClientApplicationBasicInfoRequestDto, ClientApplicationDto, ClientApplicationSinRequestDto } from '~/.server/domain/dtos';
 import type { ClientApplicationBasicInfoRequestEntity, ClientApplicationEntity, ClientApplicationSinRequestEntity } from '~/.server/domain/entities';
+import { createLogger } from '~/.server/logging';
+import type { Logger } from '~/.server/logging';
 import { isValidCoverageCopayTierCode } from '~/.server/utils/coverage.utils';
 import { expectDefined } from '~/utils/assert-utils';
 
@@ -29,12 +31,14 @@ export type DefaultClientApplicationDtoMapper_ServerConfig = Pick<
 
 @injectable()
 export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMapper {
+  private readonly log: Logger;
   private readonly serverConfig: DefaultClientApplicationDtoMapper_ServerConfig;
 
   constructor(
     @inject(TYPES.ServerConfig)
     serverConfig: DefaultClientApplicationDtoMapper_ServerConfig,
   ) {
+    this.log = createLogger('DefaultClientApplicationDtoMapper');
     this.serverConfig = serverConfig;
   }
 
@@ -112,19 +116,20 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
   mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto {
     const applicant = clientApplicationEntity.BenefitApplication.Applicant;
+    const clientId = expectDefined(
+      applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID,
+      "Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'",
+    );
 
     const applicantInformation = {
-      firstName: applicant.PersonName[0].PersonGivenName[0],
-      lastName: applicant.PersonName[0].PersonSurName,
-      maritalStatus: applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID,
-      clientId: expectDefined(
-        applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID,
-        "Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'",
-      ),
+      clientId,
       clientNumber: expectDefined(
         applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
         "Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client Number'",
       ),
+      firstName: applicant.PersonName[0].PersonGivenName[0],
+      lastName: applicant.PersonName[0].PersonSurName,
+      maritalStatus: applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID,
       socialInsuranceNumber: applicant.PersonSINIdentification.IdentificationID,
     };
 
@@ -156,25 +161,33 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
     };
 
     const homeAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');
-    invariant(homeAddress, 'Expected homeAddress to be defined');
+
+    // Check if all required home address fields are present before including the home address in the response
+    const hasHomeAddressFields =
+      homeAddress !== undefined && //
+      !!homeAddress.AddressStreet.StreetName &&
+      !!homeAddress.AddressCityName &&
+      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID;
+
+    if (!hasHomeAddressFields) {
+      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response.`);
+    }
 
     const mailingAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
     invariant(mailingAddress, 'Expected mailingAddress to be defined');
 
     const contactInformation = {
       copyMailingAddress: applicant.MailingSameAsHomeIndicator,
-      homeAddress:
-        // Only map home address if all required fields are present to ensure we don't return partial/invalid address data
-        homeAddress.AddressStreet.StreetName && homeAddress.AddressCityName && homeAddress.AddressCountry.CountryCode.ReferenceDataID
-          ? {
-              address: homeAddress.AddressStreet.StreetName,
-              apartment: homeAddress.AddressSecondaryUnitText,
-              city: homeAddress.AddressCityName,
-              country: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
-              postalCode: homeAddress.AddressPostalCode,
-              province: homeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
-            }
-          : undefined,
+      homeAddress: hasHomeAddressFields
+        ? {
+            address: homeAddress.AddressStreet.StreetName,
+            apartment: homeAddress.AddressSecondaryUnitText,
+            city: homeAddress.AddressCityName,
+            country: homeAddress.AddressCountry.CountryCode.ReferenceDataID,
+            postalCode: homeAddress.AddressPostalCode,
+            province: homeAddress.AddressProvince.ProvinceCode.ReferenceDataID,
+          }
+        : undefined,
       mailingAddress: {
         address: expectDefined(mailingAddress.AddressStreet.StreetName, 'Expected mailingAddress.AddressStreet.StreetName to be defined'),
         apartment: mailingAddress.AddressSecondaryUnitText,


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request strengthens the mapping logic for applicant and client application DTOs to ensure data integrity, especially regarding address fields. It introduces logging for missing or incomplete home address data and refines how required fields are checked before including addresses in API responses. The changes also improve error messages for better debugging.

**Address validation and logging improvements:**

* Added checks in both `DefaultApplicantDtoMapper` and `DefaultClientApplicationDtoMapper` to ensure all required home address fields are present before including the home address in the response. If any required field is missing, a warning is logged and the home address is omitted. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR56-R76) [[2]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcL66-R87) [[3]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL159-R181)
* Introduced a `Logger` instance in both mapper classes and used it to log warnings when home address data is incomplete. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR6-R7) [[2]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR18-R23) [[3]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cR8-R9) [[4]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cR34-R41)

**Error handling enhancements:**

* Improved invariant error messages to include the `clientId` when required address fields are missing, making issues easier to trace. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR56-R76) [[2]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL115-R132)

**Code maintainability:**

* Refactored code to assign `clientId` to a variable early in both mapping methods, reducing repetition and clarifying usage. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR56-R76) [[2]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL115-R132)

These changes make the mapping logic more robust and provide better observability for missing or malformed applicant address data.