### PR TITLE
fix(frontend): route handling for simplified-children in email

### DIFF
--- a/frontend/app/routes/public/application/spokes/email.tsx
+++ b/frontend/app/routes/public/application/spokes/email.tsx
@@ -30,6 +30,9 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
     case 'full-children': {
       return `public/application/$id/${applicationFlow}/parent-or-guardian`;
     }
+    case 'simplified-children': {
+      return `public/application/$id/${applicationFlow}/parent-or-guardian`;
+    }
     default: {
       return `public/application/$id/${applicationFlow}/contact-information`;
     }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the routing logic in the `getRouteFromApplicationFlow` function to handle a new application flow type. Now, both `'full-children'` and the new `'simplified-children'` flows will route users to the parent or guardian page.

Routing logic update:

* Added support for the `'simplified-children'` application flow, routing it to the same parent or guardian page as the `'full-children'` flow in `getRouteFromApplicationFlow` within `email.tsx`.

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->

```shell
2026-04-16T22:12:42.794Z ERROR --- [ entry.server/handleError]: Invariant failed: path not found for route [public/application/$id/simplified-children/contact-information] and language [en] --- {
  name: 'Error',
  stack: 'Error: Invariant failed: path not found for route [public/application/$id/simplified-children/contact-information] and language [en]\n' +
    '    at invariant (file:///home/node/node_modules/@dts-stn/invariant/src/invariant.ts:36:9)\n' +
    '    at getPathById (file:///home/node/build/server/assets/app-DtxCdMdk.js:11129:2)\n' +
    '    at action$75 (file:///home/node/build/server/assets/app-DtxCdMdk.js:31866:18)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n' +
    '    at callRouteHandler (file:///home/node/node_modules/react-router/dist/development/chunk-BFXCU3MI.mjs:510:16)\n' +
    '    at file:///home/node/node_modules/react-router/dist/development/chunk-OE4NN4TA.mjs:4858:19'
}
```