### PR TITLE
refactor(frontend): remove nanoid dependency and update ID generation to use UUIDs

### DIFF
--- a/frontend/__tests__/route-helpers/adobe-analytics-route-helpers.test.ts
+++ b/frontend/__tests__/route-helpers/adobe-analytics-route-helpers.test.ts
@@ -3,24 +3,23 @@ import { describe, expect, it } from 'vitest';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/adobe-analytics-route-helpers';
 
 describe('transformAdobeAnalyticsUrl', () => {
-  it('should remove NanoID segments (10 chars) by default', () => {
-    // NanoID length is 10
-    const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/details');
+  it('should replace UUID segments with default replacement', () => {
+    const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000/details');
     expect(url.pathname).toBe('/users/:id:/details');
   });
 
-  it('should remove UUID segments by default', () => {
+  it('should replace UUID at end of path with default replacement', () => {
     const url = transformAdobeAnalyticsUrl('https://example.com/requests/550e8400-e29b-41d4-a716-446655440000');
     expect(url.pathname).toBe('/requests/:id:');
   });
 
-  it('should replace ID segments with provided replacement', () => {
-    const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/details', '');
+  it('should replace UUID segments with provided replacement', () => {
+    const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000/details', '');
     expect(url.pathname).toBe('/users/details');
   });
 
   it('should handle URL objects as input', () => {
-    const urlObj = new URL('https://example.com/posts/V1StGXR8_Z');
+    const urlObj = new URL('https://example.com/posts/550e8400-e29b-41d4-a716-446655440000');
     const result = transformAdobeAnalyticsUrl(urlObj);
     expect(result.pathname).toBe('/posts/:id:');
   });
@@ -30,8 +29,8 @@ describe('transformAdobeAnalyticsUrl', () => {
     expect(url.pathname).toBe('/users/john/profile');
   });
 
-  it('should handle multiple ID segments', () => {
-    const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/posts/550e8400-e29b-41d4-a716-446655440000/details');
+  it('should handle multiple UUID segments', () => {
+    const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000/posts/6ba7b810-9dad-11d1-80b4-00c04fd430c8/details');
     expect(url.pathname).toBe('/users/:id:/posts/:id:/details');
   });
 
@@ -41,14 +40,19 @@ describe('transformAdobeAnalyticsUrl', () => {
   });
 
   it('should preserve query strings and fragments', () => {
-    const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z?tab=info#section');
+    const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000?tab=info#section');
     expect(url.pathname).toBe('/users/:id:');
     expect(url.search).toBe('?tab=info');
     expect(url.hash).toBe('#section');
   });
 
-  it('should handle empty replacement resulting in clean path', () => {
-    const url = transformAdobeAnalyticsUrl('https://example.com/V1StGXR8_Z', '');
+  it('should handle empty replacement with UUID-only path', () => {
+    const url = transformAdobeAnalyticsUrl('https://example.com/550e8400-e29b-41d4-a716-446655440000', '');
     expect(url.pathname).toBe('/');
+  });
+
+  it('should not replace non-UUID identifiers', () => {
+    const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/details');
+    expect(url.pathname).toBe('/users/V1StGXR8_Z/details');
   });
 });

--- a/frontend/__tests__/utils/id.utils.test.ts
+++ b/frontend/__tests__/utils/id.utils.test.ts
@@ -4,21 +4,9 @@ import { generateId, isValidId } from '~/utils/id.utils';
 
 describe('id.utils', () => {
   describe('generateId', () => {
-    it('should generate a nanoid by default', () => {
+    it('should generate a UUID', () => {
       const id = generateId();
-      expect(id).toHaveLength(10);
-      expect(/^[a-zA-Z0-9_-]+$/.test(id)).toBe(true);
-    });
-
-    it('should generate a nanoid when format is explicitly set to nanoid', () => {
-      const id = generateId('nanoid');
-      expect(id).toHaveLength(10);
-      expect(/^[a-zA-Z0-9_-]+$/.test(id)).toBe(true);
-    });
-
-    it('should generate a UUID when format is uuid', () => {
-      const uuid = generateId('uuid');
-      expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
     });
 
     it('should generate unique IDs', () => {
@@ -29,46 +17,17 @@ describe('id.utils', () => {
   });
 
   describe('isValidId', () => {
-    it('should validate a valid nanoid', () => {
-      const id = generateId('nanoid');
-      expect(isValidId(id, 'nanoid')).toBe(true);
-    });
-
-    it.each([
-      // Valid UUIDs for testing
-      ['550e8400-e29b-41d4-a716-446655440000'],
-      ['123e4567-e89b-12d3-a456-426614174000'],
-      ['fab8df50-1df6-f011-8406-6045bdf97563'], // custom UUID with 'f' in the version position
-      ['0cb9df50-1df6-f011-8406-6045bdf97563'], // custom UUID with '0' in the version position
-    ])('should validate a valid UUID: %s', (uuid) => {
-      expect(isValidId(uuid, 'uuid'), `UUID: ${uuid}`).toBe(true);
-    });
-
-    it('should reject invalid nanoid when format is specified', () => {
-      expect(isValidId('invalid-id-too-long', 'nanoid')).toBe(false);
-    });
-
-    it('should reject invalid UUID when format is specified', () => {
-      expect(isValidId('not-a-uuid', 'uuid')).toBe(false);
-    });
-
-    it('should accept valid nanoid without format specification', () => {
-      const id = generateId('nanoid');
-      expect(isValidId(id)).toBe(true);
-    });
-
-    it('should accept valid UUID without format specification', () => {
-      const uuid = generateId('uuid');
+    it.each([['550e8400-e29b-41d4-a716-446655440000'], ['123e4567-e89b-12d3-a456-426614174000'], ['fab8df50-1df6-f011-8406-6045bdf97563'], ['0cb9df50-1df6-f011-8406-6045bdf97563']])('should return true for valid UUID: %s', (uuid) => {
       expect(isValidId(uuid)).toBe(true);
     });
 
-    it('should reject invalid IDs without format specification', () => {
-      expect(isValidId('invalid')).toBe(false);
+    it('should return true for a generated ID', () => {
+      const id = generateId();
+      expect(isValidId(id)).toBe(true);
     });
 
-    it('should reject nanoid as UUID', () => {
-      const nanoid = generateId('nanoid');
-      expect(isValidId(nanoid, 'uuid')).toBe(false);
+    it.each([['not-a-uuid'], ['invalid'], [''], ['V1StGXR8_Z'], ['550e8400-e29b-41d4-a716'], ['550e8400-e29b-41d4-a716-446655440000-extra']])('should return false for invalid ID: %s', (id) => {
+      expect(isValidId(id)).toBe(false);
     });
   });
 });

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -33,7 +33,7 @@ import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
 import type { Session } from '~/.server/web/session';
 import { getAgeFromDateString } from '~/utils/date-utils';
-import { generateId, isValidId } from '~/utils/id.utils';
+import { generateId } from '~/utils/id.utils';
 import { getPathById } from '~/utils/route-utils';
 
 export type ProtectedApplicationStateSessionKey = `protected-application-flow-${string}`;
@@ -203,14 +203,12 @@ export function getProtectedApplicationState({ params, session }: LoadStateArgs)
   const locale = getLocaleFromParams(params);
   const cdcpWebsiteApplicationUrl = getCdcpWebsiteApplyUrl(locale);
 
-  const id = params.id;
-
-  if (!isValidId(id)) {
-    log.warn('Invalid "id" param format; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, params.id, session.id);
+  if (!params.id) {
+    log.warn('Invalid "id" param; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, params.id, session.id);
     throw redirectDocument(cdcpWebsiteApplicationUrl);
   }
 
-  const sessionKey = getSessionKey(id);
+  const sessionKey = getSessionKey(params.id);
 
   if (!session.has(sessionKey)) {
     log.warn('Application session state has not been found; redirecting to [%s]; sessionKey: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, sessionKey, session.id);

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -33,7 +33,7 @@ import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
 import type { Session } from '~/.server/web/session';
 import { getAgeFromDateString } from '~/utils/date-utils';
-import { generateId, isValidId } from '~/utils/id.utils';
+import { generateId } from '~/utils/id.utils';
 import { getPathById } from '~/utils/route-utils';
 
 export type PublicApplicationStateSessionKey = `public-application-flow-${string}`;
@@ -211,14 +211,12 @@ export function getPublicApplicationState({ params, session }: LoadStateArgs): P
   const locale = getLocaleFromParams(params);
   const cdcpWebsiteApplicationUrl = getCdcpWebsiteApplyUrl(locale);
 
-  const id = params.id;
-
-  if (!isValidId(id)) {
-    log.warn('Invalid "id" param format; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, params.id, session.id);
+  if (!params.id) {
+    log.warn('Invalid "id" param; redirecting to [%s]; id: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, params.id, session.id);
     throw redirectDocument(cdcpWebsiteApplicationUrl);
   }
 
-  const sessionKey = getSessionKey(id);
+  const sessionKey = getSessionKey(params.id);
 
   if (!session.has(sessionKey)) {
     log.warn('Application session state has not been found; redirecting to [%s]; sessionKey: [%s], sessionId: [%s]', cdcpWebsiteApplicationUrl, sessionKey, session.id);

--- a/frontend/app/route-helpers/adobe-analytics-route-helpers.ts
+++ b/frontend/app/route-helpers/adobe-analytics-route-helpers.ts
@@ -3,7 +3,7 @@ import { isValidId } from '~/utils/id.utils';
 /**
  * Transforms a URL for Adobe Analytics by sanitizing path segments containing dynamic identifiers.
  *
- * This function handles the removal or replacement of dynamic path segments such as NanoIDs or UUIDs,
+ * This function handles the removal or replacement of dynamic path segments such as UUIDs,
  * which is critical for grouping analytics data for logically identical pages.
  *
  * @param url - The input URL string (absolute) or URL object to transform.
@@ -13,12 +13,12 @@ import { isValidId } from '~/utils/id.utils';
  *
  * @example
  * // Remove ID segments (default)
- * const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/details');
+ * const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000/details');
  * console.log(url.pathname); // Output: "/users/:id:/details"
  *
  * @example
  * // Replace ID segments with a placeholder
- * const url = transformAdobeAnalyticsUrl('https://example.com/users/V1StGXR8_Z/details', '');
+ * const url = transformAdobeAnalyticsUrl('https://example.com/users/550e8400-e29b-41d4-a716-446655440000/details', '');
  * console.log(url.pathname); // Output: "/users/details"
  */
 export function transformAdobeAnalyticsUrl(url: string | URL, replacement: string = ':id:'): URL {

--- a/frontend/app/utils/id.utils.ts
+++ b/frontend/app/utils/id.utils.ts
@@ -1,26 +1,4 @@
-import { customAlphabet, urlAlphabet } from 'nanoid';
 import { z } from 'zod';
-
-/**
- * The fixed length for generated Nano IDs.
- * Ensure the generator and validator configurations remain synchronized with this value.
- */
-const NANO_ID_LENGTH = 10;
-
-/**
- * Configure the Nano ID generator with the standard URL-safe alphabet.
- * Using a custom alphabet allows for consistent ID behavior.
- */
-const generateNanoIdInternal = customAlphabet(urlAlphabet, NANO_ID_LENGTH);
-
-/**
- * Zod schema for validating the structure of a Nano ID.
- * Enforces length and character set (alphanumeric plus hyphens and underscores).
- */
-const nanoidSchema = z
-  .string()
-  .length(NANO_ID_LENGTH)
-  .regex(/^[a-zA-Z0-9_-]+$/);
 
 /**
  * Zod schema for validating the structure of a UUID.
@@ -34,53 +12,25 @@ const uuidSchema = z //
 /**
  * Generates a unique identifier string.
  *
- * Defaults to 'nanoid' format, but can generate standard UUID v4 strings if requested.
+ * This function uses the Web Crypto API to generate a UUID, which provides a high degree of uniqueness and is suitable
+ * for use as an identifier in various contexts.
  *
- * @param format - The format of the ID to generate ('nanoid' or 'uuid'). Defaults to 'nanoid'.
- * @returns A unique ID string in the requested format.
- *
- * @example
- * // Generate a Nano ID (default)
- * const id = generateId(); // e.g. "V1StGXR8_Z"
- *
- * @example
- * // Generate a UUID
- * const uuid = generateId('uuid'); // e.g. "550e8400-e29b-41d4-a716-446655440000"
+ * @returns A string representing the generated unique identifier.
  */
-export function generateId(format: 'nanoid' | 'uuid' = 'nanoid'): string {
-  if (format === 'uuid') {
-    return crypto.randomUUID();
-  }
-  return generateNanoIdInternal();
+export function generateId(): string {
+  return crypto.randomUUID();
 }
 
 /**
  * Validates if the provided string matches the expected ID format.
  *
- * If `format` is specified, strictly validates against that format.
- * If `format` is omitted, returns true if the string matches *either* format.
- *
  * @param id - The identifier string to validate.
- * @param format - (Optional) The specific format to validate against.
- * @returns `true` if the ID is valid for the specified (or implied) format; `false` otherwise.
+ * @returns `true` if the ID is valid; `false` otherwise.
  *
  * @example
- * isValidId('V1StGXR8_Z', 'nanoid'); // true
- * isValidId('invalid-id', 'uuid'); // false
  * isValidId('550e8400-e29b-41d4-a716-446655440000'); // true (valid UUID)
+ * isValidId('invalid-id'); // false
  */
-export function isValidId(id: string, format?: 'nanoid' | 'uuid'): boolean {
-  if (format === 'uuid') {
-    return uuidSchema.safeParse(id).success;
-  }
-
-  if (format === 'nanoid') {
-    return nanoidSchema.safeParse(id).success;
-  }
-
-  // If no specific format is requested, check if it matches any known format
-  const isUuid = uuidSchema.safeParse(id).success;
-  const isNanoid = nanoidSchema.safeParse(id).success;
-
-  return isUuid || isNanoid;
+export function isValidId(id: string): boolean {
+  return uuidSchema.safeParse(id).success;
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,7 +53,6 @@
         "minimatch": "^10.2.5",
         "moderndash": "^4.0.2",
         "morgan": "^1.10.1",
-        "nanoid": "^5.1.7",
         "oxide.ts": "^1.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -12012,24 +12011,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,6 @@
     "minimatch": "^10.2.5",
     "moderndash": "^4.0.2",
     "morgan": "^1.10.1",
-    "nanoid": "^5.1.7",
     "oxide.ts": "^1.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request removes support for NanoID identifiers throughout the codebase, standardizing all ID generation and validation to use UUIDs instead. The changes affect utility functions, test cases, and route helpers, and also remove the `nanoid` package as a dependency. The most important changes are summarized below:

**ID Generation and Validation Utilities:**

- Refactored `generateId` to only generate UUIDs using the Web Crypto API, removing all NanoID-related logic and configuration from `id.utils.ts`. The `isValidId` function now only validates UUIDs. [[1]](diffhunk://#diff-38458d1d2d36b7baa9859e49cedd286f70f6417fdb314f16f76db38d7b2d16abL1-L24) [[2]](diffhunk://#diff-38458d1d2d36b7baa9859e49cedd286f70f6417fdb314f16f76db38d7b2d16abL37-L86)

**Test Updates:**

- Updated all relevant tests to use UUIDs instead of NanoIDs, including changing test cases, descriptions, and expected outputs in `id.utils.test.ts` and `adobe-analytics-route-helpers.test.ts`. Tests for NanoID generation and validation were removed. [[1]](diffhunk://#diff-bd960516480ab9943503c9bd2b99526a9f2f64edf75850ff97762c7280b97117L7-R9) [[2]](diffhunk://#diff-bd960516480ab9943503c9bd2b99526a9f2f64edf75850ff97762c7280b97117L32-R30) [[3]](diffhunk://#diff-63d86d17a98565afee90e40148b76d887287a5bbf90eb178967101da8c0108faL6-R22) [[4]](diffhunk://#diff-63d86d17a98565afee90e40148b76d887287a5bbf90eb178967101da8c0108faL33-R33) [[5]](diffhunk://#diff-63d86d17a98565afee90e40148b76d887287a5bbf90eb178967101da8c0108faL44-R57)

**Route Helper Adjustments:**

- Cleaned up imports and logic in protected and public application route helpers to remove any validation or checks for NanoID, relying solely on UUIDs. [[1]](diffhunk://#diff-039c8b364a90138a6c482f90803bfe32f2a2f52954c3e634141fd2cee3f68b9dL36-R36) [[2]](diffhunk://#diff-039c8b364a90138a6c482f90803bfe32f2a2f52954c3e634141fd2cee3f68b9dL206-R211) [[3]](diffhunk://#diff-a4df438b0b3a9519e2893cc5e2341f86b025acb957475ddbe4a5d3aff65c27baL36-R36) [[4]](diffhunk://#diff-a4df438b0b3a9519e2893cc5e2341f86b025acb957475ddbe4a5d3aff65c27baL214-R219)

**Adobe Analytics Route Helper:**

- Updated documentation and examples in `transformAdobeAnalyticsUrl` to reference only UUIDs, removing mention of NanoIDs. [[1]](diffhunk://#diff-eb6911195ad93fbd8ad85fbfdae9981f61cb1cf306b5730bba60a55f68946204L6-R6) [[2]](diffhunk://#diff-eb6911195ad93fbd8ad85fbfdae9981f61cb1cf306b5730bba60a55f68946204L16-R21)

**Dependency Cleanup:**

- Removed the `nanoid` package from both `package.json` and `package-lock.json`, as it is no longer used anywhere in the codebase. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L75) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL56) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL12016-L12033)