### PR TITLE
refactor(frontend): Refactor address validation and expectDefined handling

### DIFF
--- a/frontend/__tests__/utils/assert-utils.test.ts
+++ b/frontend/__tests__/utils/assert-utils.test.ts
@@ -27,8 +27,8 @@ describe('expectDefined', () => {
     expect(() => expectDefined(undefined, 'value was undefined')).toThrow('value was undefined');
   });
 
-  it('should throw on empty string', () => {
-    expect(() => expectDefined('', 'value was empty')).toThrow('value was empty');
+  it('should return empty string without throwing', () => {
+    expect(expectDefined('', 'fail')).toBe('');
   });
 
   it('should return an object value', () => {

--- a/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/applicant.dto.mapper.ts
@@ -1,4 +1,3 @@
-import { invariant } from '@dts-stn/invariant';
 import { injectable } from 'inversify';
 
 import type { ApplicantDto, FindApplicantByBasicInfoDto, FindApplicantBySinRequestDto } from '~/.server/domain/dtos';
@@ -59,21 +58,33 @@ export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
     const alternatePhone = personContactInformation?.TelephoneNumber.find((phone) => phone.TelephoneNumberCategoryCode.ReferenceDataName === 'Alternate');
     const emailAddress = personContactInformation?.EmailAddress.at(0);
 
+    // Home address is not guaranteed to be present for all clients, so we need to check if it exists before trying to access its properties
     const homeAddress = personContactInformation?.Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');
 
     // Check if all required home address fields are present before including the home address in the response
-    const hasHomeAddressFields =
-      homeAddress !== undefined && //
-      !!homeAddress.AddressStreet.StreetName &&
-      !!homeAddress.AddressCityName &&
-      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID;
+    const isHomeAddressDefined =
+      homeAddress !== undefined && // Home address must exist
+      !!homeAddress.AddressStreet.StreetName && // StreetName is required for home address
+      !!homeAddress.AddressCityName && // CityName is required for home address
+      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID; // CountryCode is required for home address
 
-    if (!hasHomeAddressFields) {
-      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response.`);
+    if (!isHomeAddressDefined) {
+      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response; homeAddress: [%j]`, homeAddress);
     }
 
+    // Mailing address is not guaranteed to be present for all clients, so we need to check if it exists before trying to access its properties
     const mailingAddress = personContactInformation?.Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
-    invariant(mailingAddress, `Expected mailing address to be defined for client: ${clientId}`);
+
+    const isMailingAddressDefined =
+      mailingAddress !== undefined && // Mailing address must exist
+      !!mailingAddress.AddressStreet.StreetName && // StreetName is required for mailing address
+      !!mailingAddress.AddressCityName && // CityName is required for mailing address
+      !!mailingAddress.AddressCountry.CountryCode.ReferenceDataID; // CountryCode is required for mailing address
+
+    if (!isMailingAddressDefined) {
+      this.log.error(`Mailing address for client ${clientId} is missing required fields and is required for this operation; mailingAddress: [%j]`, mailingAddress);
+      throw new Error(`Mailing address for client ${clientId} is missing required fields`);
+    }
 
     return {
       clientId: expectDefined(applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID, 'Expected clientId to be defined'),
@@ -84,7 +95,7 @@ export class DefaultApplicantDtoMapper implements ApplicantDtoMapper {
       socialInsuranceNumber: applicant.PersonSINIdentification?.IdentificationID,
       maritalStatus: applicant.PersonMaritalStatus?.StatusCode?.ReferenceDataID,
       contactInformation: {
-        homeAddress: hasHomeAddressFields
+        homeAddress: isHomeAddressDefined
           ? {
               address: homeAddress.AddressStreet.StreetName,
               apartment: homeAddress.AddressSecondaryUnitText,

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -116,17 +116,11 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
   mapClientApplicationEntityToClientApplicationDto(clientApplicationEntity: ClientApplicationEntity): ClientApplicationDto {
     const applicant = clientApplicationEntity.BenefitApplication.Applicant;
-    const clientId = expectDefined(
-      applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID,
-      "Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'",
-    );
+    const clientId = expectDefined(applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID, 'Expected applicant.ClientIdentification.IdentificationID to be defined');
 
     const applicantInformation = {
       clientId,
-      clientNumber: expectDefined(
-        applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
-        "Expected applicant.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client Number'",
-      ),
+      clientNumber: expectDefined(applicant.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID, 'Expected applicant.ClientIdentification.IdentificationID to be defined'),
       firstName: applicant.PersonName[0].PersonGivenName[0],
       lastName: applicant.PersonName[0].PersonSurName,
       maritalStatus: applicant.PersonMaritalStatus.StatusCode?.ReferenceDataID,
@@ -142,14 +136,8 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
           lastName: child.PersonName[0].PersonSurName,
           dateOfBirth: expectDefined(child.PersonBirthDate.date, 'Expected child.PersonBirthDate.date to be defined'),
           isParent: expectDefined(child.ApplicantDetail.AttestParentOrGuardianIndicator, 'Expected child.ApplicantDetail.AttestParentOrGuardianIndicator to be defined'),
-          clientId: expectDefined(
-            child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID,
-            "Expected child.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client ID'",
-          ),
-          clientNumber: expectDefined(
-            child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID,
-            "Expected child.ClientIdentification.IdentificationID to be defined when IdentificationCategoryText === 'Client Number'",
-          ),
+          clientId: expectDefined(child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client ID')?.IdentificationID, 'Expected child.ClientIdentification.IdentificationID to be defined'),
+          clientNumber: expectDefined(child.ClientIdentification.find((id) => id.IdentificationCategoryText === 'Client Number')?.IdentificationID, 'Expected child.ClientIdentification.IdentificationID to be defined'),
           socialInsuranceNumber: child.PersonSINIdentification.IdentificationID,
         },
       })) ?? [];
@@ -175,6 +163,9 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
 
     const mailingAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
     invariant(mailingAddress, 'Expected mailingAddress to be defined');
+    invariant(mailingAddress.AddressStreet.StreetName, 'Expected mailingAddress.AddressStreet.StreetName to be defined');
+    invariant(mailingAddress.AddressCityName, 'Expected mailingAddress.AddressCityName to be defined');
+    invariant(mailingAddress.AddressCountry.CountryCode.ReferenceDataID, 'Expected mailingAddress.AddressCountry.CountryCode.ReferenceDataID to be defined');
 
     const contactInformation = {
       copyMailingAddress: applicant.MailingSameAsHomeIndicator,
@@ -189,10 +180,10 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
           }
         : undefined,
       mailingAddress: {
-        address: expectDefined(mailingAddress.AddressStreet.StreetName, 'Expected mailingAddress.AddressStreet.StreetName to be defined'),
+        address: mailingAddress.AddressStreet.StreetName,
         apartment: mailingAddress.AddressSecondaryUnitText,
-        city: expectDefined(mailingAddress.AddressCityName, 'Expected mailingAddress.AddressCityName to be defined'),
-        country: expectDefined(mailingAddress.AddressCountry.CountryCode.ReferenceDataID, 'Expected mailingAddress.AddressCountry.CountryCode.ReferenceDataID to be defined'),
+        city: mailingAddress.AddressCityName,
+        country: mailingAddress.AddressCountry.CountryCode.ReferenceDataID,
         postalCode: mailingAddress.AddressPostalCode,
         province: mailingAddress.AddressProvince.ProvinceCode.ReferenceDataID,
       },

--- a/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/client-application.dto.mapper.ts
@@ -148,28 +148,37 @@ export class DefaultClientApplicationDtoMapper implements ClientApplicationDtoMa
       preferredMethodGovernmentOfCanada: applicant.PreferredMethodCommunicationGCCode.ReferenceDataID,
     };
 
+    // Home address is not guaranteed to be present for all clients, so we need to check if it exists before trying to access its properties
     const homeAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Home');
 
     // Check if all required home address fields are present before including the home address in the response
-    const hasHomeAddressFields =
-      homeAddress !== undefined && //
-      !!homeAddress.AddressStreet.StreetName &&
-      !!homeAddress.AddressCityName &&
-      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID;
+    const isHomeAddressDefined =
+      homeAddress !== undefined && // Home address must exist
+      !!homeAddress.AddressStreet.StreetName && // StreetName is required for home address
+      !!homeAddress.AddressCityName && // CityName is required for home address
+      !!homeAddress.AddressCountry.CountryCode.ReferenceDataID; // CountryCode is required for home address
 
-    if (!hasHomeAddressFields) {
-      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response.`);
+    if (!isHomeAddressDefined) {
+      this.log.warn(`Home address for client ${clientId} is missing required fields. Home address will be omitted from the response; homeAddress: [%j]`, homeAddress);
     }
 
+    // Mailing address is not guaranteed to be present for all clients, so we need to check if it exists before trying to access its properties
     const mailingAddress = applicant.PersonContactInformation[0].Address.find((address) => address.AddressCategoryCode.ReferenceDataName === 'Mailing');
-    invariant(mailingAddress, 'Expected mailingAddress to be defined');
-    invariant(mailingAddress.AddressStreet.StreetName, 'Expected mailingAddress.AddressStreet.StreetName to be defined');
-    invariant(mailingAddress.AddressCityName, 'Expected mailingAddress.AddressCityName to be defined');
-    invariant(mailingAddress.AddressCountry.CountryCode.ReferenceDataID, 'Expected mailingAddress.AddressCountry.CountryCode.ReferenceDataID to be defined');
+
+    const isMailingAddressDefined =
+      mailingAddress !== undefined && // Mailing address must exist
+      !!mailingAddress.AddressStreet.StreetName && // StreetName is required for mailing address
+      !!mailingAddress.AddressCityName && // CityName is required for mailing address
+      !!mailingAddress.AddressCountry.CountryCode.ReferenceDataID; // CountryCode is required for mailing address
+
+    if (!isMailingAddressDefined) {
+      this.log.error(`Mailing address for client ${clientId} is missing required fields and is required for this operation; mailingAddress: [%j]`, mailingAddress);
+      throw new Error(`Mailing address for client ${clientId} is missing required fields`);
+    }
 
     const contactInformation = {
       copyMailingAddress: applicant.MailingSameAsHomeIndicator,
-      homeAddress: hasHomeAddressFields
+      homeAddress: isHomeAddressDefined
         ? {
             address: homeAddress.AddressStreet.StreetName,
             apartment: homeAddress.AddressSecondaryUnitText,

--- a/frontend/app/utils/assert-utils.ts
+++ b/frontend/app/utils/assert-utils.ts
@@ -1,14 +1,14 @@
 /**
- * Utility function to assert that a value is defined (not null, undefined, or empty string).
+ * Utility function to assert that a value is defined (not null or undefined).
  * If the value is not defined, an error is thrown with the provided message.
  *
  * @param value - The value to check for being defined.
  * @param message - The error message to throw if the value is not defined.
  * @returns The original value if it is defined.
- * @throws Error if the value is null, undefined, or an empty string.
+ * @throws Error if the value is null or undefined.
  */
 export function expectDefined<T>(value: T | null | undefined, message: string): T {
-  if (value === null || value === undefined || value === '') {
+  if (value === null || value === undefined) {
     throw new Error(message);
   }
   return value as T;


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request improves address validation and error handling in the DTO mappers, clarifies the behavior of the `expectDefined` utility, and updates related tests and usages. The changes ensure that both home and mailing addresses are properly validated for required fields, and strengthen error reporting when address data is incomplete.

**Address validation and error handling improvements:**

* Replaced the use of the `invariant` assertion with explicit validation for required fields in both home and mailing addresses in `DefaultApplicantDtoMapper` and `DefaultClientApplicationDtoMapper`. Now, the code checks for the presence of required fields and logs warnings or throws errors as appropriate, providing more informative error messages and including the problematic address in the logs. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcL1) [[2]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR61-R87) [[3]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcL87-R98) [[4]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cR151-R181)
* Mailing address is now strictly required; if missing required fields, an error is logged and thrown, preventing further processing. Home address remains optional, but missing fields trigger a warning with additional context. [[1]](diffhunk://#diff-c8de97fee0620352ffd609002a073ba0a0171dfb6ec7071ba07296ded7850cdcR61-R87) [[2]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cR151-R181)

**Utility and test updates:**

* Updated the `expectDefined` utility in `assert-utils.ts` to only throw when the value is `null` or `undefined`, no longer treating empty strings as errors. This change is reflected in the documentation and implementation.
* Modified related tests to confirm that `expectDefined` now returns empty strings without throwing, ensuring test coverage matches the new behavior.

**Code consistency and clarity:**

* Simplified and standardized error messages and logging throughout the DTO mappers, and updated usages of `expectDefined` for clarity and consistency. [[1]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL119-R123) [[2]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL145-R140) [[3]](diffhunk://#diff-d21a500c6d2ae9b4d4d9934a8f5b09fa9d1fded92eecd24c34c56149edcc557cL192-R195)