### PR TITLE
fix(frontend: resolve home address consistency based on user input

### DIFF
--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -455,10 +455,16 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       existingEmail: existingContactInformation.email,
     });
 
+    // Determine if the home address is the same as the mailing address. If either address has changed, use the
+    // isHomeAddressSameAsMailingAddress value provided by the user. If neither address has changed, use the existing
+    // copyMailingAddress value to maintain consistency with the existing data.
+    const haveAddressesChanged = renewedHomeAddress?.hasChanged === true || renewedMailingAddress?.hasChanged === true;
+    const resolvedIsHomeAddressSameAsMailingAddress = haveAddressesChanged ? isHomeAddressSameAsMailingAddress : existingContactInformation.copyMailingAddress;
+
     return {
       email: hasEmailChanged && renewedEmail ? renewedEmail : existingContactInformation.email,
-      copyMailingAddress: !!isHomeAddressSameAsMailingAddress,
-      ...this.toHomeAddress({ existingContactInformation, isHomeAddressSameAsMailingAddress, homeAddress: renewedHomeAddress, mailingAddress: renewedMailingAddress }),
+      copyMailingAddress: !!resolvedIsHomeAddressSameAsMailingAddress,
+      ...this.toHomeAddress({ existingContactInformation, isHomeAddressSameAsMailingAddress: resolvedIsHomeAddressSameAsMailingAddress, homeAddress: renewedHomeAddress, mailingAddress: renewedMailingAddress }),
       ...this.toMailingAddress({ existingContactInformation, mailingAddress: renewedMailingAddress }),
       ...phoneNumbers,
     };


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the logic for determining whether the home address is the same as the mailing address during a benefit renewal. The change ensures that if either address has changed, the user's latest input is used; otherwise, the existing value is preserved for consistency.

Address handling improvements:

* Updated `DefaultBenefitRenewalStateMapper` in `benefit-renewal.state.mapper.ts` to resolve `copyMailingAddress` based on whether home or mailing addresses have changed, ensuring user intent is respected and existing data is maintained when no changes are made.