### PR TITLE
fix(frontend): session handling in RAOIDC callback to check for missing keys

### DIFF
--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -139,10 +139,9 @@ async function handleRaoidcCallbackRequest({ context: { appContainer, session },
   const state = session.find('authState');
 
   if (codeVerifier.isNone() || state.isNone()) {
-    const missingSessionKeys = [
-      codeVerifier.mapOr('authCodeVerifier', () => ''), //
-      state.mapOr('authState', () => ''),
-    ].filter(Boolean);
+    const missingSessionKeys: string[] = [];
+    if (codeVerifier.isNone()) missingSessionKeys.push('authCodeVerifier');
+    if (state.isNone()) missingSessionKeys.push('authState');
     const missingKeys = missingSessionKeys.join(' and ');
     const authLoginUrl = `/auth/login?${new URLSearchParams({ returnto: returnUrl })}`;
     log.warn('Missing %s in session [%s]; possible stale or replayed callback -- redirecting to [%s]', missingKeys, session.id, authLoginUrl);

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -12,8 +12,8 @@ const defaultReturnUrl = '/';
 
 /**
  * Checks if a given return URL is safe to redirect to. A safe return URL is one that is a relative path (starts with a
- * single "/") and does not contain any backslashes or double slashes, which could indicate an attempt at an open
- * redirect or other malicious behavior.
+ * single "/"), is not protocol-relative (does not start with "//"), and does not contain any backslashes, which could
+ * indicate an attempt at an open redirect or other malicious behavior.
  *
  * @param returnUrl The URL to check.
  * @returns `true` if the URL is safe, `false` otherwise.

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -10,8 +10,20 @@ import { generateCallbackUri } from '~/.server/utils/raoidc.utils';
 const defaultProviderId = 'raoidc';
 const defaultReturnUrl = '/';
 
+/**
+ * Checks if a given return URL is safe to redirect to. A safe return URL is one that is a relative path (starts with a
+ * single "/") and does not contain any backslashes or double slashes, which could indicate an attempt at an open
+ * redirect or other malicious behavior.
+ *
+ * @param returnUrl The URL to check.
+ * @returns `true` if the URL is safe, `false` otherwise.
+ */
 function isSafeReturnUrl(returnUrl: string) {
-  return returnUrl.startsWith('/') && !returnUrl.startsWith('//') && !returnUrl.includes('\\');
+  return (
+    returnUrl.startsWith('/') && // Must start with a single slash to be considered a relative path
+    !returnUrl.startsWith('//') && // Must not start with double slashes, which could indicate a protocol-relative URL
+    !returnUrl.includes('\\') // Must not contain backslashes, which could be used in certain types of attacks
+  );
 }
 
 /**

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -134,14 +134,26 @@ async function handleRaoidcCallbackRequest({ context: { appContainer, session },
   instrumentationService.createCounter('auth.callback.raoidc.requests').add(1);
 
   const raoidcService = appContainer.get(TYPES.RaoidcService);
-  const codeVerifier = session.get('authCodeVerifier');
+  const codeVerifier = session.find('authCodeVerifier');
   const returnUrl = session.find('authReturnUrl').unwrapOr('/');
-  const state = session.get('authState');
+  const state = session.find('authState');
+
+  if (codeVerifier.isNone() || state.isNone()) {
+    const missingSessionKeys = [
+      codeVerifier.mapOr('authCodeVerifier', () => ''), //
+      state.mapOr('authState', () => ''),
+    ].filter(Boolean);
+    const missingKeys = missingSessionKeys.join(' and ');
+    const authLoginUrl = `/auth/login?${new URLSearchParams({ returnto: returnUrl })}`;
+    log.warn('Missing %s in session [%s]; possible stale or replayed callback -- redirecting to [%s]', missingKeys, session.id, authLoginUrl);
+    instrumentationService.createCounter('auth.callback.raoidc.requests.stale-session').add(1);
+    throw redirectDocument(authLoginUrl);
+  }
 
   const redirectUri = generateCallbackUri(new URL(request.url).origin, 'raoidc');
 
   log.debug('Storing auth tokens and userinfo in session');
-  const { idToken, userInfoToken } = await raoidcService.handleCallback({ request, codeVerifier, expectedState: state, redirectUri });
+  const { idToken, userInfoToken } = await raoidcService.handleCallback({ request, codeVerifier: codeVerifier.unwrap(), expectedState: state.unwrap(), redirectUri });
   session.set('idToken', idToken);
   session.set('userInfoToken', userInfoToken);
 

--- a/frontend/app/routes/auth/$.tsx
+++ b/frontend/app/routes/auth/$.tsx
@@ -8,6 +8,11 @@ import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { generateCallbackUri } from '~/.server/utils/raoidc.utils';
 
 const defaultProviderId = 'raoidc';
+const defaultReturnUrl = '/';
+
+function isSafeReturnUrl(returnUrl: string) {
+  return returnUrl.startsWith('/') && !returnUrl.startsWith('//') && !returnUrl.includes('\\');
+}
 
 /**
  * A do-all authentication handler for the application
@@ -100,7 +105,7 @@ async function handleRaoidcLoginRequest({ context: { appContainer, session }, re
   const { origin, searchParams } = new URL(request.url);
   const returnUrl = searchParams.get('returnto');
 
-  if (returnUrl && !returnUrl.startsWith('/')) {
+  if (returnUrl && !isSafeReturnUrl(returnUrl)) {
     log.warn('Invalid return URL [%s]', returnUrl);
     instrumentationService.createCounter('auth.login.raoidc.requests.invalid-return-url').add(1);
 
@@ -117,7 +122,7 @@ async function handleRaoidcLoginRequest({ context: { appContainer, session }, re
 
   log.debug('Storing [codeVerifier] and [state] in session for future validation');
   session.set('authCodeVerifier', codeVerifier);
-  session.set('authReturnUrl', returnUrl ?? '/');
+  session.set('authReturnUrl', returnUrl ?? defaultReturnUrl);
   session.set('authState', state);
 
   log.debug('Redirecting to RAOIDC signin URL [%s]', authUrl.href);
@@ -135,7 +140,8 @@ async function handleRaoidcCallbackRequest({ context: { appContainer, session },
 
   const raoidcService = appContainer.get(TYPES.RaoidcService);
   const codeVerifier = session.find('authCodeVerifier');
-  const returnUrl = session.find('authReturnUrl').unwrapOr('/');
+  const rawReturnUrl = session.find('authReturnUrl').unwrapOr(defaultReturnUrl);
+  const returnUrl = isSafeReturnUrl(rawReturnUrl) ? rawReturnUrl : defaultReturnUrl;
   const state = session.find('authState');
 
   if (codeVerifier.isNone() || state.isNone()) {


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

The `/auth/callback/raoidc` handler was calling `session.get('authCodeVerifier')` and `session.get('authState')`, which throw and log an `ERROR` when those keys are absent. This was hitting in production as:

```sh
Session [ae93e9ca-...]: Attempted to get non-existent key "authCodeVerifier"
```

This is an expected edge case, not a programming error. It occurs when:
- A **second login tab** triggers `session.regenerate()`, invalidating the first tab's session before its callback is processed
- The **session expires** between the IdP redirect and the callback (slow network / long IdP interaction)
- A **bot or scanner** hits the callback URL directly without going through the login flow

### Changes

- Replaced `session.get('authCodeVerifier')` and `session.get('authState')` with `session.find()` (non-throwing)
- Added an explicit guard that checks both values before proceeding
- On missing keys: logs a `WARN` (not `ERROR`) with the specific missing key names and target redirect, increments a dedicated `auth.callback.raoidc.requests.stale-session` counter, and redirects to `/auth/login?returnto=<returnUrl>` to restart the auth flow gracefully
- `returnUrl` is preserved in the redirect so the user lands at the intended page after re-authenticating (when available in the session)