### PR TITLE
fix(frontend): isAddressSectionCompleted logic and update documentation

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/protected-application-full-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-full-section-checks.test.ts
@@ -45,68 +45,58 @@ describe('protected-application-full-section-checks', () => {
   });
 
   describe('isAddressSectionCompleted', () => {
-    it('should return true when both addresses have changed', () => {
+    it('should return false when mailingAddress is undefined', () => {
+      expect(isAddressSectionCompleted({ mailingAddress: undefined, homeAddress: { hasChanged: true } })).toBe(false);
+    });
+
+    it('should return false when homeAddress is undefined', () => {
+      expect(isAddressSectionCompleted({ mailingAddress: { hasChanged: true }, homeAddress: undefined })).toBe(false);
+    });
+
+    it('should return false when both addresses are undefined', () => {
+      expect(isAddressSectionCompleted({ mailingAddress: undefined, homeAddress: undefined })).toBe(false);
+    });
+
+    it('should return true when both addresses have changed and same-address question is answered', () => {
       expect(
         isAddressSectionCompleted({
-          mailingAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
-          homeAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
-          isHomeAddressSameAsMailingAddress: true,
+          mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' } },
+          homeAddress: { hasChanged: true, value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' } },
+          isHomeAddressSameAsMailingAddress: false,
         }),
       ).toBe(true);
     });
 
-    it('should return true when mailing address has not changed', () => {
+    it('should return false when both addresses have changed but same-address question is unanswered', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' } },
+          homeAddress: { hasChanged: true, value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' } },
+          isHomeAddressSameAsMailingAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when mailing address has not changed', () => {
       expect(
         isAddressSectionCompleted({
           mailingAddress: { hasChanged: false },
-          homeAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
+          homeAddress: { hasChanged: true, value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' } },
         }),
-      ).toBe(true);
+      ).toBe(false);
     });
 
-    it('should return true when home address has not changed', () => {
+    it('should return false when home address has not changed', () => {
       expect(
         isAddressSectionCompleted({
-          mailingAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
+          mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' } },
           homeAddress: { hasChanged: false },
         }),
-      ).toBe(true);
+      ).toBe(false);
+    });
+
+    it('should return false when neither address has changed', () => {
+      expect(isAddressSectionCompleted({ mailingAddress: { hasChanged: false }, homeAddress: { hasChanged: false } })).toBe(false);
     });
   });
 

--- a/frontend/__tests__/.server/routes/helpers/protected-application-full-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-full-section-checks.test.ts
@@ -46,11 +46,24 @@ describe('protected-application-full-section-checks', () => {
 
   describe('isAddressSectionCompleted', () => {
     it('should return false when mailingAddress is undefined', () => {
-      expect(isAddressSectionCompleted({ mailingAddress: undefined, homeAddress: { hasChanged: true } })).toBe(false);
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: undefined,
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+        }),
+      ).toBe(false);
     });
 
     it('should return false when homeAddress is undefined', () => {
-      expect(isAddressSectionCompleted({ mailingAddress: { hasChanged: true }, homeAddress: undefined })).toBe(false);
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' } },
+          homeAddress: undefined,
+        }),
+      ).toBe(false);
     });
 
     it('should return false when both addresses are undefined', () => {

--- a/frontend/__tests__/.server/routes/helpers/protected-application-simplified-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-simplified-section-checks.test.ts
@@ -85,7 +85,7 @@ describe('protected-application-simplified-section-checks', () => {
       ).toBe(false);
     });
 
-    it('should return true when both addresses have changed', () => {
+    it('should return true when both addresses have changed and same-address question is answered', () => {
       expect(
         isAddressSectionCompleted({
           mailingAddress: {
@@ -96,8 +96,25 @@ describe('protected-application-simplified-section-checks', () => {
             hasChanged: true,
             value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
           },
+          isHomeAddressSameAsMailingAddress: false,
         }),
       ).toBe(true);
+    });
+
+    it('should return false when both addresses have changed but same-address question is unanswered', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+          isHomeAddressSameAsMailingAddress: undefined,
+        }),
+      ).toBe(false);
     });
 
     it('should return true when neither address has changed and both are on file in the client application', () => {

--- a/frontend/__tests__/.server/routes/helpers/protected-application-simplified-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-simplified-section-checks.test.ts
@@ -55,46 +55,13 @@ describe('protected-application-simplified-section-checks', () => {
   });
 
   describe('isAddressSectionCompleted', () => {
-    it('should return true when both mailingAddress and homeAddress are defined', () => {
-      expect(
-        isAddressSectionCompleted({
-          mailingAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
-          homeAddress: {
-            hasChanged: true,
-            value: {
-              address: '456 Oak Ave',
-              city: 'Othertown',
-              province: 'BC',
-              postalCode: 'B2B 2B2',
-              country: 'CAN',
-            },
-          },
-        }),
-      ).toBe(true);
-    });
-
     it('should return false when mailingAddress is undefined', () => {
       expect(
         isAddressSectionCompleted({
           mailingAddress: undefined,
           homeAddress: {
             hasChanged: true,
-            value: {
-              address: '456 Oak Ave',
-              city: 'Othertown',
-              province: 'BC',
-              postalCode: 'B2B 2B2',
-              country: 'CAN',
-            },
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
           },
         }),
       ).toBe(false);
@@ -103,16 +70,7 @@ describe('protected-application-simplified-section-checks', () => {
     it('should return false when homeAddress is undefined', () => {
       expect(
         isAddressSectionCompleted({
-          mailingAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
+          mailingAddress: { hasChanged: true, value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' } },
           homeAddress: undefined,
         }),
       ).toBe(false);
@@ -123,6 +81,89 @@ describe('protected-application-simplified-section-checks', () => {
         isAddressSectionCompleted({
           mailingAddress: undefined,
           homeAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return true when both addresses have changed', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('should return true when neither address has changed and both are on file in the client application', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: {
+            contactInformation: {
+              mailingAddress: { address: '123 Main St', city: 'Anytown', country: 'CAN' },
+              homeAddress: { address: '456 Oak Ave', city: 'Othertown', country: 'CAN' },
+            },
+          },
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(true);
+    });
+
+    it('should return false when neither address has changed and home address is not on file in the client application', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: {
+            contactInformation: {
+              mailingAddress: { address: '123 Main St', city: 'Anytown', country: 'CAN' },
+              homeAddress: undefined,
+            },
+          },
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(false);
+    });
+
+    it('should return false when neither address has changed and no client application is present', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: undefined,
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(false);
+    });
+
+    it('should return false when mailing address has changed but home address has not', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: false,
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when home address has changed but mailing address has not', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: false,
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
         }),
       ).toBe(false);
     });

--- a/frontend/__tests__/.server/routes/helpers/public-application-full-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/public-application-full-section-checks.test.ts
@@ -45,47 +45,80 @@ describe('public-application-full-section-checks', () => {
   });
 
   describe('isAddressSectionCompleted', () => {
-    it('should return true when both addresses have changed', () => {
+    it('should return false when mailingAddress is undefined', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: undefined,
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when homeAddress is undefined', () => {
       expect(
         isAddressSectionCompleted({
           mailingAddress: {
             hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when both addresses are undefined', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: undefined,
+          homeAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return true when both addresses have changed and same-address question is answered', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
           },
           homeAddress: {
             hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
           },
-          isHomeAddressSameAsMailingAddress: true,
+          isHomeAddressSameAsMailingAddress: false,
         }),
       ).toBe(true);
+    });
+
+    it('should return false when both addresses have changed but same-address question is unanswered', () => {
+      expect(
+        isAddressSectionCompleted({
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+          isHomeAddressSameAsMailingAddress: undefined,
+        }),
+      ).toBe(false);
     });
 
     it('should return false when mailing address has not changed', () => {
       expect(
         isAddressSectionCompleted({
-          mailingAddress: { hasChanged: false },
+          mailingAddress: {
+            hasChanged: false,
+          },
           homeAddress: {
             hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
           },
         }),
       ).toBe(false);
@@ -96,17 +129,17 @@ describe('public-application-full-section-checks', () => {
         isAddressSectionCompleted({
           mailingAddress: {
             hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
           },
-          homeAddress: { hasChanged: false },
+          homeAddress: {
+            hasChanged: false,
+          },
         }),
       ).toBe(false);
+    });
+
+    it('should return false when neither address has changed', () => {
+      expect(isAddressSectionCompleted({ mailingAddress: { hasChanged: false }, homeAddress: { hasChanged: false } })).toBe(false);
     });
   });
 

--- a/frontend/__tests__/.server/routes/helpers/public-application-simplified-section-checks.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/public-application-simplified-section-checks.test.ts
@@ -54,46 +54,14 @@ describe('public-application-simplified-section-checks', () => {
   });
 
   describe('isAddressSectionCompleted', () => {
-    it('should return true when both mailingAddress and homeAddress are defined', () => {
-      expect(
-        isAddressSectionCompleted({
-          mailingAddress: {
-            hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
-          },
-          homeAddress: {
-            hasChanged: true,
-            value: {
-              address: '456 Oak Ave',
-              city: 'Othertown',
-              province: 'BC',
-              postalCode: 'B2B 2B2',
-              country: 'CAN',
-            },
-          },
-        }),
-      ).toBe(true);
-    });
-
     it('should return false when mailingAddress is undefined', () => {
       expect(
         isAddressSectionCompleted({
+          context: 'intake',
           mailingAddress: undefined,
           homeAddress: {
             hasChanged: true,
-            value: {
-              address: '456 Oak Ave',
-              city: 'Othertown',
-              province: 'BC',
-              postalCode: 'B2B 2B2',
-              country: 'CAN',
-            },
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
           },
         }),
       ).toBe(false);
@@ -102,15 +70,10 @@ describe('public-application-simplified-section-checks', () => {
     it('should return false when homeAddress is undefined', () => {
       expect(
         isAddressSectionCompleted({
+          context: 'intake',
           mailingAddress: {
             hasChanged: true,
-            value: {
-              address: '123 Main St',
-              city: 'Anytown',
-              province: 'ON',
-              postalCode: 'A1A 1A1',
-              country: 'CAN',
-            },
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
           },
           homeAddress: undefined,
         }),
@@ -120,8 +83,132 @@ describe('public-application-simplified-section-checks', () => {
     it('should return false when both addresses are undefined', () => {
       expect(
         isAddressSectionCompleted({
+          context: 'intake',
           mailingAddress: undefined,
           homeAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return true when both addresses have changed and same-address question is answered', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'intake',
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+          isHomeAddressSameAsMailingAddress: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when both addresses have changed but same-address question is unanswered', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'intake',
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
+          isHomeAddressSameAsMailingAddress: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('should return true when neither address has changed on renewal and both are on file in the client application', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'renewal',
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: {
+            contactInformation: {
+              mailingAddress: { address: '123 Main St', city: 'Anytown', country: 'CAN' },
+              homeAddress: { address: '456 Oak Ave', city: 'Othertown', country: 'CAN' },
+            },
+          },
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(true);
+    });
+
+    it('should return false when neither address has changed on renewal and home address is not on file', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'renewal',
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: {
+            contactInformation: {
+              mailingAddress: { address: '123 Main St', city: 'Anytown', country: 'CAN' },
+              homeAddress: undefined,
+            },
+          },
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(false);
+    });
+
+    it('should return false when neither address has changed on renewal and no client application is present', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'renewal',
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: undefined,
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(false);
+    });
+
+    it('should return false when neither address has changed on intake (carry-forward not allowed)', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'intake',
+          mailingAddress: { hasChanged: false },
+          homeAddress: { hasChanged: false },
+          clientApplication: {
+            contactInformation: {
+              mailingAddress: { address: '123 Main St', city: 'Anytown', country: 'CAN' },
+              homeAddress: { address: '456 Oak Ave', city: 'Othertown', country: 'CAN' },
+            },
+          },
+        } as Parameters<typeof isAddressSectionCompleted>[0]),
+      ).toBe(false);
+    });
+
+    it('should return false when mailing address has changed but home address has not', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'renewal',
+          mailingAddress: {
+            hasChanged: true,
+            value: { address: '123 Main St', city: 'Anytown', province: 'ON', postalCode: 'A1A 1A1', country: 'CAN' },
+          },
+          homeAddress: {
+            hasChanged: false,
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when home address has changed but mailing address has not', () => {
+      expect(
+        isAddressSectionCompleted({
+          context: 'renewal',
+          mailingAddress: {
+            hasChanged: false,
+          },
+          homeAddress: {
+            hasChanged: true,
+            value: { address: '456 Oak Ave', city: 'Othertown', province: 'BC', postalCode: 'B2B 2B2', country: 'CAN' },
+          },
         }),
       ).toBe(false);
     });

--- a/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
@@ -11,10 +11,21 @@ export function isPhoneNumberSectionCompleted(state: Pick<ProtectedApplicationSt
 }
 
 /**
- * Checks if the address section is completed for intake application.
+ * Checks if the address section is completed for a protected intake application.
+ *
+ * The section is considered complete when all three conditions are met:
+ * - Both the mailing and home address responses are present,
+ * - Both addresses are marked as changed (the user has provided new addresses), and
+ * - The user has answered whether their home address is the same as their mailing address.
  */
 export function isAddressSectionCompleted(state: Pick<ProtectedApplicationState, 'mailingAddress' | 'homeAddress' | 'isHomeAddressSameAsMailingAddress'>): boolean {
-  return state.mailingAddress !== undefined && (state.homeAddress !== undefined || state.isHomeAddressSameAsMailingAddress !== undefined);
+  // Both address responses must be present before evaluating completion
+  if (!state.mailingAddress || !state.homeAddress) {
+    return false;
+  }
+
+  // Both addresses must be marked as changed and the same-address question must have been answered
+  return state.mailingAddress.hasChanged && state.homeAddress.hasChanged && state.isHomeAddressSameAsMailingAddress !== undefined;
 }
 
 /**

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
@@ -14,10 +14,37 @@ export function isPhoneNumberSectionCompleted(state: Pick<ProtectedApplicationSt
 }
 
 /**
- * Checks if the address section is completed for renewal application.
+ * Checks if the address section is completed for a protected renewal application.
+ *
+ * Both address change statuses must be answered before completion can be evaluated.
+ * The section is then considered complete in two scenarios:
+ * - Both addresses have changed: the user has provided updated mailing and home addresses, or
+ * - Neither address has changed: the client application must already have both a mailing and
+ *   home address on file so the existing addresses can be carried forward.
+ *
+ * A mismatch in change status (one changed, one did not) is always considered incomplete.
  */
-export function isAddressSectionCompleted(state: Pick<ProtectedApplicationState, 'mailingAddress' | 'homeAddress' | 'isHomeAddressSameAsMailingAddress'>): boolean {
-  return state.mailingAddress !== undefined && (state.homeAddress !== undefined || state.isHomeAddressSameAsMailingAddress !== undefined);
+export function isAddressSectionCompleted(state: PickDeep<ProtectedApplicationState, 'mailingAddress' | 'homeAddress' | 'clientApplication.contactInformation.homeAddress' | 'clientApplication.contactInformation.mailingAddress'>): boolean {
+  // Both address change statuses must be answered before evaluating completion
+  if (!state.mailingAddress || !state.homeAddress) {
+    return false;
+  }
+
+  // Both changed: user has provided updated mailing and home addresses
+  if (state.mailingAddress.hasChanged && state.homeAddress.hasChanged) {
+    return true;
+  }
+
+  // Neither changed: carry forward existing addresses only if both are on file.
+  // mailingAddress is always required on the client application (eslint suppressed); homeAddress is optional.
+  // A mismatch (one changed, one did not) also falls through here and evaluates to false.
+  return (
+    !state.mailingAddress.hasChanged && //
+    !state.homeAddress.hasChanged &&
+    state.clientApplication?.contactInformation.homeAddress !== undefined &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    state.clientApplication.contactInformation.mailingAddress !== undefined
+  );
 }
 
 /**

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
@@ -18,20 +18,30 @@ export function isPhoneNumberSectionCompleted(state: Pick<ProtectedApplicationSt
  *
  * Both address change statuses must be answered before completion can be evaluated.
  * The section is then considered complete in two scenarios:
- * - Both addresses have changed: the user has provided updated mailing and home addresses, or
+ * - Both addresses have changed: the user has provided updated mailing and home addresses, and
+ *   the user has answered whether their home address is the same as their mailing address, or
  * - Neither address has changed: the client application must already have both a mailing and
  *   home address on file so the existing addresses can be carried forward.
  *
  * A mismatch in change status (one changed, one did not) is always considered incomplete.
  */
-export function isAddressSectionCompleted(state: PickDeep<ProtectedApplicationState, 'mailingAddress' | 'homeAddress' | 'clientApplication.contactInformation.homeAddress' | 'clientApplication.contactInformation.mailingAddress'>): boolean {
+export function isAddressSectionCompleted(
+  state: PickDeep<
+    ProtectedApplicationState,
+    | 'mailingAddress' //
+    | 'homeAddress'
+    | 'isHomeAddressSameAsMailingAddress'
+    | 'clientApplication.contactInformation.homeAddress'
+    | 'clientApplication.contactInformation.mailingAddress'
+  >,
+): boolean {
   // Both address change statuses must be answered before evaluating completion
   if (!state.mailingAddress || !state.homeAddress) {
     return false;
   }
 
-  // Both changed: user has provided updated mailing and home addresses
-  if (state.mailingAddress.hasChanged && state.homeAddress.hasChanged) {
+  // Both changed: user has provided updated mailing and home addresses, and the same-address question must be answered
+  if (state.mailingAddress.hasChanged && state.homeAddress.hasChanged && state.isHomeAddressSameAsMailingAddress !== undefined) {
     return true;
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-full-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-section-checks.ts
@@ -13,13 +13,20 @@ export function isPhoneNumberSectionCompleted(state: Pick<PublicApplicationState
 
 /**
  * Checks if the address section is completed for full application.
+ *
+ * The section is considered complete when all three conditions are met:
+ * - Both the mailing and home address responses are present,
+ * - Both addresses are marked as changed (the user has provided new addresses), and
+ * - The user has answered whether their home address is the same as their mailing address.
  */
 export function isAddressSectionCompleted(state: Pick<PublicApplicationState, 'mailingAddress' | 'homeAddress' | 'isHomeAddressSameAsMailingAddress'>): boolean {
-  return (
-    state.mailingAddress?.hasChanged === true && //
-    state.homeAddress?.hasChanged === true &&
-    state.isHomeAddressSameAsMailingAddress !== undefined
-  );
+  // Both address responses must be present before evaluating completion
+  if (!state.mailingAddress || !state.homeAddress) {
+    return false;
+  }
+
+  // Both addresses must be marked as changed and the same-address question must have been answered
+  return state.mailingAddress.hasChanged && state.homeAddress.hasChanged && state.isHomeAddressSameAsMailingAddress !== undefined;
 }
 
 /**

--- a/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
@@ -14,10 +14,51 @@ export function isPhoneNumberSectionCompleted(state: Pick<PublicApplicationState
 }
 
 /**
- * Checks if the address section is completed for simplified application.
+ * Checks if the address section is completed for a public simplified application.
+ *
+ * Both address change statuses must be answered before completion can be evaluated.
+ * The section is then considered complete in two scenarios:
+ * - Both addresses have changed: the user has provided updated mailing and home addresses, and
+ *   the user has answered whether their home address is the same as their mailing address, or
+ * - Neither address has changed (renewal only): the client application must already have both
+ *   a mailing and home address on file so the existing addresses can be carried forward.
+ *
+ * A mismatch in change status (one changed, one did not) is always considered incomplete.
+ * The carry-forward path is not available for intake applications.
  */
-export function isAddressSectionCompleted(state: Pick<PublicApplicationState, 'mailingAddress' | 'homeAddress'>): boolean {
-  return state.mailingAddress !== undefined && state.homeAddress !== undefined;
+export function isAddressSectionCompleted(
+  state: PickDeep<
+    PublicApplicationState,
+    | 'context' //
+    | 'mailingAddress'
+    | 'homeAddress'
+    | 'isHomeAddressSameAsMailingAddress'
+    | 'clientApplication.contactInformation.homeAddress'
+    | 'clientApplication.contactInformation.mailingAddress'
+  >,
+): boolean {
+  // Both address change statuses must be answered before evaluating completion
+  if (!state.mailingAddress || !state.homeAddress) {
+    return false;
+  }
+
+  // Both changed: user has provided updated mailing and home addresses, and the same-address question must be answered
+  if (state.mailingAddress.hasChanged && state.homeAddress.hasChanged && state.isHomeAddressSameAsMailingAddress !== undefined) {
+    return true;
+  }
+
+  // Neither changed (renewal only): carry forward existing addresses only if both are on file.
+  // Intake applications must always provide addresses, so carry-forward is not allowed.
+  // mailingAddress is always required on the client application (eslint suppressed); homeAddress is optional.
+  // A mismatch (one changed, one did not) also falls through here and evaluates to false.
+  return (
+    state.context === 'renewal' && //
+    !state.mailingAddress.hasChanged &&
+    !state.homeAddress.hasChanged &&
+    state.clientApplication?.contactInformation.homeAddress !== undefined &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    state.clientApplication.contactInformation.mailingAddress !== undefined
+  );
 }
 
 /**


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request significantly expands and refines the test coverage for the `isAddressSectionCompleted` helper across multiple application flows (public, protected, and simplified), and clarifies the logic for when the address section is considered complete. The changes ensure that edge cases—such as missing addresses, unchanged addresses, and unanswered "same as mailing address" questions—are properly handled and tested.

**Test Coverage Improvements:**

* Added comprehensive tests to all `isAddressSectionCompleted` test suites to cover cases where either or both addresses are missing, neither address has changed, or the "same as mailing address" question is unanswered. Also added cases for when addresses are unchanged but present in the client application, especially for renewal flows. [[1]](diffhunk://#diff-83e6d5cd73f3b50b7be63a93203266913742ee25682c5381bed78a89bc122b5eL48-R112) [[2]](diffhunk://#diff-6f8468999bbab802174d66cda8cb07747e1922c7f965c6b6cc20cfebfc82e30fL48-R121) [[3]](diffhunk://#diff-6f8468999bbab802174d66cda8cb07747e1922c7f965c6b6cc20cfebfc82e30fL99-R143) [[4]](diffhunk://#diff-44647b4cab790f4c34b873a9a18a106696be7dee55613a9e7df2af889c051a6dL58-R183) [[5]](diffhunk://#diff-6a5aa249e62af99123ce31ae5da64ebe8d5649215d4fd9c2fffbebe525ef1922L57-R211)

**Business Logic Clarification:**

* Updated the documentation and implementation of `isAddressSectionCompleted` for protected intake applications to clearly state that the section is only complete if both addresses are present, both have changed, and the same-address question is answered. The implementation now explicitly checks these conditions.

These changes make the address section completion logic more robust and transparent, and ensure that all relevant scenarios are tested and validated.