### PR TITLE
refactor(frontend): streamline email handling in benefit application mappers

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -62,7 +62,6 @@ export type ContactInformationDto = ReadonlyDeep<{
   mailingProvince?: string;
   phoneNumber?: string;
   phoneNumberAlt?: string;
-  email?: string;
 }>;
 
 export type DentalInsuranceDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -24,8 +24,7 @@ interface ToAddressArgs {
 }
 
 interface ToEmailAddressArgs {
-  contactEmail?: string;
-  communicationEmail?: string;
+  email?: string;
 }
 
 @injectable()
@@ -69,7 +68,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
           PersonContactInformation: [
             {
               Address: [this.toMailingAddress(contactInformation), this.toHomeAddress(contactInformation)],
-              EmailAddress: this.toEmailAddress({ contactEmail: contactInformation.email, communicationEmail: communicationPreferences.email }),
+              EmailAddress: this.toEmailAddress({ email: communicationPreferences.email }),
               TelephoneNumber: this.toTelephoneNumber(contactInformation),
             },
           ],
@@ -190,20 +189,10 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     };
   }
 
-  private toEmailAddress({ contactEmail, communicationEmail }: ToEmailAddressArgs) {
-    const emailAddress = [];
-
-    if (contactEmail && !validator.isEmpty(contactEmail)) {
-      emailAddress.push({
-        EmailAddressID: contactEmail,
-      });
-    } else if (communicationEmail && !validator.isEmpty(communicationEmail)) {
-      emailAddress.push({
-        EmailAddressID: communicationEmail,
-      });
-    }
-
-    return emailAddress;
+  private toEmailAddress({ email }: ToEmailAddressArgs) {
+    return email && !validator.isEmpty(email) //
+      ? [{ EmailAddressID: email }]
+      : [];
   }
 
   private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: ContactInformationDto) {

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -27,6 +27,7 @@ export interface ApplicationAdultState {
   dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
   dentalInsurance: DentalInsuranceState;
   email?: string;
+  emailVerified?: boolean;
   homeAddress?: DeclaredChangeHomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -46,6 +47,7 @@ export interface ApplicationFamilyState {
   dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
   dentalInsurance: DentalInsuranceState;
   email?: string;
+  emailVerified?: boolean;
   homeAddress?: DeclaredChangeHomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -63,6 +65,7 @@ export interface ApplicationChildrenState {
   children: ChildState[];
   communicationPreferences: DeclaredChangeCommunicationPreferencesState;
   email?: string;
+  emailVerified?: boolean;
   homeAddress?: DeclaredChangeHomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
@@ -80,6 +83,7 @@ interface ToBenefitApplicationDtoArgs {
   children?: ChildState[];
   communicationPreferences: DeclaredChangeCommunicationPreferencesState;
   email?: string;
+  emailVerified?: boolean;
   dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
   dentalInsurance?: DentalInsuranceState;
   livingIndependently?: boolean;
@@ -107,11 +111,11 @@ interface ToHomeAddressArgs {
 interface ToCommunicationPreferencesArgs {
   communicationPreferences: DeclaredChangeCommunicationPreferencesState;
   email?: string;
+  emailVerified?: boolean;
 }
 
 interface ToContactInformationArgs {
   phoneNumber: DeclaredChangePhoneNumberState;
-  email?: string;
   homeAddress?: DeclaredChangeHomeAddressState;
   isHomeAddressSameAsMailingAddress?: boolean;
   mailingAddress?: DeclaredChangeMailingAddressState;
@@ -169,6 +173,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     dentalBenefits,
     dentalInsurance,
     email,
+    emailVerified,
     homeAddress,
     isHomeAddressSameAsMailingAddress,
     livingIndependently,
@@ -185,8 +190,8 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       }),
       applicationYearId: applicationYear.applicationYearId,
       children: this.toChildren(children),
-      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences, email }),
-      contactInformation: this.toContactInformation({ phoneNumber, email, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }),
+      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences, email, emailVerified }),
+      contactInformation: this.toContactInformation({ phoneNumber, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }),
       dateOfBirth: applicantInformation.dateOfBirth,
       maritalStatus,
       dentalBenefits: this.toDentalBenefits(dentalBenefits),
@@ -232,18 +237,28 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     });
   }
 
-  private toCommunicationPreferences({ communicationPreferences, email }: ToCommunicationPreferencesArgs): CommunicationPreferencesDto {
+  private toCommunicationPreferences({ communicationPreferences, email, emailVerified }: ToCommunicationPreferencesArgs): CommunicationPreferencesDto {
     invariant(communicationPreferences.value, 'Expected communicationPreferences.value to be defined');
+
+    // Only include the email if the user has verified it. This handles the case where the user entered
+    // an email, then navigated back and switched to a non-digital method.
+    const effectiveEmail = emailVerified ? email : undefined;
+
+    // The API expects emailVerified to be true if the email is verified, and undefined if it is not. It
+    // should never be false, because that would indicate that the email is not verified, but we would also
+    // not include the email in that case.
+    const effectiveEmailVerified = effectiveEmail ? true : undefined;
+
     return {
-      email,
-      emailVerified: communicationPreferences.value.preferredMethod === 'email' || communicationPreferences.value.preferredNotificationMethod === 'msca' ? true : undefined,
+      email: effectiveEmail,
+      emailVerified: effectiveEmailVerified,
       preferredLanguage: communicationPreferences.value.preferredLanguage,
       preferredMethod: communicationPreferences.value.preferredMethod,
       preferredMethodGovernmentOfCanada: communicationPreferences.value.preferredNotificationMethod,
     };
   }
 
-  private toContactInformation({ phoneNumber, email, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }: ToContactInformationArgs) {
+  private toContactInformation({ phoneNumber, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }: ToContactInformationArgs) {
     invariant(mailingAddress, 'Expected mailingAddress to be defined');
     invariant(phoneNumber.value, 'Expected phoneNumber.value to be defined');
     return {
@@ -251,7 +266,6 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       ...this.toHomeAddress({ isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }),
       ...this.toMailingAddress(mailingAddress),
       ...phoneNumber.value,
-      email,
     };
   }
 

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -244,9 +244,8 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     // an email, then navigated back and switched to a non-digital method.
     const effectiveEmail = emailVerified ? email : undefined;
 
-    // The API expects emailVerified to be true if the email is verified, and undefined if it is not. It
-    // should never be false, because that would indicate that the email is not verified, but we would also
-    // not include the email in that case.
+    // Keep emailVerified aligned with the email value emitted by this mapper: when no effective email is
+    // sent, omit emailVerified as well so we do not send a stale or contradictory false value.
     const effectiveEmailVerified = effectiveEmail ? true : undefined;
 
     return {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors how email addresses and their verification status are handled in the benefit application data mapping. The main focus is to ensure that only verified emails are included in communication preferences, and to simplify the mapping logic for email addresses throughout the DTOs and mappers.

Key changes include:

**Email and Email Verification Handling:**

* Added an `emailVerified` field to application state interfaces (`ApplicationAdultState`, `ApplicationFamilyState`, `ApplicationChildrenState`) and to the relevant mapper arguments, ensuring the verification status is tracked throughout the application state. [[1]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643R30) [[2]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643R50) [[3]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643R68) [[4]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643R86) [[5]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643R114-L114)
* Updated the `toCommunicationPreferences` method to only include the email if it has been verified, and to set `emailVerified` to true only when appropriate. This prevents unverified emails from being sent to the API and ensures the verification flag is consistent.

**DTO and Mapper Simplification:**

* Removed the `email` field from `ContactInformationDto` and stopped passing email addresses via contact information, centralizing email handling in communication preferences. [[1]](diffhunk://#diff-11782fa4b1be6ec365721d4ef3c691ad188623ecf175d568563f4ac2b377346dL65) [[2]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643L188-R194) [[3]](diffhunk://#diff-d979327eaa49f9a07bec79b5136ff077deeef3d7fae52641728c024afa4b7643L235-L254)
* Simplified the `toEmailAddress` logic in `DefaultBenefitApplicationDtoMapper` to accept a single `email` argument, removing the previous logic that handled both contact and communication emails. [[1]](diffhunk://#diff-d2d23e07d08201bcda7bb887c0db2541ee9df739b87ad18372dfb831cf373299L27-R27) [[2]](diffhunk://#diff-d2d23e07d08201bcda7bb887c0db2541ee9df739b87ad18372dfb831cf373299L72-R71) [[3]](diffhunk://#diff-d2d23e07d08201bcda7bb887c0db2541ee9df739b87ad18372dfb831cf373299L193-R195)

These changes improve data consistency, reduce redundancy, and ensure that only verified emails are processed and sent to the backend.